### PR TITLE
test: fork CI の隔離境界を確認

### DIFF
--- a/.github/fork-boundary-test.txt
+++ b/.github/fork-boundary-test.txt
@@ -1,0 +1,1 @@
+fork boundary CI test


### PR DESCRIPTION
## 現状

source-available 公開後の fork PR で、公開 CI の隔離境界を実測する必要があります。

## やること

動作へ影響しない確認用ファイルを追加し、fork 由来の `pull_request` で Public CI を実行します。この PR は検証専用であり、取り込みません。

## 受け入れ基準

- GitHub-hosted runner だけで Public CI が完了する
- secret、OIDC、self-hosted runner、deploy、npm publish に到達しない
- private repository に到達しない
