### PR TITLE
Clarify proposal validation status

### DIFF
--- a/proposals/show-proposal-validation-status.md
+++ b/proposals/show-proposal-validation-status.md
@@ -1,0 +1,17 @@
+# Show proposal validation status clearly
+
+## Situation
+
+I submitted a proposal from a fork and waited for the repository checks before a maintainer could review it.
+
+## Problem
+
+It was not clear which checks only verified the proposal boundary and which checks validated the full repository. That made it difficult to tell whether the proposal itself needed changes or was simply waiting for the maintainer workflow.
+
+## Expected change
+
+Show a short, public explanation of the proposal validation stages and what action, if any, the contributor should take at each stage.
+
+## Additional context
+
+A concise check summary in the pull request is enough. It should not expose private implementation or operational details.


### PR DESCRIPTION
## Change

Add one public proposal describing how clearer validation-stage feedback would help contributors understand whether a proposal needs changes or is waiting for maintainer processing.

## Validation

- Public export scan: 0 findings
- Proposal-only boundary guard: passed
