### PR TITLE
Preserve private overlays during handoff

### DIFF
--- a/PUBLIC-EXPORT-RECEIPT.json
+++ b/PUBLIC-EXPORT-RECEIPT.json
@@ -4103,7 +4103,7 @@
     },
     {
       "path": "config/repository-boundary.json",
-      "sha256": "c73db2ef67754711001ad458933777780419d689050ee4cec55f56c3fbabe714"
+      "sha256": "aa2f2bcf0f6609320d395c5597cc9af09bf82d3ae68a914918e1221634bc485a"
     },
     {
       "path": "docs/brand/README.md",
@@ -4691,11 +4691,11 @@
     },
     {
       "path": "scripts/public-development-guard.mjs",
-      "sha256": "583d747116161c4e92b09313c61201abbde1711b2d2353c4269ca0ef107014d5"
+      "sha256": "2a9b9cc980e64440216f8369d5eb254a14e31d60590c2b5240957608f51e59c2"
     },
     {
       "path": "scripts/public-development-guard.test.mjs",
-      "sha256": "e9168f19338395ea465a2fddc8e4ce56c9984f018e3d7d74d79b12423d044a66"
+      "sha256": "d94cbb78c7f28dfaa613e150953e5b362a0c33e1be2b7064b2c9e9d8034691c8"
     },
     {
       "path": "scripts/public-export-scan.mjs",

--- a/config/repository-boundary.json
+++ b/config/repository-boundary.json
@@ -2,18 +2,11 @@
   "schema_version": 1,
   "source": "config/public-export-include.json",
   "canonical": [
-    ".github/PULL_REQUEST_TEMPLATE.md",
-    "AGENTS.md",
-    "CLAUDE.md",
-    ".dev.vars.example",
-    ".gitignore",
     "apps/web/check-migrations.mjs",
     "apps/web/check-schema.mjs",
-    "apps/web/react-router.config.ts",
     "apps/web/tsconfig.cloudflare.json",
     "apps/web/tsconfig.json",
     "apps/web/tsconfig.node.json",
-    "apps/web/vite.config.ts",
     "apps/web/vitest.behavior.browser.config.ts",
     "apps/web/vitest.config.ts",
     "apps/web/vitest.integration.config.ts",
@@ -79,8 +72,14 @@
   "classification_prefixes": {},
   "classifications": {
     "private-overlay": [
+      "AGENTS.md",
+      "CLAUDE.md",
+      ".dev.vars.example",
+      ".gitignore",
       "package.json",
       "apps/web/package.json",
+      "apps/web/vite.config.ts",
+      "apps/web/react-router.config.ts",
       "pnpm-lock.yaml",
       "apps/web/wrangler.jsonc",
       "apps/web/wrangler.alerts.jsonc",
@@ -88,6 +87,7 @@
       "apps/web/wrangler.sandbox.jsonc"
     ],
     "public-only": [
+      ".github/PULL_REQUEST_TEMPLATE.md",
       ".github/workflows/public-ci.yml",
       "PUBLIC-EXPORT-RECEIPT.json"
     ]

--- a/scripts/public-development-guard.mjs
+++ b/scripts/public-development-guard.mjs
@@ -89,6 +89,17 @@ export function loadBoundaryManifest(repo = process.cwd()) {
     actualExactPaths.some((file) => !expectedExactPaths.includes(file))
   )
     throw new Error('boundary exact contract mismatch')
+  const projectedPaths = include.rules
+    .filter((rule) => rule.export_path)
+    .flatMap((rule) => {
+      const sources = Array.isArray(rule.exact) ? rule.exact : [rule.exact]
+      return sources
+        .filter((source) => source && source !== rule.export_path)
+        .map(() => rule.export_path)
+    })
+  for (const file of projectedPaths)
+    if (classifications.canonical.includes(file))
+      throw new Error(`projected path cannot be canonical: ${file}`)
   return { ...boundary, exported, prefixes, classifications }
 }
 

--- a/scripts/public-development-guard.test.mjs
+++ b/scripts/public-development-guard.test.mjs
@@ -97,6 +97,23 @@ test('boundary manifest rejects prefix exclusion drift', () => {
     /boundary prefix exclusion contract mismatch/,
   )
 })
+test('boundary manifest rejects a projected path classified as canonical', () => {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'boundary-projection-'))
+  fs.mkdirSync(path.join(repo, 'config'))
+  for (const file of ['public-export-include.json', 'repository-boundary.json'])
+    fs.copyFileSync(path.join('config', file), path.join(repo, 'config', file))
+  const boundaryPath = path.join(repo, 'config', 'repository-boundary.json')
+  const boundary = JSON.parse(fs.readFileSync(boundaryPath, 'utf8'))
+  boundary.classifications['private-overlay'] = boundary.classifications[
+    'private-overlay'
+  ].filter((file) => file !== '.dev.vars.example')
+  boundary.canonical.push('.dev.vars.example')
+  fs.writeFileSync(boundaryPath, JSON.stringify(boundary))
+  assert.throws(
+    () => loadBoundaryManifest(repo),
+    /projected path cannot be canonical: \.dev\.vars\.example/,
+  )
+})
 test('private-overlay is an allowed public-tree file and private paths are rejected', () => {
   assert.equal(
     inspectTree([{ path: 'package.json', mode: 'file' }], manifest)[0]


### PR DESCRIPTION
## Change

Classify projected public development files as private overlays or public-only files so a verified handoff preserves repository-specific private configuration. Add a fail-closed guard that rejects future projected paths classified as canonical.

## Validation

- Boundary and handoff tests passed
- Private and fresh public-export validation passed
- Public export scan reported 0 findings
- Runtime smoke passed
- React Doctor reported 100 with no warnings or errors
