### PR TITLE
Reserve public production deployment paths

### DIFF
--- a/config/public-export-include.json
+++ b/config/public-export-include.json
@@ -72,7 +72,8 @@
         "apps/web/check-migrations.mjs",
         "apps/web/check-schema.mjs",
         "apps/web/vitest.behavior.browser.config.ts",
-        "apps/web/vitest.integration.config.ts"
+        "apps/web/vitest.integration.config.ts",
+        "apps/web/vitest.visual.browser.config.ts"
       ],
       "reason": "公開 web 検査設定"
     },
@@ -192,6 +193,18 @@
       "reason": "credential-free public CI"
     },
     {
+      "id": "public-production-workflow",
+      "classification": "public",
+      "exact": ".github/workflows/deploy-production.yml",
+      "reason": "protected production shadow and deployment workflow"
+    },
+    {
+      "id": "public-production-config",
+      "classification": "public",
+      "exact": "apps/web/wrangler.production.jsonc",
+      "reason": "non-secret production topology"
+    },
+    {
       "id": "public-web-package",
       "classification": "public",
       "exact": "config/package.web.public.json",
@@ -269,7 +282,10 @@
       "classification": "public",
       "exact": [
         "scripts/public-ci-contract.test.mjs",
-        "scripts/public-runtime-smoke.mjs"
+        "scripts/public-runtime-smoke.mjs",
+        "scripts/deployment-contract.test.mjs",
+        "scripts/verify-validated-sha.mjs",
+        "scripts/verify-validated-sha.test.mjs"
       ],
       "reason": "公開 CI 到達性検査"
     },

--- a/config/repository-boundary.json
+++ b/config/repository-boundary.json
@@ -10,6 +10,8 @@
     "apps/web/vitest.behavior.browser.config.ts",
     "apps/web/vitest.config.ts",
     "apps/web/vitest.integration.config.ts",
+    "apps/web/vitest.visual.browser.config.ts",
+    "apps/web/wrangler.production.jsonc",
     "config/public-export-include.json",
     "config/public-export-scan.json",
     "config/repository-boundary.json",
@@ -39,6 +41,7 @@
     "scripts/generate-cli-reference.test.mjs",
     "scripts/interactive-spacing-annotation-policy.mjs",
     "scripts/public-ci-contract.test.mjs",
+    "scripts/deployment-contract.test.mjs",
     "scripts/public-development-guard.mjs",
     "scripts/public-development-guard.test.mjs",
     "scripts/public-export-scan.mjs",
@@ -46,6 +49,8 @@
     "scripts/public-hook-setup.mjs",
     "scripts/public-hook-setup.test.mjs",
     "scripts/public-runtime-smoke.mjs",
+    "scripts/verify-validated-sha.mjs",
+    "scripts/verify-validated-sha.test.mjs",
     "scripts/public-test-audit.mjs",
     "scripts/screen-ledger.mjs",
     "scripts/screen-scenarios.json",
@@ -88,6 +93,7 @@
     ],
     "public-only": [
       ".github/PULL_REQUEST_TEMPLATE.md",
+      ".github/workflows/deploy-production.yml",
       ".github/workflows/public-ci.yml",
       "PUBLIC-EXPORT-RECEIPT.json"
     ]


### PR DESCRIPTION
## What changed

Reserve the visual validation and production deployment paths in the trusted public boundary manifest.

## Why

The pull-request guard intentionally evaluates proposed commits using the manifest already trusted on `main`. New public paths therefore require a manifest-only prerequisite change before their implementation can be reviewed.

## Validation

- public development guard tests
- standalone public development guard