### PR TITLE
Reserve public visual Compose path

### DIFF
--- a/config/public-export-include.json
+++ b/config/public-export-include.json
@@ -160,6 +160,12 @@
       "reason": "公開 workspace 定義"
     },
     {
+      "id": "public-visual-compose",
+      "classification": "public",
+      "exact": "compose.playwright.yml",
+      "reason": "Linux visual regression environment"
+    },
+    {
       "id": "root-public-config",
       "classification": "public",
       "exact": [".oxfmtrc.json", ".oxlintrc.json"],

--- a/config/repository-boundary.json
+++ b/config/repository-boundary.json
@@ -15,6 +15,7 @@
     "config/public-export-include.json",
     "config/public-export-scan.json",
     "config/repository-boundary.json",
+    "compose.playwright.yml",
     "CONTRIBUTING.md",
     "doctor.config.json",
     "LICENSE",


### PR DESCRIPTION
## What changed

Reserve the Linux visual regression Compose file in the trusted public boundary manifest.

## Why

The public visual baseline must be generated in the same Linux environment used by CI. The boundary guard requires this manifest-only prerequisite before the Compose file can be reviewed.

## Validation

- standalone public development guard