### PR TITLE
Use repository pnpm version in deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -30,7 +30,6 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
-          version: 10.32.1
           run_install: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -60,7 +59,6 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
-          version: 10.32.1
           run_install: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -80,6 +80,13 @@ test('production workflow defaults to a credential-free manual shadow', () => {
     workflowSource,
     /GITHUB_TOKEN: \$\{\{ github\.token \}\}[\s\S]*verify-validated-sha\.mjs "\$\{\{ github\.sha \}\}"/u,
   )
+  for (const jobName of ['shadow', 'deploy']) {
+    const setup = workflow.jobs[jobName].steps.find((step) =>
+      step.uses?.startsWith('pnpm/action-setup@'),
+    )
+    assert.ok(setup)
+    assert.equal(setup.with?.version, undefined)
+  }
 })
 
 test('production writes require the protected environment', () => {


### PR DESCRIPTION
## What changed

Remove the duplicate pnpm version from the production workflow and let `pnpm/action-setup` use the repository `packageManager` declaration.

## Why

The first credential-free shadow run stopped before installation because the workflow requested pnpm 10.32.1 while the repository declares pnpm 11.13.1.

## Validation

- deployment workflow contract tests
- YAML formatting