### PR TITLE
Harden post-deployment origin verification

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -69,9 +69,5 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: pnpm --filter @artifactshare/web deploy:production
-      - name: Wait for edge propagation
-        run: sleep 30
       - name: Smoke test production
-        run: |
-          curl --fail --silent --show-error --retry 2 --retry-delay 15 https://artifactshare.com/ >/dev/null
-          curl --fail --silent --show-error --retry 2 --retry-delay 15 https://artifactshare.com/robots.txt | grep -q 'User-agent'
+        run: node scripts/verify-production-origin.mjs --retries 2 --retry-delay-ms 15000

--- a/config/public-export-include.json
+++ b/config/public-export-include.json
@@ -290,6 +290,8 @@
         "scripts/public-ci-contract.test.mjs",
         "scripts/public-runtime-smoke.mjs",
         "scripts/deployment-contract.test.mjs",
+        "scripts/verify-production-origin.mjs",
+        "scripts/verify-production-origin.test.mjs",
         "scripts/verify-validated-sha.mjs",
         "scripts/verify-validated-sha.test.mjs"
       ],

--- a/config/repository-boundary.json
+++ b/config/repository-boundary.json
@@ -52,6 +52,8 @@
     "scripts/public-runtime-smoke.mjs",
     "scripts/verify-validated-sha.mjs",
     "scripts/verify-validated-sha.test.mjs",
+    "scripts/verify-production-origin.mjs",
+    "scripts/verify-production-origin.test.mjs",
     "scripts/public-test-audit.mjs",
     "scripts/screen-ledger.mjs",
     "scripts/screen-scenarios.json",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "check:analytics-dimensions": "node scripts/check-analytics-dimensions.mjs",
     "check:cli-changelog": "node scripts/check-cli-changelog.mjs",
     "typecheck": "pnpm --filter @artifactshare/web typecheck && pnpm --filter @artifactshare/cli typecheck",
-    "test:scripts": "node --test scripts/check-design-tokens.test.mjs scripts/check-copy-glossary.test.mjs scripts/check-analytics-literals.test.mjs scripts/check-analytics-dimensions.test.mjs scripts/check-cli-changelog.test.mjs scripts/deployment-contract.test.mjs scripts/generate-cli-reference.test.mjs scripts/public-development-guard.test.mjs scripts/public-hook-setup.test.mjs scripts/public-ci-contract.test.mjs scripts/public-export-scan.test.mjs scripts/verify-validated-sha.test.mjs",
+    "test:scripts": "node --test scripts/check-design-tokens.test.mjs scripts/check-copy-glossary.test.mjs scripts/check-analytics-literals.test.mjs scripts/check-analytics-dimensions.test.mjs scripts/check-cli-changelog.test.mjs scripts/deployment-contract.test.mjs scripts/generate-cli-reference.test.mjs scripts/public-development-guard.test.mjs scripts/public-hook-setup.test.mjs scripts/public-ci-contract.test.mjs scripts/public-export-scan.test.mjs scripts/verify-production-origin.test.mjs scripts/verify-validated-sha.test.mjs",
     "test": "pnpm test:scripts && pnpm --filter @artifactshare/web test && pnpm --filter @artifactshare/cli test",
     "build": "pnpm --filter @artifactshare/web build && pnpm --filter @artifactshare/cli build",
     "build:alerts": "pnpm --filter @artifactshare/web build:alerts",

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -105,3 +105,12 @@ test('production writes require the protected environment', () => {
   )
   assert.equal(workflow.concurrency['cancel-in-progress'], false)
 })
+
+test('production deploy verifies the complete public origin with retries', () => {
+  const deploy = JSON.stringify(workflow.jobs.deploy)
+  assert.match(
+    deploy,
+    /node scripts\/verify-production-origin\.mjs --retries 2 --retry-delay-ms 15000/u,
+  )
+  assert.doesNotMatch(deploy, /curl|sleep 30/u)
+})

--- a/scripts/verify-production-origin.mjs
+++ b/scripts/verify-production-origin.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url'
+
+const defaultBaseUrl = 'https://artifactshare.com'
+const defaultTimeoutMs = 10_000
+const defaultRetryDelayMs = 15_000
+
+const defaultChecks = [
+  { name: 'home', path: '/', status: 200, contentType: 'text/html' },
+  {
+    name: 'robots',
+    path: '/robots.txt',
+    status: 200,
+    contentType: 'text/plain',
+    includes: 'User-agent',
+  },
+  {
+    name: 'sitemap',
+    path: '/sitemap.xml',
+    status: 200,
+    contentType: 'application/xml',
+    includes: '<urlset',
+  },
+  {
+    name: 'agent-json',
+    path: '/.well-known/agent.json',
+    status: 200,
+    contentType: 'application/json',
+  },
+  {
+    name: 'openapi-json',
+    path: '/openapi.json',
+    status: 200,
+    contentType: 'application/json',
+  },
+  { name: 'llms', path: '/llms.txt', status: 200, contentType: 'text/plain' },
+  {
+    name: 'pricing',
+    path: '/pricing.md',
+    status: 200,
+    contentType: 'text/markdown',
+  },
+  {
+    name: 'favicon',
+    path: '/favicon.svg',
+    status: 200,
+    contentType: 'image/svg+xml',
+    includes: '<svg',
+  },
+]
+
+function usage() {
+  return `Usage: node scripts/verify-production-origin.mjs [options]
+
+Options:
+  --base-url <url>      Target origin. Default: ${defaultBaseUrl}
+  --timeout-ms <ms>     Per-request timeout. Default: ${defaultTimeoutMs}
+  --retries <count>     Retry failed check sets. Default: 0
+  --retry-delay-ms <ms> Delay between retries. Default: ${defaultRetryDelayMs}
+  -h, --help            Show this help.`
+}
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: defaultBaseUrl,
+    retries: 0,
+    retryDelayMs: defaultRetryDelayMs,
+    timeoutMs: defaultTimeoutMs,
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--') continue
+    if (arg === '-h' || arg === '--help') return { ...options, help: true }
+    if (
+      !['--base-url', '--timeout-ms', '--retries', '--retry-delay-ms'].includes(
+        arg,
+      )
+    )
+      throw new Error(`Unknown option: ${arg}\n\n${usage()}`)
+    const value = argv[index + 1]
+    if (!value || value.startsWith('--'))
+      throw new Error(`Missing value for ${arg}`)
+    index += 1
+    if (arg === '--base-url') options.baseUrl = value
+    if (arg === '--retries') options.retries = Number(value)
+    if (arg === '--retry-delay-ms') options.retryDelayMs = Number(value)
+    if (arg === '--timeout-ms') options.timeoutMs = Number(value)
+  }
+  if (!Number.isInteger(options.retries) || options.retries < 0)
+    throw new Error('Invalid --retries. Use a non-negative integer.')
+  if (!Number.isInteger(options.retryDelayMs) || options.retryDelayMs <= 0)
+    throw new Error('Invalid --retry-delay-ms. Use a positive integer.')
+  if (!Number.isInteger(options.timeoutMs) || options.timeoutMs <= 0)
+    throw new Error('Invalid --timeout-ms. Use a positive integer.')
+  return options
+}
+
+function normalizeBaseUrl(value) {
+  const url = new URL(value)
+  url.pathname = url.pathname.replace(/\/+$/u, '')
+  url.search = ''
+  url.hash = ''
+  return url.toString().replace(/\/$/u, '')
+}
+
+function checkResponse({ check, response, contentType, body }) {
+  const failures = []
+  if (response.status !== check.status)
+    failures.push(`expected status ${check.status}, got ${response.status}`)
+  if (check.contentType && !contentType.includes(check.contentType))
+    failures.push(`expected content-type including ${check.contentType}`)
+  if (check.includes && !body.includes(check.includes))
+    failures.push(`expected body to include ${check.includes}`)
+  return failures
+}
+
+async function runChecks({
+  baseUrl,
+  checks = defaultChecks,
+  fetchImpl = fetch,
+  timeoutMs = defaultTimeoutMs,
+}) {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+  const results = []
+  for (const check of checks) {
+    const url = new URL(check.path, `${normalizedBaseUrl}/`)
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+    const startedAt = performance.now()
+    try {
+      const response = await fetchImpl(url, {
+        headers: { Accept: '*/*', 'User-Agent': 'artifactshare-smoke/1.0' },
+        redirect: 'follow',
+        signal: controller.signal,
+      })
+      const body = await response.text()
+      const failures = checkResponse({
+        check,
+        response,
+        contentType: response.headers.get('content-type') ?? '',
+        body,
+      })
+      results.push({
+        name: check.name,
+        url: url.toString(),
+        status: response.status,
+        durationMs: Math.round(performance.now() - startedAt),
+        ok: failures.length === 0,
+        failures,
+      })
+    } catch (error) {
+      results.push({
+        name: check.name,
+        url: url.toString(),
+        status: null,
+        durationMs: Math.round(performance.now() - startedAt),
+        ok: false,
+        failures: [error instanceof Error ? error.message : String(error)],
+      })
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+  return results
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function runChecksWithRetries({
+  retries = 0,
+  retryDelayMs = defaultRetryDelayMs,
+  waitImpl = delay,
+  ...options
+}) {
+  let results = []
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    results = await runChecks(options)
+    if (results.every((result) => result.ok))
+      return { attempt: attempt + 1, results }
+    if (attempt < retries) await waitImpl(retryDelayMs)
+  }
+  return { attempt: retries + 1, results }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (options.help) return console.log(usage())
+  const { attempt, results } = await runChecksWithRetries(options)
+  if (options.retries > 0)
+    console.log(`attempt ${attempt}/${options.retries + 1}`)
+  for (const result of results) {
+    console.log(
+      `${result.ok ? 'ok' : 'fail'} ${result.name} ${result.status ?? 'error'} ${result.durationMs}ms`,
+    )
+    for (const failure of result.failures) console.log(`  ${failure}`)
+  }
+  if (results.some((result) => !result.ok)) process.exitCode = 1
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+
+export {
+  defaultChecks,
+  normalizeBaseUrl,
+  parseArgs,
+  runChecks,
+  runChecksWithRetries,
+}

--- a/scripts/verify-production-origin.test.mjs
+++ b/scripts/verify-production-origin.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  defaultChecks,
+  normalizeBaseUrl,
+  parseArgs,
+  runChecks,
+  runChecksWithRetries,
+} from './verify-production-origin.mjs'
+
+test('covers the public production surface', () => {
+  assert.deepEqual(
+    defaultChecks.map(({ path }) => path),
+    [
+      '/',
+      '/robots.txt',
+      '/sitemap.xml',
+      '/.well-known/agent.json',
+      '/openapi.json',
+      '/llms.txt',
+      '/pricing.md',
+      '/favicon.svg',
+    ],
+  )
+})
+
+test('normalizes the target and parses retry options', () => {
+  assert.equal(
+    normalizeBaseUrl('https://artifactshare.com///?x=1#top'),
+    'https://artifactshare.com',
+  )
+  assert.deepEqual(
+    parseArgs([
+      '--base-url',
+      'https://example.test',
+      '--timeout-ms',
+      '2500',
+      '--retries',
+      '2',
+      '--retry-delay-ms',
+      '1000',
+    ]),
+    {
+      baseUrl: 'https://example.test',
+      retries: 2,
+      retryDelayMs: 1000,
+      timeoutMs: 2500,
+    },
+  )
+})
+
+test('checks status, content type, and body', async () => {
+  const [result] = await runChecks({
+    baseUrl: 'https://example.test',
+    timeoutMs: 100,
+    checks: [
+      {
+        name: 'robots',
+        path: '/robots.txt',
+        status: 200,
+        contentType: 'text/plain',
+        includes: 'User-agent',
+      },
+    ],
+    fetchImpl: () =>
+      new Response('nope', {
+        status: 503,
+        headers: { 'content-type': 'text/html' },
+      }),
+  })
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.failures, [
+    'expected status 200, got 503',
+    'expected content-type including text/plain',
+    'expected body to include User-agent',
+  ])
+})
+
+test('retries the complete check set', async () => {
+  const waits = []
+  let calls = 0
+  const result = await runChecksWithRetries({
+    baseUrl: 'https://example.test',
+    retries: 2,
+    retryDelayMs: 123,
+    timeoutMs: 100,
+    waitImpl: (ms) => {
+      waits.push(ms)
+      return Promise.resolve()
+    },
+    checks: [{ name: 'home', path: '/', status: 200 }],
+    fetchImpl: () => {
+      calls += 1
+      return new Response('ok', { status: calls === 1 ? 503 : 200 })
+    },
+  })
+  assert.equal(result.attempt, 2)
+  assert.equal(result.results[0].ok, true)
+  assert.deepEqual(waits, [123])
+})


### PR DESCRIPTION
## Summary
- verify eight public origin endpoints after a protected deployment
- check status, content type, and required body markers with bounded retries
- keep the verification implementation and contracts in the public repository

## Validation
- `pnpm test:scripts`
- `pnpm check:public-development-guard`
- `pnpm public:scan .`
- read-only verification against the current public origin