### PR TITLE
Allow origin verification scripts

### DIFF
--- a/config/public-export-include.json
+++ b/config/public-export-include.json
@@ -290,6 +290,8 @@
         "scripts/public-ci-contract.test.mjs",
         "scripts/public-runtime-smoke.mjs",
         "scripts/deployment-contract.test.mjs",
+        "scripts/verify-production-origin.mjs",
+        "scripts/verify-production-origin.test.mjs",
         "scripts/verify-validated-sha.mjs",
         "scripts/verify-validated-sha.test.mjs"
       ],

--- a/config/repository-boundary.json
+++ b/config/repository-boundary.json
@@ -52,6 +52,8 @@
     "scripts/public-runtime-smoke.mjs",
     "scripts/verify-validated-sha.mjs",
     "scripts/verify-validated-sha.test.mjs",
+    "scripts/verify-production-origin.mjs",
+    "scripts/verify-production-origin.test.mjs",
     "scripts/public-test-audit.mjs",
     "scripts/screen-ledger.mjs",
     "scripts/screen-scenarios.json",


### PR DESCRIPTION
## Summary
- reserve two public paths for post-deployment origin verification
- keep the fail-closed boundary intact before adding the implementation

## Validation
- `pnpm check:public-development-guard`
- `pnpm public:scan .`