### PR TITLE
Enable verified automatic production deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,6 +1,13 @@
 name: Production deployment
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
   workflow_dispatch:
     inputs:
       mode:
@@ -49,7 +56,7 @@ jobs:
 
   deploy:
     name: Production deploy
-    if: inputs.mode == 'deploy'
+    if: github.event_name == 'push' || inputs.mode == 'deploy'
     needs: shadow
     runs-on: ubuntu-latest
     environment: production

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -37,6 +37,8 @@ export { ArtifactLiveRoom } from './artifact-live-room'
 export { D1BackupWorkflow } from './d1-backup-workflow'
 export { PostUploadWorkflowSpike } from './post-upload-workflow-spike'
 
+// React Router resolves this virtual module and generates the Wrangler config
+// consumed by production deployment; raw wrangler.production.jsonc is build-only.
 const requestHandler = createRequestHandler(
   () => import('virtual:react-router/server-build'),
   import.meta.env.MODE,

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -74,9 +74,17 @@ test('production deployment keeps migration and Workers in one order', () => {
   )
 })
 
-test('production workflow defaults to a credential-free manual shadow', () => {
+test('production workflow deploys only production inputs from main', () => {
   assert.ok(workflow.on.workflow_dispatch)
-  assert.equal(workflow.on.push, undefined)
+  assert.deepEqual(workflow.on.push, {
+    branches: ['main'],
+    paths: [
+      'apps/web/**',
+      'package.json',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+    ],
+  })
   assert.equal(workflow.on.pull_request, undefined)
   assert.equal(workflow.on.workflow_dispatch.inputs.mode.default, 'shadow')
   assert.doesNotMatch(
@@ -99,7 +107,10 @@ test('production workflow defaults to a credential-free manual shadow', () => {
 test('production writes require the protected environment', () => {
   assert.equal(workflow.jobs.deploy.environment, 'production')
   assert.equal(workflow.jobs.deploy.needs, 'shadow')
-  assert.equal(workflow.jobs.deploy.if, "inputs.mode == 'deploy'")
+  assert.equal(
+    workflow.jobs.deploy.if,
+    "github.event_name == 'push' || inputs.mode == 'deploy'",
+  )
   assert.match(
     JSON.stringify(workflow.jobs.deploy),
     /secrets\.CLOUDFLARE_API_TOKEN/u,


### PR DESCRIPTION
## Summary
- trigger production deployment on validated `main` pushes that change production inputs only
- retain manual shadow as the safe default and require the protected `production` Environment for every write
- document that the app deploy consumes React Router’s generated Wrangler configuration

## Safety invariants
- pull requests never trigger deployment
- docs-only and workflow-only pushes do not trigger deployment
- the shadow job verifies the exact merge-queue-validated SHA before any write
- automatic and explicit manual deploys share the same protected deploy and complete origin smoke path

## Acceptance
- [x] script contracts pass
- [x] public boundary guard passes
- [x] public export scan reports zero findings
- [x] repository formatting passes
- [ ] merge queue full validation passes
- [ ] the resulting `main` push automatically deploys and all eight production origin checks pass
