### PR TITLE
Prepare CLI 0.10.1 release

### DIFF
--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "package_version": "0.10.0",
+  "package_version": "0.10.1",
   "commands": [
     {
       "path": "",
@@ -691,5 +691,5 @@
       ]
     }
   ],
-  "generated_date": "2026-08-07"
+  "generated_date": "2026-08-08"
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to `@artifactshare/cli` are documented here.
 For user-facing announcements, see https://artifactshare.com/updates?product=cli.
 
+## 0.10.1 - 2026-08-08
+
+- Publish the first npm release covered by the Artifact Share source-available license.
+
 ## 0.10.0 - 2026-08-07
 
 - Switch the repository and CLI license to the source-available license. Version 0.10.0 is not published to npm.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artifactshare/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Upload and share HTML, Markdown, folders, and static sites from terminals, AI agents, automation, and CI.",
   "homepage": "https://artifactshare.com/connect",
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/cli/src/changelog.test.ts
+++ b/packages/cli/src/changelog.test.ts
@@ -118,8 +118,8 @@ test('changelog --json returns version, updates_url, and latest section', async 
   assert.equal(payload.data.updates_url, CLI_UPDATES_URL)
   assert.deepEqual(payload.data.latest, {
     version: pkg.version,
-    date: '2026-08-07',
-    body: '- Switch the repository and CLI license to the source-available license. Version 0.10.0 is not published to npm.',
+    date: '2026-08-08',
+    body: '- Publish the first npm release covered by the Artifact Share source-available license.',
   })
 })
 


### PR DESCRIPTION
## Summary

- bump `@artifactshare/cli` from the intentionally unpublished 0.10.0 to 0.10.1
- document 0.10.1 as the first npm release under the Artifact Share source-available license
- refresh the generated CLI reference metadata and changelog contract

## Validation

- `pnpm validate`
- 2,623 web tests, 443 CLI tests, 51 browser behavior tests, 97 Linux visual tests, and 10 integration tests passed
- production builds, reference drift check, React Doctor, and public export scan passed