### PR TITLE
Use the CLI 0.10.1 publication date

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `@artifactshare/cli` are documented here.
 For user-facing announcements, see https://artifactshare.com/updates?product=cli.
 
-## 0.10.1 - 2026-08-08
+## 0.10.1 - 2026-08-09
 
 - Publish the first npm release covered by the Artifact Share source-available license.
 

--- a/packages/cli/src/changelog.test.ts
+++ b/packages/cli/src/changelog.test.ts
@@ -118,7 +118,7 @@ test('changelog --json returns version, updates_url, and latest section', async 
   assert.equal(payload.data.updates_url, CLI_UPDATES_URL)
   assert.deepEqual(payload.data.latest, {
     version: pkg.version,
-    date: '2026-08-08',
+    date: '2026-08-09',
     body: '- Publish the first npm release covered by the Artifact Share source-available license.',
   })
 })


### PR DESCRIPTION
## Summary

The release crossed midnight in Japan before the npm tag was created. Update the 0.10.1 changelog contract to the actual publication date, 2026-08-09.

## Validation

- `pnpm check:cli-changelog`
- `pnpm check:cli-reference`
- `pnpm --filter @artifactshare/cli test` (443 tests passed)