### PR TITLE
Document the CLI 0.10.1 npm release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Artifact Share shares HTML, Markdown, folders, and static sites at stable URLs. 
 
 This repository is source-available. You may study, modify, and self-host Artifact Share for your own organization, subject to [the repository license](LICENSE). The license restricts offering Artifact Share as a directly competing hosted, managed, SaaS, or cloud service. It is not an OSI-approved open-source license.
 
-The npm package through version 0.9.0 remains licensed under Apache-2.0. From the repository and version 0.10.0 onward, the CLI is covered by the source-available license. Version 0.10.0 is not published to npm.
+The npm package through version 0.9.0 remains licensed under Apache-2.0. The repository and CLI from version 0.10.0 onward are covered by the source-available license. Version 0.10.0 was intentionally not published; version 0.10.1 is the first npm release under the new license.
 
 ## Repository layout
 
@@ -41,4 +41,4 @@ Report vulnerabilities through the private process in [SECURITY.md](SECURITY.md)
 
 ## License
 
-The repository license is a lawyer-review draft with Japanese authoritative text and an English reference translation. See [LICENSE](LICENSE). The npm package through version 0.9.0 remains under Apache-2.0; the repository and version 0.10.0 onward use the source-available license. Version 0.10.0 is not published to npm.
+The repository license is a lawyer-review draft with Japanese authoritative text and an English reference translation. See [LICENSE](LICENSE). The npm package through version 0.9.0 remains under Apache-2.0; the repository and CLI from version 0.10.0 onward use the source-available license. Version 0.10.0 was intentionally not published; version 0.10.1 is the first npm release under the new license.

--- a/docs/reference/source-available-boundary.md
+++ b/docs/reference/source-available-boundary.md
@@ -6,7 +6,7 @@
 
 公開 tree には repository の入口である `README.md`、利用条件を定める `LICENSE`、参加方法を定める `CONTRIBUTING.md`、脆弱性報告先を定める `SECURITY.md`、外部からの proposal を受け付ける `proposals/` を収録します。`README.md` は製品、主要構成、開発参加への入口を担い、この文書は export の境界、検証方法、公開 checkout の技術的な成立条件を担います。
 
-root の `LICENSE` は `packages/cli/` を含む公開 tree のソフトウェアと関連文書に適用されます。npm で公開された 0.9.0 以前の CLI は Apache-2.0 のままです。repository と 0.10.0 以降の CLI は source-available license の対象で、0.10.0 は未公開です。root license は日本語版が正本、英語版が参考訳です。
+root の `LICENSE` は `packages/cli/` を含む公開 tree のソフトウェアと関連文書に適用されます。npm で公開された 0.9.0 以前の CLI は Apache-2.0 のままです。repository と 0.10.0 以降の CLI は source-available license の対象です。0.10.0 は意図的に公開せず、0.10.1 が新しい license での最初の npm 公開版です。root license は日本語版が正本、英語版が参考訳です。
 
 `proposals/` は公開 repository へ外部から寄せられる proposal の置き場です。公開前の scanner は、ここにも個人情報と非公開参照の検査を例外なく適用し、finding があれば export 全体を fail closed で停止します。
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -129,4 +129,4 @@ Quote paths and free-form text before passing them through a shell. Artifact Sha
 
 ## License
 
-The npm package through version 0.9.0 is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). From the repository and version 0.10.0 onward, `@artifactshare/cli` is covered by the [source-available license](LICENSE). Version 0.10.0 is not published to npm.
+The npm package through version 0.9.0 is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). From version 0.10.0 onward, `@artifactshare/cli` is covered by the [source-available license](LICENSE). Version 0.10.0 was intentionally not published; version 0.10.1 is the first npm release under the new license.


### PR DESCRIPTION
## Summary

- record 0.10.1 as the first npm release under the source-available license
- retain the 0.9.0 Apache-2.0 boundary and the intentionally unpublished 0.10.0 history
- align the root README, CLI README, and public boundary reference

## Validation

- `pnpm format`
- `pnpm check:public-development-guard`
- `pnpm check:cli-reference`
- `pnpm public:scan .`