### PR TITLE
Remove source inventory compatibility

### DIFF
--- a/scripts/public-development-guard.mjs
+++ b/scripts/public-development-guard.mjs
@@ -51,7 +51,7 @@ export function loadBoundaryManifest(repo = process.cwd()) {
   return { ...boundary, exported, prefixes, classifications }
 }
 
-export function checkStandalone(repo = root, { sourceInventory = false } = {}) {
+export function checkStandalone(repo = root) {
   const manifest = loadBoundaryManifest(repo)
   validateBoundaryManifest(manifest)
   const indexTree = execFileSync('git', ['write-tree'], {
@@ -64,22 +64,7 @@ export function checkStandalone(repo = root, { sourceInventory = false } = {}) {
       encoding: 'utf8',
     }),
   )
-  const inventoryFile = path.join(
-    repo,
-    'docs',
-    'reference',
-    'public-export-inventory.jsonl',
-  )
-  const checkedRows = sourceInventory
-    ? fs
-        .readFileSync(inventoryFile, 'utf8')
-        .trim()
-        .split('\n')
-        .map((line) => JSON.parse(line))
-        .filter((row) => row.classification === 'public')
-        .map((row) => ({ path: row.export_path, mode: row.entry_type }))
-    : rows
-  return inspectTree(checkedRows, manifest)
+  return inspectTree(rows, manifest)
 }
 
 export function validateBoundaryManifest(manifest) {
@@ -347,13 +332,9 @@ if (
         manifestRepo,
       })
     } else if (process.argv.includes('--check')) {
-      const unknown = args.filter(
-        (arg) => !['--check', '--source-inventory'].includes(arg),
-      )
+      const unknown = args.filter((arg) => arg !== '--check')
       if (unknown.length) throw new Error(`unknown option: ${unknown[0]}`)
-      checkStandalone(root, {
-        sourceInventory: process.argv.includes('--source-inventory'),
-      })
+      checkStandalone(root)
     } else {
       const unknown = args.filter(
         (arg) =>

--- a/scripts/public-development-guard.test.mjs
+++ b/scripts/public-development-guard.test.mjs
@@ -165,17 +165,10 @@ test('CI range inspection calls range, messages, trees, and rejects unsafe tree 
   )
 })
 
-test('standalone check classifies the current public export tree', () => {
-  const sourceInventory = fs.existsSync(
-    path.join('docs', 'reference', 'public-export-inventory.jsonl'),
-  )
-  assert.ok(checkStandalone(process.cwd(), { sourceInventory }).length > 0)
+test('standalone check classifies the current repository tree', () => {
+  assert.ok(checkStandalone(process.cwd()).length > 0)
   assert.doesNotThrow(() =>
-    execFileSync('node', [
-      'scripts/public-development-guard.mjs',
-      '--check',
-      ...(sourceInventory ? ['--source-inventory'] : []),
-    ]),
+    execFileSync('node', ['scripts/public-development-guard.mjs', '--check']),
   )
   assert.throws(
     () =>


### PR DESCRIPTION
## Implementation

- Remove the retired `--source-inventory` mode from the repository boundary guard.
- Make standalone checks inspect the staged repository tree directly.
- Update the guard contract test to use the current repository model.

## Visible effect

Repository checks no longer retain compatibility with the retired export inventory.

## Validation

- `pnpm validate`
- `node --test scripts/public-development-guard.test.mjs`