### PR TITLE
Allow the CLI release workflow path

### DIFF
--- a/config/repository-boundary.json
+++ b/config/repository-boundary.json
@@ -95,7 +95,8 @@
     "public-only": [
       ".github/PULL_REQUEST_TEMPLATE.md",
       ".github/workflows/deploy-production.yml",
-      ".github/workflows/public-ci.yml"
+      ".github/workflows/public-ci.yml",
+      ".github/workflows/release-cli.yml"
     ]
   }
 }


### PR DESCRIPTION
## Implementation

- Reserve the public CLI release workflow path in the repository boundary.

## Visible effect

The repository can add its source-authoritative CLI publishing workflow in a separately guarded change.

## Validation

- `pnpm validate`
- public boundary and CI contract tests