### PR TITLE
Run CLI releases from the public source

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,58 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - 'cli-v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: release-cli
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release CLI
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - name: Require a validated public main commit
+        run: |
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Verify tag version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#cli-v}"
+          PKG_VERSION=$(node -p "require('./packages/cli/package.json').version")
+          test "$TAG_VERSION" = "$PKG_VERSION"
+      - run: pnpm --filter @artifactshare/cli typecheck
+      - run: pnpm --filter @artifactshare/cli test
+      - name: Pack-install smoke
+        run: |
+          set -euo pipefail
+          TGZ=$(pnpm --filter @artifactshare/cli pack --pack-destination "$RUNNER_TEMP" | tail -1)
+          PKG_VERSION=$(node -p "require('./packages/cli/package.json').version")
+          SMOKE_DIR=$(mktemp -d)
+          trap 'rm -rf "$SMOKE_DIR"' EXIT
+          cd "$SMOKE_DIR"
+          npm init -y
+          npm install "$TGZ" --no-save
+          ./node_modules/.bin/artifactshare --version | grep -qF "$PKG_VERSION"
+      - run: pnpm check:cli-changelog
+      - name: Publish to npm
+        working-directory: packages/cli
+        run: pnpm publish --no-git-checks --access public --provenance

--- a/config/public-repository-scan.json
+++ b/config/public-repository-scan.json
@@ -78,6 +78,12 @@
       "reason": "production writes are isolated to the protected deployment workflow"
     },
     {
+      "category": "public-ci-reachability",
+      "path": "^\\.github/workflows/release-cli\\.yml$",
+      "pattern": "^pnpm publish$",
+      "reason": "CLI publishing is isolated to the tag-only OIDC release workflow"
+    },
+    {
       "category": "production-resource",
       "path": "^config/public-repository-scan\\.json$",
       "pattern": "^(?:prod-analytics-dashboard|prod-d1-ABC12345|G-SCANNER01|price_1ScannerFixture000)$",

--- a/scripts/public-ci-contract.test.mjs
+++ b/scripts/public-ci-contract.test.mjs
@@ -109,6 +109,24 @@ test('public CI checks out the merge-group SHA', () => {
   assert.match(workflow, /fetch-depth:\s*0/)
 })
 
+test('CLI release is tag-only, source-authoritative, and OIDC-only', () => {
+  const releaseWorkflow = YAML.parse(
+    fs.readFileSync('.github/workflows/release-cli.yml', 'utf8'),
+  )
+  assert.deepEqual(releaseWorkflow.on.push.tags, ['cli-v*'])
+  assert.equal(releaseWorkflow.permissions.contents, 'read')
+  assert.equal(releaseWorkflow.permissions['id-token'], 'write')
+  const release = releaseWorkflow.jobs.release
+  assert.equal(release['runs-on'], 'ubuntu-latest')
+  const text = JSON.stringify(release)
+  assert.match(text, /merge-base --is-ancestor/)
+  assert.match(
+    text,
+    /pnpm publish --no-git-checks --access public --provenance/,
+  )
+  assert.doesNotMatch(text, /secrets\./)
+})
+
 test('public CI installs Playwright from the web workspace', () => {
   assert.match(
     workflow,


### PR DESCRIPTION
## Implementation

- Add a tag-only CLI release workflow to the public source repository.
- Require the tagged commit to be contained in public main.
- Typecheck, test, pack-install smoke, changelog-check, and publish with npm OIDC provenance.
- Keep publishing isolated from ordinary public CI and explicitly bounded by the repository scanner.

## Visible effect

CLI releases now originate from the same public commit that owns the package source.

## Validation

- `pnpm validate`
- CLI release workflow contract test
- repository scan: 0 findings