### PR TITLE
Verify restored development harnesses in merge queue

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -65,4 +65,10 @@ jobs:
       - run: pnpm fixtures:build
       - run: pnpm db:apply:local
       - run: pnpm validate
+      - name: Verify isolated local D1 recovery
+        run: pnpm check:dev-setup
+      - name: Verify full-topology in-app navigation
+        env:
+          PLAYWRIGHT_CHANNEL: chrome
+        run: pnpm check:in-app-navigation
       - run: pnpm test:runtime

--- a/scripts/in-app-navigation.mjs
+++ b/scripts/in-app-navigation.mjs
@@ -30,6 +30,20 @@ async function waitForServer(server) {
   throw new Error('Dev server did not become ready within 120 seconds')
 }
 
+async function waitForHydratedHome(page) {
+  await page.goto(baseUrl)
+  await page.getByRole('heading', { name: 'Home', exact: true }).waitFor()
+  await page
+    .locator('[data-recent-date-heading]')
+    .first()
+    .waitFor()
+    .catch(() => {
+      throw new Error(
+        'Hydration did not complete: the recent date heading was not rendered',
+      )
+    })
+}
+
 async function main() {
   let server = null
   let ownsServer = false
@@ -115,6 +129,14 @@ async function main() {
         `Browser context could not read the dev session: HTTP ${browserSessionResponse.status()}; cookies: ${installedCookies.map(({ name }) => name).join(', ') || '(none)'}`,
       )
     }
+    // A clean CI checkout has an empty Vite dependency optimizer cache. Its
+    // first browser request may trigger an optimized-dependency reload, which
+    // deliberately invalidates the initial client module URLs. Prime that
+    // one-time transition before collecting errors for the navigation proof.
+    const warmupPage = await context.newPage()
+    await waitForHydratedHome(warmupPage)
+    await warmupPage.close()
+
     const page = await context.newPage()
     const errors = []
     page.on('console', (message) => {
@@ -124,17 +146,7 @@ async function main() {
     let step = 'open home'
     let waitingFor = 'Home'
     try {
-      await page.goto(baseUrl)
-      await page.getByRole('heading', { name: 'Home', exact: true }).waitFor()
-      await page
-        .locator('[data-recent-date-heading]')
-        .first()
-        .waitFor()
-        .catch(() => {
-          throw new Error(
-            'Hydration did not complete: the recent date heading was not rendered',
-          )
-        })
+      await waitForHydratedHome(page)
       await page.evaluate(() => {
         window.__inAppNavigation = true
       })

--- a/scripts/public-ci-contract.test.mjs
+++ b/scripts/public-ci-contract.test.mjs
@@ -109,6 +109,18 @@ test('public CI checks out the merge-group SHA', () => {
   assert.match(workflow, /fetch-depth:\s*0/)
 })
 
+test('unique browser and local-state checks run after validation', () => {
+  const validateIndex = workflow.indexOf('run: pnpm validate')
+  const devSetupIndex = workflow.indexOf('run: pnpm check:dev-setup')
+  const navigationIndex = workflow.indexOf('run: pnpm check:in-app-navigation')
+  const runtimeIndex = workflow.indexOf('run: pnpm test:runtime')
+  assert.ok(validateIndex >= 0)
+  assert.ok(validateIndex < devSetupIndex)
+  assert.ok(devSetupIndex < navigationIndex)
+  assert.ok(navigationIndex < runtimeIndex)
+  assert.match(workflow, /PLAYWRIGHT_CHANNEL:\s*chrome/u)
+})
+
 test('CLI release is tag-only, source-authoritative, and OIDC-only', () => {
   const releaseWorkflow = YAML.parse(
     fs.readFileSync('.github/workflows/release-cli.yml', 'utf8'),


### PR DESCRIPTION
## Summary

- run isolated local D1 recovery after full validation on every merge group
- run full-topology in-app navigation with the hosted Chrome already installed by the workflow
- prime the clean-runner Vite dependency optimizer before collecting navigation errors
- contract-test both commands, their order, and the explicit browser channel

These checks cover local-state recovery and hydrated client navigation. Screen capture, billing regression, production search audit, CLI timing, and performance tracing remain manual diagnostics.

## Validation

- `pnpm validate`
- `pnpm check:dev-setup` (18.07s locally)
- `PLAYWRIGHT_CHANNEL=chrome pnpm check:in-app-navigation` (exit 0; no listener remained on port 5173)
- first merge-group run exposed a clean-cache Vite optimizer reload; the follow-up primes hydration on an unobserved warm-up page and retains strict error collection on the proof page
