### PR TITLE
ci: bind manual deploys to approved SHA

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,6 +10,10 @@ on:
       - 'pnpm-workspace.yaml'
   workflow_dispatch:
     inputs:
+      expected_sha:
+        description: Exact validated main SHA approved for this manual run
+        required: true
+        type: string
       mode:
         description: Build-only shadow or protected production deployment
         required: true
@@ -42,6 +46,11 @@ jobs:
         with:
           node-version: 24.14.0
           cache: pnpm
+      - name: Bind a manual run to the explicitly approved SHA
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: test "$EXPECTED_SHA" = "$GITHUB_SHA"
       - name: Verify the exact merge-queue validated SHA
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -87,9 +87,15 @@ test('production workflow deploys only production inputs from main', () => {
   })
   assert.equal(workflow.on.pull_request, undefined)
   assert.equal(workflow.on.workflow_dispatch.inputs.mode.default, 'shadow')
+  assert.equal(workflow.on.workflow_dispatch.inputs.expected_sha.required, true)
+  assert.equal(workflow.on.workflow_dispatch.inputs.expected_sha.type, 'string')
   assert.doesNotMatch(
     JSON.stringify(workflow.jobs.shadow),
     /secrets\.|environment/u,
+  )
+  assert.match(
+    workflowSource,
+    /EXPECTED_SHA: \$\{\{ inputs\.expected_sha \}\}[\s\S]*test "\$EXPECTED_SHA" = "\$GITHUB_SHA"[\s\S]*Verify the exact merge-queue validated SHA/u,
   )
   assert.match(
     workflowSource,


### PR DESCRIPTION
## Summary

- require an expected SHA for manual production workflow dispatches
- stop before validation or deployment when the dispatched ref differs
- preserve automatic validated main deployments

## Verification

- `pnpm format`
- `node --test scripts/deployment-contract.test.mjs`