### PR TITLE
Release CLI 0.10.2

### DIFF
--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "package_version": "0.10.1",
+  "package_version": "0.10.2",
   "commands": [
     {
       "path": "",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ For user-facing announcements, see https://artifactshare.com/updates?product=cli
 
 ## Unreleased
 
+## 0.10.2 - 2026-08-09
+
 - Rotate device-login refresh credentials after use and revoke their credential family during `logout`; a failed remote revoke now leaves the local credential intact.
 
 ## 0.10.1 - 2026-08-09

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artifactshare/cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Upload and share HTML, Markdown, folders, and static sites from terminals, AI agents, automation, and CI.",
   "homepage": "https://artifactshare.com/connect",
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/cli/src/changelog.test.ts
+++ b/packages/cli/src/changelog.test.ts
@@ -119,7 +119,7 @@ test('changelog --json returns version, updates_url, and latest section', async 
   assert.deepEqual(payload.data.latest, {
     version: pkg.version,
     date: '2026-08-09',
-    body: '- Publish the first npm release covered by the Artifact Share source-available license.',
+    body: '- Rotate device-login refresh credentials after use and revoke their credential family during `logout`; a failed remote revoke now leaves the local credential intact.',
   })
 })
 


### PR DESCRIPTION
## Summary

- bump `@artifactshare/cli` to 0.10.2
- publish the refresh-credential rotation fix from Unreleased
- update the changelog command contract fixture

## Verification

- `pnpm check:cli-changelog`
- `pnpm --filter @artifactshare/cli typecheck`
- `pnpm --filter @artifactshare/cli test` (446 tests)
- pack-install smoke with `artifactshare --version` = `0.10.2`
