### PR TITLE
Fix CLI provenance repository metadata

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,11 @@
   "version": "0.10.2",
   "description": "Upload and share HTML, Markdown, folders, and static sites from terminals, AI agents, automation, and CI.",
   "homepage": "https://artifactshare.com/connect",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/artifactshare/artifactshare.git",
+    "directory": "packages/cli"
+  },
   "license": "SEE LICENSE IN LICENSE",
   "keywords": [
     "artifact-share",


### PR DESCRIPTION
## Summary

- declare the public GitHub source repository in the CLI package metadata
- identify `packages/cli` as the monorepo package directory
- allow npm trusted publishing to validate the provenance repository

## Verification

- CLI typecheck
- CLI tests (446 tests)
- CLI reference and changelog checks
- npm pack dry run
