### PR TITLE
Harden the CLI release preflight

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -29,16 +29,25 @@ jobs:
           node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
-      - name: Require a validated public main commit
+      - name: Require the current validated public main commit
         run: |
           git fetch --no-tags origin main
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          test "$GITHUB_SHA" = "$(git rev-parse origin/main)"
       - run: pnpm install --frozen-lockfile --ignore-scripts
+      - run: pnpm check:cli-release
       - name: Verify tag version
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#cli-v}"
           PKG_VERSION=$(node -p "require('./packages/cli/package.json').version")
           test "$TAG_VERSION" = "$PKG_VERSION"
+      - name: Require an unpublished npm version
+        run: |
+          PKG_NAME=$(node -p "require('./packages/cli/package.json').name")
+          PKG_VERSION=$(node -p "require('./packages/cli/package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "$PKG_NAME@$PKG_VERSION is already published" >&2
+            exit 1
+          fi
       - run: pnpm --filter @artifactshare/cli typecheck
       - run: pnpm --filter @artifactshare/cli test
       - name: Pack-install smoke
@@ -53,6 +62,7 @@ jobs:
           npm install "$TGZ" --no-save
           ./node_modules/.bin/artifactshare --version | grep -qF "$PKG_VERSION"
       - run: pnpm check:cli-changelog
+      - run: pnpm check:cli-reference
       - name: Publish to npm
         working-directory: packages/cli
         run: pnpm publish --no-git-checks --access public --provenance

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "check:analytics-literals": "node scripts/check-analytics-literals.mjs",
     "check:analytics-dimensions": "node scripts/check-analytics-dimensions.mjs",
     "check:cli-changelog": "node scripts/check-cli-changelog.mjs",
+    "check:cli-release": "node scripts/check-cli-changelog.mjs --release",
     "typecheck": "pnpm --filter @artifactshare/web typecheck && pnpm --filter @artifactshare/cli typecheck",
     "test:scripts": "node --test scripts/audit-ai-search-eligibility.test.mjs scripts/billing-regression.test.mjs scripts/check-design-tokens.test.mjs scripts/check-copy-glossary.test.mjs scripts/check-analytics-literals.test.mjs scripts/check-analytics-dimensions.test.mjs scripts/check-cli-changelog.test.mjs scripts/check-screen-ledger.test.mjs scripts/dev-setup.test.mjs scripts/deployment-contract.test.mjs scripts/generate-cli-reference.test.mjs scripts/measure-cli-tests.test.mjs scripts/public-development-guard.test.mjs scripts/public-hook-setup.test.mjs scripts/public-ci-contract.test.mjs scripts/public-repository-scan.test.mjs scripts/verify-production-origin.test.mjs scripts/verify-validated-sha.test.mjs",
     "test": "pnpm test:scripts && pnpm --filter @artifactshare/web test && pnpm --filter @artifactshare/cli test",
@@ -44,7 +45,7 @@
     "check:cli-reference": "node scripts/generate-cli-reference.mjs --check",
     "build:sandbox": "pnpm --filter @artifactshare/web build:sandbox",
     "check:doctor": "pnpm exec react-doctor . --json -y | node scripts/check-doctor.mjs",
-    "validate": "pnpm format && pnpm lint && pnpm check:public-development-guard && pnpm check:design-tokens && pnpm audit:tests && pnpm check:copy-glossary && pnpm check:screen-ledger && pnpm check:migrations && pnpm check:schema && pnpm check:analytics-literals && pnpm check:analytics-dimensions && pnpm check:cli-changelog && pnpm typecheck && pnpm test && pnpm build && pnpm build:alerts && pnpm build:og-image && pnpm integration:test:run && pnpm check:cli-reference && pnpm build:sandbox && pnpm check:doctor && pnpm public:scan .",
+    "validate": "pnpm format && pnpm lint && pnpm check:public-development-guard && pnpm check:design-tokens && pnpm audit:tests && pnpm check:copy-glossary && pnpm check:screen-ledger && pnpm check:migrations && pnpm check:schema && pnpm check:analytics-literals && pnpm check:analytics-dimensions && pnpm check:cli-release && pnpm typecheck && pnpm test && pnpm build && pnpm build:alerts && pnpm build:og-image && pnpm integration:test:run && pnpm check:cli-reference && pnpm build:sandbox && pnpm check:doctor && pnpm public:scan .",
     "test:runtime": "node scripts/public-runtime-smoke.mjs",
     "visual:compose": "docker compose -f compose.playwright.yml run --rm visual",
     "visual:compose:update": "docker compose -f compose.playwright.yml run --rm visual-update"

--- a/packages/cli/src/changelog.test.ts
+++ b/packages/cli/src/changelog.test.ts
@@ -116,11 +116,9 @@ test('changelog --json returns version, updates_url, and latest section', async 
 
   assert.equal(payload.data.version, pkg.version)
   assert.equal(payload.data.updates_url, CLI_UPDATES_URL)
-  assert.deepEqual(payload.data.latest, {
-    version: pkg.version,
-    date: '2026-08-09',
-    body: '- Rotate device-login refresh credentials after use and revoke their credential family during `logout`; a failed remote revoke now leaves the local credential intact.',
-  })
+  assert.equal(payload.data.latest?.version, pkg.version)
+  assert.match(payload.data.latest?.date ?? '', /^\d{4}-\d{2}-\d{2}$/u)
+  assert.match(payload.data.latest?.body ?? '', /^- /mu)
 })
 
 test('changelog exits 0 with version and URL when the current section is missing', () => {

--- a/scripts/check-cli-changelog.mjs
+++ b/scripts/check-cli-changelog.mjs
@@ -5,6 +5,11 @@ import { pathToFileURL } from 'node:url'
 // 受理すると、CI を通った見出しが実行時の節抽出に一致しない事故 (末尾空白など) が起きる。
 const VERSION_HEADING = /^## (\S+) - (\d{4}-\d{2}-\d{2})$/
 const LOOSE_HEADING = /^## (\S+) - (.*)$/
+const EXPECTED_NAME = '@artifactshare/cli'
+const EXPECTED_REPOSITORY =
+  'git+https://github.com/artifactshare/artifactshare.git'
+const EXPECTED_DIRECTORY = 'packages/cli'
+const SEMVER = /^\d+\.\d+\.\d+$/u
 
 export function findVersionHeadings(changelogContent) {
   const headings = []
@@ -64,18 +69,55 @@ function readCliChangelogInputs(rootUrl) {
     new URL('packages/cli/CHANGELOG.md', rootUrl),
     'utf8',
   )
-  return { version: packageJson.version, changelog }
+  return { packageJson, changelog }
 }
 
 export function checkCliChangelogAtRoot(
   rootUrl = new URL('..', import.meta.url),
 ) {
-  const { version, changelog } = readCliChangelogInputs(rootUrl)
-  return validateCliChangelog(version, changelog)
+  const { packageJson, changelog } = readCliChangelogInputs(rootUrl)
+  return validateCliChangelog(packageJson.version, changelog)
+}
+
+export function validateCliRelease({ packageJson, changelog, reference }) {
+  const errors = []
+
+  if (packageJson.name !== EXPECTED_NAME)
+    errors.push(`CLI package name must be ${EXPECTED_NAME}.`)
+  if (!SEMVER.test(packageJson.version ?? ''))
+    errors.push('CLI package version must be an exact x.y.z version.')
+  if (packageJson.repository?.url !== EXPECTED_REPOSITORY)
+    errors.push(`CLI repository.url must be ${EXPECTED_REPOSITORY}.`)
+  if (packageJson.repository?.directory !== EXPECTED_DIRECTORY)
+    errors.push(`CLI repository.directory must be ${EXPECTED_DIRECTORY}.`)
+  if (packageJson.publishConfig?.access !== 'public')
+    errors.push('CLI publishConfig.access must be public.')
+  if (reference.package_version !== packageJson.version)
+    errors.push(
+      `CLI reference snapshot is for ${reference.package_version ?? 'no version'}; expected ${packageJson.version}. Run node scripts/generate-cli-reference.mjs and format the result.`,
+    )
+
+  errors.push(...validateCliChangelog(packageJson.version ?? '', changelog))
+  return errors
+}
+
+export function checkCliReleaseAtRoot(
+  rootUrl = new URL('..', import.meta.url),
+) {
+  const { packageJson, changelog } = readCliChangelogInputs(rootUrl)
+  const reference = JSON.parse(
+    readFileSync(
+      new URL('apps/web/app/lib/cli-reference-surface.generated.json', rootUrl),
+      'utf8',
+    ),
+  )
+  return validateCliRelease({ packageJson, changelog, reference })
 }
 
 function main() {
-  const errors = checkCliChangelogAtRoot()
+  const errors = process.argv.includes('--release')
+    ? checkCliReleaseAtRoot()
+    : checkCliChangelogAtRoot()
   if (errors.length === 0) return
 
   for (const error of errors) {

--- a/scripts/check-cli-changelog.test.mjs
+++ b/scripts/check-cli-changelog.test.mjs
@@ -7,8 +7,10 @@ import { pathToFileURL } from 'node:url'
 import test from 'node:test'
 import {
   checkCliChangelogAtRoot,
+  checkCliReleaseAtRoot,
   findVersionHeadings,
   validateCliChangelog,
+  validateCliRelease,
 } from './check-cli-changelog.mjs'
 
 const SAMPLE_CHANGELOG = `# Changelog
@@ -104,6 +106,52 @@ test('validateCliChangelog fails on duplicate headings for non-current versions'
 
 test('checkCliChangelogAtRoot passes against the repo files', () => {
   assert.deepEqual(checkCliChangelogAtRoot(), [])
+})
+
+const VALID_RELEASE = {
+  packageJson: {
+    name: '@artifactshare/cli',
+    version: '1.2.3',
+    repository: {
+      url: 'git+https://github.com/artifactshare/artifactshare.git',
+      directory: 'packages/cli',
+    },
+    publishConfig: { access: 'public' },
+  },
+  changelog: '## 1.2.3 - 2026-08-09\n\n- Release\n',
+  reference: { package_version: '1.2.3' },
+}
+
+test('current CLI release inputs pass preflight', () => {
+  assert.deepEqual(checkCliReleaseAtRoot(), [])
+})
+
+test('valid release metadata passes', () => {
+  assert.deepEqual(validateCliRelease(VALID_RELEASE), [])
+})
+
+test('preflight reports provenance and generated-version drift together', () => {
+  const errors = validateCliRelease({
+    ...VALID_RELEASE,
+    packageJson: {
+      ...VALID_RELEASE.packageJson,
+      repository: undefined,
+    },
+    reference: { package_version: '1.2.2' },
+  })
+  assert.equal(errors.length, 3)
+  assert.match(errors.join('\n'), /repository\.url/)
+  assert.match(errors.join('\n'), /repository\.directory/)
+  assert.match(errors.join('\n'), /reference snapshot is for 1\.2\.2/)
+})
+
+test('preflight rejects non-release versions and missing changelog entries', () => {
+  const errors = validateCliRelease({
+    ...VALID_RELEASE,
+    packageJson: { ...VALID_RELEASE.packageJson, version: '1.2.3-next.1' },
+  })
+  assert.match(errors.join('\n'), /exact x\.y\.z/)
+  assert.match(errors.join('\n'), /missing a `## 1\.2\.3-next\.1/)
 })
 
 test('checkCliChangelogAtRoot fails when package version lacks a changelog heading', () => {

--- a/scripts/public-ci-contract.test.mjs
+++ b/scripts/public-ci-contract.test.mjs
@@ -121,7 +121,7 @@ test('unique browser and local-state checks run after validation', () => {
   assert.match(workflow, /PLAYWRIGHT_CHANNEL:\s*chrome/u)
 })
 
-test('CLI release is tag-only, source-authoritative, and OIDC-only', () => {
+test('CLI release is tag-only, current-main-only, preflighted, and OIDC-only', () => {
   const releaseWorkflow = YAML.parse(
     fs.readFileSync('.github/workflows/release-cli.yml', 'utf8'),
   )
@@ -131,7 +131,11 @@ test('CLI release is tag-only, source-authoritative, and OIDC-only', () => {
   const release = releaseWorkflow.jobs.release
   assert.equal(release['runs-on'], 'ubuntu-latest')
   const text = JSON.stringify(release)
-  assert.match(text, /merge-base --is-ancestor/)
+  const runs = release.steps.map((step) => step.run ?? '').join('\n')
+  assert.match(runs, /test "\$GITHUB_SHA" = "\$\(git rev-parse origin\/main\)"/)
+  assert.match(runs, /pnpm check:cli-release/)
+  assert.match(runs, /npm view.*PKG_NAME.*PKG_VERSION.*version/)
+  assert.match(runs, /pnpm check:cli-reference/)
   assert.match(
     text,
     /pnpm publish --no-git-checks --access public --provenance/,


### PR DESCRIPTION
## Summary

- add a CLI release preflight for provenance metadata, exact versions, changelog coverage, and generated reference alignment
- require release tags to point at the current public main and reject versions already present on npm
- remove the release-specific changelog fixture that required manual edits for every version
- enforce the release contract in normal validation and workflow contract tests

## Verification

- script tests (246 tests)
- CLI tests (446 tests)
- release preflight
- format and lint
