### PR TITLE
Expire CLI rotation replay material

### DIFF
--- a/apps/web/app/services/cli-refresh-credentials.server.test.ts
+++ b/apps/web/app/services/cli-refresh-credentials.server.test.ts
@@ -15,6 +15,7 @@ vi.mock('cloudflare:workers', () => ({
   env: { DB: createD1BatchDbMock({ sqlite: sqliteRef }) },
 }))
 import {
+  cleanupExpiredCliRotationReplays,
   issueCliRefreshCredential,
   refreshCliSession,
   revokeCliRefreshCredential,
@@ -329,6 +330,98 @@ describe('cli-refresh-credentials service', () => {
     expect(
       sqlite.prepare('SELECT COUNT(*) AS count FROM sessions').get(),
     ).toEqual({ count: 1 })
+  })
+
+  test('clears expired replay material without breaking lineage or revocation', async () => {
+    const issued = await issueCliRefreshCredential(db, 'u1')
+    const rotated = await refreshCliSession(
+      db,
+      issued.refreshToken,
+      'cleanup-request',
+      secret,
+    )
+    expect(rotated.kind).toBe('ok')
+    if (rotated.kind !== 'ok') return
+
+    sqlite
+      .prepare(
+        `UPDATE cli_refresh_credentials
+         SET rotation_retry_until = '2026-08-09T00:00:00.000Z'
+         WHERE replaced_by_id IS NOT NULL`,
+      )
+      .run()
+
+    await expect(
+      cleanupExpiredCliRotationReplays(db, '2026-08-09T00:00:01.000Z'),
+    ).resolves.toBe(1)
+    await expect(
+      cleanupExpiredCliRotationReplays(db, '2026-08-09T00:00:02.000Z'),
+    ).resolves.toBe(0)
+
+    const old = sqlite
+      .prepare(
+        `SELECT family_id, replaced_by_id, rotation_request_hash,
+                rotation_retry_until, rotation_session_id
+         FROM cli_refresh_credentials
+         WHERE replaced_by_id IS NOT NULL`,
+      )
+      .get() as Record<string, string | null>
+    expect(old.family_id).not.toBeNull()
+    expect(old.replaced_by_id).not.toBeNull()
+    expect(old.rotation_request_hash).toBeNull()
+    expect(old.rotation_retry_until).toBeNull()
+    expect(old.rotation_session_id).toBeNull()
+    expect(
+      await refreshCliSession(
+        db,
+        issued.refreshToken,
+        'cleanup-request',
+        secret,
+      ),
+    ).toEqual({ kind: 'invalid' })
+    expect(await revokeCliRefreshCredential(db, rotated.refreshToken)).toBe(
+      'ok',
+    )
+  })
+
+  test('keeps live and incomplete replay rows fail closed', async () => {
+    const issued = await issueCliRefreshCredential(db, 'u1')
+    const rotated = await refreshCliSession(
+      db,
+      issued.refreshToken,
+      'live-request',
+      secret,
+    )
+    expect(rotated.kind).toBe('ok')
+    if (rotated.kind !== 'ok') return
+
+    await expect(
+      cleanupExpiredCliRotationReplays(db, '2000-01-01T00:00:00.000Z'),
+    ).resolves.toBe(0)
+    expect(
+      await refreshCliSession(db, issued.refreshToken, 'live-request', secret),
+    ).toEqual(rotated)
+
+    sqlite
+      .prepare(
+        `UPDATE cli_refresh_credentials
+         SET rotation_retry_until = '2000-01-01T00:00:00.000Z',
+             rotation_session_id = NULL
+         WHERE replaced_by_id IS NOT NULL`,
+      )
+      .run()
+    await expect(
+      cleanupExpiredCliRotationReplays(db, '2026-08-09T00:00:00.000Z'),
+    ).resolves.toBe(0)
+    const incomplete = sqlite
+      .prepare(
+        `SELECT rotation_request_hash, rotation_retry_until
+         FROM cli_refresh_credentials
+         WHERE replaced_by_id IS NOT NULL`,
+      )
+      .get() as Record<string, string | null>
+    expect(incomplete.rotation_request_hash).not.toBeNull()
+    expect(incomplete.rotation_retry_until).not.toBeNull()
   })
 
   test('concurrent refreshes with one rotation id converge on one credential', async () => {

--- a/apps/web/app/services/cli-refresh-credentials.server.ts
+++ b/apps/web/app/services/cli-refresh-credentials.server.ts
@@ -31,6 +31,26 @@ export type RefreshedCliSession =
     }
   | { kind: 'invalid' }
 
+export async function cleanupExpiredCliRotationReplays(
+  db: Kysely<DB>,
+  now: string = nowIso(),
+): Promise<number> {
+  const result = await db
+    .updateTable('cli_refresh_credentials')
+    .set({
+      rotation_request_hash: null,
+      rotation_retry_until: null,
+      rotation_session_id: null,
+    })
+    .where('rotation_retry_until', '<=', now)
+    .where('rotation_request_hash', 'is not', null)
+    .where('rotation_session_id', 'is not', null)
+    .where('replaced_by_id', 'is not', null)
+    .where('revoked_at', 'is not', null)
+    .executeTakeFirst()
+  return Number(result.numUpdatedRows)
+}
+
 export function issueCliRefreshCredential(
   db: Kysely<DB>,
   userId: string,

--- a/apps/web/integration/harness.test.ts
+++ b/apps/web/integration/harness.test.ts
@@ -594,6 +594,48 @@ describe('Worker integration harness', () => {
     expect(await env.BUCKET.head('integration/orphan.html')).toBeNull()
   })
 
+  test('cleans expired CLI rotation replay material through scheduled runtime', async () => {
+    const env = await worker.getEnv()
+    await env.DB.batch([
+      env.DB.prepare(
+        "INSERT INTO workspaces (id, hd, name, created_at, plan, storage_quota_bytes, storage_used_bytes, storage_updated_at) VALUES ('ws-rotation-cleanup', NULL, 'Rotation Cleanup', '2026-08-09T00:00:00.000Z', 'free', 100000, 0, '2026-08-09T00:00:00.000Z')",
+      ),
+      env.DB.prepare(
+        "INSERT INTO users (id, email, email_verified, name, created_at, updated_at, workspace_id) VALUES ('user-rotation-cleanup', 'rotation-cleanup@example.test', 1, 'Rotation Cleanup', '2026-08-09T00:00:00.000Z', '2026-08-09T00:00:00.000Z', 'ws-rotation-cleanup')",
+      ),
+      env.DB.prepare(
+        "INSERT INTO sessions (id, user_id, token, expires_at, created_at, updated_at) VALUES ('session-rotation-cleanup', 'user-rotation-cleanup', 'ass_rotation_cleanup', '2026-08-16T00:00:00.000Z', '2026-08-09T00:00:00.000Z', '2026-08-09T00:00:00.000Z')",
+      ),
+      env.DB.prepare(
+        "INSERT INTO cli_refresh_credentials (id, user_id, token_hash, expires_at, revoked_at, created_at, family_id) VALUES ('next-rotation-cleanup', 'user-rotation-cleanup', 'next-hash', '2027-02-05T00:00:00.000Z', NULL, '2026-08-09T00:00:00.000Z', 'family-rotation-cleanup')",
+      ),
+      env.DB.prepare(
+        "INSERT INTO cli_refresh_credentials (id, user_id, token_hash, expires_at, revoked_at, created_at, family_id, replaced_by_id, rotation_request_hash, rotation_retry_until, rotation_session_id) VALUES ('old-rotation-cleanup', 'user-rotation-cleanup', 'old-hash', '2027-02-05T00:00:00.000Z', '2026-08-09T00:00:00.000Z', '2026-08-09T00:00:00.000Z', 'family-rotation-cleanup', 'next-rotation-cleanup', 'request-hash', '2026-08-09T00:10:00.000Z', 'session-rotation-cleanup')",
+      ),
+    ])
+
+    await expect(
+      worker.scheduled({
+        cron: '*/5 * * * *',
+        scheduledTime: new Date('2026-08-09T00:15:00.000Z'),
+      }),
+    ).resolves.toMatchObject({ outcome: 'ok' })
+
+    const old = await env.DB.prepare(
+      `SELECT family_id, replaced_by_id, rotation_request_hash,
+              rotation_retry_until, rotation_session_id
+       FROM cli_refresh_credentials
+       WHERE id = 'old-rotation-cleanup'`,
+    ).first<Record<string, string | null>>()
+    expect(old).toMatchObject({
+      family_id: 'family-rotation-cleanup',
+      replaced_by_id: 'next-rotation-cleanup',
+      rotation_request_hash: null,
+      rotation_retry_until: null,
+      rotation_session_id: null,
+    })
+  })
+
   test('runs D1 backup through the production workflow binding and saves R2 output', async () => {
     const env = await worker.getEnv()
     expect(env.D1_REST_API_TOKEN).toBe('test-token')

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -95,15 +95,15 @@ export default {
             now: new Date(controller.scheduledTime),
             claimToken: nanoid(),
           })
-          return
+        } else {
+          const options = reconciliationOptionsFromEnv(env)
+          await runReconciliation(
+            db,
+            env.BUCKET,
+            new Date(controller.scheduledTime),
+            options,
+          )
         }
-        const options = reconciliationOptionsFromEnv(env)
-        await runReconciliation(
-          db,
-          env.BUCKET,
-          new Date(controller.scheduledTime),
-          options,
-        )
       })(),
     )
   },

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -32,6 +32,7 @@ import {
   scheduledJobForCron,
 } from '../app/services/slack-notifications.server'
 import { nanoid } from 'nanoid'
+import { cleanupExpiredCliRotationReplays } from '../app/services/cli-refresh-credentials.server'
 
 export { ArtifactLiveRoom } from './artifact-live-room'
 export { D1BackupWorkflow } from './d1-backup-workflow'
@@ -84,6 +85,10 @@ export default {
     ctx.waitUntil(
       (async () => {
         const db = createDb()
+        await cleanupExpiredCliRotationReplays(
+          db,
+          new Date(controller.scheduledTime).toISOString(),
+        )
         if (scheduledJobForCron(controller.cron) === 'slack-notifications') {
           await processSlackNotificationOutbox(db, {
             origin: env.BETTER_AUTH_URL,


### PR DESCRIPTION
## Summary

- clear expired CLI rotation replay hashes and session references from the five-minute scheduled path
- preserve credential-family lineage and replacement references needed for revocation
- leave live windows untouched and incomplete rows fail closed
- cover idempotency, expiry boundaries, revocation, and the production Worker runtime

## Verification

- CLI refresh credential service tests (17 tests)
- web typecheck
- production web build
- runtime integration tests (12 tests)
