### PR TITLE
Trust same-repository PR boundary updates

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -38,10 +38,12 @@ jobs:
           PUBLIC_PR_BODY: ${{ github.event.pull_request.body }}
           PUBLIC_PR_BASE: ${{ github.event.pull_request.base.sha }}
           PUBLIC_PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUBLIC_PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PUBLIC_PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
         run: |
           node -e "const fs=require('node:fs'); fs.writeFileSync(process.env.RUNNER_TEMP + '/public-pr-title.txt', process.env.PUBLIC_PR_TITLE ?? ''); fs.writeFileSync(process.env.RUNNER_TEMP + '/public-pr-body.txt', process.env.PUBLIC_PR_BODY ?? '')"
           git -C "$GITHUB_WORKSPACE/head" fetch --no-tags "$GITHUB_WORKSPACE/trusted" "$PUBLIC_PR_BASE"
-          node trusted/scripts/public-development-guard.mjs --ci-pr --repo "$GITHUB_WORKSPACE/head" --manifest-repo "$GITHUB_WORKSPACE/trusted" --base "$PUBLIC_PR_BASE" --head "$PUBLIC_PR_HEAD" --metadata-file "$RUNNER_TEMP/public-pr-title.txt" --metadata-file "$RUNNER_TEMP/public-pr-body.txt"
+          node trusted/scripts/public-development-guard.mjs --ci-pr --repo "$GITHUB_WORKSPACE/head" --manifest-repo "$GITHUB_WORKSPACE/trusted" --base "$PUBLIC_PR_BASE" --head "$PUBLIC_PR_HEAD" --head-repo-full-name "$PUBLIC_PR_HEAD_REPO" --base-repo-full-name "$PUBLIC_PR_BASE_REPO" --metadata-file "$RUNNER_TEMP/public-pr-title.txt" --metadata-file "$RUNNER_TEMP/public-pr-body.txt"
 
   validate:
     name: Public full validation

--- a/scripts/public-ci-contract.test.mjs
+++ b/scripts/public-ci-contract.test.mjs
@@ -87,6 +87,8 @@ test('PRs run only the install-free boundary guard', () => {
   )
   assert.match(workflow, /--base\s+"\$PUBLIC_PR_BASE"/)
   assert.match(workflow, /--head\s+"\$PUBLIC_PR_HEAD"/)
+  assert.match(workflow, /--head-repo-full-name\s+"\$PUBLIC_PR_HEAD_REPO"/)
+  assert.match(workflow, /--base-repo-full-name\s+"\$PUBLIC_PR_BASE_REPO"/)
   assert.match(
     workflow,
     /git -C "\$GITHUB_WORKSPACE\/head" fetch --no-tags "\$GITHUB_WORKSPACE\/trusted" "\$PUBLIC_PR_BASE"/,

--- a/scripts/public-development-guard.mjs
+++ b/scripts/public-development-guard.mjs
@@ -187,6 +187,8 @@ export function inspectCommitRange({
   git,
   repo = root,
   manifestRepo = repo,
+  headRepoFullName = '',
+  baseRepoFullName = '',
 }) {
   if (!/^[0-9a-f]{40}$/u.test(base) || !/^[0-9a-f]{40}$/u.test(head))
     throw new Error('invalid CI PR range')
@@ -196,7 +198,9 @@ export function inspectCommitRange({
     .trim()
     .split(/\s+/u)
     .filter(Boolean)
-  const manifest = loadBoundaryManifest(manifestRepo)
+  const sameRepository =
+    headRepoFullName !== '' && headRepoFullName === baseRepoFullName
+  const manifest = loadBoundaryManifest(sameRepository ? repo : manifestRepo)
   for (const sha of commits) {
     inspectMetadata(git(['show', '-s', '--format=%B', sha]), `commit ${sha}`)
     inspectTree(parseTree(git(['ls-tree', '-r', sha])), manifest)
@@ -320,6 +324,8 @@ if (
       const head = values('--head')[0]
       const repo = values('--repo')[0] ?? root
       const manifestRepo = values('--manifest-repo')[0] ?? repo
+      const headRepoFullName = values('--head-repo-full-name')[0] ?? ''
+      const baseRepoFullName = values('--base-repo-full-name')[0] ?? ''
       const git = (gitArgs) =>
         execFileSync('git', gitArgs, { cwd: repo, encoding: 'utf8' })
       inspectCommitRange({
@@ -330,6 +336,8 @@ if (
         git,
         repo,
         manifestRepo,
+        headRepoFullName,
+        baseRepoFullName,
       })
     } else if (process.argv.includes('--check')) {
       const unknown = args.filter((arg) => arg !== '--check')
@@ -340,7 +348,14 @@ if (
         (arg) =>
           arg.startsWith('--') &&
           !['--remote'].includes(arg) &&
-          !['--ci-pr', '--base', '--head', '--metadata-file'].includes(arg),
+          ![
+            '--ci-pr',
+            '--base',
+            '--head',
+            '--metadata-file',
+            '--head-repo-full-name',
+            '--base-repo-full-name',
+          ].includes(arg),
       )
       if (unknown.length) throw new Error(`unknown option: ${unknown[0]}`)
       const remote = values('--remote')[0]

--- a/scripts/public-development-guard.test.mjs
+++ b/scripts/public-development-guard.test.mjs
@@ -165,6 +165,34 @@ test('CI range inspection calls range, messages, trees, and rejects unsafe tree 
   )
 })
 
+test('same-repository PR uses the head boundary manifest', () => {
+  const manifestRepos = []
+  const git = (args) => {
+    if (args[0] === 'rev-list') return 'a'.repeat(40)
+    if (args[0] === 'show') return 'safe commit'
+    return '100644 blob ' + 'b'.repeat(40) + '\tREADME.md\n'
+  }
+  assert.doesNotThrow(() =>
+    inspectCommitRange({
+      base: 'c'.repeat(40),
+      head: 'd'.repeat(40),
+      git,
+      repo: process.cwd(),
+      manifestRepo: new Proxy(
+        {},
+        {
+          get() {
+            manifestRepos.push('base')
+          },
+        },
+      ),
+      headRepoFullName: 'artifactshare/artifactshare',
+      baseRepoFullName: 'artifactshare/artifactshare',
+    }),
+  )
+  assert.deepEqual(manifestRepos, [])
+})
+
 test('standalone check classifies the current repository tree', () => {
   assert.ok(checkStandalone(process.cwd()).length > 0)
   assert.doesNotThrow(() =>


### PR DESCRIPTION
## Summary

Use repository identity, rather than GitHub author association, to distinguish maintainer branches from external forks. This lets a same-repository PR evolve the public boundary manifest while the guard executable remains loaded from the trusted base checkout.

## Validation

- formatting
- lint
- public development boundary check
- script test suite