### PR TITLE
Restore public UI development harnesses

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -73,4 +73,8 @@ jobs:
         env:
           PLAYWRIGHT_CHANNEL: chrome
         run: pnpm check:in-app-navigation
+      - name: Verify representative scenario routes
+        env:
+          PLAYWRIGHT_CHANNEL: chrome
+        run: pnpm check:scenario-routes
       - run: pnpm test:runtime

--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -69,12 +69,12 @@ jobs:
       - run: pnpm validate
       - name: Verify isolated local D1 recovery
         run: pnpm check:dev-setup
-      - name: Verify full-topology in-app navigation
-        env:
-          PLAYWRIGHT_CHANNEL: chrome
-        run: pnpm check:in-app-navigation
       - name: Verify representative scenario routes
         env:
           PLAYWRIGHT_CHANNEL: chrome
         run: pnpm check:scenario-routes
+      - name: Verify full-topology in-app navigation
+        env:
+          PLAYWRIGHT_CHANNEL: chrome
+        run: pnpm check:in-app-navigation
       - run: pnpm test:runtime

--- a/apps/web/app/routes/dev.scenarios.$scenario/index.tsx
+++ b/apps/web/app/routes/dev.scenarios.$scenario/index.tsx
@@ -1,4 +1,4 @@
-import { useParams, useSearchParams } from 'react-router'
+import { Link, useParams, useSearchParams } from 'react-router'
 import { isViteDev } from '~/lib/is-vite-dev'
 import { ScenarioPage } from './+components/scenario-page'
 import {
@@ -33,10 +33,19 @@ export default function DevScenario() {
   if (!isScenarioId(scenario)) return null
 
   return (
-    <ScenarioPage
-      scenario={scenario}
-      theme={parseTheme(searchParams.get('theme'))}
-    />
+    <>
+      <Link
+        to={`/dev/scenarios/${scenario === 'landing-default' ? 'viewer-default' : 'landing-default'}?theme=${parseTheme(searchParams.get('theme'))}`}
+        data-regression-route-link
+        aria-hidden="true"
+        tabIndex={-1}
+        className="fixed top-0 left-0 size-px opacity-0"
+      />
+      <ScenarioPage
+        scenario={scenario}
+        theme={parseTheme(searchParams.get('theme'))}
+      />
+    </>
   )
 }
 

--- a/apps/web/vitest.visual.browser.config.ts
+++ b/apps/web/vitest.visual.browser.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       enabled: true,
       provider: playwright(),
       headless: true,
+      screenshotFailures: !process.env.VISUAL_FAULT,
       instances: [{ browser: 'chromium' }],
       fileParallelism: false,
       expect: {

--- a/compose.playwright.yml
+++ b/compose.playwright.yml
@@ -7,6 +7,8 @@ x-visual: &visual
   environment:
     CI: 'true'
     PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+    VISUAL_FAULT: ${VISUAL_FAULT:-}
+    VITEST_TEST_NAME: ${VITEST_TEST_NAME:-}
   volumes:
     - type: bind
       source: .
@@ -36,7 +38,7 @@ services:
         corepack install --global pnpm@11.13.1 &&
         pnpm config set store-dir /pnpm/store &&
         pnpm install --frozen-lockfile --ignore-scripts &&
-        pnpm --filter @artifactshare/web exec vitest --config vitest.visual.browser.config.ts --run
+        pnpm --filter @artifactshare/web exec vitest --config vitest.visual.browser.config.ts --run $${VITEST_TEST_NAME:+--testNamePattern "$${VITEST_TEST_NAME}"}
 
   visual-update:
     <<: *visual

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -5,11 +5,41 @@ This repository is the source of truth for product development. A maintainer mus
 ## Required sequence
 
 1. Write a specification with explicit scope and acceptance criteria.
-2. Ask both Codex and Claude to review that exact specification revision. Address findings and repeat until both return GO.
-3. Implement the approved specification. Commit the complete change and run `pnpm validate`.
-4. Publish the first committed version as a Draft PR with `pnpm pr:publish -- --body-file <path> --title <title>`.
-5. Review the committed local HEAD with both `pnpm review:codex` and `pnpm review:claude`. Keep fixes in local commits while the PR remains Draft. Each review request must identify the exact SHA. Repeat the loop after every material fix until both reviewers return GO for the same final SHA.
-6. Push that final SHA once with `AS_PUSH_AFTER_GO=1 git push`, wait for the applicable checks, and run `pnpm pr:ready -- --codex-go <SHA> --claude-go <SHA>`.
+2. If the specification changes UI, capture the current screen or prepare a static mock and run the UI critique described below. Address findings and repeat the critique after material visual changes.
+3. Ask both Codex and Claude to review that exact specification revision. Address findings and repeat until both return GO.
+4. Implement the approved specification. Commit the complete change and run `pnpm validate`.
+5. Publish the first committed version as a Draft PR with `pnpm pr:publish -- --body-file <path> --title <title>`.
+6. If the PR changes UI, capture every affected state and run the UI critique before code review. Record the disposition of each finding in the PR. After material visual fixes, recapture and repeat the critique.
+7. Review the committed local HEAD with both `pnpm review:codex` and `pnpm review:claude`. Keep fixes in local commits while the PR remains Draft. Each review request must identify the exact SHA. Repeat the loop after every material fix until both reviewers return GO for the same final SHA.
+8. Push that final SHA once with `AS_PUSH_AFTER_GO=1 git push`, wait for the applicable checks, and run `pnpm pr:ready -- --codex-go <SHA> --claude-go <SHA>`.
+
+## UI critique
+
+UI critique supplements specification and code review; it does not replace either one. Use `pnpm screens:capture` and the capture rules in [Screen capture](./reference/screen-capture.md). Use [the design-system critique criteria](./reference/design-system.md#14-エージェント批評の観点) as the source of truth rather than copying the criteria into a request.
+
+The agent performing the critique receives existing PNG captures and relevant mock or product source. It must not launch another browser to fill missing evidence. If an input is missing, it returns `NEEDS INPUT` and identifies the required capture or source. The maintainer obtains additional captures through the existing screen-capture harness.
+
+Use this request template:
+
+```text
+UI critique requested.
+
+Target:
+- phase: <spec review or PR review>
+- related proposal or PR: <public URL or identifier>
+- capture PNGs: <absolute paths produced by pnpm screens:capture>
+- mock source: <HTML/CSS source paths, or none>
+- product source: <relevant component/style paths, or none>
+
+Constraints:
+- Use only the supplied PNGs, source files, and a local image viewer.
+- Do not launch Chrome, a headless browser, or an external browser.
+- If evidence is incomplete, return NEEDS INPUT with the missing captures or source instead of guessing.
+- Evaluate against docs/reference/design-system.md section 14.
+
+Response:
+- Findings in priority order, or GO when there are no findings.
+```
 
 The review commands wait for up to 30 minutes. Silence before that limit is not a reason to interrupt them. `review:codex` isolates optional Codex integrations and terminates its process tree on timeout. `review:claude` reuses its persistent reviewer and correlates every response with a request ID so a delayed response cannot be mistaken for the current round.
 

--- a/docs/reference/design-system.md
+++ b/docs/reference/design-system.md
@@ -374,6 +374,7 @@ shareable の公開範囲 (`Visibility`) を表す pill 形バッジ。shadcn `B
 - primitive の `className` では padding、幅、surface、typography、局所的 responsive 制約だけを書く。
 - 兄弟間隔を子の外側 margin (`mt-*` / `mb-*` 等) で作らず、親の `gap` へ寄せる。
 - `pnpm report:spacing-ownership` は `Stack` / `Inline` の適用 className と、そのほかの要素の実際の className 値を、ファイル・行・対象・class・構文区分・理由の安定順で棚卸しする。`ownership-review` は構文だけでは責務を決めず、親所有か意味的複合部品所有かを人手で判定する表示専用の候補であり、許可リストではない。
+- spacing ownership reportはsource上で余白の所有者を棚卸しする。描画後に隣接要素のゼロ間隔や接触を検出するgap auditとは役割が異なる。全登録画面のgap auditは `pnpm screens:capture -- --all --audit-gaps` で実行する。
 - 機械検査が deny する保証範囲は `Stack` / `Inline` の静的に解決できる display・軸・gap・alignment・justify・wrap・外側 margin、および settings route の局所的な正の block-axis margin である。dynamic-review、既存の意味的所有、reset・prose・overlay・geometry surface は report-only とし、現状件数を baseline として許可しない。表示専用の所有方針と判断理由は `scripts/spacing-ownership-policy.mjs` を正本とする。
 - 代表状態と props 一覧は `catalog.ts` と `/dev/gallery` を参照する。
 
@@ -482,13 +483,14 @@ UX Bar の「コピー」と、現行 UI の要件に整合させる。
 
 1. **デザイントークン検査 (`check:design-tokens`)**: 色、余白、寸法、セレクタ、レイアウト所有など、ソースコードの静的な禁止条件として判定できる指摘。
 2. **コピー用語検査 (`check:copy-glossary`)**: 禁止語、表示語の置換、語彙の組み合わせなど、表示文言を静的に判定できる指摘。許容表現と禁止表現の根拠は [glossary](./glossary.md) に置く。
-3. **回帰検査 (`gallery:regression` / `scenario:regression`)**: 部品や代表画面の見た目、横あふれ、重なり、主要要素の可視性など、描画結果または画面の幾何で判定する指摘。
+3. **回帰検査 (`pnpm visual:compose`)**: 部品や代表画面の見た目、横あふれ、重なり、主要要素の可視性など、描画結果または画面の幾何で判定する指摘。baselineを意図的に更新するときは `pnpm visual:compose:update` を使う。
 
 隣接ブロックの縦間隔ゼロは、2 回の再発を受けて gap audit に昇格しました。
 
 どの受け皿にも適さない指摘は、エージェント批評の観点または個別の reference / decision に残す。機械検査を追加するときは、再発した失敗例を fixture または test として固定し、既存の正当な実装を例外登録で無条件に通さない。
 
 検査を新設・改修したときは、既知の欠陥を一時的に再導入して fail することを確認する (負の対照)。検出ゼロと検査の無効は出力から区別できない。
+visual検出器の負の対照は `pnpm visual:fault-injection` で実行する。通常のPR検証には含めず、visual検出器やその配線を変更したときに明示的に実行する。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dev:setup": "node scripts/dev-setup.mjs",
     "check:dev-setup": "node scripts/check-dev-setup.mjs",
     "check:in-app-navigation": "node scripts/in-app-navigation.mjs",
+    "check:scenario-routes": "node scripts/scenario-route-integration.mjs",
     "screens:capture": "node scripts/run-screen-capture.mjs",
     "billing:regression": "node scripts/billing-regression.mjs",
     "audit:ai-search": "node scripts/audit-ai-search-eligibility.mjs",
@@ -30,6 +31,7 @@
     "format": "vp fmt -c .oxfmtrc.json --check",
     "lint": "vp lint -c .oxlintrc.json",
     "check:design-tokens": "node scripts/check-design-tokens.mjs",
+    "report:spacing-ownership": "node scripts/check-design-tokens.mjs --spacing-report",
     "audit:tests": "node scripts/public-test-audit.mjs",
     "check:copy-glossary": "node scripts/check-copy-glossary.mjs",
     "check:screen-ledger": "node scripts/check-screen-ledger.mjs",
@@ -52,7 +54,8 @@
     "validate": "pnpm format && pnpm lint && pnpm check:public-development-guard && pnpm check:design-tokens && pnpm audit:tests && pnpm check:copy-glossary && pnpm check:screen-ledger && pnpm check:migrations && pnpm check:schema && pnpm check:analytics-literals && pnpm check:analytics-dimensions && pnpm check:cli-release && pnpm typecheck && pnpm test && pnpm build && pnpm build:alerts && pnpm build:og-image && pnpm integration:test:run && pnpm check:cli-reference && pnpm build:sandbox && pnpm check:doctor && pnpm public:scan .",
     "test:runtime": "node scripts/public-runtime-smoke.mjs",
     "visual:compose": "docker compose -f compose.playwright.yml run --rm visual",
-    "visual:compose:update": "docker compose -f compose.playwright.yml run --rm visual-update"
+    "visual:compose:update": "docker compose -f compose.playwright.yml run --rm visual-update",
+    "visual:fault-injection": "node scripts/verify-visual-fault-injection.mjs"
   },
   "devDependencies": {
     "marked": "18.0.6",

--- a/scripts/scenario-route-integration.mjs
+++ b/scripts/scenario-route-integration.mjs
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { appFetch } from './lib/dev-sign-in.mjs'
 
 const ROOT = resolve(import.meta.dirname, '..')
@@ -27,6 +28,48 @@ async function waitForServer(server) {
     await sleep(1000)
   }
   throw new Error('Dev server did not become ready within 120 seconds')
+}
+
+function waitForExit(server, timeoutMs) {
+  if (server.exitCode != null || server.signalCode != null)
+    return Promise.resolve()
+  return new Promise((done, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error(`Dev server did not exit within ${timeoutMs}ms`))
+    }, timeoutMs)
+    const cleanup = () => {
+      clearTimeout(timeout)
+      server.off('exit', onExit)
+    }
+    const onExit = () => {
+      cleanup()
+      done()
+    }
+    server.once('exit', onExit)
+  })
+}
+
+async function stopServer(server) {
+  if (!server?.pid || server.exitCode != null || server.signalCode != null)
+    return
+  try {
+    process.kill(-server.pid, 'SIGTERM')
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error
+    return
+  }
+  try {
+    await waitForExit(server, 10_000)
+  } catch {
+    try {
+      process.kill(-server.pid, 'SIGKILL')
+    } catch (error) {
+      if (error?.code !== 'ESRCH') throw error
+      return
+    }
+    await waitForExit(server, 5_000)
+  }
 }
 
 function validateServerRenderedShell(html, scenario, requiredRegions) {
@@ -159,17 +202,14 @@ export async function main() {
     }
   } finally {
     await browser?.close().catch(() => {})
-    if (ownsServer && server?.pid) {
-      try {
-        process.kill(-server.pid, 'SIGTERM')
-      } catch {}
-    }
+    if (ownsServer) await stopServer(server)
     if (isolatedState)
       await rm(isolatedState, { recursive: true, force: true }).catch(() => {})
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.stack : String(error))
-  process.exitCode = 1
-})
+if (import.meta.url === pathToFileURL(process.argv[1]).href)
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack : String(error))
+    process.exitCode = 1
+  })

--- a/scripts/scenario-route-integration.mjs
+++ b/scripts/scenario-route-integration.mjs
@@ -1,0 +1,175 @@
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { appFetch } from './lib/dev-sign-in.mjs'
+
+const ROOT = resolve(import.meta.dirname, '..')
+const baseUrl = process.env.APP_BASE_URL ?? 'https://localhost:5173'
+const require = createRequire(resolve(ROOT, 'apps/web/package.json'))
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms))
+const scenarios = {
+  'landing-default': ['main', 'hero', 'footer'],
+  'viewer-default': ['main'],
+}
+
+async function waitForServer(server) {
+  const deadline = Date.now() + 120_000
+  while (Date.now() < deadline) {
+    if (server?.exitCode != null)
+      throw new Error(
+        `Dev server exited before readiness (code ${server.exitCode})`,
+      )
+    try {
+      if ((await appFetch(baseUrl, '/dev/sign-in')).ok) return
+    } catch {}
+    await sleep(1000)
+  }
+  throw new Error('Dev server did not become ready within 120 seconds')
+}
+
+function validateServerRenderedShell(html, scenario, requiredRegions) {
+  const mainCount = html.match(/<main(?:\s|>)/gu)?.length ?? 0
+  if (mainCount !== 1)
+    throw new Error(
+      `${scenario}: server render expected exactly one main, found ${mainCount}`,
+    )
+  for (const region of requiredRegions)
+    if (!html.includes(`data-regression-region="${region}"`))
+      throw new Error(`${scenario}: server render omitted region ${region}`)
+}
+
+export async function main() {
+  let server = null
+  let ownsServer = false
+  let browser = null
+  let isolatedState = null
+  try {
+    try {
+      if (!(await appFetch(baseUrl, '/dev/sign-in')).ok)
+        throw new Error('not ready')
+    } catch {
+      const { prepareDevEnvironment } = await import('./dev-setup.mjs')
+      isolatedState = await mkdtemp(join(tmpdir(), 'artifactshare-routes-'))
+      const prepared = prepareDevEnvironment({
+        reset: false,
+        persistTo: isolatedState,
+      })
+      if (!prepared.ok) throw new Error(`Dev setup failed: ${prepared.reason}`)
+      server = spawn('pnpm', ['--filter', '@artifactshare/web', 'dev:app'], {
+        cwd: ROOT,
+        stdio: ['ignore', 'inherit', 'inherit'],
+        detached: true,
+        env: {
+          ...process.env,
+          ARTIFACTSHARE_DEV_PERSIST_PATH: isolatedState,
+        },
+      })
+      ownsServer = true
+      await waitForServer(server)
+    }
+
+    const { chromium } = require('playwright')
+    browser = await chromium.launch(
+      process.env.PLAYWRIGHT_CHANNEL
+        ? { channel: process.env.PLAYWRIGHT_CHANNEL }
+        : undefined,
+    )
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      locale: 'en',
+      reducedMotion: 'reduce',
+      viewport: { width: 1440, height: 900 },
+    })
+    try {
+      // A clean checkout may trigger Vite's one-time dependency optimizer
+      // reload. Complete that transition before browser errors become test
+      // evidence, as the navigation harness does for the application routes.
+      const warmupPage = await context.newPage()
+      await warmupPage.goto(
+        new URL(
+          '/dev/scenarios/landing-default?theme=light',
+          baseUrl,
+        ).toString(),
+        { waitUntil: 'networkidle' },
+      )
+      await warmupPage.locator('main').waitFor()
+      await warmupPage.close()
+
+      for (const [scenario, requiredRegions] of Object.entries(scenarios)) {
+        const path = `/dev/scenarios/${scenario}?theme=light`
+        const serverResponse = await appFetch(baseUrl, path)
+        if (!serverResponse.ok)
+          throw new Error(
+            `${scenario}: route returned HTTP ${serverResponse.status}`,
+          )
+        validateServerRenderedShell(
+          await serverResponse.text(),
+          scenario,
+          requiredRegions,
+        )
+
+        const page = await context.newPage()
+        const errors = []
+        page.on('console', (message) => {
+          if (message.type() === 'error')
+            errors.push(`console: ${message.text()}`)
+        })
+        page.on('pageerror', (error) =>
+          errors.push(`pageerror: ${error.message}`),
+        )
+        const response = await page.goto(new URL(path, baseUrl).toString(), {
+          waitUntil: 'networkidle',
+        })
+        if (!response?.ok())
+          throw new Error(
+            `${scenario}: browser route returned HTTP ${response?.status() ?? 'unknown'}`,
+          )
+        await page.locator('main').waitFor()
+        await page.evaluate(async () => {
+          await document.fonts.ready
+          await Promise.all(
+            [...document.images].map(async (image) => {
+              if (!image.complete)
+                await new Promise((done, reject) => {
+                  image.addEventListener('load', done, { once: true })
+                  image.addEventListener(
+                    'error',
+                    () =>
+                      reject(new Error(`Image failed to load: ${image.src}`)),
+                    { once: true },
+                  )
+                })
+              if (image.naturalWidth === 0)
+                throw new Error(`Image failed to load: ${image.currentSrc}`)
+            }),
+          )
+        })
+        const geometry = await page.locator('main').boundingBox()
+        if (!geometry || geometry.width <= 0 || geometry.height <= 0)
+          throw new Error(`${scenario}: hydrated main has no visible geometry`)
+        if (errors.length)
+          throw new Error(`${scenario}: browser errors:\n${errors.join('\n')}`)
+        await page.close()
+        console.log(`scenario route integration passed: ${scenario}`)
+      }
+    } finally {
+      await context.close()
+    }
+  } finally {
+    await browser?.close().catch(() => {})
+    if (ownsServer && server?.pid) {
+      try {
+        process.kill(-server.pid, 'SIGTERM')
+      } catch {}
+    }
+    if (isolatedState)
+      await rm(isolatedState, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : String(error))
+  process.exitCode = 1
+})

--- a/scripts/scenario-route-integration.mjs
+++ b/scripts/scenario-route-integration.mjs
@@ -140,7 +140,19 @@ export async function main() {
       await warmupPage.locator('main').waitFor()
       await warmupPage.close()
 
-      for (const [scenario, requiredRegions] of Object.entries(scenarios)) {
+      const page = await context.newPage()
+      const errors = []
+      page.on('console', (message) => {
+        if (message.type() === 'error')
+          errors.push(`console: ${message.text()}`)
+      })
+      page.on('pageerror', (error) =>
+        errors.push(`pageerror: ${error.message}`),
+      )
+      let previousRegions = []
+      for (const [index, [scenario, requiredRegions]] of Object.entries(
+        scenarios,
+      ).entries()) {
         const path = `/dev/scenarios/${scenario}?theme=light`
         const serverResponse = await appFetch(baseUrl, path)
         if (!serverResponse.ok)
@@ -153,23 +165,35 @@ export async function main() {
           requiredRegions,
         )
 
-        const page = await context.newPage()
-        const errors = []
-        page.on('console', (message) => {
-          if (message.type() === 'error')
-            errors.push(`console: ${message.text()}`)
-        })
-        page.on('pageerror', (error) =>
-          errors.push(`pageerror: ${error.message}`),
-        )
-        const response = await page.goto(new URL(path, baseUrl).toString(), {
-          waitUntil: 'networkidle',
-        })
-        if (!response?.ok())
-          throw new Error(
-            `${scenario}: browser route returned HTTP ${response?.status() ?? 'unknown'}`,
-          )
+        if (index === 0) {
+          const response = await page.goto(new URL(path, baseUrl).toString(), {
+            waitUntil: 'networkidle',
+          })
+          if (!response?.ok())
+            throw new Error(
+              `${scenario}: browser route returned HTTP ${response?.status() ?? 'unknown'}`,
+            )
+        } else {
+          await page
+            .locator('[data-regression-route-link]')
+            .click({ force: true })
+          await page.waitForURL(new URL(path, baseUrl).toString())
+        }
         await page.locator('main').waitFor()
+        for (const region of requiredRegions)
+          await page
+            .locator(`[data-regression-region="${region}"]`)
+            .first()
+            .waitFor()
+        for (const region of previousRegions.filter(
+          (item) => !requiredRegions.includes(item),
+        ))
+          if (
+            await page.locator(`[data-regression-region="${region}"]`).count()
+          )
+            throw new Error(
+              `${scenario}: previous route region remained after client navigation: ${region}`,
+            )
         await page.evaluate(async () => {
           await document.fonts.ready
           await Promise.all(
@@ -194,9 +218,10 @@ export async function main() {
           throw new Error(`${scenario}: hydrated main has no visible geometry`)
         if (errors.length)
           throw new Error(`${scenario}: browser errors:\n${errors.join('\n')}`)
-        await page.close()
+        previousRegions = requiredRegions
         console.log(`scenario route integration passed: ${scenario}`)
       }
+      await page.close()
     } finally {
       await context.close()
     }

--- a/scripts/scenario-route-integration.mjs
+++ b/scripts/scenario-route-integration.mjs
@@ -188,12 +188,14 @@ export async function main() {
         for (const region of previousRegions.filter(
           (item) => !requiredRegions.includes(item),
         ))
-          if (
-            await page.locator(`[data-regression-region="${region}"]`).count()
-          )
-            throw new Error(
-              `${scenario}: previous route region remained after client navigation: ${region}`,
-            )
+          await page
+            .locator(`[data-regression-region="${region}"]`)
+            .waitFor({ state: 'detached' })
+            .catch(() => {
+              throw new Error(
+                `${scenario}: previous route region remained after client navigation: ${region}`,
+              )
+            })
         await page.evaluate(async () => {
           await document.fonts.ready
           await Promise.all(

--- a/scripts/verify-visual-fault-injection.mjs
+++ b/scripts/verify-visual-fault-injection.mjs
@@ -1,0 +1,75 @@
+import { spawn } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+const faultCases = [
+  {
+    fault: 'axe',
+    testName: 'landing-default',
+    diagnostic: /image-alt|violations/u,
+  },
+  {
+    fault: 'geometry',
+    testName: 'landing-default',
+    diagnostic: /main:0/u,
+  },
+  {
+    fault: 'image',
+    testName: 'landing-default',
+    diagnostic: /screenshot|Screenshot/u,
+  },
+  {
+    fault: 'runtime',
+    testName: 'landing-default',
+    diagnostic: /injected runtime failure/u,
+  },
+  {
+    fault: 'header',
+    testName: 'viewer-default',
+    diagnostic: /screenshot|Screenshot/u,
+  },
+]
+
+function runFault({ fault, testName }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      'docker',
+      [
+        'compose',
+        '-f',
+        'compose.playwright.yml',
+        'run',
+        '--rm',
+        '-e',
+        `VISUAL_FAULT=${fault}`,
+        '-e',
+        `VITEST_TEST_NAME=${testName}`,
+        'visual',
+      ],
+      { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    let output = ''
+    child.stdout.on('data', (chunk) => (output += chunk))
+    child.stderr.on('data', (chunk) => (output += chunk))
+    child.on('error', reject)
+    child.on('close', (code) => resolve({ code, output }))
+  })
+}
+
+export async function main() {
+  for (const faultCase of faultCases) {
+    const result = await runFault(faultCase)
+    if (result.code === 0)
+      throw new Error(`${faultCase.fault} fault injection unexpectedly passed`)
+    if (!faultCase.diagnostic.test(result.output))
+      throw new Error(
+        `${faultCase.fault} fault injection failed without its expected diagnostic:\n${result.output}`,
+      )
+    console.log(`visual fault injection detected: ${faultCase.fault}`)
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href)
+  main().catch((error) => {
+    console.error(error.stack ?? error)
+    process.exitCode = 1
+  })

--- a/scripts/verify-visual-fault-injection.mjs
+++ b/scripts/verify-visual-fault-injection.mjs
@@ -29,7 +29,9 @@ const faultCases = [
   },
 ]
 
-function runFault({ fault, testName }) {
+function runVisual({ fault, testName }) {
+  const environment = ['-e', `VITEST_TEST_NAME=${testName}`]
+  if (fault) environment.push('-e', `VISUAL_FAULT=${fault}`)
   return new Promise((resolve, reject) => {
     const child = spawn(
       'docker',
@@ -39,10 +41,7 @@ function runFault({ fault, testName }) {
         'compose.playwright.yml',
         'run',
         '--rm',
-        '-e',
-        `VISUAL_FAULT=${fault}`,
-        '-e',
-        `VITEST_TEST_NAME=${testName}`,
+        ...environment,
         'visual',
       ],
       { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'pipe'] },
@@ -56,8 +55,16 @@ function runFault({ fault, testName }) {
 }
 
 export async function main() {
+  for (const testName of new Set(faultCases.map((item) => item.testName))) {
+    const control = await runVisual({ testName })
+    if (control.code !== 0)
+      throw new Error(
+        `${testName} clean control failed before fault injection:\n${control.output}`,
+      )
+    console.log(`visual clean control passed: ${testName}`)
+  }
   for (const faultCase of faultCases) {
-    const result = await runFault(faultCase)
+    const result = await runVisual(faultCase)
     if (result.code === 0)
       throw new Error(`${faultCase.fault} fault injection unexpectedly passed`)
     if (!faultCase.diagnostic.test(result.output))


### PR DESCRIPTION
## Summary

- restore the conditional UI critique phase for specifications and Draft PRs
- reconnect the visual fault-injection negative controls to the Linux Compose suite
- add a small real-route integration check for representative landing and viewer scenarios
- restore the spacing-ownership report command and current visual command documentation

## Validation

- `pnpm validate`
- `PLAYWRIGHT_CHANNEL=chrome pnpm check:scenario-routes`
- `pnpm visual:fault-injection`
- `pnpm report:spacing-ownership`

The route integration check covers SSR structure, hydrated geometry, initial assets, and browser errors without duplicating the full component visual matrix. Fault injection remains an explicit maintenance command instead of running on every change.
