### PR TITLE
chore: allow browser local-state harness

### DIFF
--- a/config/repository-boundary.json
+++ b/config/repository-boundary.json
@@ -41,6 +41,7 @@
     "scripts/audit-ai-search-eligibility.test.mjs",
     "scripts/billing-regression.mjs",
     "scripts/billing-regression.test.mjs",
+    "scripts/browser-local-state.mjs",
     "scripts/check-copy-glossary.mjs",
     "scripts/check-copy-glossary.test.mjs",
     "scripts/check-design-tokens.mjs",


### PR DESCRIPTION
## Summary

- allow the new public browser local-state harness path through the repository boundary
- keep the boundary fail-closed: this PR adds no implementation or executable workflow change

## Validation

- `pnpm format`
- `node scripts/public-development-guard.mjs --check`
- `node --test scripts/public-development-guard.test.mjs`

## Follow-up

- land the implementation only after this trusted-base manifest change is merged
