### PR TITLE
ci: share browser validation topology

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -85,6 +85,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm db:apply:local
+      - name: Verify isolated local D1 recovery
+        run: pnpm check:dev-setup
       - run: pnpm validate:build
 
   cli-validation:
@@ -127,16 +129,10 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm --filter @artifactshare/web exec playwright install --with-deps chrome
       - run: pnpm test:behavior-browser
-      - name: Verify isolated local D1 recovery
-        run: pnpm check:dev-setup
-      - name: Verify representative scenario routes
+      - name: Verify scenario routes and in-app navigation
         env:
           PLAYWRIGHT_CHANNEL: chrome
-        run: pnpm check:scenario-routes
-      - name: Verify full-topology in-app navigation
-        env:
-          PLAYWRIGHT_CHANNEL: chrome
-        run: pnpm check:in-app-navigation
+        run: pnpm check:browser-local-state
 
   visual-validation:
     name: Public Linux visual validation

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:unit": "pnpm test:unit:noncli && pnpm --filter @artifactshare/cli test",
     "test:unit:noncli": "pnpm test:scripts && pnpm --filter @artifactshare/web test:unit",
     "test:behavior-browser": "pnpm --filter @artifactshare/web test:behavior-browser",
+    "check:browser-local-state": "node scripts/browser-local-state.mjs",
     "build": "pnpm --filter @artifactshare/web build && pnpm --filter @artifactshare/cli build",
     "build:alerts": "pnpm --filter @artifactshare/web build:alerts",
     "build:og-image": "pnpm --filter @artifactshare/web build:og-image",

--- a/scripts/browser-local-state.mjs
+++ b/scripts/browser-local-state.mjs
@@ -5,7 +5,7 @@ import { join, resolve } from 'node:path'
 import { appFetch } from './lib/dev-sign-in.mjs'
 
 const ROOT = resolve(import.meta.dirname, '..')
-const baseUrl = process.env.APP_BASE_URL ?? 'https://localhost:5173'
+const baseUrl = 'https://localhost:5173'
 const sleep = (ms) => new Promise((done) => setTimeout(done, ms))
 
 async function waitForServer(server) {
@@ -86,6 +86,10 @@ function runCheck(script) {
 }
 
 async function main() {
+  if (process.env.APP_BASE_URL && process.env.APP_BASE_URL !== baseUrl)
+    throw new Error(
+      `check:browser-local-state owns its isolated server at ${baseUrl}; run the standalone scenario-route and in-app-navigation checks to target another APP_BASE_URL`,
+    )
   let server = null
   const isolatedState = await mkdtemp(
     join(tmpdir(), 'artifactshare-browser-local-state-'),

--- a/scripts/browser-local-state.mjs
+++ b/scripts/browser-local-state.mjs
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import { mkdtemp, rm } from 'node:fs/promises'
+import { createConnection } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { appFetch } from './lib/dev-sign-in.mjs'
@@ -7,6 +8,25 @@ import { appFetch } from './lib/dev-sign-in.mjs'
 const ROOT = resolve(import.meta.dirname, '..')
 const baseUrl = 'https://localhost:5173'
 const sleep = (ms) => new Promise((done) => setTimeout(done, ms))
+
+function assertPortAvailable() {
+  return new Promise((done, reject) => {
+    const socket = createConnection({ host: '127.0.0.1', port: 5173 })
+    socket.once('connect', () => {
+      socket.destroy()
+      reject(
+        new Error(
+          'check:browser-local-state requires port 5173 to be free so it cannot validate or mutate an existing dev server',
+        ),
+      )
+    })
+    socket.once('error', (error) => {
+      socket.destroy()
+      if (error?.code === 'ECONNREFUSED') done()
+      else reject(error)
+    })
+  })
+}
 
 async function waitForServer(server) {
   const deadline = Date.now() + 120_000
@@ -90,6 +110,7 @@ async function main() {
     throw new Error(
       `check:browser-local-state owns its isolated server at ${baseUrl}; run the standalone scenario-route and in-app-navigation checks to target another APP_BASE_URL`,
     )
+  await assertPortAvailable()
   let server = null
   const isolatedState = await mkdtemp(
     join(tmpdir(), 'artifactshare-browser-local-state-'),

--- a/scripts/browser-local-state.mjs
+++ b/scripts/browser-local-state.mjs
@@ -1,0 +1,124 @@
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { appFetch } from './lib/dev-sign-in.mjs'
+
+const ROOT = resolve(import.meta.dirname, '..')
+const baseUrl = process.env.APP_BASE_URL ?? 'https://localhost:5173'
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms))
+
+async function waitForServer(server) {
+  const deadline = Date.now() + 120_000
+  while (Date.now() < deadline) {
+    if (server.exitCode != null)
+      throw new Error(
+        `Dev server exited before readiness (code ${server.exitCode})`,
+      )
+    try {
+      if ((await appFetch(baseUrl, '/dev/sign-in')).ok) return
+    } catch {}
+    await sleep(1000)
+  }
+  throw new Error('Dev server did not become ready within 120 seconds')
+}
+
+function waitForExit(server, timeoutMs) {
+  if (server.exitCode != null || server.signalCode != null)
+    return Promise.resolve()
+  return new Promise((done, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error(`Dev server did not exit within ${timeoutMs}ms`))
+    }, timeoutMs)
+    const cleanup = () => {
+      clearTimeout(timeout)
+      server.off('exit', onExit)
+    }
+    const onExit = () => {
+      cleanup()
+      done()
+    }
+    server.once('exit', onExit)
+  })
+}
+
+async function stopServer(server) {
+  if (!server?.pid || server.exitCode != null || server.signalCode != null)
+    return
+  try {
+    process.kill(-server.pid, 'SIGTERM')
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error
+    return
+  }
+  try {
+    await waitForExit(server, 10_000)
+  } catch {
+    try {
+      process.kill(-server.pid, 'SIGKILL')
+    } catch (error) {
+      if (error?.code !== 'ESRCH') throw error
+      return
+    }
+    await waitForExit(server, 5_000)
+  }
+}
+
+function runCheck(script) {
+  return new Promise((done, reject) => {
+    const child = spawn(process.execPath, [script], {
+      cwd: ROOT,
+      stdio: 'inherit',
+      env: { ...process.env, APP_BASE_URL: baseUrl },
+    })
+    child.once('error', reject)
+    child.once('exit', (code, signal) => {
+      if (code === 0) done()
+      else
+        reject(
+          new Error(
+            `${script} failed (${signal ? `signal ${signal}` : `exit code ${code}`})`,
+          ),
+        )
+    })
+  })
+}
+
+async function main() {
+  let server = null
+  const isolatedState = await mkdtemp(
+    join(tmpdir(), 'artifactshare-browser-local-state-'),
+  )
+  try {
+    const { prepareDevEnvironment } = await import('./dev-setup.mjs')
+    const prepared = prepareDevEnvironment({
+      reset: false,
+      persistTo: isolatedState,
+    })
+    if (!prepared.ok) throw new Error(`Dev setup failed: ${prepared.reason}`)
+    server = spawn('pnpm', ['--filter', '@artifactshare/web', 'dev:app'], {
+      cwd: ROOT,
+      stdio: ['ignore', 'inherit', 'inherit'],
+      detached: true,
+      env: {
+        ...process.env,
+        ARTIFACTSHARE_DEV_PERSIST_PATH: isolatedState,
+      },
+    })
+    await waitForServer(server)
+
+    // Keep the anonymous route proof ahead of the navigation proof, which
+    // seeds an authenticated persona into this otherwise shared local state.
+    await runCheck('scripts/scenario-route-integration.mjs')
+    await runCheck('scripts/in-app-navigation.mjs')
+  } finally {
+    await stopServer(server)
+    await rm(isolatedState, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : String(error))
+  process.exit(1)
+})

--- a/scripts/public-ci-contract.test.mjs
+++ b/scripts/public-ci-contract.test.mjs
@@ -161,6 +161,7 @@ test('browser lane shares one topology after behavior validation', () => {
   assert.equal((harness.match(/prepareDevEnvironment\(/gu) ?? []).length, 1)
   assert.equal((harness.match(/dev:app/gu) ?? []).length, 1)
   assert.match(harness, /APP_BASE_URL.*!==.*baseUrl/su)
+  assert.match(harness, /await assertPortAvailable\(\)/u)
 })
 
 test('static, CLI, and build lanes preserve complete nonvisual coverage', () => {

--- a/scripts/public-ci-contract.test.mjs
+++ b/scripts/public-ci-contract.test.mjs
@@ -160,7 +160,10 @@ test('browser lane shares one topology after behavior validation', () => {
   assert.ok(scenarioIndex < navigationIndex)
   assert.equal((harness.match(/prepareDevEnvironment\(/gu) ?? []).length, 1)
   assert.equal((harness.match(/dev:app/gu) ?? []).length, 1)
-  assert.match(harness, /APP_BASE_URL.*!==.*baseUrl/su)
+  assert.match(
+    harness,
+    /if \(process\.env\.APP_BASE_URL && process\.env\.APP_BASE_URL !== baseUrl\)/u,
+  )
   assert.match(harness, /await assertPortAvailable\(\)/u)
 })
 

--- a/scripts/public-ci-contract.test.mjs
+++ b/scripts/public-ci-contract.test.mjs
@@ -137,22 +137,29 @@ test('every executable validation lane checks out the merge-group SHA', () => {
   }
 })
 
-test('browser lane preserves behavior and local-state ordering', () => {
+test('browser lane shares one topology after behavior validation', () => {
   const runs = parsedWorkflow.jobs['browser-validation'].steps
     .map((step) => step.run ?? '')
     .join('\n')
   const behaviorIndex = runs.indexOf('pnpm test:behavior-browser')
-  const devSetupIndex = runs.indexOf('pnpm check:dev-setup')
-  const scenarioIndex = runs.indexOf('pnpm check:scenario-routes')
-  const navigationIndex = runs.indexOf('pnpm check:in-app-navigation')
+  const localStateIndex = runs.indexOf('pnpm check:browser-local-state')
   assert.ok(behaviorIndex >= 0)
-  assert.ok(behaviorIndex < devSetupIndex)
-  assert.ok(devSetupIndex < scenarioIndex)
-  assert.ok(scenarioIndex < navigationIndex)
+  assert.ok(behaviorIndex < localStateIndex)
+  assert.doesNotMatch(runs, /pnpm check:dev-setup/u)
+  assert.doesNotMatch(runs, /pnpm check:scenario-routes/u)
+  assert.doesNotMatch(runs, /pnpm check:in-app-navigation/u)
   assert.match(
     JSON.stringify(parsedWorkflow.jobs['browser-validation']),
     /PLAYWRIGHT_CHANNEL.*chrome/u,
   )
+
+  const harness = fs.readFileSync('scripts/browser-local-state.mjs', 'utf8')
+  const scenarioIndex = harness.indexOf('scenario-route-integration.mjs')
+  const navigationIndex = harness.indexOf('in-app-navigation.mjs')
+  assert.ok(scenarioIndex >= 0)
+  assert.ok(scenarioIndex < navigationIndex)
+  assert.equal((harness.match(/prepareDevEnvironment\(/gu) ?? []).length, 1)
+  assert.equal((harness.match(/dev:app/gu) ?? []).length, 1)
 })
 
 test('static, CLI, and build lanes preserve complete nonvisual coverage', () => {
@@ -171,6 +178,7 @@ test('static, CLI, and build lanes preserve complete nonvisual coverage', () => 
   assert.match(staticRuns, /pnpm fixtures:build/u)
   assert.doesNotMatch(buildRuns, /pnpm fixtures:build/u)
   assert.match(buildRuns, /pnpm db:apply:local/u)
+  assert.match(buildRuns, /pnpm check:dev-setup/u)
   assert.match(buildRuns, /pnpm validate:build/u)
   assert.match(rootPackage.scripts['validate:static'], /pnpm test:unit:noncli/u)
   assert.doesNotMatch(

--- a/scripts/public-ci-contract.test.mjs
+++ b/scripts/public-ci-contract.test.mjs
@@ -160,6 +160,7 @@ test('browser lane shares one topology after behavior validation', () => {
   assert.ok(scenarioIndex < navigationIndex)
   assert.equal((harness.match(/prepareDevEnvironment\(/gu) ?? []).length, 1)
   assert.equal((harness.match(/dev:app/gu) ?? []).length, 1)
+  assert.match(harness, /APP_BASE_URL.*!==.*baseUrl/su)
 })
 
 test('static, CLI, and build lanes preserve complete nonvisual coverage', () => {


### PR DESCRIPTION
## Summary

- move the browser-free isolated D1 recovery proof to the build lane
- run scenario-route and in-app-navigation proofs against one isolated D1 state and one dev server
- preserve the standalone route and navigation commands for local diagnosis

## Validation

- `pnpm validate`
- `pnpm check:browser-local-state`

## Expected CI effect

- rebalance roughly 35 seconds from the current browser critical path to the shorter build lane
- remove one local-state setup, dev-server startup, and Vite warmup from browser validation
- add no new Actions job or dependency installation
