### PR TITLE
Allow development constraints reference

### DIFF
--- a/config/public-repository-scan.json
+++ b/config/public-repository-scan.json
@@ -97,7 +97,7 @@
     },
     {
       "category": "private-reference",
-      "pattern": "^(?:(?:docs/|\\.\\./)reference/|\\./)(?:ai-search-eligibility|billing-regression|cli-command-catalog|design-system|glossary|local-dev-harness|performance-trace-automation|screen-capture|source-available-boundary)\\.md$",
+      "pattern": "^(?:(?:docs/|\\.\\./)reference/|\\./)(?:ai-search-eligibility|billing-regression|cli-command-catalog|design-system|development-constraints|glossary|local-dev-harness|performance-trace-automation|screen-capture|source-available-boundary)\\.md$",
       "reason": "public reference document"
     },
     {


### PR DESCRIPTION
## Summary

- allow the forthcoming public development-constraints reference through the trusted repository scanner
- keep the change limited to the existing anchored public-reference allowlist

## Validation

- `pnpm validate`
- Codex review: GO for the prerequisite scope
- Claude review: GO for the prerequisite scope
