### PR TITLE
Document lightweight maintainer changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,5 +6,5 @@
 - Production writes must use the protected GitHub `production` Environment and the staged deployment workflow. Do not run production commands from an ordinary development shell.
 - Install dependencies with `pnpm install --frozen-lockfile`. Before declaring a change complete, run `pnpm validate` and keep React Doctor at zero warnings and errors.
 - Review implementation, user-visible behavior, tests, security boundaries, and maintainability. Keep pull-request descriptions to the implementation, its generalized visible effect, and validation results.
-- Maintainer changes follow `docs/development-workflow.md`: review the specification with both reviewers, implement, publish a Draft PR, repeat both reviews against committed SHAs until both return GO, then make the PR ready. Do not skip a stage or review an uncommitted worktree.
+- Classify and run maintainer changes with `docs/development-workflow.md`, which is the source of truth for the required and lightweight sequences. Do not review an uncommitted worktree.
 - Follow the writing and contribution rules in `CONTRIBUTING.md`, `SECURITY.md`, and the nearest directory instructions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,5 +5,5 @@
 - Work only with files and context available in this repository. Do not use production operations, secrets, customer context, private paths, or private URLs.
 - Install dependencies with `pnpm install --frozen-lockfile`. Before declaring a change complete, run `pnpm validate` and keep React Doctor at zero warnings and errors.
 - Review implementation, user-visible behavior, tests, security boundaries, and maintainability. Keep pull-request descriptions to the implementation, its generalized visible effect, and validation results.
-- Maintainer changes follow `docs/development-workflow.md`: review the specification with both reviewers, implement, publish a Draft PR, repeat both reviews against committed SHAs until both return GO, then make the PR ready. Do not skip a stage or review an uncommitted worktree.
+- Classify and run maintainer changes with `docs/development-workflow.md`, which is the source of truth for the required and lightweight sequences. Do not review an uncommitted worktree.
 - Follow the writing and contribution rules in `CONTRIBUTING.md`, `SECURITY.md`, and the nearest directory instructions.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -2,16 +2,27 @@
 
 This repository is the source of truth for product development. A maintainer must be able to take a change from specification through a ready pull request using only a public checkout. External contributors continue to use the proposal-only process in `CONTRIBUTING.md`.
 
+## Classify the change
+
+Use the required sequence below unless every lightweight condition is true:
+
+- Only documentation files change.
+- The change only fixes a typo or clarifies wording without changing its meaning.
+- The change does not affect source code or source comments, UI, product behavior, normative development, review, or deployment policy, workflow guards, CI, security boundaries, dependencies, or configuration.
+- There is no uncertainty about the classification.
+
+A lightweight change may omit the pre-implementation specification and its Codex and Claude reviews. It must still be self-reviewed, committed, validated with `pnpm validate`, published as a Draft PR, reviewed by both reviewers at the committed HEAD, approved by both reviewers at the same SHA, pushed with the explicit final-GO override, pass required checks, and be made ready. If any condition is false or uncertain, use the full required sequence.
+
 ## Required sequence
 
 1. Write a specification with explicit scope and acceptance criteria.
 2. If the specification changes UI, capture the current screen or prepare a static mock and run the UI critique described below. Address findings and repeat the critique after material visual changes.
 3. Ask both Codex and Claude to review that exact specification revision. Address findings and repeat until both return GO.
-4. Implement the approved specification. Commit the complete change and run `pnpm validate`.
+4. Implement the approved specification. Commit the complete change and run `pnpm validate`. If validation changes files, commit those changes and rerun validation. Do not publish the Draft PR until validation succeeds and the worktree is clean.
 5. Publish the first committed version as a Draft PR with `pnpm pr:publish -- --body-file <path> --title <title>`.
 6. If the PR changes UI, capture every affected state and run the UI critique before code review. Record the disposition of each finding in the PR. After material visual fixes, recapture and repeat the critique.
 7. Review the committed local HEAD with both `pnpm review:codex` and `pnpm review:claude`. Keep fixes in local commits while the PR remains Draft. Each review request must identify the exact SHA. Repeat the loop after every material fix until both reviewers return GO for the same final SHA.
-8. Push that final SHA once with `AS_PUSH_AFTER_GO=1 git push`, wait for the applicable checks, and run `pnpm pr:ready -- --codex-go <SHA> --claude-go <SHA>`.
+8. Push that final SHA once with `AS_PUSH_AFTER_GO=1 git push`, run `gh pr checks --required --watch` for the current branch and wait for it to succeed, then run `pnpm pr:ready -- --codex-go <SHA> --claude-go <SHA>`.
 
 ## UI critique
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -22,7 +22,7 @@ A lightweight change may omit the pre-implementation specification and its Codex
 5. Publish the first committed version as a Draft PR with `pnpm pr:publish -- --body-file <path> --title <title>`.
 6. If the PR changes UI, capture every affected state and run the UI critique before code review. Record the disposition of each finding in the PR. After material visual fixes, recapture and repeat the critique.
 7. Review the committed local HEAD with both `pnpm review:codex` and `pnpm review:claude`. Keep fixes in local commits while the PR remains Draft. Each review request must identify the exact SHA. Repeat the loop after every material fix until both reviewers return GO for the same final SHA.
-8. Push that final SHA once with `AS_PUSH_AFTER_GO=1 git push`, run `gh pr checks --watch` for the current branch and wait for the checks reported for that PR to succeed, then run `pnpm pr:ready -- --codex-go <SHA> --claude-go <SHA>`. Full validation runs separately in the merge queue after the PR is ready.
+8. Push that final SHA once with `AS_PUSH_AFTER_GO=1 git push`. Poll `gh pr checks` every 5 seconds for at most 2 minutes until it reports at least one check for the current branch; if none appears, stop and investigate. Then run `gh pr checks --watch`, wait for all checks reported for that PR to succeed, and run `pnpm pr:ready -- --codex-go <SHA> --claude-go <SHA>`. Full validation runs separately in the merge queue after the PR is ready.
 
 ## UI critique
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -6,12 +6,12 @@ This repository is the source of truth for product development. A maintainer mus
 
 Use the required sequence below unless every lightweight condition is true:
 
-- Only documentation files change.
+- Only explanatory documents at the repository root or under `docs/` change. Markdown rendered in the product, shipped in a package, used as legal content, or published as an Update is not eligible.
 - The change only fixes a typo or clarifies wording without changing its meaning.
 - The change does not affect source code or source comments, UI, product behavior, normative development, review, or deployment policy, workflow guards, CI, security boundaries, dependencies, or configuration.
 - There is no uncertainty about the classification.
 
-A lightweight change may omit the pre-implementation specification and its Codex and Claude reviews. It must still be self-reviewed, committed, validated with `pnpm validate`, published as a Draft PR, reviewed by both reviewers at the committed HEAD, approved by both reviewers at the same SHA, pushed with the explicit final-GO override, pass required checks, and be made ready. If any condition is false or uncertain, use the full required sequence.
+A lightweight change may omit the pre-implementation specification and its Codex and Claude reviews. It must still be self-reviewed, committed, validated with `pnpm validate`, published as a Draft PR, reviewed by both reviewers at the committed HEAD, approved by both reviewers at the same SHA, pushed with the explicit final-GO override, pass the checks reported for the PR, and be made ready. Record the lightweight classification and how every condition above is satisfied in the PR validation section. If any condition is false or uncertain, use the full required sequence.
 
 ## Required sequence
 
@@ -22,7 +22,7 @@ A lightweight change may omit the pre-implementation specification and its Codex
 5. Publish the first committed version as a Draft PR with `pnpm pr:publish -- --body-file <path> --title <title>`.
 6. If the PR changes UI, capture every affected state and run the UI critique before code review. Record the disposition of each finding in the PR. After material visual fixes, recapture and repeat the critique.
 7. Review the committed local HEAD with both `pnpm review:codex` and `pnpm review:claude`. Keep fixes in local commits while the PR remains Draft. Each review request must identify the exact SHA. Repeat the loop after every material fix until both reviewers return GO for the same final SHA.
-8. Push that final SHA once with `AS_PUSH_AFTER_GO=1 git push`, run `gh pr checks --required --watch` for the current branch and wait for it to succeed, then run `pnpm pr:ready -- --codex-go <SHA> --claude-go <SHA>`.
+8. Push that final SHA once with `AS_PUSH_AFTER_GO=1 git push`, run `gh pr checks --watch` for the current branch and wait for the checks reported for that PR to succeed, then run `pnpm pr:ready -- --codex-go <SHA> --claude-go <SHA>`. Full validation runs separately in the merge queue after the PR is ready.
 
 ## UI critique
 


### PR DESCRIPTION
## Summary

- document a deterministic documentation-only lightweight classification
- keep Draft publication, committed-SHA reviews, reported PR checks, and Ready conversion mandatory for every maintainer change
- make the public workflow the single detailed source of truth for maintainer sequencing

## Visible effect

Maintainers can classify small wording-only documentation fixes from a public checkout without consulting another repository, while changes to behavior, policy, guards, CI, security boundaries, dependencies, or configuration continue through the full specification workflow.

## Validation

- `CI=true pnpm validate`
- managed public pre-push hook is current
- final-GO flow polls every 5 seconds for up to 2 minutes for the first reported PR check, then waits with `gh pr checks --watch`
- full validation remains a separate merge-queue gate after Ready conversion
- React Doctor: 100
- public repository scan: 0 findings
