### PR TITLE
Tier Claude review effort by risk

### DIFF
--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -21,7 +21,7 @@ A lightweight change may omit the pre-implementation specification and its Codex
 4. Implement the approved specification. Commit the complete change and run `pnpm validate`. If validation changes files, commit those changes and rerun validation. Do not publish the Draft PR until validation succeeds and the worktree is clean.
 5. Publish the first committed version as a Draft PR with `pnpm pr:publish -- --body-file <path> --title <title>`.
 6. If the PR changes UI, capture every affected state and run the UI critique before code review. Record the disposition of each finding in the PR. After material visual fixes, recapture and repeat the critique.
-7. Review the committed local HEAD with both `pnpm review:codex` and `pnpm review:claude`. Keep fixes in local commits while the PR remains Draft. Each review request must identify the exact SHA. Repeat the loop after every material fix until both reviewers return GO for the same final SHA.
+7. Review the committed local HEAD with both `pnpm review:codex` and `pnpm review:claude -- --depth loop`. Use `--depth gate` for the normal final gate, or `--depth gate --risk high` for high-risk changes. Keep fixes in local commits while the PR remains Draft. Each review request must identify the exact SHA. Repeat the loop after every material fix until both reviewers return GO for the same final SHA; only the gate GO is valid for the final Claude approval.
 8. Push that final SHA once with `AS_PUSH_AFTER_GO=1 git push`. Poll `gh pr checks` every 5 seconds for at most 2 minutes until it reports at least one check for the current branch; if none appears, stop and investigate. Then run `gh pr checks --watch`, wait for all checks reported for that PR to succeed, and run `pnpm pr:ready -- --codex-go <SHA> --claude-go <SHA>`. Full validation runs separately in the merge queue after the PR is ready.
 
 ## UI critique
@@ -53,6 +53,20 @@ Response:
 ```
 
 The review commands wait for up to 30 minutes. Silence before that limit is not a reason to interrupt them. `review:codex` isolates optional Codex integrations and terminates its process tree on timeout. `review:claude` reuses its persistent reviewer and correlates every response with a request ID so a delayed response cannot be mistaken for the current round.
+
+Claude review depth is an explicit cost and quality control:
+
+- `--depth loop` uses risk `normal`, effort `low`, and reviewer `claude-reviewer-loop-low` for focused correction rounds.
+- `--depth gate` uses risk `normal`, effort `high`, and reviewer `claude-reviewer-gate-high` for the normal final gate.
+- `--depth gate --risk high` uses effort `xhigh` and reviewer `claude-reviewer`.
+
+The model remains `opus`. High risk includes authentication, authorization, billing, cryptography, data migration, concurrency, and material design change. When uncertain, classify the change as high risk. The risk and rationale, selected gate, and result belong in the public PR validation section.
+
+The Claude wrapper fixes the full local HEAD SHA and target (`origin/main...<full SHA>`) for every depth. It rejects undefined values and `--risk high` with `loop`, and rejects replies from another reviewer, request ID, or SHA. A clean worktree and unchanged SHA are rechecked before accepting a reply. Dry-runs do not start reviewers, change delivery, send requests, or create a receipt.
+
+Only a `gate` reply whose body is `GO`, followed by the clean final recheck, creates the repository-local Git-path receipt. `pr:ready` fails closed unless that receipt contains the same SHA, `depth: gate`, the matching risk/effort/reviewer combination, and a non-empty request ID. Loop GO, missing, malformed, stale, or inconsistent receipts cannot satisfy the final gate.
+
+For 10 Ready PR trials, keep detailed per-round records and the 10-item aggregation in the private control plane. Public PRs contain only risk rationale, executed gate, and result. Record trial number, risk and rationale, loop and gate timings/SHA/effort/results, findings first discovered at gate, Codex rounds and final SHA, added rounds, timeout/restart/exception reasons, Ready time, post-gate CI or fix escapes through merge, and escapes found within seven days after merge. Seven days after the tenth merge, compare medians and maxima for Ready lead time, Claude review time, loop count, gate reruns, timeouts, medium-or-higher gate findings, and post-gate escapes. Reconsider the mapping, including returning normal gate to `xhigh`, after one medium-or-higher gate escape or two same-kind normal-gate escapes; do not omit quality gates during the trial.
 
 ## Safety boundaries
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -62,7 +62,7 @@ Claude review depth is an explicit cost and quality control:
 
 The model remains `opus`. High risk includes authentication, authorization, billing, cryptography, data migration, concurrency, and material design change. When uncertain, classify the change as high risk. The risk and rationale, selected gate, and result belong in the public PR validation section.
 
-The Claude wrapper fixes the full local HEAD SHA and target (`origin/main...<full SHA>`) for every depth. It rejects undefined values and `--risk high` with `loop`, and rejects replies from another reviewer, request ID, or SHA. A clean worktree and unchanged SHA are rechecked before accepting a reply. Dry-runs do not start reviewers, change delivery, send requests, or create a receipt.
+The Claude wrapper fixes the full local HEAD SHA for every depth. A gate fixes the target to `origin/main...<full SHA>` and rejects `--target`; a loop uses that same target by default but permits an explicit override. It rejects undefined values and `--risk high` with `loop`, and rejects replies from another reviewer, request ID, or SHA. A clean worktree and unchanged SHA are rechecked before accepting a reply. Dry-runs do not start reviewers, change delivery, send requests, or create a receipt.
 
 Only a `gate` reply whose body is `GO`, followed by the clean final recheck, creates the repository-local Git-path receipt. `pr:ready` fails closed unless that receipt contains the same SHA, `depth: gate`, the matching risk/effort/reviewer combination, and a non-empty request ID. Loop GO, missing, malformed, stale, or inconsistent receipts cannot satisfy the final gate.
 

--- a/scripts/claude-review.mjs
+++ b/scripts/claude-review.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { existsSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { spawn } from 'node:child_process'
 import { pathToFileURL } from 'node:url'
 import { terminateProcessTree } from './lib/process-tree.mjs'
@@ -23,8 +23,9 @@ function usage() {
   return `Usage: pnpm review:claude -- [options]
 
 Options:
-  --target <text>        Review target. Default: origin/main...<short HEAD SHA>
+  --target <text>        Review target. Default: origin/main...<full HEAD SHA>
   --depth <loop|gate>    Review depth. Default: loop
+  --risk <normal|high>   Risk class. Default: normal (high requires gate)
   --note <text>          Specific focus for this review
   --timeout-ms <ms>      Reply timeout. Default: ${defaultTimeoutMs}
   --dry-run              Print the planned review without starting or sending
@@ -35,6 +36,7 @@ function parseArgs(argv) {
   const options = {
     target: undefined,
     depth: 'loop',
+    risk: 'normal',
     note: undefined,
     timeoutMs: defaultTimeoutMs,
     dryRun: false,
@@ -47,12 +49,15 @@ function parseArgs(argv) {
       options.dryRun = true
       continue
     }
-    if (['--target', '--depth', '--note', '--timeout-ms'].includes(arg)) {
+    if (
+      ['--target', '--depth', '--risk', '--note', '--timeout-ms'].includes(arg)
+    ) {
       const value = argv[++i]
       if (!value || value.startsWith('--'))
         throw new Error(`Missing value for ${arg}`)
       if (arg === '--target') options.target = value
       if (arg === '--depth') options.depth = value
+      if (arg === '--risk') options.risk = value
       if (arg === '--note') options.note = value
       if (arg === '--timeout-ms') options.timeoutMs = Number(value)
       continue
@@ -63,9 +68,50 @@ function parseArgs(argv) {
   }
   if (!['loop', 'gate'].includes(options.depth))
     throw new Error('Invalid --depth. Use loop or gate.')
+  if (!['normal', 'high'].includes(options.risk))
+    throw new Error('Invalid --risk. Use normal or high.')
+  if (options.depth === 'loop' && options.risk === 'high')
+    throw new Error('--risk high requires --depth gate.')
   if (!Number.isInteger(options.timeoutMs) || options.timeoutMs <= 0)
     throw new Error('Invalid --timeout-ms. Use a positive integer.')
   return options
+}
+
+function reviewProfile(depth, risk) {
+  if (depth === 'loop')
+    return { effort: 'low', reviewer: 'claude-reviewer-loop-low' }
+  if (risk === 'high') return { effort: 'xhigh', reviewer: 'claude-reviewer' }
+  return { effort: 'high', reviewer: 'claude-reviewer-gate-high' }
+}
+
+function isGateGo(body) {
+  const lines = String(body ?? '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+  const content = lines.slice(1)
+  if (!['GO', 'GO。'].includes(content[0])) return false
+  return !content.slice(1).some((line) =>
+    /^\[(高|中|低)\]/u.test(line) || line.includes('GO ではない'),
+  )
+}
+
+function gateReceiptPath(spawnImpl) {
+  return commandResult(spawnImpl, 'git', [
+    'rev-parse',
+    '--path-format=absolute',
+    '--git-path',
+    'artifactshare/claude-gate-go.json',
+  ])
+}
+
+async function writeGateReceiptDefault(receipt, spawnImpl) {
+  const result = await gateReceiptPath(spawnImpl)
+  if (result.code !== 0 || !result.stdout.trim())
+    throw new Error(result.stderr || 'Could not determine gate receipt path.')
+  const path = result.stdout.trim()
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, `${JSON.stringify(receipt, null, 2)}\n`)
 }
 
 function firstLineValue(body, prefix) {
@@ -128,6 +174,9 @@ function buildRequestBody({
   depth,
   note,
   round,
+  risk,
+  effort,
+  reviewer: selectedReviewer,
 }) {
   const weight =
     depth === 'gate'
@@ -136,6 +185,7 @@ function buildRequestBody({
   return [
     `review-request: ${requestId}`,
     `対象: local commit ${fullSha}、${target}、このラウンドは #r${round}。`,
+    `設定: depth=${depth}、risk=${risk}、effort=${effort}、request ID=${requestId}。`,
     '読む範囲: 指定された対象だけを読み、作業ツリーの未 commit の状態や古い remote の差分は読まないこと。',
     '共有 worktree: git checkout、テスト実行、編集、commit をしないこと。追加の実機確認が必要なら別 worktree を使うこと。',
     `このラウンドの重さ: ${weight}`,
@@ -144,18 +194,23 @@ function buildRequestBody({
     '触ってよい情報: 差分、関連ファイル抜粋、issue / PR 本文、検証結果。',
     '読まないもの: secret、認証情報、.env、秘密鍵、token、顧客データ、個人情報。',
     `返答形式: 1 行目を review-reply: ${requestId} だけにし、続けて GO または重要度順の指摘。1 行目が一致しない返信はこの依頼への回答として扱われない。`,
-    `返信の送り方: ${join(scriptsDir, 'send.sh')} ${team} ${reviewer} ${requester} '<本文>'。`,
+    `返信の送り方: ${join(scriptsDir, 'send.sh')} ${team} ${selectedReviewer} ${requester} '<本文>'。`,
   ]
     .filter((line) => line !== null)
     .join('\n\n')
 }
 
-function selectReply(messages, seenIds, requestId) {
+function selectReply(
+  messages,
+  seenIds,
+  requestId,
+  selectedReviewer = reviewer,
+) {
   const ignored = []
   for (const message of messages) {
     if (
       seenIds.has(message.id) ||
-      message.from !== reviewer ||
+      message.from !== selectedReviewer ||
       message.to !== requester
     )
       continue
@@ -251,6 +306,7 @@ async function main({
   exists = existsSync,
   wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   killImpl,
+  writeGateReceipt = writeGateReceiptDefault,
 } = {}) {
   try {
     const options = parseArgs(argv)
@@ -285,6 +341,8 @@ async function main({
       throw new Error('Could not resolve the committed review SHA.')
     if (options.target === undefined)
       options.target = `origin/main...${fullSha}`
+    const profile = reviewProfile(options.depth, options.risk)
+    const selectedReviewer = profile.reviewer
     const readyResult = await commandResult(
       spawnImpl,
       'bash',
@@ -294,7 +352,7 @@ async function main({
         '_',
         scriptsDir,
         team,
-        reviewer,
+        selectedReviewer,
       ],
       {
         env: {
@@ -315,7 +373,7 @@ async function main({
       team,
       'messages',
       '--agent',
-      reviewer,
+      selectedReviewer,
       '--limit',
       String(historyLimit),
     ]
@@ -341,6 +399,9 @@ async function main({
       shortSha,
       fullSha,
       round,
+      risk: options.risk,
+      effort: profile.effort,
+      reviewer: selectedReviewer,
     })
     const rootResult = await commandResult(spawnImpl, 'git', [
       'rev-parse',
@@ -371,7 +432,7 @@ async function main({
       join(scriptsDir, 'spawn.sh'),
       [
         'claude-code',
-        reviewer,
+        selectedReviewer,
         '--project',
         root,
         '--team',
@@ -379,7 +440,7 @@ async function main({
         '--model',
         'opus',
         '--effort',
-        'xhigh',
+        profile.effort,
       ],
     ]
     if (options.dryRun) {
@@ -392,9 +453,14 @@ async function main({
           request: {
             team,
             from: requester,
-            to: reviewer,
+            to: selectedReviewer,
             requestId,
             round,
+            depth: options.depth,
+            risk: options.risk,
+            effort: profile.effort,
+            target: options.target,
+            sha: fullSha,
             body,
           },
           timeoutMs: options.timeoutMs,
@@ -431,7 +497,7 @@ async function main({
     const send = await commandResult(spawnImpl, join(scriptsDir, 'send.sh'), [
       team,
       requester,
-      reviewer,
+      selectedReviewer,
       body,
     ])
     if (send.code !== 0)
@@ -464,6 +530,7 @@ async function main({
         parseHistory(result.stdout),
         seenIds,
         requestId,
+        selectedReviewer,
       )
       for (const message of selected.ignored)
         if (!ignoredIds.has(message.id)) {
@@ -492,6 +559,23 @@ async function main({
           )
         log(`採用した返信: ${requestId} #r${round}`)
         log(selected.reply.body)
+        if (
+          !options.dryRun &&
+          options.depth === 'gate' &&
+          isGateGo(selected.reply.body)
+        ) {
+          await writeGateReceipt(
+            {
+              sha: fullSha,
+              depth: options.depth,
+              risk: options.risk,
+              effort: profile.effort,
+              reviewer: selectedReviewer,
+              requestId,
+            },
+            spawnImpl,
+          )
+        }
         return 0
       }
       if (Date.now() >= deadline) break
@@ -527,4 +611,6 @@ export {
   requester,
   timeoutExitCode,
   commandResult,
+  reviewProfile,
+  isGateGo,
 }

--- a/scripts/claude-review.mjs
+++ b/scripts/claude-review.mjs
@@ -199,7 +199,9 @@ function buildRequestBody({
     '観点: 正確性・回帰・抜けているテスト、再利用・単純化・効率・抽象度の保守性、受け入れ基準との整合。',
     '触ってよい情報: 差分、関連ファイル抜粋、issue / PR 本文、検証結果。',
     '読まないもの: secret、認証情報、.env、秘密鍵、token、顧客データ、個人情報。',
-    `返答形式: 1 行目を review-reply: ${requestId} だけにし、続けて GO または重要度順の指摘。1 行目が一致しない返信はこの依頼への回答として扱われない。`,
+    depth === 'gate'
+      ? `返答形式: 1 行目を review-reply: ${requestId} だけにする。問題がなければ 2 行目を GO だけにし、補足は書かない。補足や未確認事項が必要なら GO にせず、重要度順の指摘として書く。1 行目が一致しない返信はこの依頼への回答として扱われない。`
+      : `返答形式: 1 行目を review-reply: ${requestId} だけにし、続けて GO または重要度順の指摘。1 行目が一致しない返信はこの依頼への回答として扱われない。`,
     `返信の送り方: ${join(scriptsDir, 'send.sh')} ${team} ${selectedReviewer} ${requester} '<本文>'。`,
   ]
     .filter((line) => line !== null)

--- a/scripts/claude-review.mjs
+++ b/scripts/claude-review.mjs
@@ -91,9 +91,11 @@ function isGateGo(body) {
     .filter(Boolean)
   const content = lines.slice(1)
   if (!['GO', 'GO。'].includes(content[0])) return false
-  return !content.slice(1).some((line) =>
-    /^\[(高|中|低)\]/u.test(line) || line.includes('GO ではない'),
-  )
+  return !content
+    .slice(1)
+    .some(
+      (line) => /^\[(高|中|低)\]/u.test(line) || line.includes('GO ではない'),
+    )
 }
 
 function gateReceiptPath(spawnImpl) {

--- a/scripts/claude-review.mjs
+++ b/scripts/claude-review.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { spawn } from 'node:child_process'
@@ -111,6 +111,13 @@ async function writeGateReceiptDefault(receipt, spawnImpl) {
   const path = result.stdout.trim()
   mkdirSync(dirname(path), { recursive: true })
   writeFileSync(path, `${JSON.stringify(receipt, null, 2)}\n`)
+}
+
+async function invalidateGateReceiptDefault(spawnImpl) {
+  const result = await gateReceiptPath(spawnImpl)
+  if (result.code !== 0 || !result.stdout.trim())
+    throw new Error(result.stderr || 'Could not determine gate receipt path.')
+  rmSync(result.stdout.trim(), { force: true })
 }
 
 function firstLineValue(body, prefix) {
@@ -306,6 +313,7 @@ async function main({
   wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   killImpl,
   writeGateReceipt = writeGateReceiptDefault,
+  invalidateGateReceipt = invalidateGateReceiptDefault,
 } = {}) {
   try {
     const options = parseArgs(argv)
@@ -493,6 +501,7 @@ async function main({
         return 1
       }
     }
+    if (options.depth === 'gate') await invalidateGateReceipt(spawnImpl)
     const send = await commandResult(spawnImpl, join(scriptsDir, 'send.sh'), [
       team,
       requester,

--- a/scripts/claude-review.mjs
+++ b/scripts/claude-review.mjs
@@ -23,7 +23,7 @@ function usage() {
   return `Usage: pnpm review:claude -- [options]
 
 Options:
-  --target <text>        Review target. Default: origin/main...<full HEAD SHA>
+  --target <text>        Loop-only review target. Default: origin/main...<full HEAD SHA>
   --depth <loop|gate>    Review depth. Default: loop
   --risk <normal|high>   Risk class. Default: normal (high requires gate)
   --note <text>          Specific focus for this review
@@ -72,6 +72,8 @@ function parseArgs(argv) {
     throw new Error('Invalid --risk. Use normal or high.')
   if (options.depth === 'loop' && options.risk === 'high')
     throw new Error('--risk high requires --depth gate.')
+  if (options.depth === 'gate' && options.target !== undefined)
+    throw new Error('--depth gate fixes the target; omit --target.')
   if (!Number.isInteger(options.timeoutMs) || options.timeoutMs <= 0)
     throw new Error('Invalid --timeout-ms. Use a positive integer.')
   return options

--- a/scripts/claude-review.mjs
+++ b/scripts/claude-review.mjs
@@ -92,12 +92,7 @@ function isGateGo(body) {
     .map((line) => line.trim())
     .filter(Boolean)
   const content = lines.slice(1)
-  if (!['GO', 'GO。'].includes(content[0])) return false
-  return !content
-    .slice(1)
-    .some(
-      (line) => /^\[(高|中|低)\]/u.test(line) || line.includes('GO ではない'),
-    )
+  return content.length === 1 && ['GO', 'GO。'].includes(content[0])
 }
 
 function gateReceiptPath(spawnImpl) {

--- a/scripts/claude-review.test.mjs
+++ b/scripts/claude-review.test.mjs
@@ -56,10 +56,13 @@ test('selects the contracted reviewer and effort for each profile', () => {
   })
 })
 
-test('accepts explanatory GO replies but rejects findings and ambiguous text', () => {
+test('accepts only an unqualified GO reply', () => {
   assert.equal(isGateGo('review-reply: id\nGO'), true)
-  assert.equal(isGateGo('review-reply: id\nGO。\n確認しました。'), true)
+  assert.equal(isGateGo('review-reply: id\nGO。'), true)
+  assert.equal(isGateGo('review-reply: id\nGO\n確認しました。'), false)
   assert.equal(isGateGo('review-reply: id\nGO\n[中] typing issue'), false)
+  assert.equal(isGateGo('review-reply: id\nGO\n[P1] typing issue'), false)
+  assert.equal(isGateGo('review-reply: id\nGO\nP1: typing issue'), false)
   assert.equal(isGateGo('review-reply: id\nGO\nこれは GO ではない'), false)
   assert.equal(isGateGo('review-reply: id\nGO ではない'), false)
   assert.equal(isGateGo('review-reply: id\n[低] issue\nGO'), false)

--- a/scripts/claude-review.test.mjs
+++ b/scripts/claude-review.test.mjs
@@ -371,8 +371,12 @@ test('main keeps each depth/risk profile aligned across ready, history, spawn, s
     })
     assert.equal(code, 0)
     const ready = fake.calls.find((call) => call.executable === 'bash')
-    const history = fake.calls.find((call) => call.executable.endsWith('/api.sh'))
-    const spawn = fake.calls.find((call) => call.executable.endsWith('/spawn.sh'))
+    const history = fake.calls.find((call) =>
+      call.executable.endsWith('/api.sh'),
+    )
+    const spawn = fake.calls.find((call) =>
+      call.executable.endsWith('/spawn.sh'),
+    )
     const send = fake.calls.find((call) => call.executable.endsWith('/send.sh'))
     assert.equal(ready.args.at(-1), reviewer)
     assert.equal(history.args[history.args.indexOf('--agent') + 1], reviewer)

--- a/scripts/claude-review.test.mjs
+++ b/scripts/claude-review.test.mjs
@@ -366,6 +366,7 @@ test('main keeps each depth/risk profile aligned across ready, history, spawn, s
   ]) {
     const fake = fakeSpawn({ matchingReply: true })
     const receipts = []
+    const invalidations = []
     const code = await main({
       argv: [...argv, '--timeout-ms', '10'],
       spawnImpl: fake.spawnImpl,
@@ -373,6 +374,7 @@ test('main keeps each depth/risk profile aligned across ready, history, spawn, s
       exists: () => false,
       wait: async () => {},
       writeGateReceipt: (receipt) => receipts.push(receipt),
+      invalidateGateReceipt: () => invalidations.push(true),
       log: () => {},
       errorLog: () => {},
     })
@@ -392,6 +394,7 @@ test('main keeps each depth/risk profile aligned across ready, history, spawn, s
     assert.equal(send.args[2], reviewer)
     assert.match(send.args[3], /設定: depth=/u)
     assert.equal(receipts.length, argv.includes('--depth') ? 1 : 0)
+    assert.equal(invalidations.length, argv.includes('--depth') ? 1 : 0)
   }
 })
 

--- a/scripts/claude-review.test.mjs
+++ b/scripts/claude-review.test.mjs
@@ -8,12 +8,15 @@ import {
   parseArgs,
   parseDeliveryMode,
   selectReply,
+  reviewProfile,
+  isGateGo,
 } from './claude-review.mjs'
 
 test('parses defaults and options after --', () => {
   assert.deepEqual(parseArgs(['--', '--depth', 'gate']), {
     target: undefined,
     depth: 'gate',
+    risk: 'normal',
     note: undefined,
     timeoutMs: 1800000,
     dryRun: false,
@@ -27,6 +30,35 @@ test('rejects invalid arguments', () => {
     /Invalid --timeout-ms/,
   )
   assert.throws(() => parseArgs(['--unknown']), /Unknown option/)
+  assert.throws(
+    () => parseArgs(['--depth', 'loop', '--risk', 'high']),
+    /requires/,
+  )
+  assert.throws(() => parseArgs(['--risk', 'urgent']), /Invalid --risk/)
+})
+
+test('selects the contracted reviewer and effort for each profile', () => {
+  assert.deepEqual(reviewProfile('loop', 'normal'), {
+    effort: 'low',
+    reviewer: 'claude-reviewer-loop-low',
+  })
+  assert.deepEqual(reviewProfile('gate', 'normal'), {
+    effort: 'high',
+    reviewer: 'claude-reviewer-gate-high',
+  })
+  assert.deepEqual(reviewProfile('gate', 'high'), {
+    effort: 'xhigh',
+    reviewer: 'claude-reviewer',
+  })
+})
+
+test('accepts explanatory GO replies but rejects findings and ambiguous text', () => {
+  assert.equal(isGateGo('review-reply: id\nGO'), true)
+  assert.equal(isGateGo('review-reply: id\nGO。\n確認しました。'), true)
+  assert.equal(isGateGo('review-reply: id\nGO\n[中] typing issue'), false)
+  assert.equal(isGateGo('review-reply: id\nGO\nこれは GO ではない'), false)
+  assert.equal(isGateGo('review-reply: id\nGO ではない'), false)
+  assert.equal(isGateGo('review-reply: id\n[低] issue\nGO'), false)
 })
 
 test('builds distinct loop and gate requests', () => {
@@ -219,7 +251,7 @@ function fakeSpawn({
             listeners.stdout?.(
               JSON.stringify({
                 id: 'reply',
-                from: 'claude-reviewer',
+                from: send?.args[2],
                 to: 'claude',
                 body: `review-reply: ${requestId}\nGO`,
               }),
@@ -315,8 +347,41 @@ test('main boots when sentinel is absent', async () => {
     '--model',
     'opus',
     '--effort',
-    'xhigh',
+    'low',
   ])
+})
+
+test('main keeps each depth/risk profile aligned across ready, history, spawn, send, and reply', async () => {
+  for (const [argv, reviewer, effort] of [
+    [[], 'claude-reviewer-loop-low', 'low'],
+    [['--depth', 'gate'], 'claude-reviewer-gate-high', 'high'],
+    [['--depth', 'gate', '--risk', 'high'], 'claude-reviewer', 'xhigh'],
+  ]) {
+    const fake = fakeSpawn({ matchingReply: true })
+    const receipts = []
+    const code = await main({
+      argv: [...argv, '--timeout-ms', '10'],
+      spawnImpl: fake.spawnImpl,
+      killImpl: fake.killImpl,
+      exists: () => false,
+      wait: async () => {},
+      writeGateReceipt: (receipt) => receipts.push(receipt),
+      log: () => {},
+      errorLog: () => {},
+    })
+    assert.equal(code, 0)
+    const ready = fake.calls.find((call) => call.executable === 'bash')
+    const history = fake.calls.find((call) => call.executable.endsWith('/api.sh'))
+    const spawn = fake.calls.find((call) => call.executable.endsWith('/spawn.sh'))
+    const send = fake.calls.find((call) => call.executable.endsWith('/send.sh'))
+    assert.equal(ready.args.at(-1), reviewer)
+    assert.equal(history.args[history.args.indexOf('--agent') + 1], reviewer)
+    assert.equal(spawn.args[1], reviewer)
+    assert.equal(spawn.args.at(-1), effort)
+    assert.equal(send.args[2], reviewer)
+    assert.match(send.args[3], /設定: depth=/u)
+    assert.equal(receipts.length, argv.includes('--depth') ? 1 : 0)
+  }
 })
 
 test('main enables monitor before spawn when delivery is off', async () => {
@@ -578,7 +643,7 @@ test('main shows an unmatched reply and counts it at the limit', async () => {
   const fake = fakeSpawn({
     reply: JSON.stringify({
       id: 'stale',
-      from: 'claude-reviewer',
+      from: 'claude-reviewer-loop-low',
       to: 'claude',
       body: 'review-reply: 前のラウンドの依頼 ID\n遅れて届いた返信',
     }),

--- a/scripts/claude-review.test.mjs
+++ b/scripts/claude-review.test.mjs
@@ -83,6 +83,10 @@ test('builds distinct loop and gate requests', () => {
   )
   assert.match(buildRequestBody({ ...common, depth: 'gate' }), /全差分を対象/)
   assert.match(
+    buildRequestBody({ ...common, depth: 'gate' }),
+    /2 行目を GO だけにし、補足は書かない/,
+  )
+  assert.match(
     buildRequestBody({ ...common, depth: 'loop' }),
     /^review-request: abc@/,
   )

--- a/scripts/claude-review.test.mjs
+++ b/scripts/claude-review.test.mjs
@@ -35,6 +35,10 @@ test('rejects invalid arguments', () => {
     /requires/,
   )
   assert.throws(() => parseArgs(['--risk', 'urgent']), /Invalid --risk/)
+  assert.throws(
+    () => parseArgs(['--depth', 'gate', '--target', 'HEAD^..HEAD']),
+    /fixes the target/,
+  )
 })
 
 test('selects the contracted reviewer and effort for each profile', () => {

--- a/scripts/pr-ready.mjs
+++ b/scripts/pr-ready.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
+import { reviewProfile } from './claude-review.mjs'
 
 function output(exec, file, args) {
   return exec(file, args, { encoding: 'utf8' }).trim()
@@ -30,16 +31,17 @@ function currentPullRequests(exec, branch) {
 }
 
 export function validateClaudeGateReceipt(receipt, head) {
+  const profile =
+    receipt?.depth === 'gate' && ['normal', 'high'].includes(receipt.risk)
+      ? reviewProfile(receipt.depth, receipt.risk)
+      : null
   if (
     !receipt ||
     receipt.sha !== head ||
     receipt.depth !== 'gate' ||
     !['normal', 'high'].includes(receipt.risk) ||
-    (receipt.risk === 'normal' &&
-      (receipt.effort !== 'high' ||
-        receipt.reviewer !== 'claude-reviewer-gate-high')) ||
-    (receipt.risk === 'high' &&
-      (receipt.effort !== 'xhigh' || receipt.reviewer !== 'claude-reviewer')) ||
+    receipt.effort !== profile?.effort ||
+    receipt.reviewer !== profile?.reviewer ||
     typeof receipt.requestId !== 'string' ||
     !receipt.requestId.trim()
   )

--- a/scripts/pr-ready.mjs
+++ b/scripts/pr-ready.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
 
 function output(exec, file, args) {
@@ -28,11 +29,52 @@ function currentPullRequests(exec, branch) {
   return rows
 }
 
+export function validateClaudeGateReceipt(receipt, head) {
+  if (
+    !receipt ||
+    receipt.sha !== head ||
+    receipt.depth !== 'gate' ||
+    !['normal', 'high'].includes(receipt.risk) ||
+    (receipt.risk === 'normal' &&
+      (receipt.effort !== 'high' ||
+        receipt.reviewer !== 'claude-reviewer-gate-high')) ||
+    (receipt.risk === 'high' &&
+      (receipt.effort !== 'xhigh' || receipt.reviewer !== 'claude-reviewer')) ||
+    typeof receipt.requestId !== 'string' ||
+    !receipt.requestId.trim()
+  )
+    throw new Error(
+      'Claude gate GO receipt is missing or inconsistent; no write performed',
+    )
+  return receipt
+}
+
+export function readClaudeGateReceipt(exec, head, readFile = readFileSync) {
+  const path = output(exec, 'git', [
+    'rev-parse',
+    '--path-format=absolute',
+    '--git-path',
+    'artifactshare/claude-gate-go.json',
+  ])
+  if (!path)
+    throw new Error('Claude gate GO receipt path is empty; no write performed')
+  let receipt
+  try {
+    receipt = JSON.parse(readFile(path, 'utf8'))
+  } catch (error) {
+    throw new Error(
+      `Claude gate GO receipt is missing or invalid; no write performed: ${error.message}`,
+    )
+  }
+  return validateClaudeGateReceipt(receipt, head)
+}
+
 export function readyPullRequest({
   codexGo,
   claudeGo,
   dryRun = false,
   exec = execFileSync,
+  readGateReceipt = (runner, sha) => readClaudeGateReceipt(runner, sha),
 } = {}) {
   if (!codexGo || !claudeGo)
     throw new Error(
@@ -47,6 +89,7 @@ export function readyPullRequest({
     throw new Error(
       'both reviewer GO values must equal local HEAD; no write performed',
     )
+  readGateReceipt(exec, head)
   const rows = currentPullRequests(exec, branch)
   if (rows.length !== 1)
     throw new Error(

--- a/scripts/pr-ready.test.mjs
+++ b/scripts/pr-ready.test.mjs
@@ -70,10 +70,10 @@ function ready(fake, options = {}) {
  * production code, rather than a fakeExec property. */
 test('readies the only draft PR after both reviewers approve pushed HEAD', () => {
   const fake = fakeExec()
-  assert.deepEqual(
-    ready(fake, { codexGo: head, claudeGo: head }),
-    { number: 32, head },
-  )
+  assert.deepEqual(ready(fake, { codexGo: head, claudeGo: head }), {
+    number: 32,
+    head,
+  })
   assert.deepEqual(fake.calls.at(-1)[0], 'gh')
   assert.deepEqual(fake.calls.at(-1)[1].slice(0, 3), ['pr', 'list', '--state'])
 })
@@ -133,9 +133,7 @@ test('fails closed before writes when local or PR state is unsafe', () => {
     { failQuery: true },
   ]) {
     const fake = fakeExec(options)
-    assert.throws(() =>
-      ready(fake, { codexGo: head, claudeGo: head }),
-    )
+    assert.throws(() => ready(fake, { codexGo: head, claudeGo: head }))
     assert.equal(
       fake.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
       false,
@@ -149,9 +147,7 @@ test('requires both reviewer GO values to equal local HEAD', () => {
     [head, 'b'.repeat(40)],
   ]) {
     const fake = fakeExec()
-    assert.throws(() =>
-      ready(fake, { codexGo, claudeGo }),
-    )
+    assert.throws(() => ready(fake, { codexGo, claudeGo }))
     assert.equal(
       fake.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
       false,

--- a/scripts/pr-ready.test.mjs
+++ b/scripts/pr-ready.test.mjs
@@ -4,9 +4,22 @@ import {
   parseReadyArgs,
   readClaudeGateReceipt,
   readyPullRequest,
+  validateClaudeGateReceipt,
 } from './pr-ready.mjs'
 
 const head = 'a'.repeat(40)
+
+test('accepts the high-risk gate profile', () => {
+  const receipt = {
+    sha: head,
+    depth: 'gate',
+    risk: 'high',
+    effort: 'xhigh',
+    reviewer: 'claude-reviewer',
+    requestId: 'request-id',
+  }
+  assert.equal(validateClaudeGateReceipt(receipt, head), receipt)
+})
 
 function fakeExec({
   dirty = '',

--- a/scripts/pr-ready.test.mjs
+++ b/scripts/pr-ready.test.mjs
@@ -24,7 +24,7 @@ function fakeExec({
   postReadyPrs,
 } = {}) {
   const calls = []
-  let ready = false
+  let isReady = false
   const exec = (file, args) => {
     calls.push([file, args])
     if (file === 'git' && args[0] === 'branch') return 'feature\n'
@@ -32,15 +32,15 @@ function fakeExec({
     if (file === 'git' && args[0] === 'rev-parse') return `${head}\n`
     if (file === 'gh' && args[0] === 'pr' && args[1] === 'list') {
       if (failQuery) throw new Error('offline')
-      if (ready && failPostQuery) throw new Error('confirmation offline')
-      if (ready)
+      if (isReady && failPostQuery) throw new Error('confirmation offline')
+      if (isReady)
         return JSON.stringify(
           postReadyPrs ?? prs.map((pr) => ({ ...pr, isDraft: false })),
         )
       return JSON.stringify(prs)
     }
     if (file === 'gh' && args[0] === 'pr' && args[1] === 'ready') {
-      ready = !args.includes('--undo')
+      isReady = !args.includes('--undo')
       return ''
     }
     throw new Error(`unexpected command: ${file} ${args.join(' ')}`)

--- a/scripts/pr-ready.test.mjs
+++ b/scripts/pr-ready.test.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { parseReadyArgs, readyPullRequest } from './pr-ready.mjs'
+import {
+  parseReadyArgs,
+  readClaudeGateReceipt,
+  readyPullRequest,
+} from './pr-ready.mjs'
 
 const head = 'a'.repeat(40)
 
@@ -44,10 +48,30 @@ function fakeExec({
   return { exec, calls }
 }
 
+function ready(fake, options = {}) {
+  return readyPullRequest({
+    ...options,
+    exec: fake.exec,
+    readGateReceipt: (exec, sha) =>
+      readClaudeGateReceipt(exec, sha, () =>
+        JSON.stringify({
+          sha,
+          depth: 'gate',
+          risk: 'normal',
+          effort: 'high',
+          reviewer: 'claude-reviewer-gate-high',
+          requestId: 'request-id',
+        }),
+      ),
+  })
+}
+
+/* Keep this fixture data separate from exec: receipt validation must remain
+ * production code, rather than a fakeExec property. */
 test('readies the only draft PR after both reviewers approve pushed HEAD', () => {
   const fake = fakeExec()
   assert.deepEqual(
-    readyPullRequest({ codexGo: head, claudeGo: head, exec: fake.exec }),
+    ready(fake, { codexGo: head, claudeGo: head }),
     { number: 32, head },
   )
   assert.deepEqual(fake.calls.at(-1)[0], 'gh')
@@ -67,7 +91,7 @@ test('restores Draft when the remote SHA changes during readying', () => {
     ],
   })
   assert.throws(
-    () => readyPullRequest({ codexGo: head, claudeGo: head, exec: fake.exec }),
+    () => ready(fake, { codexGo: head, claudeGo: head }),
     /restored Draft/,
   )
   assert.deepEqual(fake.calls.at(-1), ['gh', ['pr', 'ready', '32', '--undo']])
@@ -76,7 +100,7 @@ test('restores Draft when the remote SHA changes during readying', () => {
 test('restores Draft when post-ready confirmation fails', () => {
   const fake = fakeExec({ failPostQuery: true })
   assert.throws(
-    () => readyPullRequest({ codexGo: head, claudeGo: head, exec: fake.exec }),
+    () => ready(fake, { codexGo: head, claudeGo: head }),
     /confirmation failed; restored Draft/,
   )
   assert.deepEqual(fake.calls.at(-1), ['gh', ['pr', 'ready', '32', '--undo']])
@@ -110,7 +134,7 @@ test('fails closed before writes when local or PR state is unsafe', () => {
   ]) {
     const fake = fakeExec(options)
     assert.throws(() =>
-      readyPullRequest({ codexGo: head, claudeGo: head, exec: fake.exec }),
+      ready(fake, { codexGo: head, claudeGo: head }),
     )
     assert.equal(
       fake.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
@@ -126,7 +150,7 @@ test('requires both reviewer GO values to equal local HEAD', () => {
   ]) {
     const fake = fakeExec()
     assert.throws(() =>
-      readyPullRequest({ codexGo, claudeGo, exec: fake.exec }),
+      ready(fake, { codexGo, claudeGo }),
     )
     assert.equal(
       fake.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
@@ -152,11 +176,10 @@ test('parses exact ready arguments', () => {
 test('dry-run validates without readying the PR', () => {
   const fake = fakeExec()
   assert.deepEqual(
-    readyPullRequest({
+    ready(fake, {
       codexGo: head,
       claudeGo: head,
       dryRun: true,
-      exec: fake.exec,
     }),
     { number: 32, head, dryRun: true },
   )
@@ -164,4 +187,55 @@ test('dry-run validates without readying the PR', () => {
     fake.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
     false,
   )
+})
+
+test('rejects missing, loop, mismatched, and invalid gate receipts before writing', () => {
+  for (const receipt of [
+    null,
+    '{not json',
+    {
+      sha: head,
+      depth: 'loop',
+      risk: 'normal',
+      effort: 'low',
+      reviewer: 'claude-reviewer-loop-low',
+      requestId: 'id',
+    },
+    {
+      sha: 'b'.repeat(40),
+      depth: 'gate',
+      risk: 'normal',
+      effort: 'high',
+      reviewer: 'claude-reviewer-gate-high',
+      requestId: 'id',
+    },
+    {
+      sha: head,
+      depth: 'gate',
+      risk: 'normal',
+      effort: 'low',
+      reviewer: 'claude-reviewer-loop-low',
+      requestId: 'id',
+    },
+  ]) {
+    const fake = fakeExec()
+    assert.throws(() =>
+      readyPullRequest({
+        codexGo: head,
+        claudeGo: head,
+        exec: fake.exec,
+        readGateReceipt: (exec, sha) =>
+          readClaudeGateReceipt(exec, sha, () => {
+            if (receipt === null) throw new Error('missing')
+            return typeof receipt === 'string'
+              ? receipt
+              : JSON.stringify(receipt)
+          }),
+      }),
+    )
+    assert.equal(
+      fake.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
+      false,
+    )
+  }
 })


### PR DESCRIPTION
## Summary

- tier Claude review effort by review depth and explicit risk classification
- bind gate approval to the exact commit SHA and selected reviewer profile
- require the validated Claude gate receipt before a PR can become ready
- document a ten-PR evaluation period with timing and review-quality measures

## Reviewer behavior

- loop reviews use low effort
- normal-risk gates use high effort
- high-risk gates use xhigh effort
- authentication, authorization, billing, cryptography, data migration, concurrency, and material design changes are always high risk

## Validation

- `pnpm test:scripts` (339 tests)
- focused Claude review and PR-ready tests (41 tests)
- dry runs for loop/normal, gate/normal, and gate/high reviewer selection
- `pnpm validate` (including 97 browser visual tests)
