### PR TITLE
Warn about agent destination mismatch in doctor

### DIFF
--- a/apps/web/app/routes/api.cli.doctor.test.ts
+++ b/apps/web/app/routes/api.cli.doctor.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const requireUserApiWithBearerMiddlewareMock = vi.hoisted(() => vi.fn())
 const requireUserMock = vi.hoisted(() => vi.fn())
+const getCliAuthorityMock = vi.hoisted(() => vi.fn())
 const checkUploadAccessMock = vi.hoisted(() => vi.fn())
 const createDbMock = vi.hoisted(() => vi.fn())
 const logUploadPermissionFailureMock = vi.hoisted(() => vi.fn())
@@ -11,6 +12,7 @@ vi.mock('~/middleware/auth', () => ({
 }))
 vi.mock('~/middleware/context', () => ({
   requireUser: requireUserMock,
+  getCliAuthority: getCliAuthorityMock,
 }))
 vi.mock('~/services/db.server', () => ({
   createDb: createDbMock,
@@ -30,6 +32,7 @@ describe('/api/cli/doctor', () => {
     requireUserApiWithBearerMiddlewareMock.mockReset()
     logUploadPermissionFailureMock.mockReset()
     requireUserMock.mockReset()
+    getCliAuthorityMock.mockReset()
     checkUploadAccessMock.mockReset()
     createDbMock.mockReturnValue({
       destroy: vi.fn().mockResolvedValue(undefined),
@@ -39,6 +42,27 @@ describe('/api/cli/doctor', () => {
       email: 'owner@example.com',
       workspaceId: 'ws1',
       hd: 'example.com',
+    })
+    getCliAuthorityMock.mockReturnValue({ kind: 'unrestricted' })
+  })
+
+  test('reports the project selected by an agent credential', async () => {
+    checkUploadAccessMock.mockResolvedValue({ kind: 'allowed' })
+    getCliAuthorityMock.mockReturnValue({
+      kind: 'agent',
+      projectId: 'prj-agent',
+    })
+
+    const response = await loader({ context: new Map() } as never)
+    const body = (await response.json()) as {
+      auth: {
+        authority: { preset: string; project_id: string | null }
+      }
+    }
+
+    expect(body.auth.authority).toEqual({
+      preset: 'agent',
+      project_id: 'prj-agent',
     })
   })
 

--- a/apps/web/app/routes/api.cli.doctor.tsx
+++ b/apps/web/app/routes/api.cli.doctor.tsx
@@ -1,5 +1,5 @@
 import { requireUserApiWithBearerMiddleware } from '~/middleware/auth'
-import { requireUser } from '~/middleware/context'
+import { getCliAuthority, requireUser } from '~/middleware/context'
 import { logUploadPermissionFailure } from '~/lib/upload-permission.server'
 import { checkUploadAccess } from '~/services/upload-access.server'
 import type { Route } from './+types/api.cli.doctor'
@@ -8,6 +8,7 @@ export const middleware = [requireUserApiWithBearerMiddleware]
 
 export async function loader({ context }: Route.LoaderArgs) {
   const user = requireUser(context)
+  const authority = getCliAuthority(context)
   const permission = await checkUploadAccess(user)
   const payload = {
     user: {
@@ -21,6 +22,13 @@ export async function loader({ context }: Route.LoaderArgs) {
     auth: {
       kind: 'bearer_or_session',
       ok: true,
+      authority:
+        authority?.kind === 'agent'
+          ? {
+              preset: 'agent',
+              project_id: authority.projectId,
+            }
+          : { preset: 'unrestricted', project_id: null },
     },
   } as const
 

--- a/packages/cli/src/command-runners/doctor.ts
+++ b/packages/cli/src/command-runners/doctor.ts
@@ -39,6 +39,11 @@ type DoctorApiData =
   | { kind: 'network_failed'; hint: string }
   | { kind: 'body'; body: ApiBody | null }
 
+type DoctorAuthority = {
+  preset: 'unrestricted' | 'agent'
+  project_id: string | null
+}
+
 function bearerTokenBlocksLogin(data: DoctorData): boolean {
   return (
     data.auth.credential_source === 'env' ||
@@ -63,6 +68,11 @@ function resolveDoctorNextCommand(data: DoctorData): string | null {
     return data.auth.profile
       ? `${LOGIN_COMMAND} --profile ${data.auth.profile}`
       : LOGIN_COMMAND
+  }
+  if (data.destination.ok && data.destination.code === 'agent_scope_mismatch') {
+    return data.destination.approved_project_id && data.auth.profile
+      ? `${CLI_INVOCATION} init --profile ${data.auth.profile} --project-id ${data.destination.approved_project_id} --json`
+      : null
   }
   return null
 }
@@ -201,6 +211,9 @@ export async function runDoctor(
 
   data.auth.ok = body.auth?.ok ?? true
   data.auth.email = body.user?.email ?? null
+  const authority = doctorAuthority(body.auth?.authority)
+  if (authority) data.auth.authority = authority
+  applyAgentDestinationDiagnostic(data, authority)
   data.upload.checked = true
   data.upload.ok = body.upload?.ok ?? false
   if (!data.upload.ok) {
@@ -208,6 +221,49 @@ export async function runDoctor(
     data.upload.hint = uploadBlockedHint(data.upload.code)
   }
   return writeSuccess(command, doctorDataWithNextCommand(data), mode)
+}
+
+function doctorAuthority(value: unknown): DoctorAuthority | null {
+  if (!value || typeof value !== 'object') return null
+  const authority = value as Record<string, unknown>
+  if (
+    authority.preset === 'agent' &&
+    typeof authority.project_id === 'string' &&
+    authority.project_id
+  ) {
+    return { preset: 'agent', project_id: authority.project_id }
+  }
+  if (
+    authority.preset === 'unrestricted' &&
+    (authority.project_id === null || authority.project_id === undefined)
+  ) {
+    return { preset: 'unrestricted', project_id: null }
+  }
+  return null
+}
+
+function applyAgentDestinationDiagnostic(
+  data: DoctorData,
+  authority: DoctorAuthority | null,
+): void {
+  if (
+    authority?.preset !== 'agent' ||
+    !authority.project_id ||
+    !data.destination.ok ||
+    data.destination.project_id === authority.project_id
+  ) {
+    return
+  }
+  data.destination = {
+    ok: true,
+    type: data.destination.type,
+    project_id: data.destination.project_id,
+    approved_project_id: authority.project_id,
+    code: 'agent_scope_mismatch',
+    hint: data.auth.profile
+      ? `The configured default destination is outside this agent credential's approved project. Run ${CLI_INVOCATION} init --profile ${data.auth.profile} --project-id ${authority.project_id} --json to use the approved project by default.`
+      : `The configured default destination is outside this agent credential's approved project. Pass --project-id ${authority.project_id} when sharing.`,
+  }
 }
 
 async function configDiagnostics(

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -94,6 +94,84 @@ test('doctor next_command is null when all checks pass', async () => {
   )
 })
 
+test('doctor warns when an agent profile default is outside its approved project', async () => {
+  const workDir = await mkdtemp(join(tmpdir(), 'artifactshare-doctor-scope-'))
+  const configHome = await mkdtemp(join(tmpdir(), 'artifactshare-doctor-home-'))
+  await mkdir(join(workDir, '.artifactshare'))
+  await writeFile(
+    join(workDir, '.artifactshare/config.local.json'),
+    JSON.stringify({ default_project_id: 'prj-old' }),
+  )
+
+  try {
+    await withServer(
+      (_request, response) => {
+        response.setHeader('content-type', 'application/json')
+        response.end(
+          JSON.stringify({
+            auth: {
+              ok: true,
+              authority: { preset: 'agent', project_id: 'prj-agent' },
+            },
+            user: { email: 'person@example.com' },
+            upload: { ok: true },
+          }),
+        )
+      },
+      async (baseUrl) => {
+        await writeFile(
+          join(configHome, 'config.json'),
+          JSON.stringify({
+            profiles: {
+              agent: { base_url: baseUrl, preset: 'agent' },
+            },
+          }),
+        )
+        await writeFile(
+          join(configHome, 'tokens.json'),
+          JSON.stringify({
+            [`${baseUrl}:agent`]: JSON.stringify({
+              kind: 'api_token',
+              token: 'test-token',
+            }),
+          }),
+        )
+
+        const result = await runAsync(
+          [
+            'doctor',
+            '--profile',
+            'agent',
+            '--allow-plaintext-token-store',
+            '--json',
+          ],
+          {
+            ARTIFACTSHARE_CONFIG_HOME: configHome,
+            ARTIFACTSHARE_DISABLE_NATIVE_TOKEN_STORE: '1',
+          },
+          { cwd: workDir },
+        )
+        const payload = expectSuccess(result, 'doctor')
+        assert.equal(
+          payload.data.destination.code,
+          'agent_scope_mismatch',
+          JSON.stringify(payload.data),
+        )
+        assert.equal(payload.data.destination.project_id, 'prj-old')
+        assert.equal(payload.data.destination.approved_project_id, 'prj-agent')
+        assert.match(payload.data.destination.hint, /prj-old|approved project/)
+        assert.equal(
+          payload.data.next_command,
+          'npx --yes @artifactshare/cli init --profile agent --project-id prj-agent --json',
+        )
+      },
+    )
+  } finally {
+    await rm(workDir, { recursive: true, force: true })
+    await rm(configHome, { recursive: true, force: true })
+  }
+})
+
 test('doctor reports blocked upload without a next_command', async () => {
   await withServer(
     (_request, response) => {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -301,7 +301,13 @@ export type ApiBody = {
   thread?: unknown
   files?: unknown[]
   total_size_bytes?: number
-  auth?: { ok?: boolean }
+  auth?: {
+    ok?: boolean
+    authority?: {
+      preset?: unknown
+      project_id?: unknown
+    }
+  }
   user?: { email?: string | null }
   upload?: { ok?: boolean; code?: unknown }
   status?: string | null
@@ -603,10 +609,21 @@ export type DoctorData = {
     hint?: string
     email?: string | null
     recovery?: AuthRecoveryData
+    authority?: {
+      preset: 'unrestricted' | 'agent'
+      project_id: string | null
+    }
   }
   destination:
     | { ok: false; code: string; hint: string }
-    | { ok: true; type: 'project' | 'home'; project_id: string | null }
+    | {
+        ok: true
+        type: 'project' | 'home'
+        project_id: string | null
+        approved_project_id?: string
+        code?: string
+        hint?: string
+      }
   network: {
     ok: boolean
     code?: string


### PR DESCRIPTION
## Summary

- expose the authenticated CLI authority in the doctor API response
- warn when an agent credential's approved project differs from the configured default destination
- provide an `init` recovery command without changing local configuration automatically

## Validation

- `pnpm validate:cli` (447 tests)
- `pnpm --filter @artifactshare/web exec vitest run app/routes/api.cli.doctor.test.ts`
- CLI and web typechecks
- `pnpm format`
- `pnpm lint`
- `pnpm check:cli-reference`
- `pnpm check:doctor` (100)
- `pnpm public:scan .`
- Codex and Claude implementation reviews (no blockers)
