### PR TITLE
Release Artifact Share CLI 0.11.1

### DIFF
--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "package_version": "0.11.0",
+  "package_version": "0.11.1",
   "commands": [
     {
       "path": "",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,10 @@ For user-facing announcements, see https://artifactshare.com/updates?product=cli
 
 ## Unreleased
 
+## 0.11.1 - 2026-08-12
+
+- Warn in `doctor` when an agent credential's approved project differs from the configured default destination, and provide an `init` command to align them.
+
 ## 0.11.0 - 2026-08-12
 
 - Add `login --preset agent` for browser-approved credentials restricted to one project, with scoped defaults and guidance across login, `whoami`, and `doctor`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artifactshare/cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Upload and share HTML, Markdown, folders, and static sites from terminals, AI agents, automation, and CI.",
   "homepage": "https://artifactshare.com/connect",
   "repository": {


### PR DESCRIPTION
## Summary

- prepare `@artifactshare/cli` 0.11.1
- document the new `doctor` warning for agent destination mismatches
- refresh the generated Web CLI reference version

## Validation

- `pnpm check:cli-release`
- `pnpm check:cli-changelog`
- `pnpm check:cli-reference`
- `pnpm --filter @artifactshare/cli typecheck`
- `pnpm --filter @artifactshare/cli test` (447 tests)
- `pnpm public:scan .`
- Codex and Claude implementation reviews (no blockers)
