### PR TITLE
Run dual reviews in parallel

### DIFF
--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -69,22 +69,30 @@ UI critique is required only for UI changes and supplements code review. Use `pn
 For a specification gate, start both commands concurrently with the same Artifact Share URL and version id. Wait for both to finish before acting on either result:
 
 ```sh
-pnpm review:codex -- --phase spec --artifact-url <url> --version-id <id> & codex_pid=$!
-pnpm review:claude -- --phase spec --artifact-url <url> --version-id <id> & claude_pid=$!
+codex_log=$(mktemp); claude_log=$(mktemp)
+pnpm review:codex -- --phase spec --artifact-url <url> --version-id <id> >"$codex_log" 2>&1 & codex_pid=$!
+pnpm review:claude -- --phase spec --artifact-url <url> --version-id <id> >"$claude_log" 2>&1 & claude_pid=$!
 codex_status=0; wait "$codex_pid" || codex_status=$?
 claude_status=0; wait "$claude_pid" || claude_status=$?
+cat "$codex_log"; cat "$claude_log"
 test "$codex_status" -eq 0 && test "$claude_status" -eq 0
 ```
+
+The final `test` only confirms that both review commands completed successfully. Read both logs and classify every finding; the gate passes only when neither result has an unresolved blocker.
 
 For an implementation gate, start both commands concurrently on the same clean commit. Wait for both to finish before acting on either result:
 
 ```sh
-pnpm review:codex -- --phase implementation & codex_pid=$!
-pnpm review:claude -- --phase implementation & claude_pid=$!
+codex_log=$(mktemp); claude_log=$(mktemp)
+pnpm review:codex -- --phase implementation >"$codex_log" 2>&1 & codex_pid=$!
+pnpm review:claude -- --phase implementation >"$claude_log" 2>&1 & claude_pid=$!
 codex_status=0; wait "$codex_pid" || codex_status=$?
 claude_status=0; wait "$claude_pid" || claude_status=$?
+cat "$codex_log"; cat "$claude_log"
 test "$codex_status" -eq 0 && test "$claude_status" -eq 0
 ```
+
+Again, successful command exit only establishes that both review results are available. Classify the findings from both logs together before deciding whether the implementation gate passes.
 
 Normal session history is the review record and the source for elapsed time, review count, and findings. The repository does not duplicate it in receipts or attempt logs.
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -16,9 +16,9 @@ Typos and explanatory documentation changes need a careful self-review but no se
 
 Write a specification when behavior, requirements, UI states, or acceptance criteria need a design decision before implementation. Routine fixes and contained maintenance may proceed directly when the desired behavior is already clear.
 
-When a specification is required, have Codex and Claude independently deep-review the exact Artifact Share version that will be handed to implementation. Implementation starts only after every finding from both reviewers is classified and neither has an unresolved blocker on that version.
+When a specification is required, start Codex and Claude deep reviews in parallel against the exact Artifact Share version that will be handed to implementation. Let both independent reviews finish before classifying findings or changing the specification. Implementation starts only after every finding from both reviewers is classified and neither has an unresolved blocker on that version.
 
-For an ordinary code, workflow, or normative documentation change, run both Codex and Claude as deep independent reviewers of the exact commit intended for Ready. Their different exploration paths are a permanent part of the gate, not a risk category selected per change.
+For an ordinary code, workflow, or normative documentation change, start Codex and Claude deep reviews in parallel against the exact commit intended for Ready. Let both independent reviews finish before classifying findings or changing the implementation. Their different exploration paths are a permanent part of the gate, not a risk category selected per change.
 
 Classify every review finding by its effect on the current change:
 
@@ -28,7 +28,7 @@ Classify every review finding by its effect on the current change:
 
 The gate passes when neither reviewer has an unresolved blocker on the reviewed target, not when both reviewers report zero findings. There is no fixed review count. A quick `low` review or a single-reviewer pass may help during development but never replaces the dual deep final gate.
 
-Changing the specification after its gate invalidates that gate. Changing the implementation after its gate invalidates that gate. Finish mechanical corrections before the final review; if the version or commit changes afterward, run the deep gate again against the new target. Keep dispositions in the normal task or reviewer session, and summarize the final gate and any follow-ups in the pull request. Do not create receipts, digests, locks, attempt logs, or review-specific push guards.
+Changing the specification after its gate invalidates that gate. Changing the implementation after its gate invalidates that gate. Finish mechanical corrections before the final review; if the version or commit changes afterward, start both deep reviews again in parallel against the new target. Do not stop or restart one reviewer merely because the other finishes first or reports a blocker: wait for both results so one correction pass can address the complete finding set. Keep dispositions in the normal task or reviewer session, and summarize the final gate and any follow-ups in the pull request. Do not create receipts, digests, locks, attempt logs, or review-specific push guards.
 
 ## Choose local validation
 
@@ -46,11 +46,11 @@ Record the commands and results in the pull request. If the affected surface is 
 ## Delivery sequence
 
 1. Confirm the intended behavior and write a specification when design is needed.
-2. If a specification is required, have Codex and Claude deep-review its fixed final version, classify every finding, and repeat both reviews on each new version until no blocker remains.
+2. If a specification is required, start Codex and Claude deep reviews of its fixed final version in parallel, wait for both, classify every finding together, and repeat both reviews in parallel on each new version until no blocker remains.
 3. If UI changes, capture the current state or prepare a static mock and use the UI critique below before implementation.
 4. Implement and commit the complete change.
 5. Run the selected local validation. If validation changes files, commit them and rerun the affected checks. Keep the worktree clean before review or publication.
-6. Have Codex and Claude deep-review the committed Ready candidate, classify every finding, and repeat both reviews on each new commit until the latest commit has no unresolved blocker.
+6. Start Codex and Claude deep reviews of the committed Ready candidate in parallel, wait for both, classify every finding together, and repeat both reviews in parallel on each new commit until the latest commit has no unresolved blocker.
 7. Publish a Draft PR with `pnpm pr:publish -- --body-file <path> --title <title>`. Further fixes use normal commits and pushes; the pre-push boundary guard scans every push.
 8. If UI changed, capture every affected state and repeat UI critique after material visual fixes. Commit any resulting change and return to the implementation gate.
 9. Push the final commit normally and run `pnpm pr:ready`. It verifies the Draft targets `main`, the remote PR head equals local `HEAD`, and required PR checks have succeeded before calling `gh pr ready`.
@@ -66,14 +66,14 @@ UI critique is required only for UI changes and supplements code review. Use `pn
 
 `review:claude` is a thin launcher with a 30-minute limit. Its implementation phase runs Claude Code's built-in `/code-review high` against `origin/main...HEAD`. Its spec phase reads the current Artifact Share version and unresolved comments; the supplied version id prevents review of a stale revision. The default `high` review is the final gate. Use `--level low` only for a quick intermediate pass, never as gate evidence.
 
-For a specification gate, run both commands with the same Artifact Share URL and version id:
+For a specification gate, start both commands concurrently with the same Artifact Share URL and version id. Wait for both to finish before acting on either result:
 
 ```sh
 pnpm review:codex -- --phase spec --artifact-url <url> --version-id <id>
 pnpm review:claude -- --phase spec --artifact-url <url> --version-id <id>
 ```
 
-For an implementation gate, run both commands on the same clean commit:
+For an implementation gate, start both commands concurrently on the same clean commit. Wait for both to finish before acting on either result:
 
 ```sh
 pnpm review:codex -- --phase implementation
@@ -85,6 +85,7 @@ Normal session history is the review record and the source for elapsed time, rev
 ## Safety boundaries
 
 - Use a committed, clean worktree for every review and never review a stale remote branch.
+- Start the Codex and Claude reviews concurrently, but do not run commands that can change HEAD or the worktree until both finish.
 - A specification gate applies to one exact Artifact Share version. Any new version requires new Codex and Claude deep reviews before implementation.
 - An implementation gate applies to one exact commit. Any later commit requires new Codex and Claude deep reviews before Ready.
 - Keep only one open PR in this repository at a time.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -75,6 +75,7 @@ pnpm review:claude -- --phase spec --artifact-url <url> --version-id <id> >"$cla
 codex_status=0; wait "$codex_pid" || codex_status=$?
 claude_status=0; wait "$claude_pid" || claude_status=$?
 cat "$codex_log"; cat "$claude_log"
+rm -f "$codex_log" "$claude_log"
 test "$codex_status" -eq 0 && test "$claude_status" -eq 0
 ```
 
@@ -89,6 +90,7 @@ pnpm review:claude -- --phase implementation >"$claude_log" 2>&1 & claude_pid=$!
 codex_status=0; wait "$codex_pid" || codex_status=$?
 claude_status=0; wait "$claude_pid" || claude_status=$?
 cat "$codex_log"; cat "$claude_log"
+rm -f "$codex_log" "$claude_log"
 test "$codex_status" -eq 0 && test "$claude_status" -eq 0
 ```
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -69,15 +69,21 @@ UI critique is required only for UI changes and supplements code review. Use `pn
 For a specification gate, start both commands concurrently with the same Artifact Share URL and version id. Wait for both to finish before acting on either result:
 
 ```sh
-pnpm review:codex -- --phase spec --artifact-url <url> --version-id <id>
-pnpm review:claude -- --phase spec --artifact-url <url> --version-id <id>
+pnpm review:codex -- --phase spec --artifact-url <url> --version-id <id> & codex_pid=$!
+pnpm review:claude -- --phase spec --artifact-url <url> --version-id <id> & claude_pid=$!
+codex_status=0; wait "$codex_pid" || codex_status=$?
+claude_status=0; wait "$claude_pid" || claude_status=$?
+test "$codex_status" -eq 0 && test "$claude_status" -eq 0
 ```
 
 For an implementation gate, start both commands concurrently on the same clean commit. Wait for both to finish before acting on either result:
 
 ```sh
-pnpm review:codex -- --phase implementation
-pnpm review:claude -- --phase implementation
+pnpm review:codex -- --phase implementation & codex_pid=$!
+pnpm review:claude -- --phase implementation & claude_pid=$!
+codex_status=0; wait "$codex_pid" || codex_status=$?
+claude_status=0; wait "$claude_pid" || claude_status=$?
+test "$codex_status" -eq 0 && test "$claude_status" -eq 0
 ```
 
 Normal session history is the review record and the source for elapsed time, review count, and findings. The repository does not duplicate it in receipts or attempt logs.

--- a/scripts/codex-review.mjs
+++ b/scripts/codex-review.mjs
@@ -132,7 +132,9 @@ function main({
     }
     const result = run('codex', request.args, {
       input: request.input,
-      stdio: request.input ? ['pipe', 'inherit', 'inherit'] : 'inherit',
+      stdio: request.input
+        ? ['pipe', 'inherit', 'inherit']
+        : ['ignore', 'inherit', 'inherit'],
     })
     if (result.error) throw result.error
     if (result.status !== 0) return result.status ?? 1

--- a/scripts/codex-review.test.mjs
+++ b/scripts/codex-review.test.mjs
@@ -115,7 +115,10 @@ test('runs native review and verifies the checkout did not change', () => {
       phase: 'implementation',
     }).args,
   )
-  assert.deepEqual(calls[0][2], { input: undefined, stdio: 'inherit' })
+  assert.deepEqual(calls[0][2], {
+    input: undefined,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  })
 })
 
 test('reads the fixed spec version and runs Codex against the same clean HEAD', () => {


### PR DESCRIPTION
## Summary

- run Codex and Claude specification and implementation reviews concurrently
- wait for both independent results before classifying findings or changing the reviewed artifact
- preserve separate reviewer output and clarify that command success is not the review gate
- make implementation Codex review stdin non-interactive so background execution cannot suspend on terminal input

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm test:scripts` (289 passed)
- `pnpm public:scan .`
- `git diff --check`
- parallel final implementation reviews on `3bbb66ede0c6de6bebe59f783a66a64a1789cfc4`: Codex no findings; Claude Code no findings
