### PR TITLE
Prepare CLI 0.11.2 release

### DIFF
--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "package_version": "0.11.1",
+  "package_version": "0.11.2",
   "commands": [
     {
       "path": "",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ For user-facing announcements, see https://artifactshare.com/updates?product=cli
 
 ## Unreleased
 
+## 0.11.2 - 2026-08-12
+
 - Direct agents with a user present to project-scoped browser login, and reserve API-token guidance for unattended CI or scripts without browser approval.
 
 ## 0.11.1 - 2026-08-12

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artifactshare/cli",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Upload and share HTML, Markdown, folders, and static sites from terminals, AI agents, automation, and CI.",
   "homepage": "https://artifactshare.com/connect",
   "repository": {


### PR DESCRIPTION
## Summary

- prepare `@artifactshare/cli` 0.11.2
- publish the attended-agent scoped-login guidance and structured `agent_login_command`
- synchronize the generated CLI reference version

## Validation

- `pnpm check:cli-release`
- `pnpm check:cli-reference`
- `pnpm public:scan .`
- `git diff --check`
- parallel Codex and Claude Code final reviews on `5294d1cd3cc5d63ce7259068d094e47ce109b9e1`: no findings
