### PR TITLE
fix(web): allow deleting projects pinned by non-live agent CLI credentials

### DIFF
--- a/apps/web/app/components/app/project-manage-dialogs.tsx
+++ b/apps/web/app/components/app/project-manage-dialogs.tsx
@@ -19,7 +19,14 @@ async function postProjectAction(
   projectId: string,
   action: ProjectAction,
 ): Promise<
-  { ok: true } | { ok: false; status: number; code?: string; limit?: number }
+  | { ok: true }
+  | {
+      ok: false
+      status: number
+      code?: string
+      limit?: number
+      holderName?: string
+    }
 > {
   try {
     const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}`, {
@@ -29,15 +36,21 @@ async function postProjectAction(
     })
     if (res.ok) return { ok: true }
     const body = (await res.json().catch(() => null)) as {
-      error?: { code?: string; message?: string }
+      error?: {
+        code?: string
+        message?: string
+        details?: { holder_name?: string | null }
+      }
     } | null
     const code = body?.error?.code
     const limitMatch = body?.error?.message?.match(/\((\d+) projects?\)/)
+    const holderName = body?.error?.details?.holder_name
     return {
       ok: false,
       status: res.status,
       code,
       limit: limitMatch ? Number(limitMatch[1]) : undefined,
+      holderName: typeof holderName === 'string' ? holderName : undefined,
     }
   } catch {
     return { ok: false, status: 0 }
@@ -201,6 +214,14 @@ export function DeleteProjectDialog({
     if (result.ok) {
       toast.success(t('toast.projectDeleted', { name: projectName }))
       onSuccess()
+    } else if (result.code === 'project-has-agent-credentials') {
+      // A live agent CLI credential still targets this project; its holder
+      // must revoke or stop it before the project can be deleted.
+      toast.error(
+        result.holderName
+          ? t('toast.projectHasAgentCredentials', { holder: result.holderName })
+          : t('toast.projectHasAgentCredentialsUnknownHolder'),
+      )
     } else if (result.status === 409) {
       // A file slipped in (or was hidden from this viewer): not actually empty.
       toast.error(t('toast.projectNotEmpty'))

--- a/apps/web/app/i18n/en.json
+++ b/apps/web/app/i18n/en.json
@@ -1044,6 +1044,8 @@
   "toast.projectRestored": "Restored {name}",
   "toast.projectDeleted": "Deleted {name}",
   "toast.projectNotEmpty": "Move its files out first, then delete it.",
+  "toast.projectHasAgentCredentials": "{holder}'s agent CLI credential still targets this project. Ask them to stop or revoke it, then delete the project.",
+  "toast.projectHasAgentCredentialsUnknownHolder": "An agent CLI credential still targets this project. Stop or revoke it, then delete the project.",
   "toast.projectLimitReached": "You've reached your plan's project limit ({limit} projects). Upgrade your plan or archive existing projects.",
   "toast.projectActionFailed": "Could not complete that. Please try again.",
   "projectShareDefaults.title": "Project members",

--- a/apps/web/app/i18n/ja.json
+++ b/apps/web/app/i18n/ja.json
@@ -1044,6 +1044,8 @@
   "toast.projectRestored": "{name} を元に戻しました",
   "toast.projectDeleted": "{name} を削除しました",
   "toast.projectNotEmpty": "先にファイルを移してから削除してください。",
+  "toast.projectHasAgentCredentials": "{holder} さんのエージェント CLI 資格情報がこのプロジェクトを対象にしています。資格情報の停止・失効を行ってから削除してください。",
+  "toast.projectHasAgentCredentialsUnknownHolder": "エージェント CLI 資格情報がこのプロジェクトを対象にしています。資格情報の停止・失効を行ってから削除してください。",
   "toast.projectLimitReached": "プランのプロジェクト上限（{limit} 件）に達しています。プランをアップグレードするか、既存プロジェクトをアーカイブしてください。",
   "toast.projectActionFailed": "処理できませんでした。もう一度お試しください。",
   "projectShareDefaults.title": "プロジェクトの関係者",

--- a/apps/web/app/routes/api.projects.$id.tsx
+++ b/apps/web/app/routes/api.projects.$id.tsx
@@ -50,6 +50,24 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     if (result === 'not-empty') {
       return errorResponse('not-empty', 'Project still has files.', 409)
     }
+    if (typeof result === 'object') {
+      // The holder name is only revealed to callers who may delete the
+      // project (creator or workspace admin), which deleteProjectContainer
+      // has already verified.
+      const holder = result.holderName ?? 'another member'
+      return Response.json(
+        {
+          error: {
+            code: 'project-has-agent-credentials',
+            message: `Agent CLI credentials held by ${holder} still target this project.`,
+            hint: '資格情報の停止・失効を行ってから、もう一度削除してください。',
+            recovery: { kind: 'ask_human' },
+            details: { holder_name: result.holderName },
+          },
+        },
+        { status: 409 },
+      )
+    }
     return Response.json({ ok: true })
   }
 

--- a/apps/web/app/services/cli-authority.server.test.ts
+++ b/apps/web/app/services/cli-authority.server.test.ts
@@ -84,6 +84,20 @@ describe('CLI authority resolution', () => {
       resolveCliAuthorityBySessionToken('ass_test'),
     ).resolves.toBeNull()
   })
+
+  test('fails closed for an agent authority detached from its project', async () => {
+    seedAgentAuthority(sqlite)
+    // Project deletion sets project_id to NULL on non-live agent authorities;
+    // such an authority must not resolve, so it can perform no operation.
+    sqlite
+      .prepare(
+        "UPDATE cli_family_authorities SET project_id = NULL WHERE family_id = 'family-1'",
+      )
+      .run()
+    await expect(
+      resolveCliAuthorityBySessionToken('ass_test'),
+    ).resolves.toBeNull()
+  })
 })
 
 function seedAgentAuthority(sqlite: DatabaseSync) {

--- a/apps/web/app/services/projects-archive.server.test.ts
+++ b/apps/web/app/services/projects-archive.server.test.ts
@@ -217,6 +217,261 @@ describe('deleteProjectContainer', () => {
   })
 })
 
+describe('deleteProjectContainer with agent CLI credentials', () => {
+  let db: Kysely<DB>
+  beforeEach(async () => {
+    ;({ db } = createMigratedInMemoryDb())
+    await seed(db)
+    await db
+      .insertInto('agent_profiles')
+      .values({
+        id: 'agent-1',
+        user_id: OWNER.id,
+        workspace_id: WS,
+        created_at: TS,
+      })
+      .execute()
+  })
+  afterEach(async () => {
+    await db.destroy()
+  })
+
+  const PAST = '2020-01-01T00:00:00.000Z'
+  const FUTURE = '2099-01-01T00:00:00.000Z'
+
+  async function seedFamily(options: {
+    credentialExpiresAt: string
+    revokedAt?: string | null
+    sessionExpiresAt?: string
+  }) {
+    await db
+      .insertInto('cli_family_authorities')
+      .values({
+        family_id: 'family-1',
+        user_id: OWNER.id,
+        preset: 'agent',
+        workspace_id: WS,
+        project_id: 'project-empty',
+        project_name_snapshot: 'project-empty',
+        agent_profile_id: 'agent-1',
+        approved_at: TS,
+        device_name: 'Laptop',
+        status: 'active',
+        created_at: TS,
+        updated_at: TS,
+      })
+      .execute()
+    await db
+      .insertInto('cli_refresh_credentials')
+      .values({
+        id: 'cred-1',
+        user_id: OWNER.id,
+        token_hash: 'hash-1',
+        expires_at: options.credentialExpiresAt,
+        revoked_at: options.revokedAt ?? null,
+        created_at: TS,
+        family_id: 'family-1',
+      })
+      .execute()
+    if (options.sessionExpiresAt) {
+      await db
+        .insertInto('sessions')
+        .values({
+          id: 'sess-1',
+          user_id: OWNER.id,
+          token: 'tok-1',
+          expires_at: options.sessionExpiresAt,
+          created_at: TS,
+          updated_at: TS,
+        })
+        .execute()
+      await db
+        .insertInto('cli_refresh_sessions')
+        .values({
+          session_id: 'sess-1',
+          credential_id: 'cred-1',
+          family_id: 'family-1',
+        })
+        .execute()
+      await db
+        .insertInto('cli_session_authorities')
+        .values({
+          session_id: 'sess-1',
+          family_id: 'family-1',
+          kind: 'family',
+          preset: 'agent',
+          expires_at: null,
+          bearer_only: 1,
+          created_at: TS,
+        })
+        .execute()
+    }
+  }
+
+  async function seedBootstrap(options: {
+    authorityExpiresAt: string
+    sessionExpiresAt: string
+  }) {
+    await db
+      .insertInto('sessions')
+      .values({
+        id: 'sess-boot',
+        user_id: OWNER.id,
+        token: 'tok-boot',
+        expires_at: options.sessionExpiresAt,
+        created_at: TS,
+        updated_at: TS,
+      })
+      .execute()
+    await db
+      .insertInto('cli_session_authorities')
+      .values({
+        session_id: 'sess-boot',
+        family_id: null,
+        kind: 'bootstrap',
+        preset: 'agent',
+        workspace_id: WS,
+        project_id: 'project-empty',
+        agent_profile_id: 'agent-1',
+        expires_at: options.authorityExpiresAt,
+        bearer_only: 1,
+        created_at: TS,
+      })
+      .execute()
+  }
+
+  test('an expired credential with no live session no longer blocks deletion', async () => {
+    await seedFamily({ credentialExpiresAt: PAST })
+    const result = await deleteProjectContainer(
+      db,
+      WS,
+      'project-empty',
+      OWNER.id,
+    )
+    expect(result).toBe('ok')
+    expect(await containerExists(db, 'project-empty')).toBe(false)
+    // The authority row survives detached, keeping its name snapshot.
+    const family = await db
+      .selectFrom('cli_family_authorities')
+      .select(['project_id', 'project_name_snapshot'])
+      .where('family_id', '=', 'family-1')
+      .executeTakeFirstOrThrow()
+    expect(family.project_id).toBeNull()
+    expect(family.project_name_snapshot).toBe('project-empty')
+  })
+
+  test('a revoked credential with no live session no longer blocks deletion', async () => {
+    await seedFamily({ credentialExpiresAt: FUTURE, revokedAt: TS })
+    const result = await deleteProjectContainer(
+      db,
+      WS,
+      'project-empty',
+      OWNER.id,
+    )
+    expect(result).toBe('ok')
+    expect(await containerExists(db, 'project-empty')).toBe(false)
+  })
+
+  test('an expired credential with a live linked session blocks deletion', async () => {
+    await seedFamily({ credentialExpiresAt: PAST, sessionExpiresAt: FUTURE })
+    const result = await deleteProjectContainer(
+      db,
+      WS,
+      'project-empty',
+      OWNER.id,
+    )
+    expect(result).toEqual({
+      kind: 'has-agent-credentials',
+      holderName: OWNER.id,
+    })
+    expect(await containerExists(db, 'project-empty')).toBe(true)
+  })
+
+  test('a live credential blocks deletion with the holder name', async () => {
+    await seedFamily({ credentialExpiresAt: FUTURE })
+    const result = await deleteProjectContainer(
+      db,
+      WS,
+      'project-empty',
+      OWNER.id,
+    )
+    expect(result).toEqual({
+      kind: 'has-agent-credentials',
+      holderName: OWNER.id,
+    })
+    expect(await containerExists(db, 'project-empty')).toBe(true)
+  })
+
+  test('an unexpired bootstrap authority on an expired session no longer blocks deletion', async () => {
+    await seedBootstrap({ authorityExpiresAt: FUTURE, sessionExpiresAt: PAST })
+    const result = await deleteProjectContainer(
+      db,
+      WS,
+      'project-empty',
+      OWNER.id,
+    )
+    expect(result).toBe('ok')
+    expect(await containerExists(db, 'project-empty')).toBe(false)
+    const authority = await db
+      .selectFrom('cli_session_authorities')
+      .select('project_id')
+      .where('session_id', '=', 'sess-boot')
+      .executeTakeFirstOrThrow()
+    expect(authority.project_id).toBeNull()
+  })
+
+  test('a live bootstrap authority blocks deletion', async () => {
+    await seedBootstrap({
+      authorityExpiresAt: FUTURE,
+      sessionExpiresAt: FUTURE,
+    })
+    const result = await deleteProjectContainer(
+      db,
+      WS,
+      'project-empty',
+      OWNER.id,
+    )
+    expect(result).toEqual({
+      kind: 'has-agent-credentials',
+      holderName: OWNER.id,
+    })
+    expect(await containerExists(db, 'project-empty')).toBe(true)
+  })
+
+  test('a not-empty project reports not-empty even when credentials also block', async () => {
+    await db
+      .insertInto('cli_family_authorities')
+      .values({
+        family_id: 'family-a',
+        user_id: OWNER.id,
+        preset: 'agent',
+        workspace_id: WS,
+        project_id: 'project-a',
+        project_name_snapshot: 'project-a',
+        agent_profile_id: 'agent-1',
+        approved_at: TS,
+        device_name: 'Laptop',
+        status: 'active',
+        created_at: TS,
+        updated_at: TS,
+      })
+      .execute()
+    await db
+      .insertInto('cli_refresh_credentials')
+      .values({
+        id: 'cred-a',
+        user_id: OWNER.id,
+        token_hash: 'hash-a',
+        expires_at: FUTURE,
+        created_at: TS,
+        family_id: 'family-a',
+      })
+      .execute()
+    const result = await deleteProjectContainer(db, WS, 'project-a', OWNER.id)
+    expect(result).toBe('not-empty')
+  })
+})
+
 describe('listArchivedWorkspaceProjects', () => {
   let db: Kysely<DB>
   beforeEach(async () => {

--- a/apps/web/app/services/projects.server.ts
+++ b/apps/web/app/services/projects.server.ts
@@ -1103,7 +1103,12 @@ export type ProjectArchiveResult = 'ok' | 'not-found' | 'forbidden'
 export type ProjectUnarchiveResult =
   | ProjectArchiveResult
   | { kind: 'project-limit-reached'; limit: number }
-export type ProjectDeleteResult = 'ok' | 'not-found' | 'forbidden' | 'not-empty'
+export type ProjectDeleteResult =
+  | 'ok'
+  | 'not-found'
+  | 'forbidden'
+  | 'not-empty'
+  | { kind: 'has-agent-credentials'; holderName: string | null }
 
 export type EditProjectContainerSettingsInput = {
   name?: string | undefined
@@ -1341,6 +1346,118 @@ function isContainerNotEmptyTriggerError(error: unknown): boolean {
   )
 }
 
+// cli_family_authorities.project_id and cli_session_authorities.project_id
+// reference artifact_containers ON DELETE RESTRICT, so a lingering agent
+// credential row blocks project deletion at the FK level.
+function isForeignKeyConstraintError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return String(error).includes('FOREIGN KEY constraint failed')
+  }
+  // D1 can wrap the SQLite text so it only appears on error.cause.
+  return (
+    error.message.includes('FOREIGN KEY constraint failed') ||
+    (error.cause instanceof Error &&
+      error.cause.message.includes('FOREIGN KEY constraint failed'))
+  )
+}
+
+// A family is live when it still has a usable credential or a linked live
+// session — the same predicate listCliRefreshCredentialFamilies applies.
+// Everything else (expired, revoked, sessionless) is non-live and must not
+// keep a project undeletable.
+const liveFamilySql = (now: string) => sql<number>`
+  EXISTS (
+    SELECT 1 FROM cli_refresh_credentials AS credential
+    WHERE credential.family_id = fa.family_id
+      AND credential.revoked_at IS NULL
+      AND credential.expires_at > ${now}
+  )
+  OR EXISTS (
+    SELECT 1 FROM cli_refresh_sessions AS link
+    JOIN sessions ON sessions.id = link.session_id
+    WHERE link.family_id = fa.family_id
+      AND sessions.expires_at > ${now}
+  )
+`
+
+// Name of a user whose LIVE agent credential (family or bootstrap) still
+// targets the project, or null when none does. Callers are already authorized
+// to delete the project, so returning the holder name does not widen access.
+async function findLiveAgentCredentialHolder(
+  db: Kysely<DB>,
+  projectId: string,
+  now: string,
+): Promise<{ found: boolean; holderName: string | null }> {
+  const family = await sql<{ name: string | null }>`
+    SELECT users.name AS name
+    FROM cli_family_authorities AS fa
+    JOIN users ON users.id = fa.user_id
+    WHERE fa.project_id = ${projectId}
+      AND (${liveFamilySql(now)})
+    LIMIT 1
+  `.execute(db)
+  if (family.rows.length > 0) {
+    return { found: true, holderName: family.rows[0]?.name ?? null }
+  }
+  const bootstrap = await sql<{ name: string | null }>`
+    SELECT users.name AS name
+    FROM cli_session_authorities AS sa
+    JOIN sessions ON sessions.id = sa.session_id
+    JOIN users ON users.id = sessions.user_id
+    WHERE sa.project_id = ${projectId}
+      AND sa.family_id IS NULL
+      AND sa.expires_at > ${now}
+      AND sessions.expires_at > ${now}
+    LIMIT 1
+  `.execute(db)
+  if (bootstrap.rows.length > 0) {
+    return { found: true, holderName: bootstrap.rows[0]?.name ?? null }
+  }
+  return { found: false, holderName: null }
+}
+
+// Detach non-live agent credential rows from the project so the FK RESTRICT
+// no longer blocks the delete. project_name_snapshot is kept so credential
+// listings can still show what the credential used to target.
+async function detachNonLiveAgentCredentials(
+  db: Kysely<DB>,
+  projectId: string,
+  now: string,
+): Promise<void> {
+  await sql`
+    UPDATE cli_family_authorities
+    SET project_id = NULL
+    WHERE project_id = ${projectId}
+      AND NOT EXISTS (
+        SELECT 1 FROM cli_family_authorities AS fa
+        WHERE fa.family_id = cli_family_authorities.family_id
+          AND (${liveFamilySql(now)})
+      )
+  `.execute(db)
+  await sql`
+    UPDATE cli_session_authorities
+    SET project_id = NULL
+    WHERE project_id = ${projectId}
+      AND NOT (
+        family_id IS NULL
+        AND expires_at > ${now}
+        AND EXISTS (
+          SELECT 1 FROM sessions
+          WHERE sessions.id = cli_session_authorities.session_id
+            AND sessions.expires_at > ${now}
+        )
+      )
+      AND NOT (
+        family_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM cli_family_authorities AS fa
+          WHERE fa.family_id = cli_session_authorities.family_id
+            AND (${liveFamilySql(now)})
+        )
+      )
+  `.execute(db)
+}
+
 export async function deleteProjectContainer(
   db: Kysely<DB>,
   workspaceId: string,
@@ -1368,6 +1485,18 @@ export async function deleteProjectContainer(
     .executeTakeFirst()
   if (occupant) return 'not-empty'
 
+  // Agent CLI credentials reference the project with ON DELETE RESTRICT. A
+  // live credential blocks deletion with a typed error; non-live ones are
+  // detached (project_id set to NULL) so they stop pinning the project. The
+  // detach commits even when the later DELETE fails — accepted, since the
+  // snapshot name is retained and a non-live credential cannot act anyway.
+  const now = nowIso()
+  const live = await findLiveAgentCredentialHolder(db, projectId, now)
+  if (live.found) {
+    return { kind: 'has-agent-credentials', holderName: live.holderName }
+  }
+  await detachNonLiveAgentCredentials(db, projectId, now)
+
   // project_share_defaults rows cascade with the container row.
   try {
     const result = await db
@@ -1381,6 +1510,12 @@ export async function deleteProjectContainer(
   } catch (error) {
     // A shareable inserted or moved in after the check above trips the trigger.
     if (isContainerNotEmptyTriggerError(error)) return 'not-empty'
+    // A credential created or rotated between the detach above and the DELETE
+    // trips the FK RESTRICT; report it the same way as a live credential.
+    if (isForeignKeyConstraintError(error)) {
+      const raced = await findLiveAgentCredentialHolder(db, projectId, nowIso())
+      return { kind: 'has-agent-credentials', holderName: raced.holderName }
+    }
     throw error
   }
 }

--- a/apps/web/app/test/migrations.test.ts
+++ b/apps/web/app/test/migrations.test.ts
@@ -238,6 +238,164 @@ describe('database migrations', () => {
     })
   })
 
+  test('0082 relaxes the agent project CHECK and keeps session authorities linked', () => {
+    sqlite = new DatabaseSync(':memory:')
+    sqlite.exec('PRAGMA foreign_keys = ON')
+    const migrations = loadMigrations()
+    for (const migration of migrations) {
+      if (migration.name === '0082_relax_agent_authority_project_check.sql') {
+        break
+      }
+      sqlite.exec(migration.sql)
+    }
+    sqlite.exec(`
+      INSERT INTO workspaces (id, name, created_at)
+      VALUES ('w1', 'W1', '2026-01-01');
+      INSERT INTO users (
+        id, email, email_verified, name, created_at, updated_at,
+        workspace_id, google_sub
+      ) VALUES (
+        'u1', 'u1@example.com', 1, 'U1', '2026-01-01', '2026-01-01',
+        'w1', 'sub1'
+      );
+      INSERT INTO artifact_containers (
+        id, workspace_id, kind, owner_user_id, created_by_id, name,
+        created_at, updated_at
+      ) VALUES ('p1', 'w1', 'project', 'u1', 'u1', 'P1',
+        '2026-01-01', '2026-01-01');
+      INSERT INTO agent_profiles (id, user_id, workspace_id, created_at)
+      VALUES ('agent-1', 'u1', 'w1', '2026-01-01');
+      INSERT INTO cli_family_authorities (
+        family_id, user_id, preset, workspace_id, project_id,
+        project_name_snapshot, agent_profile_id, approved_at, device_name,
+        status, created_at, updated_at
+      ) VALUES ('family-1', 'u1', 'agent', 'w1', 'p1', 'P1', 'agent-1',
+        '2026-01-01', 'Laptop', 'active', '2026-01-01', '2026-01-01');
+      INSERT INTO sessions (
+        id, user_id, token, expires_at, created_at, updated_at
+      ) VALUES
+        ('s1', 'u1', 'tok1', '2099-01-01', '2026-01-01', '2026-01-01'),
+        ('s2', 'u1', 'tok2', '2099-01-01', '2026-01-01', '2026-01-01');
+      INSERT INTO cli_session_authorities (
+        session_id, family_id, kind, preset, workspace_id, project_id,
+        agent_profile_id, expires_at, bearer_only, created_at
+      ) VALUES
+        ('s1', 'family-1', 'family', 'agent', NULL, NULL,
+          NULL, NULL, 1, '2026-01-01'),
+        ('s2', NULL, 'bootstrap', 'agent', 'w1', 'p1',
+          'agent-1', '2099-01-01', 1, '2026-01-01');
+    `)
+
+    sqlite.exec(
+      migrations.find(
+        (m) => m.name === '0082_relax_agent_authority_project_check.sql',
+      )!.sql,
+    )
+
+    // Family rows and the CASCADE child rows survive the rebuild unchanged.
+    expect(
+      sqlite
+        .prepare(
+          `SELECT family_id, preset, workspace_id, project_id,
+                  project_name_snapshot, agent_profile_id, status
+             FROM cli_family_authorities`,
+        )
+        .get(),
+    ).toEqual({
+      family_id: 'family-1',
+      preset: 'agent',
+      workspace_id: 'w1',
+      project_id: 'p1',
+      project_name_snapshot: 'P1',
+      agent_profile_id: 'agent-1',
+      status: 'active',
+    })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT session_id, family_id, kind, preset, workspace_id,
+                  project_id, agent_profile_id, expires_at, bearer_only,
+                  created_at
+             FROM cli_session_authorities
+            ORDER BY session_id`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        session_id: 's1',
+        family_id: 'family-1',
+        kind: 'family',
+        preset: 'agent',
+        workspace_id: null,
+        project_id: null,
+        agent_profile_id: null,
+        expires_at: null,
+        bearer_only: 1,
+        created_at: '2026-01-01',
+      },
+      {
+        session_id: 's2',
+        family_id: null,
+        kind: 'bootstrap',
+        preset: 'agent',
+        workspace_id: 'w1',
+        project_id: 'p1',
+        agent_profile_id: 'agent-1',
+        expires_at: '2099-01-01',
+        bearer_only: 1,
+        created_at: '2026-01-01',
+      },
+    ])
+    // No temp or guard table survives the migration.
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS n FROM sqlite_master
+            WHERE name LIKE '%_tmp' OR name LIKE '_migration_0082%'`,
+        )
+        .get(),
+    ).toEqual({ n: 0 })
+
+    // The relaxed CHECK accepts an agent authority without project_id, so
+    // project deletion can detach non-live families in place.
+    sqlite
+      .prepare(
+        "UPDATE cli_family_authorities SET project_id = NULL WHERE family_id = 'family-1'",
+      )
+      .run()
+    sqlite.exec(`
+      INSERT INTO cli_family_authorities (
+        family_id, user_id, preset, workspace_id, project_id,
+        project_name_snapshot, agent_profile_id, approved_at, device_name,
+        status, created_at, updated_at
+      ) VALUES ('family-2', 'u1', 'agent', 'w1', NULL, 'P1', 'agent-1',
+        '2026-01-01', 'Laptop', 'active', '2026-01-01', '2026-01-01');
+    `)
+
+    // Agent authorities still require workspace and agent profile.
+    const rebuilt = sqlite
+    expect(() =>
+      rebuilt.exec(`
+        INSERT INTO cli_family_authorities (
+          family_id, user_id, preset, workspace_id, project_id,
+          project_name_snapshot, agent_profile_id, approved_at, device_name,
+          status, created_at, updated_at
+        ) VALUES ('family-3', 'u1', 'agent', NULL, NULL, NULL, NULL,
+          NULL, NULL, 'active', '2026-01-01', '2026-01-01');
+      `),
+    ).toThrow(/CHECK/)
+
+    // The FK cascade onto the rebuilt table still works.
+    sqlite
+      .prepare(
+        "DELETE FROM cli_family_authorities WHERE family_id = 'family-1'",
+      )
+      .run()
+    expect(
+      sqlite.prepare('SELECT session_id FROM cli_session_authorities').all(),
+    ).toEqual([{ session_id: 's2' }])
+  })
+
   test('0070 backfills artifact, version, and comment events deterministically', () => {
     sqlite = new DatabaseSync(':memory:')
     sqlite.exec('PRAGMA foreign_keys = ON')

--- a/apps/web/check-migrations.mjs
+++ b/apps/web/check-migrations.mjs
@@ -119,6 +119,19 @@ const allowedLegacyDrops = new Map([
   ],
   ['0062_remove_upload_suspension.sql', ['workspace_members_legacy']],
   ['0063_workspace_owner_role.sql', ['workspace_members_legacy']],
+  // Dependency-ordered rebuild to relax the agent-preset CHECK; both tables
+  // are copied to temp tables first, and guard tables assert row counts and
+  // child-row linkage survived.
+  [
+    '0082_relax_agent_authority_project_check.sql',
+    [
+      'cli_family_authorities',
+      'cli_family_authorities_tmp',
+      'cli_session_authorities',
+      'cli_session_authorities_tmp',
+      '_migration_0082_guard',
+    ],
+  ],
 ])
 
 const identifierPattern =

--- a/apps/web/db/migrations/0082_relax_agent_authority_project_check.sql
+++ b/apps/web/db/migrations/0082_relax_agent_authority_project_check.sql
@@ -1,0 +1,158 @@
+-- Migration: 0082_relax_agent_authority_project_check
+-- Created: 2026-08-13
+-- Description: Allow cli_family_authorities.project_id to be NULL for agent
+-- presets. project_id REFERENCES artifact_containers ON DELETE RESTRICT, so a
+-- project targeted by an agent credential could never be deleted — even after
+-- the credential expired or was revoked. Project deletion now detaches the
+-- project from non-live agent authorities by setting project_id to NULL, which
+-- the old composite CHECK forbade. SQLite cannot alter a CHECK constraint in
+-- place, so the table is rebuilt.
+--
+-- D1 ignores `PRAGMA foreign_keys = OFF`, and `PRAGMA defer_foreign_keys`
+-- still fires cascade actions, so dropping cli_family_authorities while
+-- cli_session_authorities rows still reference it (family_id ON DELETE
+-- CASCADE) would silently delete every child row. The rebuild therefore runs
+-- in dependency order with foreign keys fully enforced: copy both tables to
+-- FK-free temp tables, drop the child first, then the parent, recreate both,
+-- and reinsert from the copies. Guards abort the migration if either table's
+-- row count changed or a child row lost its family linkage.
+
+CREATE TABLE cli_family_authorities_tmp (
+  family_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  preset TEXT NOT NULL,
+  workspace_id TEXT,
+  project_id TEXT,
+  project_name_snapshot TEXT,
+  agent_profile_id TEXT,
+  approved_at TEXT,
+  device_name TEXT,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+INSERT INTO cli_family_authorities_tmp (
+  family_id, user_id, preset, workspace_id, project_id,
+  project_name_snapshot, agent_profile_id, approved_at, device_name,
+  status, created_at, updated_at
+)
+SELECT
+  family_id, user_id, preset, workspace_id, project_id,
+  project_name_snapshot, agent_profile_id, approved_at, device_name,
+  status, created_at, updated_at
+FROM cli_family_authorities;
+
+CREATE TABLE cli_session_authorities_tmp (
+  session_id TEXT PRIMARY KEY,
+  family_id TEXT,
+  kind TEXT NOT NULL,
+  preset TEXT NOT NULL,
+  workspace_id TEXT,
+  project_id TEXT,
+  agent_profile_id TEXT,
+  expires_at TEXT,
+  bearer_only INTEGER NOT NULL,
+  created_at TEXT NOT NULL
+);
+INSERT INTO cli_session_authorities_tmp (
+  session_id, family_id, kind, preset, workspace_id, project_id,
+  agent_profile_id, expires_at, bearer_only, created_at
+)
+SELECT
+  session_id, family_id, kind, preset, workspace_id, project_id,
+  agent_profile_id, expires_at, bearer_only, created_at
+FROM cli_session_authorities;
+
+-- Child first: dropping it triggers no cascade. Only then is the parent free
+-- of referencing rows and safe to drop.
+DROP TABLE cli_session_authorities;
+DROP TABLE cli_family_authorities;
+
+CREATE TABLE cli_family_authorities (
+  family_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  preset TEXT NOT NULL CHECK (preset IN ('unrestricted', 'agent')),
+  workspace_id TEXT REFERENCES workspaces(id) ON DELETE RESTRICT,
+  project_id TEXT REFERENCES artifact_containers(id) ON DELETE RESTRICT,
+  project_name_snapshot TEXT,
+  agent_profile_id TEXT REFERENCES agent_profiles(id) ON DELETE RESTRICT,
+  approved_at TEXT,
+  device_name TEXT,
+  status TEXT NOT NULL CHECK (status IN ('active', 'revoked', 'superseded')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  CHECK (
+    (preset = 'unrestricted' AND workspace_id IS NULL AND project_id IS NULL AND agent_profile_id IS NULL)
+    OR
+    (preset = 'agent' AND workspace_id IS NOT NULL AND agent_profile_id IS NOT NULL)
+  )
+);
+INSERT INTO cli_family_authorities (
+  family_id, user_id, preset, workspace_id, project_id,
+  project_name_snapshot, agent_profile_id, approved_at, device_name,
+  status, created_at, updated_at
+)
+SELECT
+  family_id, user_id, preset, workspace_id, project_id,
+  project_name_snapshot, agent_profile_id, approved_at, device_name,
+  status, created_at, updated_at
+FROM cli_family_authorities_tmp;
+CREATE INDEX cli_family_authorities_user_id ON cli_family_authorities(user_id);
+CREATE INDEX cli_family_authorities_agent_profile_id ON cli_family_authorities(agent_profile_id);
+
+CREATE TABLE cli_session_authorities (
+  session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+  family_id TEXT REFERENCES cli_family_authorities(family_id) ON DELETE CASCADE,
+  kind TEXT NOT NULL CHECK (kind IN ('bootstrap', 'family')),
+  preset TEXT NOT NULL CHECK (preset IN ('unrestricted', 'agent')),
+  workspace_id TEXT REFERENCES workspaces(id) ON DELETE RESTRICT,
+  project_id TEXT REFERENCES artifact_containers(id) ON DELETE RESTRICT,
+  agent_profile_id TEXT REFERENCES agent_profiles(id) ON DELETE RESTRICT,
+  expires_at TEXT,
+  bearer_only INTEGER NOT NULL DEFAULT 1 CHECK (bearer_only IN (0, 1)),
+  created_at TEXT NOT NULL,
+  CHECK (
+    (kind = 'bootstrap' AND family_id IS NULL AND expires_at IS NOT NULL)
+    OR
+    (kind = 'family' AND family_id IS NOT NULL AND expires_at IS NULL)
+  )
+);
+INSERT INTO cli_session_authorities (
+  session_id, family_id, kind, preset, workspace_id, project_id,
+  agent_profile_id, expires_at, bearer_only, created_at
+)
+SELECT
+  session_id, family_id, kind, preset, workspace_id, project_id,
+  agent_profile_id, expires_at, bearer_only, created_at
+FROM cli_session_authorities_tmp;
+CREATE INDEX cli_session_authorities_family_id ON cli_session_authorities(family_id);
+
+-- Post-rebuild guards: both tables must keep their exact row counts, and every
+-- family-kind session authority must still link to a surviving family row. A
+-- violation inserts 0 into a CHECK (ok = 1) column and aborts the migration.
+CREATE TABLE _migration_0082_guard (ok INTEGER NOT NULL CHECK (ok = 1));
+INSERT INTO _migration_0082_guard (ok)
+SELECT CASE
+  WHEN (SELECT COUNT(*) FROM cli_family_authorities)
+       = (SELECT COUNT(*) FROM cli_family_authorities_tmp)
+  THEN 1 ELSE 0 END;
+INSERT INTO _migration_0082_guard (ok)
+SELECT CASE
+  WHEN (SELECT COUNT(*) FROM cli_session_authorities)
+       = (SELECT COUNT(*) FROM cli_session_authorities_tmp)
+  THEN 1 ELSE 0 END;
+INSERT INTO _migration_0082_guard (ok)
+SELECT CASE
+  WHEN (
+    SELECT COUNT(*)
+    FROM cli_session_authorities sa
+    WHERE sa.family_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM cli_family_authorities fa
+        WHERE fa.family_id = sa.family_id
+      )
+  ) = 0 THEN 1 ELSE 0 END;
+DROP TABLE _migration_0082_guard;
+
+DROP TABLE cli_family_authorities_tmp;
+DROP TABLE cli_session_authorities_tmp;

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -326,7 +326,9 @@ CREATE TABLE cli_family_authorities (
   status TEXT NOT NULL CHECK (status IN ('active', 'revoked', 'superseded')),
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
-  CHECK ((preset = 'unrestricted' AND workspace_id IS NULL AND project_id IS NULL AND agent_profile_id IS NULL) OR (preset = 'agent' AND workspace_id IS NOT NULL AND project_id IS NOT NULL AND agent_profile_id IS NOT NULL))
+  -- project_id may be NULL for agent presets: project deletion detaches
+  -- non-live agent authorities from the project (project_name_snapshot stays).
+  CHECK ((preset = 'unrestricted' AND workspace_id IS NULL AND project_id IS NULL AND agent_profile_id IS NULL) OR (preset = 'agent' AND workspace_id IS NOT NULL AND agent_profile_id IS NOT NULL))
 );
 CREATE INDEX cli_family_authorities_user_id ON cli_family_authorities(user_id);
 CREATE INDEX cli_family_authorities_agent_profile_id ON cli_family_authorities(agent_profile_id);


### PR DESCRIPTION
## Summary

- allow deleting projects that are pinned only by non-live agent CLI credentials: migration `0082` rebuilds `cli_family_authorities` with a relaxed agent CHECK (`project_id` optional) using a D1-safe child-first drop/reinsert with row-count and linkage guards
- `deleteProjectContainer` detaches `project_id` (snapshot name retained) from non-live family and session authorities before the delete; the not-empty check keeps precedence
- projects still targeted by a live agent credential (unrevoked+unexpired credential, live linked session, or live bootstrap) return a typed `409 project-has-agent-credentials` naming the holder instead of a 500, including on the FK race between detach and delete (`error.cause` covered)
- the project delete dialog shows a dedicated toast for the new error code (en/ja) instead of the misleading "not empty" message
- resolver behavior for detached agent authorities is unchanged (fails closed) and now covered by a regression test

## Validation

- `pnpm format`, `pnpm lint`, `pnpm --filter @artifactshare/web typecheck`
- `pnpm check:migrations`, `pnpm check:schema`
- `pnpm --filter @artifactshare/web test:unit` (265 files, 2706 passed / 1 skipped)
- `pnpm public:scan .` (0 findings)
- parallel Codex and Claude Code final reviews on `6c756d680be4`: no actionable findings (one non-blocking note recorded: the 409 body's `hint` locale/shape on a cookie-only route)
