### PR TITLE
feat(web): add selective TanStack syntax highlighting

### DIFF
--- a/apps/web/app/lib/tanstack-highlight.server.test.ts
+++ b/apps/web/app/lib/tanstack-highlight.server.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  highlightTanStackCode,
+  normalizeTanStackLanguage,
+  TANSTACK_HIGHLIGHT_ALIASES,
+  TANSTACK_HIGHLIGHT_LANGUAGES,
+} from './tanstack-highlight.server'
+
+const INITIAL_LANGUAGES = [
+  'css',
+  'diff',
+  'dockerfile',
+  'html',
+  'js',
+  'json',
+  'jsx',
+  'markdown',
+  'python',
+  'shell',
+  'sql',
+  'toml',
+  'ts',
+  'tsx',
+  'yaml',
+]
+
+const INITIAL_ALIASES = {
+  'angular-html': 'html',
+  'angular-ts': 'ts',
+  bash: 'shell',
+  cjs: 'js',
+  cmd: 'shell',
+  console: 'shell',
+  docker: 'dockerfile',
+  htm: 'html',
+  javascript: 'js',
+  'js-vue': 'js',
+  json5: 'json',
+  jsonc: 'json',
+  md: 'markdown',
+  mjs: 'js',
+  patch: 'diff',
+  py: 'python',
+  sh: 'shell',
+  typescript: 'ts',
+  xml: 'html',
+  yml: 'yaml',
+  zsh: 'shell',
+}
+
+describe('TanStack syntax highlighting registry', () => {
+  test('registers the explicit initial language set', () => {
+    expect(TANSTACK_HIGHLIGHT_LANGUAGES).toEqual(INITIAL_LANGUAGES)
+    expect(TANSTACK_HIGHLIGHT_ALIASES).toEqual(INITIAL_ALIASES)
+  })
+
+  test.each(Object.entries(INITIAL_ALIASES))(
+    'normalizes the %s alias to %s',
+    (alias, expected) => {
+      expect(TANSTACK_HIGHLIGHT_ALIASES[alias]).toBe(expected)
+      expect(normalizeTanStackLanguage(alias)).toBe(expected)
+    },
+  )
+
+  test.each(INITIAL_LANGUAGES)(
+    'preserves the complete source while highlighting %s',
+    (language) => {
+      const source = 'const value = "<artifact>"\n'
+      const result = highlightTanStackCode(source, language)
+
+      expect(result.lang).toBe(language)
+      expect(result.tokens.map((token) => token.value).join('')).toBe(source)
+      expect(result.html).toContain(`data-language="${language}"`)
+    },
+  )
+
+  test.each([undefined, '', 'ruby', 'unknown-language'])(
+    'falls back from %s to readable plaintext',
+    (language) => {
+      const source = '<script>alert("still text")</script>'
+      const result = highlightTanStackCode(source, language)
+
+      expect(result.lang).toBe('plaintext')
+      expect(result.tokens).toEqual([{ value: source }])
+      expect(result.html).toContain('data-language="plaintext"')
+      expect(result.html).toContain(
+        '&lt;script&gt;alert(&quot;still text&quot;)&lt;/script&gt;',
+      )
+      expect(result.html).not.toContain('<script>')
+    },
+  )
+})

--- a/apps/web/app/lib/tanstack-highlight.server.ts
+++ b/apps/web/app/lib/tanstack-highlight.server.ts
@@ -1,0 +1,62 @@
+import { createHighlighter } from '@tanstack/highlight/core'
+import { css } from '@tanstack/highlight/languages/css'
+import { diff } from '@tanstack/highlight/languages/diff'
+import { dockerfile } from '@tanstack/highlight/languages/dockerfile'
+import { html } from '@tanstack/highlight/languages/html'
+import { js } from '@tanstack/highlight/languages/js'
+import { json } from '@tanstack/highlight/languages/json'
+import { jsx } from '@tanstack/highlight/languages/jsx'
+import { markdown } from '@tanstack/highlight/languages/markdown'
+import { python } from '@tanstack/highlight/languages/python'
+import { shell } from '@tanstack/highlight/languages/shell'
+import { sql } from '@tanstack/highlight/languages/sql'
+import { toml } from '@tanstack/highlight/languages/toml'
+import { ts } from '@tanstack/highlight/languages/ts'
+import { tsx } from '@tanstack/highlight/languages/tsx'
+import { yaml } from '@tanstack/highlight/languages/yaml'
+import { createThemeCss } from '@tanstack/highlight/theme'
+import { githubLightTheme } from '@tanstack/highlight/themes/github-light'
+
+const languageDefinitions = [
+  css,
+  diff,
+  dockerfile,
+  html,
+  js,
+  json,
+  jsx,
+  markdown,
+  python,
+  shell,
+  sql,
+  toml,
+  ts,
+  tsx,
+  yaml,
+] as const
+
+const highlighter = createHighlighter({ languages: languageDefinitions })
+
+export const TANSTACK_HIGHLIGHT_LANGUAGES = Object.freeze(
+  highlighter.listLanguages(),
+)
+
+export const TANSTACK_HIGHLIGHT_ALIASES = Object.freeze(
+  Object.fromEntries(
+    languageDefinitions.flatMap((definition) =>
+      (definition.aliases ?? []).map((alias) => [alias, definition.name]),
+    ),
+  ),
+)
+
+export const TANSTACK_HIGHLIGHT_CSS = createThemeCss({
+  light: githubLightTheme,
+})
+
+export function highlightTanStackCode(code: string, language?: string) {
+  return highlighter.highlight(code, { lang: language })
+}
+
+export function normalizeTanStackLanguage(language?: string) {
+  return highlighter.normalizeLanguage(language)
+}

--- a/apps/web/app/routes/markdown-lab.server.ts
+++ b/apps/web/app/routes/markdown-lab.server.ts
@@ -1,9 +1,10 @@
-import { createHighlighter as createTanStackHighlighter } from '@tanstack/highlight/core'
-import { ts } from '@tanstack/highlight/languages/ts'
-import { createThemeCss } from '@tanstack/highlight/theme'
-import { githubLightTheme } from '@tanstack/highlight/themes/github-light'
 import { createBundledHighlighter } from 'shiki/core'
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+
+import {
+  highlightTanStackCode,
+  TANSTACK_HIGHLIGHT_CSS,
+} from '~/lib/tanstack-highlight.server'
 
 const createHighlighter = createBundledHighlighter({
   langs: {
@@ -14,11 +15,7 @@ const createHighlighter = createBundledHighlighter({
   },
   engine: () => createJavaScriptRegexEngine(),
 })
-const tanstackHighlighter = createTanStackHighlighter({ languages: [ts] })
-
-export const TANSTACK_HIGHLIGHT_CSS = createThemeCss({
-  light: githubLightTheme,
-})
+export { TANSTACK_HIGHLIGHT_CSS }
 
 export async function enhanceHtml(
   html: string,
@@ -35,12 +32,12 @@ export async function enhanceHtml(
         })
       : undefined
   const replacements = matches.map(([original, language, encodedCode]) => {
-    if (language !== 'typescript' && language !== 'ts') return original
     if (renderer === 'tanstack') {
-      return tanstackHighlighter.highlight(decodeHtml(encodedCode), {
-        lang: 'ts',
-      }).html
+      // Mermaid keeps its source class until the browser-side diagram pass.
+      if (language === 'mermaid') return original
+      return highlightTanStackCode(decodeHtml(encodedCode), language).html
     }
+    if (language !== 'typescript' && language !== 'ts') return original
     return shiki!.codeToHtml(decodeHtml(encodedCode), {
       lang: 'typescript',
       theme: 'github-light',

--- a/apps/web/app/routes/poc.markdown.$renderer.test.ts
+++ b/apps/web/app/routes/poc.markdown.$renderer.test.ts
@@ -80,6 +80,30 @@ describe('Markdown renderer lab', () => {
     )
   })
 
+  test('highlights registered aliases and preserves unsupported code', async () => {
+    const html = [
+      '<pre><code class="language-javascript">const answer = 42</code></pre>',
+      '<pre><code class="language-ruby">puts &quot;hello&quot;</code></pre>',
+      '<pre><code>language-free &lt;text&gt;</code></pre>',
+    ].join('')
+    const output = await enhanceHtml(html, 'tanstack')
+
+    expect(output).toContain('class="th-code th-code--js"')
+    expect(output).toContain('data-language="js"')
+    expect(output).toContain('class="th-code th-code--plaintext"')
+    expect(output).toContain('puts &quot;hello&quot;')
+    expect(output).toContain(
+      '<pre><code>language-free &lt;text&gt;</code></pre>',
+    )
+  })
+
+  test('leaves Mermaid blocks available for client-side rendering', async () => {
+    const html =
+      '<pre><code class="language-mermaid">flowchart LR\nA --&gt; B</code></pre>'
+
+    expect(await enhanceHtml(html, 'tanstack')).toBe(html)
+  })
+
   test('reports representative comment-anchor compatibility', () => {
     const { renderSource } = splitFrontmatter(MARKDOWN_LAB_SOURCE)
     const markedText = searchText(renderMarked(renderSource).html)


### PR DESCRIPTION
## 現状

Markdown renderer labのTanStack Highlight設定はTypeScriptだけを登録していたため、JavaScript、JSON、Pythonなどの一般的なfenced codeもハイライトされなかった。未登録言語の表示契約と、Mermaidのクライアント側変換を維持する境界も共有化されていなかった。

## 変更

- TanStack Highlightの選択的な共有registryを追加した
- JavaScript、TypeScript、JSX、TSX、JSON、HTML、CSS、Shell、Python、SQL、YAML、TOML、Dockerfile、Diff、Markdownの15言語と同梱aliasを登録した
- 未登録または未知の言語を、コード本文を失わないplaintextへフォールバックした
- Mermaid blockは`language-mermaid` classを保ち、既存のクライアント側diagram変換を維持した
- renderer labを共有registryへ切り替えた
- registry、alias、全言語のsource保持、HTML escape、未知言語、Mermaidの回帰テストを追加した

既存の製品Markdown ViewerはまだTanStack rendererへ切り替えない。

## 計測

- production server build: 13,583,912 bytes → 13,603,951 bytes（+20,039 bytes、約19.6 KiB）
- 15言語module load: 6.831 ms
- registry初期化: 0.055 ms
- warm後15,000 block render: 68.253 ms（0.0046 ms/block）

計測はApple Silicon上のNode.js 24.19.0で実施したローカル参考値であり、性能保証値ではない。

## 検証

- `pnpm public:scan .` — 0 findings
- `pnpm validate:static` — success（2,819 tests passed、1 skipped、React Doctor 100）
- 対象Vitest — 51 tests passed
- `pnpm --filter @artifactshare/web build` — success
- Codex deep review — blockerなし
- Claude deep review — blockerなし
