### PR TITLE
fix(web): bound Markdown YouTube embeds

### DIFF
--- a/apps/web/app/routes/poc.markdown.$renderer.test.ts
+++ b/apps/web/app/routes/poc.markdown.$renderer.test.ts
@@ -3,6 +3,9 @@ import { Window } from 'happy-dom'
 
 import {
   MARKDOWN_LAB_SOURCE,
+  MARKDOWN_FRAME_SANDBOX,
+  YOUTUBE_FRAME_ALLOW,
+  YOUTUBE_FRAME_SANDBOX,
   loader,
   renderMarked,
   renderTanStack,
@@ -80,12 +83,13 @@ flowchart LR
     'keeps raw HTML visible but inactive',
     (render) => {
       const result = render(
-        '<div onclick="alert(1)">visible</div>\n\n<iframe src="https://example.com"></iframe>',
+        '<div onclick="alert(1)">visible</div>\n\n<iframe src="https://example.com"></iframe>\n\n<script>globalThis.untrusted = true</script>',
       )
       expect(result.html).toContain('&lt;div')
       expect(result.html).toContain('&lt;iframe')
       expect(result.html).not.toContain('<iframe')
       expect(result.html).not.toContain('<div onclick=')
+      expect(result.html).not.toContain('<script>')
     },
   )
 
@@ -155,6 +159,16 @@ flowchart LR
   test('does not convert arbitrary YouTube-like text into HTML', async () => {
     expect(await enhanceHtml('<p>youtube:not/a/video</p>', 'tanstack')).toBe(
       '<p>youtube:not/a/video</p>',
+    )
+  })
+
+  test('keeps Markdown scripts disabled while granting YouTube only its required frame capabilities', () => {
+    expect(MARKDOWN_FRAME_SANDBOX).toBe('allow-same-origin')
+    expect(YOUTUBE_FRAME_SANDBOX).toBe('allow-scripts allow-same-origin')
+    expect(YOUTUBE_FRAME_SANDBOX).not.toContain('allow-popups')
+    expect(YOUTUBE_FRAME_SANDBOX).not.toContain('allow-top-navigation')
+    expect(YOUTUBE_FRAME_ALLOW).toBe(
+      'encrypted-media; picture-in-picture; fullscreen',
     )
   })
 

--- a/apps/web/app/routes/poc.markdown.$renderer.tsx
+++ b/apps/web/app/routes/poc.markdown.$renderer.tsx
@@ -11,6 +11,10 @@ import { enableMarkdownFragmentNavigation } from '~/lib/markdown-fragment-naviga
 const MARKED_VERSION = '18.0.6'
 const TANSTACK_VERSION = '0.0.13'
 const YOUTUBE_VIDEO_ID = 'aqz-KE-bpKQ'
+export const MARKDOWN_FRAME_SANDBOX = 'allow-same-origin'
+export const YOUTUBE_FRAME_SANDBOX = 'allow-scripts allow-same-origin'
+export const YOUTUBE_FRAME_ALLOW =
+  'encrypted-media; picture-in-picture; fullscreen'
 
 export const MARKDOWN_LAB_SOURCE = `---
 title: Markdown renderer lab
@@ -307,7 +311,7 @@ export default function MarkdownRendererLab() {
         <iframe
           ref={frameRef}
           title={`${data.renderer} Markdown output`}
-          sandbox="allow-same-origin allow-presentation"
+          sandbox={MARKDOWN_FRAME_SANDBOX}
           srcDoc={data.document}
           onLoad={(event) => prepareMarkdownFrame(event.currentTarget)}
           className="border-border h-dvh w-full rounded-lg border bg-white"
@@ -317,10 +321,10 @@ export default function MarkdownRendererLab() {
           <iframe
             title="YouTube video"
             src={`https://www.youtube-nocookie.com/embed/${data.youtubeVideoId}`}
-            sandbox="allow-scripts allow-presentation"
-            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
+            sandbox={YOUTUBE_FRAME_SANDBOX}
+            allow={YOUTUBE_FRAME_ALLOW}
             loading="lazy"
+            referrerPolicy="strict-origin"
             className="border-border aspect-video w-full rounded-lg border"
           />
         </section>

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -1688,7 +1688,10 @@ describe('handleArtifactSandboxRequest', () => {
       r2Key: 'artifacts/md123abcde/v-md/index.md',
     })
     storageMock.getArtifact.mockResolvedValue(
-      storedArtifact('# Hello', 'text/markdown'),
+      storedArtifact(
+        '# Hello\n\n<iframe src="https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ" allow="fullscreen"></iframe>\n\n<script>globalThis.untrusted = true</script>',
+        'text/markdown',
+      ),
     )
     const token = await singleFileToken({
       id: 'md123abcde',
@@ -1712,7 +1715,18 @@ describe('handleArtifactSandboxRequest', () => {
     expect(cspDirective(csp, 'frame-src')).toBe(
       `frame-src ${youtubeFrameCspSources}`,
     )
-    await expect(response.text()).resolves.toContain('<h1>Hello</h1>')
+    expect(cspDirective(csp, 'script-src')).toBe(
+      `script-src 'sha256-${VIOLATION_REPORTER_SHA256}'`,
+    )
+    expect(response.headers.get('Permissions-Policy')).toBe(
+      expectedPermissionsPolicy,
+    )
+    const body = await response.text()
+    expect(body).toContain('<h1>Hello</h1>')
+    expect(body).toContain(
+      '<iframe src="https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ" allow="fullscreen"></iframe>',
+    )
+    expect(body).toContain('<script>globalThis.untrusted = true</script>')
   })
 
   test('renders utf-8 markdown without mojibake', async () => {


### PR DESCRIPTION
## What

Fix the disposable Markdown renderer lab's YouTube sandbox while preserving the production Markdown security boundary.

- grant the cross-origin YouTube No-Cookie frame scripts and its own origin so the player can use required browser storage
- delegate only encrypted media, picture-in-picture, and fullscreen
- remove unused presentation, popup, navigation, sensor, and autoplay permissions
- keep the Markdown srcdoc frame scriptless
- align the PoC referrer policy with the existing Artifact sandbox policy
- strengthen the production-equivalent Markdown fixture around YouTube origins, fullscreen, and hash-only script execution

The production renderer and Viewer remain unchanged.

## Security boundary

The YouTube frame is cross-origin and receives `allow-scripts allow-same-origin`. The Markdown frame receives only `allow-same-origin`, so Markdown-authored scripts remain inactive. The existing per-Artifact sandbox response continues to allow only YouTube frame origins, delegates fullscreen only to those origins, and permits scripts only when they match the fixed violation-reporter hash.

## Validation

- focused route and sandbox tests — 68 passed
- browser behavior suite — 51 passed
- `pnpm public:scan .` — 0 findings
- `pnpm validate:static` — passed (2827 unit tests passed, 1 skipped; React Doctor 100)
- production build — passed
- final typecheck — passed

An interactive external-player console check was not available in the local browser surface. The merge-queue browser and integration lanes remain the final automated gate; post-merge public verification will confirm the external player response.

## Review

Codex and Claude reviewed the exact Ready candidate. There are no unresolved blockers. Presentation API removal is intentional because casting is outside the playback/fullscreen requirement. Restoring YouTube No-Cookie's own cross-origin identity is required for its storage APIs and does not grant scripts to the Markdown document.
