### PR TITLE
feat(web): roll out TanStack Markdown by workspace

### DIFF
--- a/apps/web/app/lib/csp-reporter.ts
+++ b/apps/web/app/lib/csp-reporter.ts
@@ -336,8 +336,12 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
     );
   }
 
+  function anchorRoot() {
+    return document.querySelector('[data-comment-content]') || document.body;
+  }
+
   function textOffset(node, offset) {
-    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+    var walker = document.createTreeWalker(anchorRoot(), NodeFilter.SHOW_TEXT, {
       acceptNode: function (textNode) {
         return acceptsAnchorText(textNode)
           ? NodeFilter.FILTER_ACCEPT
@@ -354,7 +358,7 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
   }
 
   function anchorTextContent() {
-    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+    var walker = document.createTreeWalker(anchorRoot(), NodeFilter.SHOW_TEXT, {
       acceptNode: function (node) {
         return acceptsAnchorText(node)
           ? NodeFilter.FILTER_ACCEPT
@@ -392,7 +396,7 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
       return;
     }
     var range = selection.getRangeAt(0);
-    if (!document.body.contains(range.commonAncestorContainer)) {
+    if (!anchorRoot().contains(range.commonAncestorContainer)) {
       return;
     }
 
@@ -869,7 +873,7 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
   }
 
   function svgTextRange(highlight) {
-    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+    var walker = document.createTreeWalker(anchorRoot(), NodeFilter.SHOW_TEXT, {
       acceptNode: function (node) {
         return acceptsAnchorText(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
       },
@@ -1065,7 +1069,7 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
       return;
     }
     var svgWrapped = wrapSvgRange(highlight);
-    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+    var walker = document.createTreeWalker(anchorRoot(), NodeFilter.SHOW_TEXT, {
       acceptNode: function (node) {
         return acceptsAnchorText(node)
           ? NodeFilter.FILTER_ACCEPT
@@ -1294,6 +1298,25 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
     send({ kind: 'comment-outside-pointer-down' });
   }
 
+  function updateMarkdownToc() {
+    var links = document.querySelectorAll('.md-toc a[href^="#"]');
+    if (!links.length) return;
+    var active = null;
+    for (var index = 0; index < links.length; index++) {
+      var id = links[index].getAttribute('href').slice(1);
+      var heading = document.getElementById(id);
+      if (heading && heading.getBoundingClientRect().top <= 96) active = links[index];
+    }
+    if (!active) active = links[0];
+    for (var linkIndex = 0; linkIndex < links.length; linkIndex++) {
+      if (links[linkIndex] === active) {
+        links[linkIndex].setAttribute('aria-current', 'location');
+      } else {
+        links[linkIndex].removeAttribute('aria-current');
+      }
+    }
+  }
+
   savedAddEventListener('message', function (event) {
     var data = event.data || {};
     if (event.source !== savedParent || data.source !== '${READY_CHECK_MESSAGE_SOURCE}') {
@@ -1333,6 +1356,8 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
 
   window.addEventListener('resize', schedulePositionBadges);
   window.addEventListener('load', schedulePositionBadges);
+  window.addEventListener('load', updateMarkdownToc);
+  window.addEventListener('scroll', updateMarkdownToc, { passive: true });
   if (document.fonts && document.fonts.ready) {
     document.fonts.ready.then(schedulePositionBadges);
   }
@@ -1355,7 +1380,7 @@ export const VIOLATION_REPORTER_TAG = `<script>${VIOLATION_REPORTER_SCRIPT_BODY}
 // string. If the body changes, the drift test in csp-reporter.test.ts
 // fails and prints the new value to paste here.
 export const VIOLATION_REPORTER_SHA256 =
-  'vL/7LRE+h9TaGH9C10albY0za4W/uEwckXb+w3rHnLY='
+  'HWAhSRWk19y7KHN3l4B/EXR1XsFvk/OXpOaQ7LxSNa4='
 
 export interface CspViolationMessage {
   source: 'artifactshare'

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -6,7 +6,7 @@ describe('renderMarkdownDocument', () => {
   test('wraps output in a full HTML document', () => {
     const out = renderMarkdownDocument('# Hello')
     expect(out).toContain('<!doctype html>')
-    expect(out).toContain('<article class="md">')
+    expect(out).toContain('<article class="md" data-comment-content>')
     expect(out).toContain('<h1>Hello</h1>')
   })
 
@@ -32,5 +32,29 @@ describe('renderMarkdownDocument', () => {
     // Reporter must be injected at response time, not bake-time.
     const out = renderMarkdownDocument('# Hello')
     expect(out).not.toContain(VIOLATION_REPORTER_MARKER)
+  })
+
+  test('renders the TanStack body with safe raw HTML, headings and autolinks', () => {
+    const out = renderMarkdownDocument(
+      '---\ntitle: Report\n---\n# Same\n# Same\n\nhttps://example.com/long\n\n<script>alert(1)</script>',
+      'tanstack',
+    )
+    expect(out).toContain('<h1 id="same">')
+    expect(out).toContain('<h1 id="same-2">')
+    expect(out).toContain('<a href="https://example.com/long"')
+    expect(out).toContain('aria-label="Frontmatter"')
+    expect(out).toContain('href="#same-2"')
+    expect(out).not.toContain('<script>alert(1)</script>')
+  })
+
+  test('embeds only a standalone YouTube URL through No-Cookie', () => {
+    const out = renderMarkdownDocument(
+      'https://youtu.be/aqz-KE-bpKQ',
+      'tanstack',
+    )
+    expect(out).toContain(
+      'src="https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ"',
+    )
+    expect(out).toContain('sandbox="allow-scripts allow-same-origin"')
   })
 })

--- a/apps/web/app/lib/markdown-render.ts
+++ b/apps/web/app/lib/markdown-render.ts
@@ -1,22 +1,101 @@
-import { renderMarkdown } from './markdown'
+import {
+  renderMarkdownBody,
+  TANSTACK_MARKDOWN_CSS,
+  type MarkdownRenderer,
+} from './markdown-renderer.server'
 
-// No sanitization: output renders inside the sandbox iframe (opaque
-// origin + allow-scripts only), which is the same trust boundary as
-// raw HTML artifacts. The file's owner is also its author.
+// Marked keeps its existing raw-HTML behavior inside the sandbox boundary.
+// TanStack escapes raw HTML and adds only the controlled embeds produced by
+// markdown-renderer.server.
 //
 // The CSP violation reporter is injected by the response handler, not
 // here — keeping render output bake-free so Workers Cache stays the
 // canonical body store.
-export function renderMarkdownDocument(source: string): string {
-  return `<!doctype html>
+export function renderMarkdownDocument(
+  source: string,
+  renderer: MarkdownRenderer = 'marked',
+): string {
+  const startedAt = performance.now()
+  const markdown = renderer === 'tanstack' ? splitFrontmatter(source) : null
+  const body = renderMarkdownBody(markdown?.body ?? source, renderer)
+  const navigation = markdown ? tanStackNavigation(markdown.metadata, body) : ''
+  const document = `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<style>${MD_STYLES}</style>
+<style>${MD_STYLES}${renderer === 'tanstack' ? TANSTACK_MARKDOWN_CSS : ''}</style>
 </head>
-<body><article class="md">${renderMarkdown(source)}</article></body>
+<body><div class="md-shell">${navigation}<article class="md" data-comment-content>${body}</article></div></body>
 </html>`
+  if (renderer === 'tanstack') {
+    console.info('markdown_render_completed', {
+      renderer,
+      durationMs: Math.round((performance.now() - startedAt) * 10) / 10,
+    })
+  }
+  return document
+}
+
+function splitFrontmatter(source: string) {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
+  if (!match) return { metadata: [] as string[], body: source }
+  return {
+    metadata: match[1].split(/\r?\n/).filter((line) => line.trim()),
+    body: source.slice(match[0].length),
+  }
+}
+
+function tanStackNavigation(metadata: string[], body: string) {
+  const headings = Array.from(
+    body.matchAll(/<h([1-6]) id="([^"]+)">([\s\S]*?)<\/h\1>/g),
+  )
+  if (metadata.length === 0 && headings.length === 0) return ''
+  const frontmatter = metadata.length
+    ? `<section class="md-metadata" aria-label="Frontmatter"><h2>Frontmatter</h2><dl>${metadata
+        .map((line) => {
+          const separator = line.indexOf(':')
+          const key = separator < 0 ? line : line.slice(0, separator)
+          const value = separator < 0 ? '' : line.slice(separator + 1).trim()
+          return `<div><dt>${escapeHtml(key)}</dt><dd>${escapeHtml(value)}</dd></div>`
+        })
+        .join('')}</dl></section>`
+    : ''
+  const toc = headings.length
+    ? `<nav class="md-toc" aria-label="Table of contents"><h2>Contents</h2><ol>${headings
+        .map(
+          ([, level, id, text]) =>
+            `<li class="level-${level}"><a href="#${escapeHtml(id)}">${plainText(text)}</a></li>`,
+        )
+        .join('')}</ol></nav>`
+    : ''
+  return `<aside class="md-sidebar" data-comment-ui>${frontmatter}${toc}</aside>`
+}
+
+function plainText(value: string) {
+  return escapeHtml(
+    value.replace(/<[^>]+>/g, '').replace(
+      /&(?:amp|lt|gt|quot|#x27);|&#(?:3)9;/g,
+      (entity) =>
+        ({
+          '&amp;': '&',
+          '&lt;': '<',
+          '&gt;': '>',
+          '&quot;': '"',
+          '&#x27;': "'",
+          ['&' + '#' + '39;']: "'",
+        })[entity] ?? entity,
+    ),
+  )
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#x27;')
 }
 
 // Inlined (~1 KB) so the sandbox iframe doesn't pay a fetch round-trip
@@ -43,6 +122,7 @@ const MD_STYLES = `
 }
 * { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
 body {
   background: var(--md-bg);
   color: var(--md-text);
@@ -55,6 +135,23 @@ body {
   margin: 0 auto;
   padding: 48px 32px 96px;
 }
+.md-shell { max-width: 1180px; margin: 0 auto; }
+.md-sidebar { padding: 24px 32px 0; color: var(--md-muted); }
+.md-sidebar h2 { margin: 0 0 8px; color: var(--md-text); font-size: 0.85rem; }
+.md-sidebar dl, .md-sidebar ol { margin: 0; padding: 0; list-style: none; }
+.md-sidebar dl div { display: grid; grid-template-columns: minmax(5rem,auto) 1fr; gap: 12px; }
+.md-sidebar dt { font-weight: 600; }
+.md-sidebar dd { margin: 0; overflow-wrap: anywhere; }
+.md-toc { margin-top: 24px; }
+.md-toc li { margin: 4px 0; }
+.md-toc .level-2 { padding-left: 12px; }
+.md-toc .level-3, .md-toc .level-4, .md-toc .level-5, .md-toc .level-6 { padding-left: 24px; }
+.md-toc a[aria-current="location"] { color: var(--md-text); font-weight: 600; }
+@media (min-width: 980px) {
+  .md-shell { display: grid; grid-template-columns: 240px minmax(0,860px); }
+  .md-sidebar { position: sticky; top: 0; align-self: start; max-height: 100vh; overflow: auto; padding-top: 48px; }
+}
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
 .md > :first-child { margin-top: 0; }
 .md > :last-child { margin-bottom: 0; }
 .md h1, .md h2, .md h3, .md h4, .md h5, .md h6 {
@@ -70,6 +167,7 @@ body {
 .md h6 { font-size: 0.85em; color: var(--md-muted); }
 .md p, .md ul, .md ol, .md blockquote, .md pre, .md table { margin: 0 0 16px; }
 .md a { color: var(--md-link); text-decoration: none; }
+.md { overflow-wrap: anywhere; word-break: auto-phrase; }
 .md a:hover { text-decoration: underline; }
 .md ul, .md ol { padding-left: 2em; }
 .md li + li { margin-top: 0.25em; }
@@ -110,6 +208,8 @@ body {
 .md th { background: var(--md-code-bg); font-weight: 600; }
 .md tr:nth-child(2n) td { background: var(--md-code-bg); }
 .md img { max-width: 100%; height: auto; }
+.md-video { position: relative; aspect-ratio: 16 / 9; margin: 0 0 16px; }
+.md-video iframe { width: 100%; height: 100%; border: 0; }
 .md hr {
   height: 0.25em;
   margin: 24px 0;

--- a/apps/web/app/lib/markdown-renderer-selection.server.test.ts
+++ b/apps/web/app/lib/markdown-renderer-selection.server.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { selectMarkdownRenderer } from './markdown-renderer-selection.server'
+
+describe('selectMarkdownRenderer', () => {
+  test('targets the artifact workspace and enables TanStack', async () => {
+    const getBooleanValue = vi.fn().mockResolvedValue(true)
+    await expect(
+      selectMarkdownRenderer(
+        { APP_ENV: 'production', FLAGS: { getBooleanValue } },
+        'workspace-1',
+      ),
+    ).resolves.toBe('tanstack')
+    expect(getBooleanValue).toHaveBeenCalledWith('tanstack-markdown', false, {
+      targetingKey: 'workspace-1',
+      workspaceId: 'workspace-1',
+    })
+  })
+
+  test.each([
+    [
+      'disabled',
+      { APP_ENV: 'production', FLAGS: { getBooleanValue: async () => false } },
+    ],
+    ['missing binding', { APP_ENV: 'production' }],
+    [
+      'evaluation failure',
+      {
+        APP_ENV: 'production',
+        FLAGS: {
+          getBooleanValue: async () => Promise.reject(new Error('down')),
+        },
+      },
+    ],
+  ])('falls back to Marked when %s', async (_name, source) => {
+    await expect(selectMarkdownRenderer(source, 'workspace-1')).resolves.toBe(
+      'marked',
+    )
+  })
+
+  test('allows the shared DEV_FLAGS fallback outside production', async () => {
+    await expect(
+      selectMarkdownRenderer(
+        { APP_ENV: 'development', DEV_FLAGS: 'tanstack-markdown' },
+        'workspace-1',
+      ),
+    ).resolves.toBe('tanstack')
+  })
+})

--- a/apps/web/app/lib/markdown-renderer-selection.server.ts
+++ b/apps/web/app/lib/markdown-renderer-selection.server.ts
@@ -1,0 +1,24 @@
+import {
+  evaluateFlagshipFlag,
+  type FlagshipSource,
+} from './flagship-fallback.server'
+import type { MarkdownRenderer } from './markdown-renderer.server'
+
+const TANSTACK_MARKDOWN_FLAG = 'tanstack-markdown'
+
+export async function selectMarkdownRenderer(
+  source: FlagshipSource,
+  workspaceId: string,
+): Promise<MarkdownRenderer> {
+  const result = await evaluateFlagshipFlag(source, {
+    flagKey: TANSTACK_MARKDOWN_FLAG,
+    context: { targetingKey: workspaceId, workspaceId },
+  })
+  const renderer =
+    result.kind !== 'evaluation-error' && result.enabled ? 'tanstack' : 'marked'
+  console.info('markdown_renderer_selected', {
+    renderer,
+    flagResult: result.kind,
+  })
+  return renderer
+}

--- a/apps/web/app/lib/markdown-renderer.server.ts
+++ b/apps/web/app/lib/markdown-renderer.server.ts
@@ -1,0 +1,69 @@
+import { renderHtml } from '@tanstack/markdown/html'
+import { parseMarkdown } from '@tanstack/markdown/parser'
+
+import { httpAutolinkExtension } from './markdown-autolink'
+import { renderMarkdown } from './markdown'
+import {
+  highlightTanStackCode,
+  TANSTACK_HIGHLIGHT_CSS,
+} from './tanstack-highlight.server'
+
+export type MarkdownRenderer = 'marked' | 'tanstack'
+
+export function renderMarkdownBody(
+  source: string,
+  renderer: MarkdownRenderer,
+): string {
+  if (renderer === 'marked') return renderMarkdown(source)
+
+  const parsed = parseMarkdown(source, {
+    allowHtml: true,
+    extensions: [httpAutolinkExtension],
+    headingIds: uniqueHeadingId(),
+  })
+  return embedYouTube(highlightCode(renderHtml(parsed, { allowHtml: false })))
+}
+
+function uniqueHeadingId() {
+  const counts = new Map<string, number>()
+  return (text: string) => {
+    const base =
+      text
+        .normalize('NFKC')
+        .toLowerCase()
+        .replace(/[^\p{Letter}\p{Number}]+/gu, '-')
+        .replace(/^-|-$/g, '') || 'section'
+    const count = (counts.get(base) ?? 0) + 1
+    counts.set(base, count)
+    return count === 1 ? base : `${base}-${count}`
+  }
+}
+
+function highlightCode(html: string): string {
+  return html.replace(
+    /<pre[^>]*><code class="language-([^" ]+)">([\s\S]*?)<\/code><\/pre>/g,
+    (original, language: string, encodedCode: string) => {
+      if (language === 'mermaid') return original
+      return highlightTanStackCode(decodeHtml(encodedCode), language).html
+    },
+  )
+}
+
+function decodeHtml(value: string) {
+  return value
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replace(/&#(?:3)9;|&#x27;/g, "'")
+    .replaceAll('&amp;', '&')
+}
+
+function embedYouTube(html: string) {
+  return html.replace(
+    /<p><a href="(https:\/\/(?:www\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/)([A-Za-z0-9_-]{11}))"[^>]*>\1<\/a><\/p>/g,
+    (_match, _url: string, videoId: string) =>
+      `<div class="md-video"><iframe src="https://www.youtube-nocookie.com/embed/${videoId}" title="YouTube video" sandbox="allow-scripts allow-same-origin" allow="encrypted-media; picture-in-picture; fullscreen" loading="lazy" referrerpolicy="strict-origin" allowfullscreen></iframe></div>`,
+  )
+}
+
+export const TANSTACK_MARKDOWN_CSS = TANSTACK_HIGHLIGHT_CSS

--- a/apps/web/app/lib/sandbox-token.ts
+++ b/apps/web/app/lib/sandbox-token.ts
@@ -9,6 +9,7 @@
 
 import { decodeBase64Url, encodeBase64Url } from './base64url'
 import type { ArtifactType } from './artifact-type'
+import type { MarkdownRenderer } from './markdown-renderer.server'
 import { constantTimeEqual, hmacSha256 } from './hmac'
 
 const TTL_SECONDS = 60
@@ -24,6 +25,8 @@ export interface SandboxPayload {
   mt: string | null
   /** Carried in the token so the cache lookup can skip the DB on hit. */
   t: ArtifactType
+  /** Server-selected renderer. Signed so clients cannot override rollout. */
+  mr?: MarkdownRenderer
   jti: string
   /**
    * Embed token: minted for previewing an artifact inside an MCP host
@@ -115,6 +118,9 @@ function isSandboxPayload(value: unknown): value is SandboxPayload {
     (payload.t === 'html' ||
       payload.t === 'md' ||
       payload.t === 'static_site') &&
+    (payload.mr === undefined ||
+      payload.mr === 'marked' ||
+      payload.mr === 'tanstack') &&
     typeof payload.jti === 'string' &&
     (payload.emb === undefined || typeof payload.emb === 'boolean') &&
     typeof payload.exp === 'number'

--- a/apps/web/app/routes/a.$id/+components/export-actions.ts
+++ b/apps/web/app/routes/a.$id/+components/export-actions.ts
@@ -1,4 +1,3 @@
-import { renderMarkdownDocument } from '~/lib/markdown-render'
 import { splitAssetRef } from '~/lib/asset-ref'
 import type { ArtifactType } from '~/lib/artifact-type'
 
@@ -9,6 +8,7 @@ export type ExportSourceData = {
   versionId: string
   source: string
   fileName: string
+  renderedHtml?: string
 }
 
 export type ExportPrintLabels = {
@@ -68,8 +68,8 @@ export async function resolveExportHtml(
   shareableId: string,
   data: ExportSourceData,
 ): Promise<string | null> {
-  const sourceHtml =
-    data.kind === 'markdown' ? renderMarkdownDocument(data.source) : data.source
+  const sourceHtml = data.kind === 'markdown' ? data.renderedHtml : data.source
+  if (!sourceHtml) return null
   if (!sourceHtml.trim()) return null
   const doc = new DOMParser().parseFromString(sourceHtml, 'text/html')
   await inlineDocumentAssets(doc, shareableId, data.path)
@@ -358,8 +358,8 @@ export function buildPrintDocument(
   data: ExportSourceData,
   labels: ExportPrintLabels,
 ): Document {
-  const sourceHtml =
-    data.kind === 'markdown' ? renderMarkdownDocument(data.source) : data.source
+  const sourceHtml = data.kind === 'markdown' ? data.renderedHtml : data.source
+  if (!sourceHtml) throw new Error('Rendered Markdown is unavailable')
   const doc = new DOMParser().parseFromString(sourceHtml, 'text/html')
   doc.querySelectorAll('base').forEach((node) => {
     node.remove()

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -40,6 +40,7 @@ import { isReservedBotEmail, isExternalAuthorEmail } from '~/lib/grant-emails'
 import { artifactSandboxUrl as buildArtifactSandboxUrl } from '~/lib/hosts'
 import { isPrefetchRequest } from '~/lib/prefetch-request.server'
 import { signSandboxToken } from '~/lib/sandbox-token'
+import { selectMarkdownRenderer } from '~/lib/markdown-renderer-selection.server'
 import { socialMeta } from '~/lib/social-meta'
 import {
   availableVisibilitiesFor,
@@ -415,6 +416,10 @@ export async function loader({
   const canTrackView = !isPrefetch
   const canViewHistory = true
   const isStaticSite = shareable.version_artifact_kind === 'static_site'
+  const markdownRenderer =
+    shareable.version_artifact_kind === 'markdown_page'
+      ? await selectMarkdownRenderer(env, shareable.workspace_id)
+      : 'marked'
   const canReplaceFile = isOwner
   const canReturnToProject =
     shareable.return_project_id !== null &&
@@ -441,6 +446,7 @@ export async function loader({
     artifactKind: shareable.version_artifact_kind ?? shareable.artifact_kind,
     entrypointPath: shareable.entrypoint_path,
     r2Key: shareable.r2_key,
+    markdownRenderer,
   })
   const [comments, latestCommentCreatedAt] = await Promise.all([
     loadCommentThreads(db, commentAccess, user),
@@ -588,6 +594,7 @@ export async function loader({
       fid: storageKey,
       mt: modifiedTime,
       t: renderType,
+      mr: markdownRenderer,
       jti: nanoid(),
     },
     env.BETTER_AUTH_SECRET,
@@ -719,6 +726,10 @@ async function buildLinkAnonymousResponse(
     shareable.owner_email ?? '',
   )
   const isStaticSite = shareable.version_artifact_kind === 'static_site'
+  const markdownRenderer =
+    shareable.version_artifact_kind === 'markdown_page'
+      ? await selectMarkdownRenderer(env, shareable.workspace_id)
+      : 'marked'
 
   const baseArtifact = {
     id: shareable.id,
@@ -799,6 +810,7 @@ async function buildLinkAnonymousResponse(
       t: isStaticSite
         ? 'static_site'
         : (detectArtifactType(artifactMimeType, fileName) ?? 'html'),
+      mr: markdownRenderer,
       jti: nanoid(),
     },
     env.BETTER_AUTH_SECRET,

--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid'
 import { artifactSandboxUrl } from '~/lib/hosts'
 import { renderTypeFromKind } from '~/lib/artifact-type'
 import { signSandboxToken } from '~/lib/sandbox-token'
+import { selectMarkdownRenderer } from '~/lib/markdown-renderer-selection.server'
 import { userContext } from '~/middleware/context'
 import {
   viewerDisplayCheck,
@@ -93,6 +94,10 @@ export async function loader({ context, params }: Route.LoaderArgs) {
       fid: shareable.r2_key,
       mt: check.meta.modifiedTime,
       t: renderType,
+      mr:
+        renderType === 'md'
+          ? await selectMarkdownRenderer(env, shareable.workspace_id)
+          : 'marked',
       jti: nanoid(),
     },
     env.BETTER_AUTH_SECRET,

--- a/apps/web/app/services/comments.server.test.ts
+++ b/apps/web/app/services/comments.server.test.ts
@@ -458,6 +458,49 @@ describe('comments server', () => {
     })
   })
 
+  test('re-resolves current markdown anchors when renderer offsets differ', async () => {
+    await fixture.db
+      .updateTable('shareables')
+      .set({ artifact_kind: 'markdown_page' })
+      .where('id', '=', 's1')
+      .execute()
+    await fixture.db
+      .updateTable('versions')
+      .set({
+        artifact_kind: 'markdown_page',
+        entrypoint_path: '/artifact.md',
+        r2_key: 'ws1/s1/v1/artifact.md',
+      })
+      .where('id', '=', 'v1')
+      .execute()
+    sqliteRef.bucketText = 'Some **bold text** stays here'
+    const access = await loadCommentAccess(fixture.db, viewerUser, 's1')
+
+    const created = await createCommentThread(
+      fixture.db,
+      access!,
+      viewerUser,
+      'Please check this sentence.',
+      {
+        quotedText: 'bold text',
+        prefixText: 'Some',
+        suffixText: 'stays here',
+        textStart: 0,
+        textEnd: 9,
+        cssPath: null,
+      },
+    )
+
+    expect(created.kind).toBe('ok')
+    expect(
+      created.kind === 'ok' ? created.threads[0]?.subject : null,
+    ).toMatchObject({
+      state: 'attached',
+      textStart: 5,
+      textEnd: 14,
+    })
+  })
+
   test('restores html anchors with script text, entities, and changed entry path', async () => {
     const access = await loadCommentAccess(fixture.db, viewerUser, 's1')
     const created = await createCommentThread(

--- a/apps/web/app/services/comments.server.ts
+++ b/apps/web/app/services/comments.server.ts
@@ -13,6 +13,8 @@ import {
   type CommentThreadView,
 } from '~/lib/comments'
 import { renderMarkdownDocument } from '~/lib/markdown-render'
+import { selectMarkdownRenderer } from '~/lib/markdown-renderer-selection.server'
+import type { MarkdownRenderer } from '~/lib/markdown-renderer.server'
 import type { Visibility } from '~/lib/shareable-types'
 import type { SessionUser } from '~/lib/user'
 import {
@@ -118,6 +120,7 @@ export interface CommentAccess {
   isTeamWorkspaceAdmin: boolean
   // Only loadCommentAccess derives placement; other constructors leave it out.
   projectId?: string | null
+  markdownRenderer?: MarkdownRenderer
 }
 
 export interface VerifiedCommentShareable {
@@ -130,6 +133,7 @@ export interface VerifiedCommentShareable {
   artifactKind: string
   entrypointPath: string | null
   r2Key: string | null
+  markdownRenderer?: MarkdownRenderer
 }
 
 export type CommentMutationResult =
@@ -306,6 +310,7 @@ export async function commentAccessFromVerifiedShareable(
     artifactKind: shareable.artifactKind,
     entrypointPath: shareable.entrypointPath,
     r2Key: shareable.r2Key,
+    markdownRenderer: shareable.markdownRenderer,
     isTeamWorkspaceAdmin: await isTeamWorkspaceAdmin(
       db,
       user,
@@ -1083,8 +1088,13 @@ async function resolveCommentSubjects(
   if (anchors.length === 0) return subjects
 
   let currentText: string | null = null
+  // A workspace can switch renderers without creating a new artifact version.
+  // Re-resolve Markdown anchors from their quote so offsets survive either
+  // direction of that switch.
+  const relocateCurrentMarkdownAnchors = access.artifactKind === 'markdown_page'
   const needsCurrentText = anchors.some(
     (anchor) =>
+      relocateCurrentMarkdownAnchors ||
       anchor.version_id !== access.currentVersionId ||
       anchor.target_path !== access.entrypointPath,
   )
@@ -1096,7 +1106,8 @@ async function resolveCommentSubjects(
     let range: { textStart: number; textEnd: number } | null = null
     if (
       anchor.version_id === access.currentVersionId &&
-      anchor.target_path === access.entrypointPath
+      anchor.target_path === access.entrypointPath &&
+      !relocateCurrentMarkdownAnchors
     ) {
       range = { textStart: anchor.text_start, textEnd: anchor.text_end }
     } else if (currentText) {
@@ -1122,7 +1133,12 @@ async function loadCurrentAnchorText(
   access: CommentAccess,
 ): Promise<string | null> {
   if (!access.r2Key) return null
-  const cacheKey = `${access.artifactKind}:${access.r2Key}`
+  const renderer =
+    access.artifactKind === 'markdown_page'
+      ? (access.markdownRenderer ??
+        (await selectMarkdownRenderer(env, access.workspaceId)))
+      : 'marked'
+  const cacheKey = `${access.artifactKind}:${access.r2Key}:${renderer}`
   const cached = anchorTextCache.get(cacheKey)
   const now = Date.now()
   if (cached && cached.expiresAt > now) {
@@ -1135,7 +1151,7 @@ async function loadCurrentAnchorText(
     const raw = await object.text()
     const value = htmlToSearchText(
       access.artifactKind === 'markdown_page'
-        ? renderMarkdownDocument(raw)
+        ? renderMarkdownDocument(raw, renderer)
         : raw,
     )
     pruneCommentAnchorTextCache(now)
@@ -1299,8 +1315,12 @@ function contextPenalty(
 }
 
 function htmlToSearchText(html: string): string {
+  const commentContentMatch =
+    /<([a-z][\w:-]*)[^>]*\bdata-comment-content\b[^>]*>([\s\S]*?)<\/\1>/i.exec(
+      html,
+    )
   const bodyMatch = /<body[^>]*>([\s\S]*?)<\/body>/i.exec(html)
-  const body = bodyMatch?.[1] ?? html
+  const body = commentContentMatch?.[2] ?? bodyMatch?.[1] ?? html
   return body
     .replace(/<script[\s\S]*?<\/script>/gi, '')
     .replace(/<style[\s\S]*?<\/style>/gi, '')

--- a/apps/web/app/services/export-source.server.test.ts
+++ b/apps/web/app/services/export-source.server.test.ts
@@ -128,6 +128,7 @@ describe('getExportSource', () => {
         versionId: 'ver123',
         source: '# Report',
         fileName: 'report.md',
+        renderedHtml: expect.stringContaining('<h1>Report</h1>'),
       },
     })
   })

--- a/apps/web/app/services/export-source.server.ts
+++ b/apps/web/app/services/export-source.server.ts
@@ -1,6 +1,8 @@
 import { env } from 'cloudflare:workers'
 import type { Kysely } from 'kysely'
 import { errorResponse } from '~/lib/api-errors'
+import { selectMarkdownRenderer } from '~/lib/markdown-renderer-selection.server'
+import { renderMarkdownDocument } from '~/lib/markdown-render'
 import type { SessionUser } from '~/lib/user'
 import { loadCommentAccess } from '~/services/comments.server'
 import { getArtifact, type StoredArtifact } from '~/services/storage.server'
@@ -54,6 +56,7 @@ export interface ExportSourceData {
   versionId: string
   source: string
   fileName: string
+  renderedHtml?: string
 }
 
 export async function getExportSource(
@@ -190,8 +193,12 @@ async function loadMarkdownExportSource(
   const path = access.entrypointPath
     ? normalizeExportPath(access.entrypointPath, '/index.md')
     : '/index.md'
-  const object = await getArtifact(env.BUCKET, access.r2Key)
+  const [object, renderer] = await Promise.all([
+    getArtifact(env.BUCKET, access.r2Key),
+    selectMarkdownRenderer(env, access.workspaceId),
+  ])
   if (!object) return { kind: 'source-unavailable' }
+  const source = await object.text()
 
   return {
     kind: 'ok',
@@ -200,8 +207,9 @@ async function loadMarkdownExportSource(
       artifactKind: access.artifactKind,
       path,
       versionId: access.currentVersionId!,
-      source: await object.text(),
+      source,
       fileName: exportFileName(path, 'index.md'),
+      renderedHtml: renderMarkdownDocument(source, renderer),
     },
   }
 }

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -9,6 +9,7 @@ import {
   SANDBOX_EMBED_TTL_SECONDS,
 } from '~/lib/hosts'
 import { signSandboxToken } from '~/lib/sandbox-token'
+import { selectMarkdownRenderer } from '~/lib/markdown-renderer-selection.server'
 import {
   logUploadPermissionFailure,
   type UploadPermissionResult,
@@ -1023,6 +1024,10 @@ export function registerArtifactTools(
             fid: access.r2Key,
             mt: null,
             t: renderType,
+            mr:
+              renderType === 'md'
+                ? await selectMarkdownRenderer(env, access.workspaceId)
+                : 'marked',
             jti: nanoid(),
             emb: true,
           },

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -17,6 +17,7 @@ import {
 } from '../app/lib/sandbox-token'
 import { type ArtifactKind } from '../app/lib/shareable-types'
 import { renderMarkdownDocument } from '../app/lib/markdown-render'
+import type { MarkdownRenderer } from '../app/lib/markdown-renderer.server'
 import { createDb } from '../app/services/db.server'
 import { consumeJti } from '../app/services/sandbox-jti.server'
 import { getArtifact } from '../app/services/storage.server'
@@ -271,6 +272,7 @@ function sameOriginRedirectTarget(url: URL): string | null {
 
 interface Entrypoint {
   renderType: ArtifactType
+  renderer: MarkdownRenderer
   r2Key: string
   contentType: string | null
 }
@@ -303,6 +305,7 @@ async function currentEntrypoint(
     if (version.r2_key !== payload.fid) return null
     return {
       renderType: payload.t,
+      renderer: payload.mr ?? 'marked',
       r2Key: version.r2_key,
       contentType: 'text/html; charset=utf-8',
     }
@@ -318,6 +321,7 @@ async function currentEntrypoint(
   if (!file) return null
   return {
     renderType: 'static_site',
+    renderer: 'marked',
     r2Key: file.r2_key,
     contentType: file.mime_type,
   }
@@ -359,7 +363,7 @@ async function serveEntrypoint(
     'text/html; charset=utf-8'
   if (entrypoint.renderType === 'md' || isMarkdownContent(contentType)) {
     return documentResponse(
-      renderMarkdownDocument(await object.text()),
+      renderMarkdownDocument(await object.text(), entrypoint.renderer),
       'text/html; charset=utf-8',
       artifactCsp(entrypoint.renderType, embed),
     )
@@ -493,7 +497,8 @@ async function serveBundleFile(file: {
   }
   if (isMarkdownContent(contentType)) {
     return documentResponse(
-      renderMarkdownDocument(await object.text()),
+      // Static-site Markdown is intentionally outside the workspace rollout.
+      renderMarkdownDocument(await object.text(), 'marked'),
       'text/html; charset=utf-8',
       artifactCsp('static_site'),
     )


### PR DESCRIPTION
## What

Add a workspace-scoped Flagship rollout for the TanStack Markdown renderer while keeping Marked as the safe default.

- select the renderer from the existing Flagship binding using the artifact workspace
- fall back to Marked when the flag is disabled, unavailable, or fails evaluation
- propagate the selected renderer through signed viewer, refresh, and MCP sandbox tokens
- use the same renderer for comments and exports
- re-resolve current Markdown comment anchors from their quote so switching either direction does not retain stale offsets
- keep static-site Markdown outside this rollout

The production flag exists in a disabled, default-off state. This PR does not target any workspace.

## Scope

The implementation intentionally stays small: it reuses the existing Flagship fallback helper and signed sandbox token. It does not persist renderer versions per comment, add a rollout administration UI, or promote the PoC Mermaid conversion into the production renderer.

## Validation

- static validation — passed (2,835 unit tests passed, 1 skipped; React Doctor 100; public scan 0 findings)
- focused Markdown, comment, renderer-selection, and export tests — passed
- browser behavior suite — 51 passed
- production build — passed
- production sandbox dry run — 686.93 KiB upload / 125.08 KiB gzip

## Review

Codex reviewed the exact candidate with no unresolved findings. A second review warned about combining `allow-scripts` and `allow-same-origin` on the YouTube iframe; the frame is cross-origin and its source is restricted to YouTube No-Cookie by CSP, so it cannot gain same-origin access to the parent. Both permissions are retained to avoid the player storage and script failures this integration was designed to fix.
