### PR TITLE
Render Mermaid diagrams in TanStack Markdown

### DIFF
--- a/apps/web/app/lib/csp-reporter.behavior.browser.test.tsx
+++ b/apps/web/app/lib/csp-reporter.behavior.browser.test.tsx
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import { VIOLATION_REPORTER_SCRIPT_BODY } from './csp-reporter'
+import { renderMermaidSvg } from './mermaid-render.client'
+import {
+  buildPrintDocument,
+  resolveExportHtml,
+} from '../routes/a.$id/+components/export-actions'
 
 type ReporterMessage = { kind?: string; [key: string]: unknown }
 
@@ -50,6 +55,85 @@ afterEach(() => {
 })
 
 describe('CSP reporter runtime behavior', () => {
+  test('renders Mermaid only after the parent ready check and preserves source text', async () => {
+    const source = 'flowchart LR\nA --> B'
+    const doc = await fixture(
+      `<pre><code class="language-mermaid">${source}</code></pre>`,
+    )
+    doc.body.dataset.markdownRenderer = 'tanstack'
+    messages = []
+
+    frame!.contentWindow!.postMessage(
+      {
+        source: 'artifactshare-parent',
+        kind: 'ready-check',
+        challenge: 'browser-test',
+      },
+      '*',
+    )
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    const request = messages.find(
+      (message) => message.kind === 'mermaid-render-request',
+    ) as { diagrams?: Array<{ id: string; source: string }> } | undefined
+    expect(request?.diagrams).toEqual([
+      { id: 'artifactshare-mermaid-0', source },
+    ])
+
+    const svg = await renderMermaidSvg(source)
+    frame!.contentWindow!.postMessage(
+      {
+        source: 'artifactshare-parent',
+        kind: 'mermaid-rendered',
+        results: [{ id: request!.diagrams![0].id, svg }],
+      },
+      '*',
+    )
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(doc.querySelector('.mermaid-diagram svg')).not.toBeNull()
+    expect(doc.querySelector('pre')?.hidden).toBe(true)
+    expect(doc.querySelector('pre')?.textContent).toBe(source)
+
+    await applyHighlights([
+      {
+        threadId: 'mermaid-source',
+        textStart: 0,
+        textEnd: source.length,
+        count: 1,
+      },
+    ])
+    expect(doc.querySelector('.ash-comment-highlight')?.textContent).toBe(
+      source,
+    )
+  })
+
+  test('uses the same Mermaid rendering for HTML and print exports', async () => {
+    const source = 'flowchart LR\nA --> B'
+    const data = {
+      kind: 'markdown' as const,
+      artifactKind: 'markdown_page',
+      path: '/index.md',
+      versionId: 'version-1',
+      source: `\`\`\`mermaid\n${source}\n\`\`\``,
+      fileName: 'diagram.md',
+      renderedHtml: `<html><body data-markdown-renderer="tanstack"><article data-comment-content><pre><code class="language-mermaid">${source}</code></pre></article></body></html>`,
+    }
+
+    const html = await resolveExportHtml('artifact-1', data)
+    expect(html).toContain('class="mermaid-diagram"')
+    expect(html).toContain('<svg')
+    expect(html).toContain('data-mermaid-rendered="true" hidden')
+
+    const print = await buildPrintDocument('artifact-1', data, {
+      savePdf: 'Save PDF',
+      backgroundHint: 'Print backgrounds',
+      preparing: 'Preparing',
+      heightLimited: 'Height limited',
+    })
+    expect(print.querySelector('.mermaid-diagram svg')).not.toBeNull()
+    expect(print.querySelector('pre')?.hidden).toBe(true)
+  })
+
   test('keyboard operation on a comment badge sends selection to the parent', async () => {
     const doc = await fixture('<p>Highlighted text</p>')
     await applyHighlights([

--- a/apps/web/app/lib/csp-reporter.behavior.browser.test.tsx
+++ b/apps/web/app/lib/csp-reporter.behavior.browser.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import { VIOLATION_REPORTER_SCRIPT_BODY } from './csp-reporter'
-import { renderMermaidSvg } from './mermaid-render.client'
+import { renderMermaidSvg, sanitizeMermaidSvg } from './mermaid-render.client'
 import {
   buildPrintDocument,
   resolveExportHtml,
@@ -55,6 +55,17 @@ afterEach(() => {
 })
 
 describe('CSP reporter runtime behavior', () => {
+  test('sanitizes Mermaid SVG before it reaches the artifact frame', () => {
+    const sanitized = sanitizeMermaidSvg(
+      '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><text>Safe</text><script>alert(1)</script></svg>',
+    )
+
+    expect(sanitized).toContain('<svg')
+    expect(sanitized).toContain('<text>Safe</text>')
+    expect(sanitized).not.toContain('onload')
+    expect(sanitized).not.toContain('<script')
+  })
+
   test('renders Mermaid only after the parent ready check and preserves source text', async () => {
     const source = 'flowchart LR\nA --> B'
     const doc = await fixture(
@@ -74,7 +85,13 @@ describe('CSP reporter runtime behavior', () => {
     await new Promise((resolve) => setTimeout(resolve, 20))
     const request = messages.find(
       (message) => message.kind === 'mermaid-render-request',
-    ) as { diagrams?: Array<{ id: string; source: string }> } | undefined
+    ) as
+      | {
+          renderToken?: string
+          diagrams?: Array<{ id: string; source: string }>
+        }
+      | undefined
+    expect(request?.renderToken).toBe('browser-test')
     expect(request?.diagrams).toEqual([
       { id: 'artifactshare-mermaid-0', source },
     ])
@@ -84,6 +101,19 @@ describe('CSP reporter runtime behavior', () => {
       {
         source: 'artifactshare-parent',
         kind: 'mermaid-rendered',
+        renderToken: 'previous-document',
+        results: [{ id: request!.diagrams![0].id, svg }],
+      },
+      '*',
+    )
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(doc.querySelector('.mermaid-diagram')).toBeNull()
+
+    frame!.contentWindow!.postMessage(
+      {
+        source: 'artifactshare-parent',
+        kind: 'mermaid-rendered',
+        renderToken: request!.renderToken,
         results: [{ id: request!.diagrams![0].id, svg }],
       },
       '*',

--- a/apps/web/app/lib/csp-reporter.test.ts
+++ b/apps/web/app/lib/csp-reporter.test.ts
@@ -49,6 +49,7 @@ describe('isSandboxMessage', () => {
       isSandboxMessage({
         source: 'artifactshare',
         kind: 'mermaid-render-request',
+        renderToken: 'current-document',
         diagrams: [
           { id: 'artifactshare-mermaid-0', source: 'flowchart LR\nA --> B' },
         ],
@@ -80,7 +81,16 @@ describe('isSandboxMessage', () => {
       isSandboxMessage({
         source: 'artifactshare',
         kind: 'mermaid-render-request',
+        renderToken: 'current-document',
         diagrams: [{ id: '../other', source: 'flowchart LR' }],
+      }),
+    ).toBe(false)
+    expect(
+      isSandboxMessage({
+        source: 'artifactshare',
+        kind: 'mermaid-render-request',
+        renderToken: '',
+        diagrams: [{ id: 'artifactshare-mermaid-0', source: 'flowchart LR' }],
       }),
     ).toBe(false)
     expect(

--- a/apps/web/app/lib/csp-reporter.test.ts
+++ b/apps/web/app/lib/csp-reporter.test.ts
@@ -48,6 +48,15 @@ describe('isSandboxMessage', () => {
     expect(
       isSandboxMessage({
         source: 'artifactshare',
+        kind: 'mermaid-render-request',
+        diagrams: [
+          { id: 'artifactshare-mermaid-0', source: 'flowchart LR\nA --> B' },
+        ],
+      }),
+    ).toBe(true)
+    expect(
+      isSandboxMessage({
+        source: 'artifactshare',
         kind: 'ready',
         challenge: 'c',
         token: 't',
@@ -66,6 +75,13 @@ describe('isSandboxMessage', () => {
   test('rejects malformed security fields', () => {
     expect(
       isSandboxMessage({ source: 'artifactshare', kind: 'ready', token: 1 }),
+    ).toBe(false)
+    expect(
+      isSandboxMessage({
+        source: 'artifactshare',
+        kind: 'mermaid-render-request',
+        diagrams: [{ id: '../other', source: 'flowchart LR' }],
+      }),
     ).toBe(false)
     expect(
       isSandboxMessage({

--- a/apps/web/app/lib/csp-reporter.ts
+++ b/apps/web/app/lib/csp-reporter.ts
@@ -156,6 +156,8 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
   var badgeDragged = false;
   var appliedHighlightKey = '';
   var textAnchorsEnabled = false;
+  var mermaidBlocks = objectCreate(null);
+  var mermaidRequested = false;
   var commentLabels = {
     openOne: 'Open 1 unresolved comment on this text',
     openOther: 'Open {n} unresolved comments on this text',
@@ -177,6 +179,50 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
     }
   }
 
+  function requestMermaidRendering() {
+    if (mermaidRequested) return;
+    if (!document.body || document.body.dataset.markdownRenderer !== 'tanstack') return;
+    var blocks = document.querySelectorAll('pre code.language-mermaid');
+    var diagrams = [];
+    for (var index = 0; index < blocks.length && index < 32; index++) {
+      var source = blocks[index].textContent || '';
+      if (!source || source.length > 100000) continue;
+      var pre = blocks[index].closest('pre');
+      if (!pre) continue;
+      var id = 'artifactshare-mermaid-' + index;
+      mermaidBlocks[id] = pre;
+      diagrams.push({ id: id, source: source });
+    }
+    if (diagrams.length) {
+      mermaidRequested = true;
+      send({ kind: 'mermaid-render-request', diagrams: diagrams });
+    }
+  }
+
+  function installMermaidResults(results) {
+    if (!Array.isArray(results)) return;
+    for (var index = 0; index < results.length; index++) {
+      var result = results[index] || {};
+      var pre = typeof result.id === 'string' ? mermaidBlocks[result.id] : null;
+      if (!pre || typeof result.svg !== 'string' || !result.svg.startsWith('<svg')) continue;
+      var svgDocument = new DOMParser().parseFromString(result.svg, 'image/svg+xml');
+      var svg = svgDocument.documentElement;
+      if (
+        svg.localName !== 'svg' ||
+        svg.namespaceURI !== 'http://www.w3.org/2000/svg' ||
+        svgDocument.querySelector('parsererror')
+      ) continue;
+      var container = document.createElement('div');
+      container.className = 'mermaid-diagram';
+      container.appendChild(document.importNode(svg, true));
+      pre.dataset.mermaidRendered = 'true';
+      pre.hidden = true;
+      pre.before(container);
+      delete mermaidBlocks[result.id];
+    }
+    schedulePositionBadges();
+  }
+
   function onReadyCheck(event) {
     var message = event && event.data;
     if (
@@ -188,6 +234,7 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
     ) return;
     if (typeof message.challenge !== 'string' || !message.challenge) return;
     readyChallenge = message.challenge;
+    requestMermaidRendering();
     ready();
   }
   try {
@@ -323,16 +370,20 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
   function acceptsAnchorText(node) {
     return !(
       node.parentElement &&
-      node.parentElement.closest('script,style,.ash-comment-highlight-badge')
+      (node.parentElement.closest('script,style,.ash-comment-highlight-badge') ||
+        (document.body.dataset.markdownRenderer === 'tanstack' &&
+          node.parentElement.closest('.mermaid-diagram')))
     );
   }
 
   function acceptsHighlightText(node) {
     return !(
       node.parentElement &&
-      node.parentElement.closest(
+      (node.parentElement.closest(
         'script,style,.ash-comment-highlight,.ash-comment-highlight-badge,.ash-comment-highlight-svg',
-      )
+      ) ||
+        (document.body.dataset.markdownRenderer === 'tanstack' &&
+          node.parentElement.closest('.mermaid-diagram')))
     );
   }
 
@@ -1332,6 +1383,8 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
       applyHighlights(data.highlights);
     } else if (data.kind === 'scroll-to-comment') {
       scrollToThread(data.threadId);
+    } else if (data.kind === 'mermaid-rendered') {
+      installMermaidResults(data.results);
     }
   });
 
@@ -1380,7 +1433,7 @@ export const VIOLATION_REPORTER_TAG = `<script>${VIOLATION_REPORTER_SCRIPT_BODY}
 // string. If the body changes, the drift test in csp-reporter.test.ts
 // fails and prints the new value to paste here.
 export const VIOLATION_REPORTER_SHA256 =
-  'HWAhSRWk19y7KHN3l4B/EXR1XsFvk/OXpOaQ7LxSNa4='
+  'Jo4TkrSV96q9DhCquEVOwkda3pq5g+gc9fKWssFp58w='
 
 export interface CspViolationMessage {
   source: 'artifactshare'
@@ -1437,6 +1490,12 @@ export interface LinkClickedMessage {
   token?: string
 }
 
+export interface MermaidRenderRequestMessage {
+  source: 'artifactshare'
+  kind: 'mermaid-render-request'
+  diagrams: Array<{ id: string; source: string }>
+}
+
 interface ReadyMessage {
   source: 'artifactshare'
   kind: 'ready'
@@ -1452,6 +1511,7 @@ export type SandboxMessage =
   | CommentThreadSelectedMessage
   | CommentOutsidePointerDownMessage
   | LinkClickedMessage
+  | MermaidRenderRequestMessage
 
 export function isSandboxMessage(value: unknown): value is SandboxMessage {
   if (!value || typeof value !== 'object') return false
@@ -1501,6 +1561,26 @@ export function isSandboxMessage(value: unknown): value is SandboxMessage {
     return (
       typeof v.href === 'string' &&
       (v.token === undefined || typeof v.token === 'string')
+    )
+  }
+  if (v.kind === 'mermaid-render-request') {
+    return (
+      Array.isArray(v.diagrams) &&
+      v.diagrams.length > 0 &&
+      v.diagrams.length <= 32 &&
+      v.diagrams.every(
+        (diagram) =>
+          diagram !== null &&
+          typeof diagram === 'object' &&
+          typeof (diagram as Record<string, unknown>).id === 'string' &&
+          /^artifactshare-mermaid-\d+$/.test(
+            (diagram as Record<string, unknown>).id as string,
+          ) &&
+          typeof (diagram as Record<string, unknown>).source === 'string' &&
+          ((diagram as Record<string, unknown>).source as string).length > 0 &&
+          ((diagram as Record<string, unknown>).source as string).length <=
+            100_000,
+      )
     )
   }
   return false

--- a/apps/web/app/lib/csp-reporter.ts
+++ b/apps/web/app/lib/csp-reporter.ts
@@ -184,9 +184,9 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
     if (!document.body || document.body.dataset.markdownRenderer !== 'tanstack') return;
     var blocks = document.querySelectorAll('pre code.language-mermaid');
     var diagrams = [];
-    for (var index = 0; index < blocks.length && index < 32; index++) {
+    for (var index = 0; index < blocks.length && index < 16; index++) {
       var source = blocks[index].textContent || '';
-      if (!source || source.length > 100000) continue;
+      if (!source || source.length > 20000) continue;
       var pre = blocks[index].closest('pre');
       if (!pre) continue;
       var id = 'artifactshare-mermaid-' + index;
@@ -1438,7 +1438,7 @@ export const VIOLATION_REPORTER_TAG = `<script>${VIOLATION_REPORTER_SCRIPT_BODY}
 // string. If the body changes, the drift test in csp-reporter.test.ts
 // fails and prints the new value to paste here.
 export const VIOLATION_REPORTER_SHA256 =
-  'Ea5NG2Y9cBGJC/uThhmExtG7ZLz1766GDwBEClbaTac='
+  'o7q4NtfTh6Xe6a8rjC10kYSucZVqtVkVdTDWD5yN1bw='
 
 export interface CspViolationMessage {
   source: 'artifactshare'
@@ -1576,7 +1576,7 @@ export function isSandboxMessage(value: unknown): value is SandboxMessage {
       v.renderToken.length <= 128 &&
       Array.isArray(v.diagrams) &&
       v.diagrams.length > 0 &&
-      v.diagrams.length <= 32 &&
+      v.diagrams.length <= 16 &&
       v.diagrams.every(
         (diagram) =>
           diagram !== null &&
@@ -1588,7 +1588,7 @@ export function isSandboxMessage(value: unknown): value is SandboxMessage {
           typeof (diagram as Record<string, unknown>).source === 'string' &&
           ((diagram as Record<string, unknown>).source as string).length > 0 &&
           ((diagram as Record<string, unknown>).source as string).length <=
-            100_000,
+            20_000,
       )
     )
   }

--- a/apps/web/app/lib/csp-reporter.ts
+++ b/apps/web/app/lib/csp-reporter.ts
@@ -184,7 +184,11 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
     if (!document.body || document.body.dataset.markdownRenderer !== 'tanstack') return;
     var blocks = document.querySelectorAll('pre code.language-mermaid');
     var diagrams = [];
-    for (var index = 0; index < blocks.length && index < 16; index++) {
+    for (
+      var index = 0;
+      index < blocks.length && diagrams.length < 16;
+      index++
+    ) {
       var source = blocks[index].textContent || '';
       if (!source || source.length > 20000) continue;
       var pre = blocks[index].closest('pre');
@@ -1438,7 +1442,7 @@ export const VIOLATION_REPORTER_TAG = `<script>${VIOLATION_REPORTER_SCRIPT_BODY}
 // string. If the body changes, the drift test in csp-reporter.test.ts
 // fails and prints the new value to paste here.
 export const VIOLATION_REPORTER_SHA256 =
-  'o7q4NtfTh6Xe6a8rjC10kYSucZVqtVkVdTDWD5yN1bw='
+  'GMHSYRSUYjY7pwcMEEfaGI7flq2W3LhkOU8cO8ar3NU='
 
 export interface CspViolationMessage {
   source: 'artifactshare'

--- a/apps/web/app/lib/csp-reporter.ts
+++ b/apps/web/app/lib/csp-reporter.ts
@@ -195,11 +195,16 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
     }
     if (diagrams.length) {
       mermaidRequested = true;
-      send({ kind: 'mermaid-render-request', diagrams: diagrams });
+      send({
+        kind: 'mermaid-render-request',
+        renderToken: readyChallenge,
+        diagrams: diagrams,
+      });
     }
   }
 
-  function installMermaidResults(results) {
+  function installMermaidResults(renderToken, results) {
+    if (renderToken !== readyChallenge) return;
     if (!Array.isArray(results)) return;
     for (var index = 0; index < results.length; index++) {
       var result = results[index] || {};
@@ -1384,7 +1389,7 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
     } else if (data.kind === 'scroll-to-comment') {
       scrollToThread(data.threadId);
     } else if (data.kind === 'mermaid-rendered') {
-      installMermaidResults(data.results);
+      installMermaidResults(data.renderToken, data.results);
     }
   });
 
@@ -1433,7 +1438,7 @@ export const VIOLATION_REPORTER_TAG = `<script>${VIOLATION_REPORTER_SCRIPT_BODY}
 // string. If the body changes, the drift test in csp-reporter.test.ts
 // fails and prints the new value to paste here.
 export const VIOLATION_REPORTER_SHA256 =
-  'Jo4TkrSV96q9DhCquEVOwkda3pq5g+gc9fKWssFp58w='
+  'Ea5NG2Y9cBGJC/uThhmExtG7ZLz1766GDwBEClbaTac='
 
 export interface CspViolationMessage {
   source: 'artifactshare'
@@ -1493,6 +1498,7 @@ export interface LinkClickedMessage {
 export interface MermaidRenderRequestMessage {
   source: 'artifactshare'
   kind: 'mermaid-render-request'
+  renderToken: string
   diagrams: Array<{ id: string; source: string }>
 }
 
@@ -1565,6 +1571,9 @@ export function isSandboxMessage(value: unknown): value is SandboxMessage {
   }
   if (v.kind === 'mermaid-render-request') {
     return (
+      typeof v.renderToken === 'string' &&
+      v.renderToken.length > 0 &&
+      v.renderToken.length <= 128 &&
       Array.isArray(v.diagrams) &&
       v.diagrams.length > 0 &&
       v.diagrams.length <= 32 &&

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -6,6 +6,7 @@ describe('renderMarkdownDocument', () => {
   test('wraps output in a full HTML document', () => {
     const out = renderMarkdownDocument('# Hello')
     expect(out).toContain('<!doctype html>')
+    expect(out).toContain('<body data-markdown-renderer="marked">')
     expect(out).toContain('<article class="md" data-comment-content>')
     expect(out).toContain('<h1>Hello</h1>')
   })
@@ -40,6 +41,7 @@ describe('renderMarkdownDocument', () => {
       'tanstack',
     )
     expect(out).toContain('<h1 id="same">')
+    expect(out).toContain('<body data-markdown-renderer="tanstack">')
     expect(out).toContain('<h1 id="same-2">')
     expect(out).toContain('<a href="https://example.com/long"')
     expect(out).toContain('aria-label="Frontmatter"')

--- a/apps/web/app/lib/markdown-render.ts
+++ b/apps/web/app/lib/markdown-render.ts
@@ -26,7 +26,7 @@ export function renderMarkdownDocument(
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <style>${MD_STYLES}${renderer === 'tanstack' ? TANSTACK_MARKDOWN_CSS : ''}</style>
 </head>
-<body><div class="md-shell">${navigation}<article class="md" data-comment-content>${body}</article></div></body>
+<body data-markdown-renderer="${renderer}"><div class="md-shell">${navigation}<article class="md" data-comment-content>${body}</article></div></body>
 </html>`
   if (renderer === 'tanstack') {
     console.info('markdown_render_completed', {
@@ -210,6 +210,9 @@ body {
 .md img { max-width: 100%; height: auto; }
 .md-video { position: relative; aspect-ratio: 16 / 9; margin: 0 0 16px; }
 .md-video iframe { width: 100%; height: 100%; border: 0; }
+.mermaid-diagram { margin: 0 0 16px; overflow: auto; text-align: center; }
+.mermaid-diagram svg { max-width: 100%; height: auto; }
+.mermaid-error { border: 1px solid #cf222e; }
 .md hr {
   height: 0.25em;
   margin: 24px 0;

--- a/apps/web/app/lib/mermaid-render.client.test.ts
+++ b/apps/web/app/lib/mermaid-render.client.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const render = vi.fn(async (_id: string, source: string) => ({
+  svg: `<svg xmlns="http://www.w3.org/2000/svg"><text>${source}</text></svg>`,
+}))
+
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: vi.fn(),
+    render,
+  },
+}))
+
+import { renderMermaidInDocument } from './mermaid-render.client'
+
+describe('renderMermaidInDocument', () => {
+  beforeEach(() => render.mockClear())
+
+  test('renders TanStack blocks while preserving hidden source for comments', async () => {
+    const doc = new DOMParser().parseFromString(
+      '<body data-markdown-renderer="tanstack"><article data-comment-content><pre><code class="language-mermaid">flowchart LR\nA --&gt; B</code></pre></article></body>',
+      'text/html',
+    )
+
+    await renderMermaidInDocument(doc)
+
+    expect(render).toHaveBeenCalledWith(
+      expect.stringMatching(/^artifactshare-mermaid-/),
+      'flowchart LR\nA --> B',
+    )
+    expect(doc.querySelector('.mermaid-diagram svg')).not.toBeNull()
+    expect(doc.querySelector('pre')?.hasAttribute('hidden')).toBe(true)
+    expect(doc.querySelector('pre')?.textContent).toBe('flowchart LR\nA --> B')
+  })
+
+  test('leaves Marked output unchanged', async () => {
+    const doc = new DOMParser().parseFromString(
+      '<body data-markdown-renderer="marked"><pre><code class="language-mermaid">flowchart LR</code></pre></body>',
+      'text/html',
+    )
+
+    await renderMermaidInDocument(doc)
+
+    expect(render).not.toHaveBeenCalled()
+    expect(doc.querySelector('.mermaid-diagram')).toBeNull()
+    expect(doc.querySelector('pre')?.hasAttribute('hidden')).toBe(false)
+  })
+})

--- a/apps/web/app/lib/mermaid-render.client.test.ts
+++ b/apps/web/app/lib/mermaid-render.client.test.ts
@@ -72,8 +72,8 @@ describe('renderMermaidInDocument', () => {
 
     await renderMermaidInDocument(doc)
 
-    expect(render).toHaveBeenCalledTimes(32)
-    expect(doc.querySelectorAll('.mermaid-diagram')).toHaveLength(32)
-    expect(doc.querySelectorAll('pre:not([hidden])')).toHaveLength(8)
+    expect(render).toHaveBeenCalledTimes(16)
+    expect(doc.querySelectorAll('.mermaid-diagram')).toHaveLength(16)
+    expect(doc.querySelectorAll('pre:not([hidden])')).toHaveLength(24)
   })
 })

--- a/apps/web/app/lib/mermaid-render.client.test.ts
+++ b/apps/web/app/lib/mermaid-render.client.test.ts
@@ -3,13 +3,20 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const render = vi.fn(async (_id: string, source: string) => ({
-  svg: `<svg xmlns="http://www.w3.org/2000/svg"><text>${source}</text></svg>`,
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><text>${source}</text><script>alert(1)</script></svg>`,
 }))
 
 vi.mock('mermaid', () => ({
   default: {
     initialize: vi.fn(),
     render,
+  },
+}))
+
+vi.mock('dompurify', () => ({
+  default: {
+    sanitize: (svg: string) =>
+      svg.replace(/ onload="[^"]*"/g, '').replace(/<script>.*<\/script>/g, ''),
   },
 }))
 
@@ -31,6 +38,10 @@ describe('renderMermaidInDocument', () => {
       'flowchart LR\nA --> B',
     )
     expect(doc.querySelector('.mermaid-diagram svg')).not.toBeNull()
+    expect(doc.querySelector('.mermaid-diagram script')).toBeNull()
+    expect(
+      doc.querySelector('.mermaid-diagram svg')?.hasAttribute('onload'),
+    ).toBe(false)
     expect(doc.querySelector('pre')?.hasAttribute('hidden')).toBe(true)
     expect(doc.querySelector('pre')?.textContent).toBe('flowchart LR\nA --> B')
   })
@@ -46,5 +57,23 @@ describe('renderMermaidInDocument', () => {
     expect(render).not.toHaveBeenCalled()
     expect(doc.querySelector('.mermaid-diagram')).toBeNull()
     expect(doc.querySelector('pre')?.hasAttribute('hidden')).toBe(false)
+  })
+
+  test('caps export rendering to the live viewer limit', async () => {
+    const blocks = Array.from(
+      { length: 40 },
+      (_, index) =>
+        `<pre><code class="language-mermaid">flowchart LR\nA${index} --&gt; B${index}</code></pre>`,
+    ).join('')
+    const doc = new DOMParser().parseFromString(
+      `<body data-markdown-renderer="tanstack">${blocks}</body>`,
+      'text/html',
+    )
+
+    await renderMermaidInDocument(doc)
+
+    expect(render).toHaveBeenCalledTimes(32)
+    expect(doc.querySelectorAll('.mermaid-diagram')).toHaveLength(32)
+    expect(doc.querySelectorAll('pre:not([hidden])')).toHaveLength(8)
   })
 })

--- a/apps/web/app/lib/mermaid-render.client.test.ts
+++ b/apps/web/app/lib/mermaid-render.client.test.ts
@@ -31,7 +31,7 @@ describe('renderMermaidInDocument', () => {
       'text/html',
     )
 
-    await renderMermaidInDocument(doc)
+    await renderMermaidInDocument(doc, true)
 
     expect(render).toHaveBeenCalledWith(
       expect.stringMatching(/^artifactshare-mermaid-/),
@@ -52,7 +52,7 @@ describe('renderMermaidInDocument', () => {
       'text/html',
     )
 
-    await renderMermaidInDocument(doc)
+    await renderMermaidInDocument(doc, true)
 
     expect(render).not.toHaveBeenCalled()
     expect(doc.querySelector('.mermaid-diagram')).toBeNull()
@@ -70,10 +70,22 @@ describe('renderMermaidInDocument', () => {
       'text/html',
     )
 
-    await renderMermaidInDocument(doc)
+    await renderMermaidInDocument(doc, true)
 
     expect(render).toHaveBeenCalledTimes(16)
     expect(doc.querySelectorAll('.mermaid-diagram')).toHaveLength(16)
     expect(doc.querySelectorAll('pre:not([hidden])')).toHaveLength(24)
+  })
+
+  test('does not trust a TanStack marker on a non-Markdown export', async () => {
+    const doc = new DOMParser().parseFromString(
+      '<body data-markdown-renderer="tanstack"><pre><code class="language-mermaid">flowchart LR</code></pre></body>',
+      'text/html',
+    )
+
+    await renderMermaidInDocument(doc, false)
+
+    expect(render).not.toHaveBeenCalled()
+    expect(doc.querySelector('.mermaid-diagram')).toBeNull()
   })
 })

--- a/apps/web/app/lib/mermaid-render.client.ts
+++ b/apps/web/app/lib/mermaid-render.client.ts
@@ -1,0 +1,73 @@
+const MAX_MERMAID_SOURCE_LENGTH = 100_000
+
+let mermaidPromise: Promise<(typeof import('mermaid'))['default']> | null = null
+
+async function getMermaid() {
+  mermaidPromise ??= import('mermaid').then(({ default: mermaid }) => {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'strict',
+      suppressErrorRendering: true,
+    })
+    return mermaid
+  })
+  return await mermaidPromise
+}
+
+export async function renderMermaidSvg(source: string): Promise<string> {
+  if (!source.trim()) throw new Error('Mermaid source is empty')
+  if (source.length > MAX_MERMAID_SOURCE_LENGTH) {
+    throw new Error('Mermaid source is too large')
+  }
+  const mermaid = await getMermaid()
+  const id = `artifactshare-mermaid-${crypto.randomUUID().replaceAll('-', '')}`
+  return (await mermaid.render(id, source)).svg
+}
+
+function appendMermaidSvg(doc: Document, container: HTMLElement, svg: string) {
+  const parsed = new DOMParser().parseFromString(svg, 'image/svg+xml')
+  const root = parsed.documentElement
+  if (
+    root.localName !== 'svg' ||
+    root.namespaceURI !== 'http://www.w3.org/2000/svg' ||
+    parsed.querySelector('parsererror')
+  ) {
+    throw new Error('Mermaid returned invalid SVG')
+  }
+  container.appendChild(doc.importNode(root, true))
+}
+
+export async function renderMermaidInDocument(doc: Document): Promise<void> {
+  if (doc.body.dataset.markdownRenderer !== 'tanstack') return
+  const blocks = Array.from(
+    doc.querySelectorAll<HTMLElement>('pre code.language-mermaid'),
+  )
+  const rendered = await Promise.all(
+    blocks.map(async (block) => {
+      const pre = block.closest('pre')
+      if (!pre || pre.dataset.mermaidRendered === 'true') return null
+      try {
+        return {
+          pre,
+          svg: await renderMermaidSvg(block.textContent ?? ''),
+        }
+      } catch {
+        pre.classList.add('mermaid-error')
+        return null
+      }
+    }),
+  )
+  for (const result of rendered) {
+    if (!result) continue
+    try {
+      const container = doc.createElement('div')
+      container.className = 'mermaid-diagram'
+      appendMermaidSvg(doc, container, result.svg)
+      result.pre.dataset.mermaidRendered = 'true'
+      result.pre.hidden = true
+      result.pre.parentNode?.insertBefore(container, result.pre)
+    } catch {
+      result.pre.classList.add('mermaid-error')
+    }
+  }
+}

--- a/apps/web/app/lib/mermaid-render.client.ts
+++ b/apps/web/app/lib/mermaid-render.client.ts
@@ -1,4 +1,7 @@
+import DOMPurify from 'dompurify'
+
 const MAX_MERMAID_SOURCE_LENGTH = 100_000
+const MAX_MERMAID_DIAGRAMS = 32
 
 let mermaidPromise: Promise<(typeof import('mermaid'))['default']> | null = null
 
@@ -8,6 +11,7 @@ async function getMermaid() {
       startOnLoad: false,
       securityLevel: 'strict',
       suppressErrorRendering: true,
+      htmlLabels: false,
     })
     return mermaid
   })
@@ -21,7 +25,14 @@ export async function renderMermaidSvg(source: string): Promise<string> {
   }
   const mermaid = await getMermaid()
   const id = `artifactshare-mermaid-${crypto.randomUUID().replaceAll('-', '')}`
-  return (await mermaid.render(id, source)).svg
+  const { svg } = await mermaid.render(id, source)
+  return sanitizeMermaidSvg(svg)
+}
+
+export function sanitizeMermaidSvg(svg: string): string {
+  return DOMPurify.sanitize(svg, {
+    USE_PROFILES: { svg: true, svgFilters: true },
+  })
 }
 
 function appendMermaidSvg(doc: Document, container: HTMLElement, svg: string) {
@@ -41,7 +52,7 @@ export async function renderMermaidInDocument(doc: Document): Promise<void> {
   if (doc.body.dataset.markdownRenderer !== 'tanstack') return
   const blocks = Array.from(
     doc.querySelectorAll<HTMLElement>('pre code.language-mermaid'),
-  )
+  ).slice(0, MAX_MERMAID_DIAGRAMS)
   const rendered = await Promise.all(
     blocks.map(async (block) => {
       const pre = block.closest('pre')

--- a/apps/web/app/lib/mermaid-render.client.ts
+++ b/apps/web/app/lib/mermaid-render.client.ts
@@ -1,7 +1,7 @@
 import DOMPurify from 'dompurify'
 
-const MAX_MERMAID_SOURCE_LENGTH = 100_000
-const MAX_MERMAID_DIAGRAMS = 32
+const MAX_MERMAID_SOURCE_LENGTH = 20_000
+const MAX_MERMAID_DIAGRAMS = 16
 
 let mermaidPromise: Promise<(typeof import('mermaid'))['default']> | null = null
 
@@ -15,7 +15,12 @@ async function getMermaid() {
     })
     return mermaid
   })
-  return await mermaidPromise
+  try {
+    return await mermaidPromise
+  } catch (error) {
+    mermaidPromise = null
+    throw error
+  }
 }
 
 export async function renderMermaidSvg(source: string): Promise<string> {

--- a/apps/web/app/lib/mermaid-render.client.ts
+++ b/apps/web/app/lib/mermaid-render.client.ts
@@ -53,19 +53,29 @@ function appendMermaidSvg(doc: Document, container: HTMLElement, svg: string) {
   container.appendChild(doc.importNode(root, true))
 }
 
-export async function renderMermaidInDocument(doc: Document): Promise<void> {
-  if (doc.body.dataset.markdownRenderer !== 'tanstack') return
-  const blocks = Array.from(
-    doc.querySelectorAll<HTMLElement>('pre code.language-mermaid'),
-  ).slice(0, MAX_MERMAID_DIAGRAMS)
+export async function renderMermaidInDocument(
+  doc: Document,
+  trustedMarkdown: boolean,
+): Promise<void> {
+  if (!trustedMarkdown || doc.body.dataset.markdownRenderer !== 'tanstack')
+    return
+  const blocks: Array<{ pre: HTMLElement; source: string }> = []
+  for (const block of doc.querySelectorAll<HTMLElement>(
+    'pre code.language-mermaid',
+  )) {
+    const pre = block.closest('pre')
+    const source = block.textContent ?? ''
+    if (!pre || !source || source.length > MAX_MERMAID_SOURCE_LENGTH) continue
+    blocks.push({ pre, source })
+    if (blocks.length === MAX_MERMAID_DIAGRAMS) break
+  }
   const rendered = await Promise.all(
-    blocks.map(async (block) => {
-      const pre = block.closest('pre')
-      if (!pre || pre.dataset.mermaidRendered === 'true') return null
+    blocks.map(async ({ pre, source }) => {
+      if (pre.dataset.mermaidRendered === 'true') return null
       try {
         return {
           pre,
-          svg: await renderMermaidSvg(block.textContent ?? ''),
+          svg: await renderMermaidSvg(source),
         }
       } catch {
         pre.classList.add('mermaid-error')

--- a/apps/web/app/lib/mermaid-render.client.ts
+++ b/apps/web/app/lib/mermaid-render.client.ts
@@ -69,20 +69,20 @@ export async function renderMermaidInDocument(
     blocks.push({ pre, source })
     if (blocks.length === MAX_MERMAID_DIAGRAMS) break
   }
-  const rendered = await Promise.all(
-    blocks.map(async ({ pre, source }) => {
-      if (pre.dataset.mermaidRendered === 'true') return null
-      try {
-        return {
-          pre,
-          svg: await renderMermaidSvg(source),
-        }
-      } catch {
-        pre.classList.add('mermaid-error')
-        return null
-      }
-    }),
-  )
+  const rendered = await blocks.reduce<
+    Promise<Array<{ pre: HTMLElement; svg: string }>>
+  >(async (pending, { pre, source }) => {
+    // Mermaid diagram renderers share temporary DOM state, so keep the batch sequential.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    const results = await pending
+    if (pre.dataset.mermaidRendered === 'true') return results
+    try {
+      results.push({ pre, svg: await renderMermaidSvg(source) })
+    } catch {
+      pre.classList.add('mermaid-error')
+    }
+    return results
+  }, Promise.resolve([]))
   for (const result of rendered) {
     if (!result) continue
     try {

--- a/apps/web/app/lib/sandbox-frame-message.test.ts
+++ b/apps/web/app/lib/sandbox-frame-message.test.ts
@@ -64,6 +64,25 @@ describe('sandboxMessageFromFrame', () => {
       kind: 'link-clicked',
       href: 'https://artifactshare.com/a/abc123def4',
     })
+
+    expect(
+      sandboxMessageFromFrame(
+        messageEvent({
+          data: {
+            source: 'artifactshare',
+            kind: 'mermaid-render-request',
+            diagrams: [
+              {
+                id: 'artifactshare-mermaid-0',
+                source: 'flowchart LR\nA --> B',
+              },
+            ],
+          },
+        }),
+        trustedOrigin,
+        trustedWindow,
+      ),
+    ).toMatchObject({ kind: 'mermaid-render-request' })
   })
 
   test('rejects sibling frames and non-sandbox origins', () => {

--- a/apps/web/app/lib/sandbox-frame-message.test.ts
+++ b/apps/web/app/lib/sandbox-frame-message.test.ts
@@ -71,6 +71,7 @@ describe('sandboxMessageFromFrame', () => {
           data: {
             source: 'artifactshare',
             kind: 'mermaid-render-request',
+            renderToken: 'current-document',
             diagrams: [
               {
                 id: 'artifactshare-mermaid-0',

--- a/apps/web/app/routes/a.$id/+components/export-actions.ts
+++ b/apps/web/app/routes/a.$id/+components/export-actions.ts
@@ -73,7 +73,7 @@ export async function resolveExportHtml(
   if (!sourceHtml) return null
   if (!sourceHtml.trim()) return null
   const doc = new DOMParser().parseFromString(sourceHtml, 'text/html')
-  await renderMermaidInDocument(doc)
+  await renderMermaidInDocument(doc, data.kind === 'markdown')
   await inlineDocumentAssets(doc, shareableId, data.path)
   return `<!doctype html>\n${doc.documentElement.outerHTML}`
 }
@@ -363,7 +363,7 @@ export async function buildPrintDocument(
   const sourceHtml = data.kind === 'markdown' ? data.renderedHtml : data.source
   if (!sourceHtml) throw new Error('Rendered Markdown is unavailable')
   const doc = new DOMParser().parseFromString(sourceHtml, 'text/html')
-  await renderMermaidInDocument(doc)
+  await renderMermaidInDocument(doc, data.kind === 'markdown')
   doc.querySelectorAll('base').forEach((node) => {
     node.remove()
   })

--- a/apps/web/app/routes/a.$id/+components/export-actions.ts
+++ b/apps/web/app/routes/a.$id/+components/export-actions.ts
@@ -1,5 +1,6 @@
 import { splitAssetRef } from '~/lib/asset-ref'
 import type { ArtifactType } from '~/lib/artifact-type'
+import { renderMermaidInDocument } from '~/lib/mermaid-render.client'
 
 export type ExportSourceData = {
   kind: 'markdown' | 'html'
@@ -72,6 +73,7 @@ export async function resolveExportHtml(
   if (!sourceHtml) return null
   if (!sourceHtml.trim()) return null
   const doc = new DOMParser().parseFromString(sourceHtml, 'text/html')
+  await renderMermaidInDocument(doc)
   await inlineDocumentAssets(doc, shareableId, data.path)
   return `<!doctype html>\n${doc.documentElement.outerHTML}`
 }
@@ -322,13 +324,13 @@ export function openPrintWindow(): Window | null {
   return window.open('', '_blank')
 }
 
-export function writePrintPdf(
+export async function writePrintPdf(
   printWindow: Window,
   shareableId: string,
   data: ExportSourceData,
   labels: ExportPrintLabels,
 ) {
-  const printDoc = buildPrintDocument(shareableId, data, labels)
+  const printDoc = await buildPrintDocument(shareableId, data, labels)
   const targetDoc = printWindow.document
   printWindow.opener = null
   targetDoc.open()
@@ -353,14 +355,15 @@ function replaceDocumentContents(targetDoc: Document, sourceDoc: Document) {
   )
 }
 
-export function buildPrintDocument(
+export async function buildPrintDocument(
   shareableId: string,
   data: ExportSourceData,
   labels: ExportPrintLabels,
-): Document {
+): Promise<Document> {
   const sourceHtml = data.kind === 'markdown' ? data.renderedHtml : data.source
   if (!sourceHtml) throw new Error('Rendered Markdown is unavailable')
   const doc = new DOMParser().parseFromString(sourceHtml, 'text/html')
+  await renderMermaidInDocument(doc)
   doc.querySelectorAll('base').forEach((node) => {
     node.remove()
   })

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -75,22 +75,22 @@ function addFrameOffset(
 }
 
 async function renderMermaidRequest(message: MermaidRenderRequestMessage) {
-  const results = await Promise.all(
-    message.diagrams.map(async (diagram) => {
-      try {
-        return {
-          id: diagram.id,
-          svg: await renderMermaidSvg(diagram.source),
-        }
-      } catch {
-        // The source code block remains visible when a diagram cannot render.
-        return null
-      }
-    }),
-  )
-  return results.filter(
-    (result): result is { id: string; svg: string } => result !== null,
-  )
+  return await message.diagrams.reduce<
+    Promise<Array<{ id: string; svg: string }>>
+  >(async (pending, diagram) => {
+    // Mermaid diagram renderers share temporary DOM state, so keep the batch sequential.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    const results = await pending
+    try {
+      results.push({
+        id: diagram.id,
+        svg: await renderMermaidSvg(diagram.source),
+      })
+    } catch {
+      // The source code block remains visible when a diagram cannot render.
+    }
+    return results
+  }, Promise.resolve([]))
 }
 
 type SandboxFrameProps = {

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -659,6 +659,7 @@ function useSandboxFrameController({
             {
               source: 'artifactshare-parent',
               kind: 'mermaid-rendered',
+              renderToken: message.renderToken,
               results,
             },
             trustedMessageOrigin,

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -97,6 +97,7 @@ type SandboxFrameProps = {
   shareableId: string
   url: string
   name: string
+  mermaidEnabled: boolean
   textAnchorsEnabled: boolean
   linkNavigationMode: LinkNavigationMode
   bundlePaths: ReadonlyArray<string>
@@ -261,6 +262,7 @@ function useSandboxFrameController({
   shareableId,
   url,
   name,
+  mermaidEnabled,
   textAnchorsEnabled,
   linkNavigationMode,
   bundlePaths,
@@ -648,6 +650,7 @@ function useSandboxFrameController({
         handleLinkClickedMessage(message)
       } else if (message.kind === 'mermaid-render-request') {
         if (
+          !mermaidEnabled ||
           message.renderToken !== securityChallengeRef.current ||
           mermaidRenderChallengeRef.current === message.renderToken
         ) {
@@ -678,7 +681,7 @@ function useSandboxFrameController({
     }
     window.addEventListener('message', onMessage)
     return () => window.removeEventListener('message', onMessage)
-  }, [clearReadyFallback, trustedMessageOrigin])
+  }, [clearReadyFallback, mermaidEnabled, trustedMessageOrigin])
 
   useEffect(() => {
     if (loadState !== 'ready') return

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -21,6 +21,7 @@ import {
   ensureSandboxChallenge,
   type CspViolationMessage,
   type LinkClickedMessage,
+  type MermaidRenderRequestMessage,
   type TextSelectionMessage,
 } from '~/lib/csp-reporter'
 import { t as translate, tPlural as translatePlural } from '~/lib/i18n'
@@ -32,6 +33,7 @@ import {
 import { DeniedPanel } from '~/components/app/denied-panel'
 import { Button } from '~/components/ui/button'
 import { sandboxMessageFromFrame } from '~/lib/sandbox-frame-message'
+import { renderMermaidSvg } from '~/lib/mermaid-render.client'
 import {
   classifyViewerLinkNavigation,
   hasBrowserUserActivation,
@@ -70,6 +72,25 @@ function addFrameOffset(
     width: rect.width,
     height: rect.height,
   }
+}
+
+async function renderMermaidRequest(message: MermaidRenderRequestMessage) {
+  const results = await Promise.all(
+    message.diagrams.map(async (diagram) => {
+      try {
+        return {
+          id: diagram.id,
+          svg: await renderMermaidSvg(diagram.source),
+        }
+      } catch {
+        // The source code block remains visible when a diagram cannot render.
+        return null
+      }
+    }),
+  )
+  return results.filter(
+    (result): result is { id: string; svg: string } => result !== null,
+  )
 }
 
 type SandboxFrameProps = {
@@ -623,6 +644,26 @@ function useSandboxFrameController({
         handleOutsidePointerDownMessage()
       } else if (message.kind === 'link-clicked') {
         handleLinkClickedMessage(message)
+      } else if (message.kind === 'mermaid-render-request') {
+        const sourceWindow = event.source
+        void renderMermaidRequest(message).then((results) => {
+          const frameWindow = frameRef.current?.contentWindow
+          if (
+            !frameWindow ||
+            results.length === 0 ||
+            sourceWindow !== frameWindow
+          ) {
+            return
+          }
+          frameWindow.postMessage(
+            {
+              source: 'artifactshare-parent',
+              kind: 'mermaid-rendered',
+              results,
+            },
+            trustedMessageOrigin,
+          )
+        })
       }
     }
     window.addEventListener('message', onMessage)

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -300,6 +300,7 @@ function useSandboxFrameController({
   const focusRetryFailureRef = useRef(false)
   const securityChallengeRef = useRef<string | null>(null)
   const securityTokenRef = useRef<string | null>(null)
+  const mermaidRenderChallengeRef = useRef<string | null>(null)
   if (staticSiteAuthRef.current === null) {
     staticSiteAuthRef.current = Date.now()
   }
@@ -607,6 +608,7 @@ function useSandboxFrameController({
   const handleFrameLoad = useCallback(() => {
     securityChallengeRef.current = createSandboxChallenge()
     securityTokenRef.current = null
+    mermaidRenderChallengeRef.current = null
     requestFrameReady()
     clearReadyFallback()
     sendHighlights()
@@ -645,6 +647,13 @@ function useSandboxFrameController({
       } else if (message.kind === 'link-clicked') {
         handleLinkClickedMessage(message)
       } else if (message.kind === 'mermaid-render-request') {
+        if (
+          message.renderToken !== securityChallengeRef.current ||
+          mermaidRenderChallengeRef.current === message.renderToken
+        ) {
+          return
+        }
+        mermaidRenderChallengeRef.current = message.renderToken
         const sourceWindow = event.source
         void renderMermaidRequest(message).then((results) => {
           const frameWindow = frameRef.current?.contentWindow

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -1860,6 +1860,7 @@ function ViewerShellView({
           shareableId={artifact.id}
           url={sandboxUrl}
           name={frameTitle}
+          mermaidEnabled={renderType === 'md'}
           textAnchorsEnabled={textAnchorsEnabled}
           linkNavigationMode={
             renderType ? linkNavigationModeFor(renderType) : 'document'

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -1621,8 +1621,8 @@ function useViewerShellController({
       toast.error(t('toast.exportPopupBlocked'))
       return
     }
-    void runExportAction('pdf', (source) => {
-      writePrintPdf(printWindow, artifact.id, source, exportPrintLabels)
+    void runExportAction('pdf', async (source) => {
+      await writePrintPdf(printWindow, artifact.id, source, exportPrintLabels)
     }).then((ok) => {
       if (!ok) printWindow.close()
     })

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,6 +58,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "^1.1.1",
+    "dompurify": "3.4.13",
     "isbot": "5.2.1",
     "kysely": "0.29.3",
     "kysely-d1": "0.4.0",

--- a/apps/web/vitest.behavior.browser.config.ts
+++ b/apps/web/vitest.behavior.browser.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   cacheDir: 'node_modules/.vite-browser-behavior',
+  optimizeDeps: { include: ['mermaid'] },
   resolve: { alias: { '~': resolve(import.meta.dirname, 'app') } },
   plugins: [
     tailwindcss(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 0.7.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0))(oxlint-tsgolint@0.24.0)
       vite-plus:
         specifier: 0.2.4
-        version: 0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1)
+        version: 0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1)
       wrangler:
         specifier: 4.111.0
         version: 4.111.0(@cloudflare/workers-types@5.20260716.1)
@@ -88,6 +88,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      dompurify:
+        specifier: 3.4.13
+        version: 3.4.13
       isbot:
         specifier: 5.2.1
         version: 5.2.1
@@ -9553,7 +9556,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))
       playwright: 1.58.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -9592,7 +9595,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -9638,7 +9641,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))
       ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
@@ -11625,7 +11628,7 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
-  oxfmt@0.57.0(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1)):
+  oxfmt@0.57.0(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -11648,7 +11651,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.57.0
       '@oxfmt/binding-win32-ia32-msvc': 0.57.0
       '@oxfmt/binding-win32-x64-msvc': 0.57.0
-      vite-plus: 0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1)
+      vite-plus: 0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1)
 
   oxfmt@0.57.0(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
@@ -11714,7 +11717,7 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.66.0
       oxlint-tsgolint: 0.24.0
 
-  oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1)):
+  oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.72.0
       '@oxlint/binding-android-arm64': 1.72.0
@@ -11736,7 +11739,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.72.0
       '@oxlint/binding-win32-x64-msvc': 1.72.0
       oxlint-tsgolint: 0.24.0
-      vite-plus: 0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1)
+      vite-plus: 0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1)
 
   oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
@@ -12658,7 +12661,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1):
+  vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1):
     dependencies:
       '@oxc-project/types': 0.138.0
       '@oxlint/plugins': 1.68.0
@@ -12672,10 +12675,10 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       '@voidzero-dev/vite-plus-core': 0.2.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.1)
-      oxfmt: 0.57.0(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1))
-      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1))
+      oxfmt: 0.57.0(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1))
+      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(yaml@2.8.1))
       oxlint-tsgolint: 0.24.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))
     optionalDependencies:
       '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10)
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.4
@@ -12849,7 +12852,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.58.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.1))


### PR DESCRIPTION
## Summary

- render Mermaid fenced code blocks in the TanStack Markdown viewer through the trusted parent viewer
- lazy-load Mermaid only when a supported Markdown document requests diagram rendering
- keep the original source block in the document for comment anchors and as a fallback when rendering fails
- apply the same rendered output to HTML download and PDF/print preparation while leaving Marked, HTML, and static-site artifacts unchanged

## Safety and limits

- keep the existing artifact iframe sandbox and CSP permissions unchanged
- authenticate each render request to the current Markdown document and accept only one request per frame load
- sanitize Mermaid output with DOMPurify, then validate the SVG root before importing it into the artifact document
- render diagrams sequentially, with a limit of 16 diagrams and 20 KB of source per diagram

## Bundle impact

- Mermaid remains code-split and loads only when a diagram is requested
- the regular sandbox Worker dry-run is 689.50 KiB raw / 125.72 KiB gzip
- a flowchart request loads the shared Mermaid chunks and the diagram-specific chunk on demand

## Validation

- `pnpm validate:static`
- `pnpm --filter @artifactshare/web build:production`
- `pnpm --filter @artifactshare/web build:sandbox:production`
- `pnpm public:scan .`
- browser behavior coverage for real Mermaid rendering, SVG sanitization, stale-response rejection, preserved comment anchors, and HTML/PDF export preparation
- Codex and Claude implementation reviews
