### PR TITLE
Improve Markdown typography

### DIFF
--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -11,6 +11,17 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('<h1>Hello</h1>')
   })
 
+  test('applies prose typography without wrapping code or tables', () => {
+    const out = renderMarkdownDocument('# Heading\n\nBody')
+
+    expect(out).toContain('"Helvetica Neue", Arial')
+    expect(out).toContain('font-feature-settings: "palt"')
+    expect(out).toContain('text-wrap: balance')
+    expect(out).toContain('line-break: strict')
+    expect(out).toContain('font-feature-settings: normal')
+    expect(out).toMatch(/\.md table \{[\s\S]*?overflow-wrap: normal;/)
+  })
+
   test('renders GFM tables', () => {
     const md = `| a | b |\n|---|---|\n| 1 | 2 |`
     const out = renderMarkdownDocument(md)

--- a/apps/web/app/lib/markdown-render.ts
+++ b/apps/web/app/lib/markdown-render.ts
@@ -126,8 +126,8 @@ html { scroll-behavior: smooth; }
 body {
   background: var(--md-bg);
   color: var(--md-text);
-  font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Sans",
-    "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif;
+  font: 16px/1.7 "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN",
+    "Hiragino Sans", "Noto Sans JP", Meiryo, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
 .md {
@@ -157,7 +157,9 @@ body {
 .md h1, .md h2, .md h3, .md h4, .md h5, .md h6 {
   margin: 32px 0 16px;
   font-weight: 600;
+  font-feature-settings: "palt";
   line-height: 1.25;
+  text-wrap: balance;
 }
 .md h1 { font-size: 2em; padding-bottom: 0.3em; border-bottom: 1px solid var(--md-border); }
 .md h2 { font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid var(--md-border); }
@@ -167,7 +169,11 @@ body {
 .md h6 { font-size: 0.85em; color: var(--md-muted); }
 .md p, .md ul, .md ol, .md blockquote, .md pre, .md table { margin: 0 0 16px; }
 .md a { color: var(--md-link); text-decoration: none; }
-.md { overflow-wrap: anywhere; word-break: auto-phrase; }
+.md {
+  overflow-wrap: anywhere;
+  word-break: auto-phrase;
+  line-break: strict;
+}
 .md a:hover { text-decoration: underline; }
 .md ul, .md ol { padding-left: 2em; }
 .md li + li { margin-top: 0.25em; }
@@ -178,6 +184,7 @@ body {
 }
 .md code {
   font: 0.85em ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-feature-settings: normal;
   background: var(--md-code-bg);
   padding: 0.2em 0.4em;
   border-radius: 6px;
@@ -188,6 +195,9 @@ body {
   overflow: auto;
   border-radius: 8px;
   line-height: 1.45;
+  line-break: auto;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 .md pre code {
   background: transparent;
@@ -200,6 +210,9 @@ body {
   width: max-content;
   max-width: 100%;
   overflow: auto;
+  line-break: auto;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 .md th, .md td {
   padding: 6px 13px;


### PR DESCRIPTION
## Summary

- refine the lightweight Markdown viewer font stack and reading line height
- apply proportional Japanese metrics and balanced wrapping to headings
- add strict Japanese line-breaking while preserving scrolling behavior for code blocks and wide tables

## Validation

- `pnpm --filter @artifactshare/web exec vitest --config vitest.config.ts --run app/lib/markdown-render.test.ts`
- `pnpm validate:static`
- Codex and Claude implementation reviews: no blockers or follow-ups
- local TanStack Markdown PoC inspected at desktop and 390px widths
