### PR TITLE
Improve rich Markdown block presentation

### DIFF
--- a/apps/web/app/lib/csp-reporter.behavior.browser.test.tsx
+++ b/apps/web/app/lib/csp-reporter.behavior.browser.test.tsx
@@ -55,6 +55,35 @@ afterEach(() => {
 })
 
 describe('CSP reporter runtime behavior', () => {
+  test('copies a rendered code block without selecting it for comments', async () => {
+    const doc = await fixture(
+      '<figure class="md-code-block"><button data-code-copy>Copy</button><pre><code>const answer = 42</code></pre></figure>',
+    )
+    await applyHighlights([])
+    let copied = ''
+    Object.defineProperty(doc.defaultView!.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: (value: string) => {
+          copied = value
+          return Promise.resolve()
+        },
+      },
+    })
+    const button = doc.querySelector<HTMLButtonElement>('[data-code-copy]')!
+    button.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    button.click()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(copied).toBe('const answer = 42')
+    expect(button.textContent).toBe('Copied')
+    expect(
+      messages.filter(
+        (message) => message.kind === 'comment-outside-pointer-down',
+      ),
+    ).toHaveLength(0)
+  })
+
   test('marks matching desktop and mobile table-of-contents links as current', async () => {
     const doc = await fixture(
       '<nav class="md-toc"><a href="#intro">Intro</a></nav><details><nav class="md-toc"><a href="#intro">Intro</a></nav></details><h2 id="intro">Intro</h2>',

--- a/apps/web/app/lib/csp-reporter.ts
+++ b/apps/web/app/lib/csp-reporter.ts
@@ -1351,7 +1351,9 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
     if (
       target &&
       target.closest &&
-      target.closest('.ash-comment-highlight, .ash-comment-highlight-badge')
+      target.closest(
+        '.ash-comment-highlight, .ash-comment-highlight-badge, [data-code-copy]',
+      )
     ) {
       return;
     }
@@ -1403,6 +1405,42 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
   document.addEventListener('keyup', function () {
     setTimeout(sendSelection, 0);
   });
+  document.addEventListener('click', function (event) {
+    var target = event.target;
+    var button = target && target.closest && target.closest('[data-code-copy]');
+    if (!button) return;
+    var block = button.closest('.md-code-block');
+    var code = block && block.querySelector('pre code');
+    if (!code) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    var copied = function () {
+      button.textContent = 'Copied';
+      button.setAttribute('aria-label', 'Code copied');
+      setTimeout(function () {
+        button.textContent = 'Copy';
+        button.setAttribute('aria-label', 'Copy code');
+      }, 1500);
+    };
+    var fallback = function () {
+      var textarea = document.createElement('textarea');
+      textarea.value = code.textContent || '';
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+        if (document.execCommand('copy')) copied();
+      } catch (error) {}
+      textarea.remove();
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(code.textContent || '').then(copied, fallback);
+    } else {
+      fallback();
+    }
+  });
   addEventListener(window, 'click', prepareLinkClick, true);
   addEventListener(window, 'click', finishLinkClick);
   document.addEventListener('pointerdown', sendOutsidePointerDown);
@@ -1442,7 +1480,7 @@ export const VIOLATION_REPORTER_TAG = `<script>${VIOLATION_REPORTER_SCRIPT_BODY}
 // string. If the body changes, the drift test in csp-reporter.test.ts
 // fails and prints the new value to paste here.
 export const VIOLATION_REPORTER_SHA256 =
-  'OGAhwYAxIcUbglYL1GOvkewxJlfQl7ZWlSaaSTGz5y8='
+  'ZAbB8gDgPK6wFJQDGUlP0/PMTt2DtEnE3fQv+yEojqM='
 
 export interface CspViolationMessage {
   source: 'artifactshare'

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -21,6 +21,11 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('font-feature-settings: normal')
     expect(out).toMatch(/\.md table \{[\s\S]*?overflow-wrap: normal;/)
     expect(out).toContain('--md-bg: #fbfaf8')
+    expect(out).toContain('border-radius: 12px')
+    expect(out).toMatch(/\.md-toc-desktop \{[\s\S]*?border-radius: 8px;/)
+    expect(out).toMatch(
+      /@media \(max-width: 699px\) \{[\s\S]*?border-radius: 0;/,
+    )
     expect(out).toContain('box-shadow: inset 2px 0')
   })
 
@@ -91,5 +96,42 @@ describe('renderMarkdownDocument', () => {
       'src="https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ"',
     )
     expect(out).toContain('sandbox="allow-scripts allow-same-origin"')
+  })
+
+  test('renders titled code in a dark code frame with a copy action', () => {
+    const out = renderMarkdownDocument(
+      '```ts title="app.ts"\nconst answer = 42\n```',
+      'tanstack',
+    )
+
+    expect(out).toContain('class="md-code-block"')
+    expect(out).toContain('class="md-code-label">app.ts</span>')
+    expect(out).toContain('data-code-copy')
+    expect(out).toContain('--md-code-block-bg: #0d1117')
+  })
+
+  test('centers only image paragraphs that use the caption convention', () => {
+    const out = renderMarkdownDocument(
+      '![Diagram](https://example.com/diagram.png)\n*Caption*',
+      'tanstack',
+    )
+
+    expect(out).toContain(
+      '.md p:has(> img:first-child + em:last-child) { text-align: center; }',
+    )
+    expect(out).not.toContain(
+      '.md p:has(> img:first-child) { text-align: center; }',
+    )
+  })
+
+  test('uses the shared code frame for titled Mermaid blocks', () => {
+    const out = renderMarkdownDocument(
+      '```mermaid title="`Flow`.mmd"\ngraph LR\nA --> B\n```',
+      'tanstack',
+    )
+
+    expect(out).toContain('class="md-code-label">`Flow`.mmd</span>')
+    expect(out).toContain('<code class="language-mermaid">')
+    expect(out).not.toContain('class="tm-code-frame"')
   })
 })

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -110,6 +110,15 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('--md-code-block-bg: #0d1117')
   })
 
+  test('renders untitled code without a language in the shared code frame', () => {
+    const out = renderMarkdownDocument('```\nplain text\n```', 'tanstack')
+
+    expect(out).toContain('class="md-code-block" data-lang="plaintext"')
+    expect(out).toContain('class="md-code-label">plaintext</span>')
+    expect(out).toContain('data-code-copy')
+    expect(out).toContain('plain text')
+  })
+
   test('centers only image paragraphs that use the caption convention', () => {
     const out = renderMarkdownDocument(
       '![Diagram](https://example.com/diagram.png)\n*Caption*',

--- a/apps/web/app/lib/markdown-render.ts
+++ b/apps/web/app/lib/markdown-render.ts
@@ -114,6 +114,11 @@ const MD_STYLES = `
   --md-accent-bg: rgba(55, 53, 47, 0.04);
   --md-link-soft: rgba(35, 131, 226, 0.1);
   --md-code-bg: #f7f6f3;
+  --md-code-block-bg: #0d1117;
+  --md-code-block-surface: #161b22;
+  --md-code-block-text: #f0f6fc;
+  --md-code-block-muted: #9da7b3;
+  --md-code-block-border: rgba(240, 246, 252, 0.14);
   --md-link: #116bb1;
   --md-link-hover: #125892;
   --md-radius-sm: 3px;
@@ -150,9 +155,14 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 .md {
+  width: min(860px, calc(100% - 48px));
   max-width: 860px;
-  margin: 0 auto;
+  margin: 32px auto 64px;
   padding: 48px 32px 96px;
+  border: 1px solid var(--md-border);
+  border-radius: 12px;
+  background: var(--md-surface);
+  box-shadow: var(--md-shadow-sm);
 }
 .md-shell { max-width: 1180px; margin: 0 auto; }
 .md-sidebar { padding: 24px 32px 0; color: var(--md-muted); font-size: 0.875rem; }
@@ -211,6 +221,13 @@ body {
 .md-sidebar dt { color: var(--md-faint); font-size: 0.75rem; font-weight: 600; }
 .md-sidebar dd { margin: 0; color: var(--md-text); overflow-wrap: anywhere; }
 .md-toc-mobile { display: none; }
+.md-toc-desktop {
+  padding: 12px;
+  border: 1px solid var(--md-border);
+  border-radius: 8px;
+  background: var(--md-surface);
+  box-shadow: var(--md-shadow-sm);
+}
 .md-sidebar li { margin: 1px 0; }
 .md-sidebar a {
   display: block;
@@ -232,7 +249,8 @@ body {
   font-weight: 600;
 }
 @media (min-width: 980px) {
-  .md-shell { display: grid; grid-template-columns: 240px minmax(0,860px); }
+  .md-shell:has(> .md-sidebar) { display: grid; grid-template-columns: 240px minmax(0,860px); }
+  .md-shell:has(> .md-sidebar) .md { width: 100%; }
   .md-sidebar { position: sticky; top: 0; align-self: start; max-height: 100vh; overflow: auto; padding-top: 48px; border-right: 1px solid var(--md-border); }
   .md-toc-mobile + .md-metadata { margin-top: 24px; }
 }
@@ -258,6 +276,17 @@ body {
     background: var(--md-muted-bg);
   }
 }
+@media (max-width: 699px) {
+  .md {
+    width: 100%;
+    margin: 16px 0 0;
+    padding: 32px 20px 72px;
+    border-right: 0;
+    border-left: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+}
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   .md-sidebar summary::before { transition: none; }
@@ -277,7 +306,7 @@ body {
 .md h4 { font-size: 1em; }
 .md h5 { font-size: 0.875em; }
 .md h6 { font-size: 0.85em; color: var(--md-muted); }
-.md p, .md ul, .md ol, .md blockquote, .md pre, .md table { margin: 0 0 16px; }
+.md p, .md ul, .md ol, .md blockquote, .md table { margin: 0 0 16px; }
 .md a { color: var(--md-link); text-decoration: none; text-underline-offset: 0.15em; }
 .md {
   overflow-wrap: anywhere;
@@ -302,7 +331,9 @@ body {
   border-radius: 6px;
 }
 .md pre {
-  background: var(--md-code-bg);
+  margin: 0 0 16px;
+  background: var(--md-code-block-bg);
+  color: var(--md-code-block-text);
   padding: 16px;
   overflow: auto;
   border-radius: 8px;
@@ -311,6 +342,39 @@ body {
   overflow-wrap: normal;
   word-break: normal;
 }
+.md-code-block {
+  position: relative;
+  margin: 0 0 20px;
+  overflow: hidden;
+  border: 1px solid var(--md-code-block-border);
+  border-radius: 9px;
+  background: var(--md-code-block-bg);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+}
+.md-code-block pre { margin: 0; }
+.md-code-toolbar {
+  display: flex;
+  min-height: 38px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 8px 0 14px;
+  color: var(--md-code-block-muted);
+  border-bottom: 1px solid var(--md-code-block-border);
+  background: var(--md-code-block-surface);
+  font: 600 0.75rem/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.md-code-copy {
+  padding: 6px 8px;
+  color: var(--md-code-block-muted);
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+.md-code-copy:hover { color: var(--md-code-block-text); background: rgba(240, 246, 252, 0.08); }
+.md-code-copy:focus-visible { outline: 2px solid #58a6ff; outline-offset: 1px; }
 .md pre code {
   background: transparent;
   padding: 0;
@@ -332,7 +396,37 @@ body {
 }
 .md th { background: var(--md-code-bg); font-weight: 600; }
 .md tr:nth-child(2n) td { background: var(--md-code-bg); }
-.md img { max-width: 100%; height: auto; }
+.md img { max-width: 100%; height: auto; border-radius: var(--md-radius-md); }
+.md p:has(> img:first-child + em:last-child) { text-align: center; }
+.md p:has(> img:first-child) > em:last-child {
+  display: block;
+  margin-top: 6px;
+  color: var(--md-faint);
+  font-size: 0.8125rem;
+  font-style: normal;
+}
+.md details:not(.md-metadata):not(.md-toc-mobile) {
+  margin: 0 0 16px;
+  padding: 0 16px 12px;
+  border: 1px solid var(--md-border);
+  border-radius: var(--md-radius-md);
+  background: var(--md-surface);
+}
+.md details:not(.md-metadata):not(.md-toc-mobile) > summary {
+  margin: 0 -16px -12px;
+  padding: 10px 16px;
+  color: var(--md-text);
+  cursor: pointer;
+  font-weight: 600;
+}
+.md details:not(.md-metadata):not(.md-toc-mobile)[open] > summary {
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--md-border);
+}
+.md details:not(.md-metadata):not(.md-toc-mobile) > summary:focus-visible {
+  outline: 2px solid var(--md-link);
+  outline-offset: 2px;
+}
 .md-video { position: relative; aspect-ratio: 16 / 9; margin: 0 0 16px; }
 .md-video iframe { width: 100%; height: 100%; border: 0; }
 .mermaid-diagram { margin: 0 0 16px; overflow: auto; text-align: center; }

--- a/apps/web/app/lib/markdown-renderer.server.ts
+++ b/apps/web/app/lib/markdown-renderer.server.ts
@@ -41,8 +41,14 @@ function uniqueHeadingId() {
 
 function highlightCode(html: string): string {
   const highlighted = html.replace(
-    /<pre([^>]*)><code class="language-([^" ]+)">([\s\S]*?)<\/code><\/pre>/g,
-    (original, attributes: string, language: string, encodedCode: string) => {
+    /<pre([^>]*)><code(?: class="language-([^" ]+)")?>([\s\S]*?)<\/code><\/pre>/g,
+    (
+      original,
+      attributes: string,
+      matchedLanguage: string | undefined,
+      encodedCode: string,
+    ) => {
+      const language = matchedLanguage ?? 'text'
       const title =
         readAttribute(attributes, 'data-code-title') ??
         readAttribute(attributes, 'data-filename')

--- a/apps/web/app/lib/markdown-renderer.server.ts
+++ b/apps/web/app/lib/markdown-renderer.server.ts
@@ -40,13 +40,42 @@ function uniqueHeadingId() {
 }
 
 function highlightCode(html: string): string {
-  return html.replace(
-    /<pre[^>]*><code class="language-([^" ]+)">([\s\S]*?)<\/code><\/pre>/g,
-    (original, language: string, encodedCode: string) => {
-      if (language === 'mermaid') return original
-      return highlightTanStackCode(decodeHtml(encodedCode), language).html
+  const highlighted = html.replace(
+    /<pre([^>]*)><code class="language-([^" ]+)">([\s\S]*?)<\/code><\/pre>/g,
+    (original, attributes: string, language: string, encodedCode: string) => {
+      const title =
+        readAttribute(attributes, 'data-code-title') ??
+        readAttribute(attributes, 'data-filename')
+      const label = title ?? language
+      const renderedCode =
+        language === 'mermaid'
+          ? original
+          : highlightTanStackCode(decodeHtml(encodedCode), language).html
+      return `<figure class="md-code-block" data-lang="${escapeAttribute(language)}"><figcaption class="md-code-toolbar"><span class="md-code-label">${escapeHtml(label)}</span><button type="button" class="md-code-copy" data-code-copy aria-label="Copy code">Copy</button></figcaption>${renderedCode}</figure>`
     },
   )
+  return highlighted.replace(
+    /<figure class="tm-code-frame"[^>]*><figcaption>[\s\S]*?<\/figcaption>(<figure class="md-code-block"[\s\S]*?<\/figure>)<\/figure>/g,
+    '$1',
+  )
+}
+
+function readAttribute(attributes: string, name: string) {
+  const match = attributes.match(new RegExp(`\\s${name}="([^"]*)"`))
+  return match ? decodeHtml(match[1]) : null
+}
+
+function escapeAttribute(value: string) {
+  return escapeHtml(value)
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#x27;')
 }
 
 function decodeHtml(value: string) {
@@ -54,6 +83,7 @@ function decodeHtml(value: string) {
     .replaceAll('&lt;', '<')
     .replaceAll('&gt;', '>')
     .replaceAll('&quot;', '"')
+    .replaceAll('&#96;', '`')
     .replace(/&#(?:3)9;|&#x27;/g, "'")
     .replaceAll('&amp;', '&')
 }

--- a/apps/web/app/lib/tanstack-highlight.server.ts
+++ b/apps/web/app/lib/tanstack-highlight.server.ts
@@ -15,7 +15,7 @@ import { ts } from '@tanstack/highlight/languages/ts'
 import { tsx } from '@tanstack/highlight/languages/tsx'
 import { yaml } from '@tanstack/highlight/languages/yaml'
 import { createThemeCss } from '@tanstack/highlight/theme'
-import { githubLightTheme } from '@tanstack/highlight/themes/github-light'
+import { githubDarkTheme } from '@tanstack/highlight/themes/github-dark'
 
 const languageDefinitions = [
   css,
@@ -50,7 +50,7 @@ export const TANSTACK_HIGHLIGHT_ALIASES = Object.freeze(
 )
 
 export const TANSTACK_HIGHLIGHT_CSS = createThemeCss({
-  light: githubLightTheme,
+  light: githubDarkTheme,
 })
 
 export function highlightTanStackCode(code: string, language?: string) {


### PR DESCRIPTION
## Summary

- present Markdown articles and the desktop contents panel as restrained Artifact Share surfaces
- use always-dark TanStack Highlight code blocks with titles, copy actions, and Mermaid support
- add lightweight styling for image captions and disclosure blocks while keeping mobile articles edge-to-edge

## Validation

- `pnpm validate:static`
- focused Markdown rendering and browser behavior tests
- Codex implementation review: no findings
- Claude implementation review: no findings
