### PR TITLE
Remove Markdown sidebar divider

### DIFF
--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -24,6 +24,7 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('border-radius: 12px')
     expect(out).toMatch(/\.md-toc-desktop \{[\s\S]*?border-radius: 8px;/)
     expect(out).not.toMatch(/\.md-sidebar \{[^}]*border-right:/)
+    expect(out).toMatch(/\.md-sidebar \{[^}]*padding-top: 32px;/)
     expect(out).toMatch(
       /@media \(max-width: 699px\) \{[\s\S]*?border-radius: 0;/,
     )

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -23,6 +23,7 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('--md-bg: #fbfaf8')
     expect(out).toContain('border-radius: 12px')
     expect(out).toMatch(/\.md-toc-desktop \{[\s\S]*?border-radius: 8px;/)
+    expect(out).not.toMatch(/\.md-sidebar \{[^}]*border-right:/)
     expect(out).toMatch(
       /@media \(max-width: 699px\) \{[\s\S]*?border-radius: 0;/,
     )

--- a/apps/web/app/lib/markdown-render.ts
+++ b/apps/web/app/lib/markdown-render.ts
@@ -251,7 +251,7 @@ body {
 @media (min-width: 980px) {
   .md-shell:has(> .md-sidebar) { display: grid; grid-template-columns: 240px minmax(0,860px); }
   .md-shell:has(> .md-sidebar) .md { width: 100%; }
-  .md-sidebar { position: sticky; top: 0; align-self: start; max-height: 100vh; overflow: auto; padding-top: 48px; border-right: 1px solid var(--md-border); }
+  .md-sidebar { position: sticky; top: 0; align-self: start; max-height: 100vh; overflow: auto; padding-top: 48px; }
   .md-toc-mobile + .md-metadata { margin-top: 24px; }
 }
 @media (max-width: 979px) {

--- a/apps/web/app/lib/markdown-render.ts
+++ b/apps/web/app/lib/markdown-render.ts
@@ -251,7 +251,7 @@ body {
 @media (min-width: 980px) {
   .md-shell:has(> .md-sidebar) { display: grid; grid-template-columns: 240px minmax(0,860px); }
   .md-shell:has(> .md-sidebar) .md { width: 100%; }
-  .md-sidebar { position: sticky; top: 0; align-self: start; max-height: 100vh; overflow: auto; padding-top: 48px; }
+  .md-sidebar { position: sticky; top: 0; align-self: start; max-height: 100vh; overflow: auto; padding-top: 32px; }
   .md-toc-mobile + .md-metadata { margin-top: 24px; }
 }
 @media (max-width: 979px) {


### PR DESCRIPTION
## Summary

- remove the obsolete desktop divider between the Markdown navigation and article cards
- align the navigation card's top edge with the article card
- add a focused regression assertion for the sidebar styling

## Validation

- `pnpm validate:static`
- focused Markdown rendering tests
- Codex implementation review: no findings
- Claude implementation review: no findings
