### PR TITLE
Support safe Markdown disclosure blocks

### DIFF
--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -15,16 +15,9 @@ export const markdownDisclosureExtension: MarkdownExtension = {
     )
     if (!summary) return undefined
 
-    const body: string[] = []
-    let cursor = context.index + 2
-    while (
-      cursor < context.lines.length &&
-      !detailsClosing.test(context.lines[cursor] ?? '')
-    ) {
-      body.push(context.lines[cursor] ?? '')
-      cursor++
-    }
-    if (cursor >= context.lines.length) return undefined
+    const bodyStart = context.index + 2
+    const cursor = findClosingDetails(context.lines, bodyStart)
+    if (cursor === undefined) return undefined
 
     context.consume(cursor - context.index + 1)
     return {
@@ -34,7 +27,9 @@ export const markdownDisclosureExtension: MarkdownExtension = {
         summary: summary[1] ?? '',
         open: opening[1] ? 'true' : 'false',
       },
-      children: context.parseBlocks(body.join('\n')),
+      children: context.parseBlocks(
+        context.lines.slice(bodyStart, cursor).join('\n'),
+      ),
     }
   },
   renderHtml(node, context) {
@@ -46,6 +41,40 @@ export const markdownDisclosureExtension: MarkdownExtension = {
     const body = node.children.map(context.renderBlock).join('\n')
     return `<details${open}><summary>${summary}</summary>${body}</details>`
   },
+}
+
+function findClosingDetails(lines: string[], start: number) {
+  let depth = 1
+  let fence: { marker: string; length: number } | undefined
+
+  for (let cursor = start; cursor < lines.length; cursor++) {
+    const line = lines[cursor] ?? ''
+    if (fence) {
+      if (isClosingFence(line, fence)) fence = undefined
+      continue
+    }
+
+    const openingFence = line.match(/^ {0,3}(`{3,}|~{3,})/u)?.[1]
+    if (openingFence) {
+      fence = { marker: openingFence[0] ?? '', length: openingFence.length }
+      continue
+    }
+
+    if (detailsOpening.test(line)) depth++
+    else if (detailsClosing.test(line) && --depth === 0) return cursor
+  }
+
+  return undefined
+}
+
+function isClosingFence(
+  line: string,
+  fence: { marker: string; length: number },
+) {
+  const value = line.replace(/^ {0,3}/u, '')
+  let length = 0
+  while (value[length] === fence.marker) length++
+  return length >= fence.length && value.slice(length).trim() === ''
 }
 
 function escapeHtml(value: string) {

--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -52,11 +52,18 @@ function closingDetails(lines: string[]) {
   const closings = new Map<number, number>()
   const openings: Array<{ index: number; supported: boolean }> = []
   let fence: { marker: string; length: number } | undefined
+  let rawHtml: 'comment' | 'block' | undefined
 
   for (let cursor = 0; cursor < lines.length; cursor++) {
     const line = lines[cursor] ?? ''
     if (fence) {
       if (isClosingFence(line, fence)) fence = undefined
+      continue
+    }
+
+    if (rawHtml) {
+      if (rawHtml === 'comment' && line.includes('-->')) rawHtml = undefined
+      else if (rawHtml === 'block' && line.trim() === '') rawHtml = undefined
       continue
     }
 
@@ -67,15 +74,19 @@ function closingDetails(lines: string[]) {
     }
 
     if (anyDetailsOpening.test(line)) {
+      const hasSummary = detailsSummary.test(lines[cursor + 1] ?? '')
       openings.push({
         index: cursor,
-        supported:
-          detailsOpening.test(line) &&
-          detailsSummary.test(lines[cursor + 1] ?? ''),
+        supported: detailsOpening.test(line) && hasSummary,
       })
+      if (hasSummary) cursor++
     } else if (detailsClosing.test(line)) {
       const opening = openings.pop()
       if (opening?.supported) closings.set(opening.index, cursor)
+    } else if (/^ {0,3}<!--/u.test(line)) {
+      if (!line.includes('-->')) rawHtml = 'comment'
+    } else if (/^ {0,3}<([A-Za-z][\w:-]*|!--|\/[A-Za-z])/u.test(line)) {
+      rawHtml = 'block'
     }
   }
 

--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -4,7 +4,21 @@ const detailsOpening = /^ {0,3}<details( open)?>\s*$/i
 const anyDetailsOpening = /^ {0,3}<details(?:\s[^>]*)?>\s*$/i
 const detailsSummary = /^ {0,3}<summary>(.*?)<\/summary>\s*$/i
 const detailsClosing = /^ {0,3}<\/details>\s*$/i
+const rawElementOpening = /^ {0,3}<(pre|script|style|textarea)(?:\s|>|$)/i
+const rawElementClosings = {
+  pre: /<\/pre\s*>/i,
+  script: /<\/script\s*>/i,
+  style: /<\/style\s*>/i,
+  textarea: /<\/textarea\s*>/i,
+} as const
 const closingDetailsCache = new WeakMap<string[], Map<number, number>>()
+
+type RawElementTag = keyof typeof rawElementClosings
+
+type RawHtmlRegion =
+  | { kind: 'comment' }
+  | { kind: 'block' }
+  | { kind: 'element'; tag: RawElementTag }
 
 export const markdownDisclosureExtension: MarkdownExtension = {
   name: 'safe-details',
@@ -57,7 +71,7 @@ function closingDetails(lines: string[]) {
   }> = []
   let unsupportedDepth = 0
   let fence: { marker: string; length: number } | undefined
-  let rawHtml: 'comment' | 'block' | undefined
+  let rawHtml: RawHtmlRegion | undefined
 
   for (let cursor = 0; cursor < lines.length; cursor++) {
     const line = lines[cursor] ?? ''
@@ -67,8 +81,15 @@ function closingDetails(lines: string[]) {
     }
 
     if (rawHtml) {
-      if (rawHtml === 'comment' && line.includes('-->')) rawHtml = undefined
-      else if (rawHtml === 'block' && line.trim() === '') rawHtml = undefined
+      if (rawHtml.kind === 'comment' && line.includes('-->'))
+        rawHtml = undefined
+      else if (rawHtml.kind === 'block' && line.trim() === '')
+        rawHtml = undefined
+      else if (
+        rawHtml.kind === 'element' &&
+        rawElementClosings[rawHtml.tag].test(line)
+      )
+        rawHtml = undefined
       continue
     }
 
@@ -93,9 +114,14 @@ function closingDetails(lines: string[]) {
       if (opening && !opening.supported) unsupportedDepth--
       if (opening?.renderable) closings.set(opening.index, cursor)
     } else if (/^ {0,3}<!--/u.test(line)) {
-      if (!line.includes('-->')) rawHtml = 'comment'
+      if (!line.includes('-->')) rawHtml = { kind: 'comment' }
     } else if (/^ {0,3}<([A-Za-z][\w:-]*|!--|\/[A-Za-z])/u.test(line)) {
-      rawHtml = 'block'
+      const rawElement = line.match(rawElementOpening)?.[1]?.toLowerCase() as
+        | RawElementTag
+        | undefined
+      if (rawElement && !rawElementClosings[rawElement].test(line))
+        rawHtml = { kind: 'element', tag: rawElement }
+      else rawHtml = { kind: 'block' }
     }
   }
 

--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -50,7 +50,12 @@ function closingDetails(lines: string[]) {
   if (cached) return cached
 
   const closings = new Map<number, number>()
-  const openings: Array<{ index: number; supported: boolean }> = []
+  const openings: Array<{
+    index: number
+    supported: boolean
+    renderable: boolean
+  }> = []
+  let unsupportedDepth = 0
   let fence: { marker: string; length: number } | undefined
   let rawHtml: 'comment' | 'block' | undefined
 
@@ -75,14 +80,18 @@ function closingDetails(lines: string[]) {
 
     if (anyDetailsOpening.test(line)) {
       const hasSummary = detailsSummary.test(lines[cursor + 1] ?? '')
+      const supported = detailsOpening.test(line) && hasSummary
       openings.push({
         index: cursor,
-        supported: detailsOpening.test(line) && hasSummary,
+        supported,
+        renderable: supported && unsupportedDepth === 0,
       })
+      if (!supported) unsupportedDepth++
       if (hasSummary) cursor++
     } else if (detailsClosing.test(line)) {
       const opening = openings.pop()
-      if (opening?.supported) closings.set(opening.index, cursor)
+      if (opening && !opening.supported) unsupportedDepth--
+      if (opening?.renderable) closings.set(opening.index, cursor)
     } else if (/^ {0,3}<!--/u.test(line)) {
       if (!line.includes('-->')) rawHtml = 'comment'
     } else if (/^ {0,3}<([A-Za-z][\w:-]*|!--|\/[A-Za-z])/u.test(line)) {

--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -1,0 +1,58 @@
+import type { MarkdownExtension } from '@tanstack/markdown'
+
+const detailsOpening = /^ {0,3}<details( open)?>\s*$/i
+const detailsSummary = /^ {0,3}<summary>(.*?)<\/summary>\s*$/i
+const detailsClosing = /^ {0,3}<\/details>\s*$/i
+
+export const markdownDisclosureExtension: MarkdownExtension = {
+  name: 'safe-details',
+  parseBlock(context) {
+    const opening = (context.lines[context.index] ?? '').match(detailsOpening)
+    if (!opening) return undefined
+
+    const summary = (context.lines[context.index + 1] ?? '').match(
+      detailsSummary,
+    )
+    if (!summary) return undefined
+
+    const body: string[] = []
+    let cursor = context.index + 2
+    while (
+      cursor < context.lines.length &&
+      !detailsClosing.test(context.lines[cursor] ?? '')
+    ) {
+      body.push(context.lines[cursor] ?? '')
+      cursor++
+    }
+    if (cursor >= context.lines.length) return undefined
+
+    context.consume(cursor - context.index + 1)
+    return {
+      type: 'component',
+      name: 'safe-details',
+      attributes: {
+        summary: summary[1] ?? '',
+        open: opening[1] ? 'true' : 'false',
+      },
+      children: context.parseBlocks(body.join('\n')),
+    }
+  },
+  renderHtml(node, context) {
+    if (node.type !== 'component' || node.name !== 'safe-details')
+      return undefined
+
+    const open = node.attributes.open === 'true' ? ' open' : ''
+    const summary = escapeHtml(node.attributes.summary ?? '')
+    const body = node.children.map(context.renderBlock).join('\n')
+    return `<details${open}><summary>${summary}</summary>${body}</details>`
+  },
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#x27;')
+}

--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -3,6 +3,7 @@ import type { MarkdownExtension } from '@tanstack/markdown'
 const detailsOpening = /^ {0,3}<details( open)?>\s*$/i
 const detailsSummary = /^ {0,3}<summary>(.*?)<\/summary>\s*$/i
 const detailsClosing = /^ {0,3}<\/details>\s*$/i
+const closingDetailsCache = new WeakMap<string[], Map<number, number>>()
 
 export const markdownDisclosureExtension: MarkdownExtension = {
   name: 'safe-details',
@@ -16,7 +17,7 @@ export const markdownDisclosureExtension: MarkdownExtension = {
     if (!summary) return undefined
 
     const bodyStart = context.index + 2
-    const cursor = findClosingDetails(context.lines, bodyStart)
+    const cursor = closingDetails(context.lines).get(context.index)
     if (cursor === undefined) return undefined
 
     context.consume(cursor - context.index + 1)
@@ -43,11 +44,15 @@ export const markdownDisclosureExtension: MarkdownExtension = {
   },
 }
 
-function findClosingDetails(lines: string[], start: number) {
-  let depth = 1
+function closingDetails(lines: string[]) {
+  const cached = closingDetailsCache.get(lines)
+  if (cached) return cached
+
+  const closings = new Map<number, number>()
+  const openings: Array<{ index: number; supported: boolean }> = []
   let fence: { marker: string; length: number } | undefined
 
-  for (let cursor = start; cursor < lines.length; cursor++) {
+  for (let cursor = 0; cursor < lines.length; cursor++) {
     const line = lines[cursor] ?? ''
     if (fence) {
       if (isClosingFence(line, fence)) fence = undefined
@@ -60,11 +65,19 @@ function findClosingDetails(lines: string[], start: number) {
       continue
     }
 
-    if (detailsOpening.test(line)) depth++
-    else if (detailsClosing.test(line) && --depth === 0) return cursor
+    if (detailsOpening.test(line)) {
+      openings.push({
+        index: cursor,
+        supported: detailsSummary.test(lines[cursor + 1] ?? ''),
+      })
+    } else if (detailsClosing.test(line)) {
+      const opening = openings.pop()
+      if (opening?.supported) closings.set(opening.index, cursor)
+    }
   }
 
-  return undefined
+  closingDetailsCache.set(lines, closings)
+  return closings
 }
 
 function isClosingFence(

--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -61,6 +61,7 @@ function closingDetails(lines: string[]) {
   }> = []
   let unsupportedDepth = 0
   let limitedDepth = 0
+  let ignoredDepth = 0
   let fence: { marker: string; length: number } | undefined
   let rawHtml: RawHtmlRegion | undefined
 
@@ -87,6 +88,11 @@ function closingDetails(lines: string[]) {
 
     if (anyDetailsOpening.test(line)) {
       const hasSummary = detailsSummary.test(lines[cursor + 1] ?? '')
+      if (ignoredDepth > 0 || !isOpeningBoundary(lines, cursor)) {
+        ignoredDepth++
+        if (hasSummary) cursor++
+        continue
+      }
       const supported = detailsOpening.test(line) && hasSummary
       const limited =
         limitedDepth > 0 ||
@@ -104,7 +110,12 @@ function closingDetails(lines: string[]) {
       if (!supported) unsupportedDepth++
       if (limited) limitedDepth++
       if (hasSummary) cursor++
-    } else if (detailsClosing.test(line)) {
+    } else if (detailsClosing.test(line) && ignoredDepth > 0) {
+      ignoredDepth--
+    } else if (
+      detailsClosing.test(line) &&
+      (isClosingBoundary(lines, cursor) || openings.at(-1)?.supported === false)
+    ) {
       const opening = openings.pop()
       if (opening && !opening.supported) unsupportedDepth--
       if (opening?.limited) limitedDepth--
@@ -128,6 +139,15 @@ function isClosingFence(
   let length = 0
   while (value[length] === fence.marker) length++
   return length >= fence.length && value.slice(length).trim() === ''
+}
+
+function isOpeningBoundary(lines: string[], index: number) {
+  return index === 0 || (lines[index - 1] ?? '').trim() === ''
+}
+
+function isClosingBoundary(lines: string[], index: number) {
+  const previous = lines[index - 1] ?? ''
+  return previous.trim() === '' || detailsClosing.test(previous)
 }
 
 function escapeHtml(value: string) {

--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -4,22 +4,10 @@ const detailsOpening = /^ {0,3}<details( open)?>\s*$/i
 const anyDetailsOpening = /^ {0,3}<details(?:\s[^>]*)?>\s*$/i
 const detailsSummary = /^ {0,3}<summary>(.*?)<\/summary>\s*$/i
 const detailsClosing = /^ {0,3}<\/details>\s*$/i
-const rawElementOpening = /^ {0,3}<(pre|script|style|textarea)(?:\s|>|$)/i
-const rawElementClosings = {
-  pre: /<\/pre\s*>/i,
-  script: /<\/script\s*>/i,
-  style: /<\/style\s*>/i,
-  textarea: /<\/textarea\s*>/i,
-} as const
 const maxDisclosureNesting = 16
 const closingDetailsCache = new WeakMap<string[], Map<number, number>>()
 
-type RawElementTag = keyof typeof rawElementClosings
-
-type RawHtmlRegion =
-  | { kind: 'comment' }
-  | { kind: 'block' }
-  | { kind: 'element'; tag: RawElementTag }
+type RawHtmlRegion = { kind: 'comment' } | { kind: 'block' }
 
 export const markdownDisclosureExtension: MarkdownExtension = {
   name: 'safe-details',
@@ -88,11 +76,6 @@ function closingDetails(lines: string[]) {
         rawHtml = undefined
       else if (rawHtml.kind === 'block' && line.trim() === '')
         rawHtml = undefined
-      else if (
-        rawHtml.kind === 'element' &&
-        rawElementClosings[rawHtml.tag].test(line)
-      )
-        rawHtml = undefined
       continue
     }
 
@@ -129,13 +112,7 @@ function closingDetails(lines: string[]) {
     } else if (/^ {0,3}<!--/u.test(line)) {
       if (!line.includes('-->')) rawHtml = { kind: 'comment' }
     } else if (/^ {0,3}<([A-Za-z][\w:-]*|!--|\/[A-Za-z])/u.test(line)) {
-      const rawElement = line.match(rawElementOpening)?.[1]?.toLowerCase() as
-        | RawElementTag
-        | undefined
-      if (rawElement) {
-        if (!rawElementClosings[rawElement].test(line))
-          rawHtml = { kind: 'element', tag: rawElement }
-      } else rawHtml = { kind: 'block' }
+      rawHtml = { kind: 'block' }
     }
   }
 

--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -119,9 +119,10 @@ function closingDetails(lines: string[]) {
       const rawElement = line.match(rawElementOpening)?.[1]?.toLowerCase() as
         | RawElementTag
         | undefined
-      if (rawElement && !rawElementClosings[rawElement].test(line))
-        rawHtml = { kind: 'element', tag: rawElement }
-      else rawHtml = { kind: 'block' }
+      if (rawElement) {
+        if (!rawElementClosings[rawElement].test(line))
+          rawHtml = { kind: 'element', tag: rawElement }
+      } else rawHtml = { kind: 'block' }
     }
   }
 

--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -11,6 +11,7 @@ const rawElementClosings = {
   style: /<\/style\s*>/i,
   textarea: /<\/textarea\s*>/i,
 } as const
+const maxDisclosureNesting = 16
 const closingDetailsCache = new WeakMap<string[], Map<number, number>>()
 
 type RawElementTag = keyof typeof rawElementClosings
@@ -68,8 +69,10 @@ function closingDetails(lines: string[]) {
     index: number
     supported: boolean
     renderable: boolean
+    limited: boolean
   }> = []
   let unsupportedDepth = 0
+  let limitedDepth = 0
   let fence: { marker: string; length: number } | undefined
   let rawHtml: RawHtmlRegion | undefined
 
@@ -102,16 +105,26 @@ function closingDetails(lines: string[]) {
     if (anyDetailsOpening.test(line)) {
       const hasSummary = detailsSummary.test(lines[cursor + 1] ?? '')
       const supported = detailsOpening.test(line) && hasSummary
+      const limited =
+        limitedDepth > 0 ||
+        (supported &&
+          unsupportedDepth === 0 &&
+          openings.length >= maxDisclosureNesting)
+      if (limited && limitedDepth === 0)
+        for (const opening of openings) opening.renderable = false
       openings.push({
         index: cursor,
         supported,
-        renderable: supported && unsupportedDepth === 0,
+        renderable: supported && unsupportedDepth === 0 && !limited,
+        limited,
       })
       if (!supported) unsupportedDepth++
+      if (limited) limitedDepth++
       if (hasSummary) cursor++
     } else if (detailsClosing.test(line)) {
       const opening = openings.pop()
       if (opening && !opening.supported) unsupportedDepth--
+      if (opening?.limited) limitedDepth--
       if (opening?.renderable) closings.set(opening.index, cursor)
     } else if (/^ {0,3}<!--/u.test(line)) {
       if (!line.includes('-->')) rawHtml = { kind: 'comment' }

--- a/apps/web/app/lib/markdown-disclosure.ts
+++ b/apps/web/app/lib/markdown-disclosure.ts
@@ -1,6 +1,7 @@
 import type { MarkdownExtension } from '@tanstack/markdown'
 
 const detailsOpening = /^ {0,3}<details( open)?>\s*$/i
+const anyDetailsOpening = /^ {0,3}<details(?:\s[^>]*)?>\s*$/i
 const detailsSummary = /^ {0,3}<summary>(.*?)<\/summary>\s*$/i
 const detailsClosing = /^ {0,3}<\/details>\s*$/i
 const closingDetailsCache = new WeakMap<string[], Map<number, number>>()
@@ -65,10 +66,12 @@ function closingDetails(lines: string[]) {
       continue
     }
 
-    if (detailsOpening.test(line)) {
+    if (anyDetailsOpening.test(line)) {
       openings.push({
         index: cursor,
-        supported: detailsSummary.test(lines[cursor + 1] ?? ''),
+        supported:
+          detailsOpening.test(line) &&
+          detailsSummary.test(lines[cursor + 1] ?? ''),
       })
     } else if (detailsClosing.test(line)) {
       const opening = openings.pop()

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -69,6 +69,28 @@ describe('renderMarkdownDocument', () => {
     expect(out).not.toContain('<script>alert(1)</script>')
   })
 
+  test('renders a safe details block with Markdown content', () => {
+    const out = renderMarkdownDocument(
+      '<details>\n<summary>Why this approach?</summary>\n\nBody with **emphasis**.\n\n</details>',
+      'tanstack',
+    )
+
+    expect(out).toContain('<details><summary>Why this approach?</summary>')
+    expect(out).toContain('<p>Body with <strong>emphasis</strong>.</p>')
+    expect(out).toContain('</details>')
+  })
+
+  test('limits details support to safe markup', () => {
+    const out = renderMarkdownDocument(
+      '<details onclick="alert(1)">\n<summary><img src=x onerror=alert(1)></summary>\n\nBody\n\n</details>',
+      'tanstack',
+    )
+
+    expect(out).not.toContain('<details onclick=')
+    expect(out).not.toContain('<img src=x')
+    expect(out).not.toContain('<summary>')
+  })
+
   test('prioritizes contents and collapses secondary navigation', () => {
     const out = renderMarkdownDocument(
       '---\ntitle: Report\nauthor: Artifact Share\n---\n# Start\n## Next',

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -180,9 +180,30 @@ describe('renderMarkdownDocument', () => {
       'tanstack',
     )
 
-    expect(out).not.toContain('<details>')
+    expect(out.match(/<details>/g)).toHaveLength(16)
     expect(out).toContain('&lt;details&gt;')
     expect(out).toContain('&lt;summary&gt;Level 17&lt;/summary&gt;')
+  })
+
+  test('does not let tag-like paragraph text steal disclosure boundaries', () => {
+    const out = renderMarkdownDocument(
+      '<details>\n<summary>Outer</summary>\n\nVisible only when open.\n</details>\n\nStill in outer.\n\n</details>',
+      'tanstack',
+    )
+
+    expect(out).toContain('<p>Visible only when open.\n&lt;/details&gt;</p>')
+    expect(out).toContain('<p>Still in outer.</p></details>')
+  })
+
+  test('does not match disclosure openings embedded in paragraphs', () => {
+    const out = renderMarkdownDocument(
+      '<details>\n<summary>Outer</summary>\n\nProse about the syntax.\n<details>\n<summary>Not a block</summary>\n\n</details>\n\n</details>',
+      'tanstack',
+    )
+
+    expect(out.match(/<details>/g)).toHaveLength(1)
+    expect(out).toContain('&lt;details&gt;')
+    expect(out).toContain('&lt;summary&gt;Not a block&lt;/summary&gt;')
   })
 
   test('does not render supported details inside unsupported details', () => {

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -136,6 +136,17 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('<p>Still in outer.</p></details>')
   })
 
+  test('ignores closing tags inside raw HTML blocks', () => {
+    const out = renderMarkdownDocument(
+      '<details>\n<summary>Outer</summary>\n\n<!--\n</details>\n-->\n\n<pre>\n</details>\n</pre>\n\nStill in outer.\n\n</details>',
+      'tanstack',
+    )
+
+    expect(out).toContain('&lt;!--\n&lt;/details&gt;\n--&gt;')
+    expect(out).toContain('&lt;pre&gt;\n&lt;/details&gt;\n&lt;/pre&gt;')
+    expect(out).toContain('<p>Still in outer.</p></details>')
+  })
+
   test('prioritizes contents and collapses secondary navigation', () => {
     const out = renderMarkdownDocument(
       '---\ntitle: Report\nauthor: Artifact Share\n---\n# Start\n## Next',

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -138,7 +138,7 @@ describe('renderMarkdownDocument', () => {
 
   test('ignores closing tags inside raw HTML blocks', () => {
     const out = renderMarkdownDocument(
-      '<details>\n<summary>Outer</summary>\n\n<!--\n</details>\n-->\n\n<pre>\n\n</details>\n\n</pre>\n\nStill in outer.\n\n</details>',
+      '<details>\n<summary>Outer</summary>\n\n<!--\n</details>\n-->\n\n<pre>\n</details>\n</pre>\n\nStill in outer.\n\n</details>',
       'tanstack',
     )
 
@@ -150,12 +150,23 @@ describe('renderMarkdownDocument', () => {
 
   test('ends a raw element region when it closes on its opening line', () => {
     const out = renderMarkdownDocument(
-      '<details>\n<summary>Outer</summary>\n\n<pre>Example</pre>\n</details>',
+      '<details>\n<summary>Outer</summary>\n\n<pre>Example</pre>\n\n</details>',
       'tanstack',
     )
 
     expect(out).toContain('<details><summary>Outer</summary>')
     expect(out).toContain('&lt;pre&gt;Example&lt;/pre&gt;</details>')
+  })
+
+  test('ends every raw HTML block at a blank line like TanStack Markdown', () => {
+    const out = renderMarkdownDocument(
+      '<details>\n<summary>Outer</summary>\n\n<pre>\n\n<details>\n<summary>Inner</summary>\n\nInner body.\n\n</details>\n\n</details>',
+      'tanstack',
+    )
+
+    expect(out.match(/<details>/g)).toHaveLength(2)
+    expect(out).toContain('<summary>Inner</summary>')
+    expect(out).toContain('<p>Inner body.</p></details></details>')
   })
 
   test('escapes disclosure trees beyond the supported nesting limit', () => {

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -147,6 +147,17 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('<p>Still in outer.</p></details>')
   })
 
+  test('does not render supported details inside unsupported details', () => {
+    const out = renderMarkdownDocument(
+      '<details class="unsupported">\n<summary>Outer</summary>\n\n<details>\n<summary>Inner</summary>\n\nNested body.\n\n</details>\n\n</details>',
+      'tanstack',
+    )
+
+    expect(out).not.toContain('<details><summary>Inner</summary>')
+    expect(out).toContain('&lt;details class=&quot;unsupported&quot;&gt;')
+    expect(out).toContain('&lt;details&gt;')
+  })
+
   test('prioritizes contents and collapses secondary navigation', () => {
     const out = renderMarkdownDocument(
       '---\ntitle: Report\nauthor: Artifact Share\n---\n# Start\n## Next',

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -138,12 +138,13 @@ describe('renderMarkdownDocument', () => {
 
   test('ignores closing tags inside raw HTML blocks', () => {
     const out = renderMarkdownDocument(
-      '<details>\n<summary>Outer</summary>\n\n<!--\n</details>\n-->\n\n<pre>\n</details>\n</pre>\n\nStill in outer.\n\n</details>',
+      '<details>\n<summary>Outer</summary>\n\n<!--\n</details>\n-->\n\n<pre>\n\n</details>\n\n</pre>\n\nStill in outer.\n\n</details>',
       'tanstack',
     )
 
     expect(out).toContain('&lt;!--\n&lt;/details&gt;\n--&gt;')
-    expect(out).toContain('&lt;pre&gt;\n&lt;/details&gt;\n&lt;/pre&gt;')
+    expect(out).toContain('&lt;pre&gt;')
+    expect(out).toContain('&lt;/pre&gt;')
     expect(out).toContain('<p>Still in outer.</p></details>')
   })
 

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -173,14 +173,14 @@ describe('renderMarkdownDocument', () => {
     const opening = Array.from(
       { length: 17 },
       (_, index) => `<details>\n<summary>Level ${index + 1}</summary>`,
-    ).join('\n')
-    const closing = Array.from({ length: 17 }, () => '</details>').join('\n')
+    ).join('\n\n')
+    const closing = Array.from({ length: 17 }, () => '</details>').join('\n\n')
     const out = renderMarkdownDocument(
       `${opening}\nBody\n${closing}`,
       'tanstack',
     )
 
-    expect(out.match(/<details>/g)).toHaveLength(16)
+    expect(out).not.toContain('<details>')
     expect(out).toContain('&lt;details&gt;')
     expect(out).toContain('&lt;summary&gt;Level 17&lt;/summary&gt;')
   })

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -148,6 +148,16 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('<p>Still in outer.</p></details>')
   })
 
+  test('ends a raw element region when it closes on its opening line', () => {
+    const out = renderMarkdownDocument(
+      '<details>\n<summary>Outer</summary>\n\n<pre>Example</pre>\n</details>',
+      'tanstack',
+    )
+
+    expect(out).toContain('<details><summary>Outer</summary>')
+    expect(out).toContain('&lt;pre&gt;Example&lt;/pre&gt;</details>')
+  })
+
   test('does not render supported details inside unsupported details', () => {
     const out = renderMarkdownDocument(
       '<details class="unsupported">\n<summary>Outer</summary>\n\n<details>\n<summary>Inner</summary>\n\nNested body.\n\n</details>\n\n</details>',

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -114,6 +114,17 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('<p>Outer body.</p></details>')
   })
 
+  test('handles many unclosed details blocks without rendering them', () => {
+    const source = Array.from(
+      { length: 2_000 },
+      (_, index) => `<details>\n<summary>Unclosed ${index}</summary>`,
+    ).join('\n')
+    const out = renderMarkdownDocument(source, 'tanstack')
+
+    expect(out).not.toContain('<details><summary>')
+    expect(out).toContain('&lt;details&gt;')
+  })
+
   test('prioritizes contents and collapses secondary navigation', () => {
     const out = renderMarkdownDocument(
       '---\ntitle: Report\nauthor: Artifact Share\n---\n# Start\n## Next',

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -158,6 +158,22 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('&lt;pre&gt;Example&lt;/pre&gt;</details>')
   })
 
+  test('escapes disclosure trees beyond the supported nesting limit', () => {
+    const opening = Array.from(
+      { length: 17 },
+      (_, index) => `<details>\n<summary>Level ${index + 1}</summary>`,
+    ).join('\n')
+    const closing = Array.from({ length: 17 }, () => '</details>').join('\n')
+    const out = renderMarkdownDocument(
+      `${opening}\nBody\n${closing}`,
+      'tanstack',
+    )
+
+    expect(out).not.toContain('<details>')
+    expect(out).toContain('&lt;details&gt;')
+    expect(out).toContain('&lt;summary&gt;Level 17&lt;/summary&gt;')
+  })
+
   test('does not render supported details inside unsupported details', () => {
     const out = renderMarkdownDocument(
       '<details class="unsupported">\n<summary>Outer</summary>\n\n<details>\n<summary>Inner</summary>\n\nNested body.\n\n</details>\n\n</details>',

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -91,6 +91,29 @@ describe('renderMarkdownDocument', () => {
     expect(out).not.toContain('<summary>')
   })
 
+  test('does not close details on a tag inside a code fence', () => {
+    const out = renderMarkdownDocument(
+      '<details>\n<summary>Markup example</summary>\n\n```html\n</details>\n```\n\nStill inside.\n\n</details>',
+      'tanstack',
+    )
+
+    expect(out).toContain('class="md-code-block" data-lang="html"')
+    expect(out).toContain('class="th-token th-tag">details</span>')
+    expect(out).toContain('<p>Still inside.</p></details>')
+  })
+
+  test('supports nested safe details blocks', () => {
+    const out = renderMarkdownDocument(
+      '<details>\n<summary>Outer</summary>\n\n<details>\n<summary>Inner</summary>\n\nNested body.\n\n</details>\n\nOuter body.\n\n</details>',
+      'tanstack',
+    )
+
+    expect(out).toContain(
+      '<details><summary>Outer</summary><details><summary>Inner</summary>',
+    )
+    expect(out).toContain('<p>Outer body.</p></details>')
+  })
+
   test('prioritizes contents and collapses secondary navigation', () => {
     const out = renderMarkdownDocument(
       '---\ntitle: Report\nauthor: Artifact Share\n---\n# Start\n## Next',

--- a/apps/web/app/lib/markdown-render.test.ts
+++ b/apps/web/app/lib/markdown-render.test.ts
@@ -125,6 +125,17 @@ describe('renderMarkdownDocument', () => {
     expect(out).toContain('&lt;details&gt;')
   })
 
+  test('balances unsupported nested details without rendering them', () => {
+    const out = renderMarkdownDocument(
+      '<details>\n<summary>Outer</summary>\n\n<details class="unsupported">\nUnsupported body.\n</details>\n\nStill in outer.\n\n</details>',
+      'tanstack',
+    )
+
+    expect(out).not.toContain('<details class="unsupported">')
+    expect(out).toContain('&lt;details class=&quot;unsupported&quot;&gt;')
+    expect(out).toContain('<p>Still in outer.</p></details>')
+  })
+
   test('prioritizes contents and collapses secondary navigation', () => {
     const out = renderMarkdownDocument(
       '---\ntitle: Report\nauthor: Artifact Share\n---\n# Start\n## Next',

--- a/apps/web/app/lib/markdown-renderer.server.ts
+++ b/apps/web/app/lib/markdown-renderer.server.ts
@@ -2,6 +2,7 @@ import { renderHtml } from '@tanstack/markdown/html'
 import { parseMarkdown } from '@tanstack/markdown/parser'
 
 import { httpAutolinkExtension } from './markdown-autolink'
+import { markdownDisclosureExtension } from './markdown-disclosure'
 import { renderMarkdown } from './markdown'
 import {
   highlightTanStackCode,
@@ -9,6 +10,8 @@ import {
 } from './tanstack-highlight.server'
 
 export type MarkdownRenderer = 'marked' | 'tanstack'
+
+const markdownExtensions = [markdownDisclosureExtension, httpAutolinkExtension]
 
 export function renderMarkdownBody(
   source: string,
@@ -18,10 +21,17 @@ export function renderMarkdownBody(
 
   const parsed = parseMarkdown(source, {
     allowHtml: true,
-    extensions: [httpAutolinkExtension],
+    extensions: markdownExtensions,
     headingIds: uniqueHeadingId(),
   })
-  return embedYouTube(highlightCode(renderHtml(parsed, { allowHtml: false })))
+  return embedYouTube(
+    highlightCode(
+      renderHtml(parsed, {
+        allowHtml: false,
+        extensions: markdownExtensions,
+      }),
+    ),
+  )
 }
 
 function uniqueHeadingId() {


### PR DESCRIPTION
## Summary

- render blank-line-delimited `<details>` / `<summary>` blocks in TanStack Markdown
- keep arbitrary raw HTML, unsupported attributes, malformed blocks, and excessive nesting escaped
- preserve Markdown rendering inside supported disclosures without enabling raw HTML globally

## Supported syntax

```md
<details>
<summary>More information</summary>

Markdown body

</details>
```

`<details open>` is also supported. Disclosure tags embedded in paragraphs or not separated from surrounding blocks by blank lines remain escaped.

## Validation

- `pnpm validate:static`
- 26 focused Markdown rendering tests
- 2,858 unit tests passed; 1 skipped
- React Doctor: 100
- public repository scan: 0 findings
- Codex and Claude implementation reviews completed; safe fallback limitations documented above
