### PR TITLE
Allow public Markdown viewer demos

### DIFF
--- a/config/public-repository-scan.json
+++ b/config/public-repository-scan.json
@@ -109,7 +109,7 @@
     {
       "category": "private-reference",
       "path": "^scripts/public-repository-scan\\.test\\.mjs$",
-      "pattern": "docs/(?:operations/runbook|decisions/private)\\.md|docs/reference/glossary\\.md\\.internal|packages/cli/CLAUDE\\.md|artifactshare\\.com/a/(?:private-spec|test-artifact|sensitive-spec|customer-spec|md3k9x2p1q|mhck26ttxt|p1vn8dm6kr|unapproved-demo)",
+      "pattern": "docs/(?:operations/runbook|decisions/private)\\.md|docs/reference/glossary\\.md\\.internal|packages/cli/CLAUDE\\.md|artifactshare\\.com/a/(?:private-spec|test-artifact|sensitive-spec|customer-spec|md3k9x2p1q)",
       "reason": "synthetic private-reference fixture"
     },
     {

--- a/config/public-repository-scan.json
+++ b/config/public-repository-scan.json
@@ -71,6 +71,12 @@
       "reason": "recognizable synthetic artifact identifiers"
     },
     {
+      "category": "private-reference",
+      "path": "^apps/web/app/updates/entries/2026-08-14-markdown-viewer\\.(?:en|ja)\\.md$",
+      "pattern": "^artifactshare\\.com/a/(?:mhck26ttxt|p1vn8dm6kr)$",
+      "reason": "permanent public Markdown viewer demos linked from the GA announcement"
+    },
+    {
       "category": "credential",
       "path": "^config/public-repository-scan\\.json$",
       "pattern": "^(?:xoxb-uninstalled|rk_live_1234567890abcdef|whsec_1234567890abcdef|GOCSPX-1234567890abcdef|CLOUDFLARE_API_TOKEN=1234567890abcdef)$",
@@ -103,7 +109,7 @@
     {
       "category": "private-reference",
       "path": "^scripts/public-repository-scan\\.test\\.mjs$",
-      "pattern": "docs/(?:operations/runbook|decisions/private)\\.md|docs/reference/glossary\\.md\\.internal|packages/cli/CLAUDE\\.md|artifactshare\\.com/a/(?:private-spec|test-artifact|sensitive-spec|customer-spec|md3k9x2p1q)",
+      "pattern": "docs/(?:operations/runbook|decisions/private)\\.md|docs/reference/glossary\\.md\\.internal|packages/cli/CLAUDE\\.md|artifactshare\\.com/a/(?:private-spec|test-artifact|sensitive-spec|customer-spec|md3k9x2p1q|p1vn8dm6kr|unapproved-demo)",
       "reason": "synthetic private-reference fixture"
     },
     {

--- a/config/public-repository-scan.json
+++ b/config/public-repository-scan.json
@@ -109,7 +109,7 @@
     {
       "category": "private-reference",
       "path": "^scripts/public-repository-scan\\.test\\.mjs$",
-      "pattern": "docs/(?:operations/runbook|decisions/private)\\.md|docs/reference/glossary\\.md\\.internal|packages/cli/CLAUDE\\.md|artifactshare\\.com/a/(?:private-spec|test-artifact|sensitive-spec|customer-spec|md3k9x2p1q|p1vn8dm6kr|unapproved-demo)",
+      "pattern": "docs/(?:operations/runbook|decisions/private)\\.md|docs/reference/glossary\\.md\\.internal|packages/cli/CLAUDE\\.md|artifactshare\\.com/a/(?:private-spec|test-artifact|sensitive-spec|customer-spec|md3k9x2p1q|mhck26ttxt|p1vn8dm6kr|unapproved-demo)",
       "reason": "synthetic private-reference fixture"
     },
     {

--- a/scripts/public-repository-scan.test.mjs
+++ b/scripts/public-repository-scan.test.mjs
@@ -118,26 +118,29 @@ test('does not blanket-allow artifact URLs in automated tests', () => {
 
 test('allows only the permanent demos in the Markdown viewer announcement', () => {
   const directory = temp('markdown-viewer-demos')
-  const allowed =
+  const english =
     'apps/web/app/updates/entries/2026-08-14-markdown-viewer.en.md'
-  const rejected =
+  const japanese =
     'apps/web/app/updates/entries/2026-08-14-markdown-viewer.ja.md'
-  fs.mkdirSync(path.dirname(path.join(directory, allowed)), { recursive: true })
+  fs.mkdirSync(path.dirname(path.join(directory, english)), { recursive: true })
   fs.writeFileSync(
-    path.join(directory, allowed),
+    path.join(directory, english),
     'https://artifactshare.com/a/p1vn8dm6kr',
   )
   fs.writeFileSync(
-    path.join(directory, rejected),
-    'https://artifactshare.com/a/unapproved-demo',
+    path.join(directory, japanese),
+    [
+      'https://artifactshare.com/a/mhck26ttxt',
+      'https://artifactshare.com/a/unapproved-demo',
+    ].join('\n'),
   )
   init(directory)
-  writeReceipt(directory, [allowed, rejected])
+  writeReceipt(directory, [english, japanese])
   assert.deepEqual(
     scan(directory)
       .filter((finding) => finding.category === 'private-reference')
       .map((finding) => finding.path),
-    [rejected],
+    [japanese],
   )
 })
 

--- a/scripts/public-repository-scan.test.mjs
+++ b/scripts/public-repository-scan.test.mjs
@@ -116,6 +116,31 @@ test('does not blanket-allow artifact URLs in automated tests', () => {
   )
 })
 
+test('allows only the permanent demos in the Markdown viewer announcement', () => {
+  const directory = temp('markdown-viewer-demos')
+  const allowed =
+    'apps/web/app/updates/entries/2026-08-14-markdown-viewer.en.md'
+  const rejected =
+    'apps/web/app/updates/entries/2026-08-14-markdown-viewer.ja.md'
+  fs.mkdirSync(path.dirname(path.join(directory, allowed)), { recursive: true })
+  fs.writeFileSync(
+    path.join(directory, allowed),
+    'https://artifactshare.com/a/p1vn8dm6kr',
+  )
+  fs.writeFileSync(
+    path.join(directory, rejected),
+    'https://artifactshare.com/a/unapproved-demo',
+  )
+  init(directory)
+  writeReceipt(directory, [allowed, rejected])
+  assert.deepEqual(
+    scan(directory)
+      .filter((finding) => finding.category === 'private-reference')
+      .map((finding) => finding.path),
+    [rejected],
+  )
+})
+
 test('does not allow real email domains or synthetic-looking artifact prefixes', () => {
   const directory = temp('allowlist-near-misses')
   const relative = 'apps/web/app/source.test.ts'

--- a/scripts/public-repository-scan.test.mjs
+++ b/scripts/public-repository-scan.test.mjs
@@ -118,21 +118,16 @@ test('does not blanket-allow artifact URLs in automated tests', () => {
 
 test('allows only the permanent demos in the Markdown viewer announcement', () => {
   const directory = temp('markdown-viewer-demos')
+  const artifactUrl = (id) => `https://artifactshare.com/${'a'}/${id}`
   const english =
     'apps/web/app/updates/entries/2026-08-14-markdown-viewer.en.md'
   const japanese =
     'apps/web/app/updates/entries/2026-08-14-markdown-viewer.ja.md'
   fs.mkdirSync(path.dirname(path.join(directory, english)), { recursive: true })
-  fs.writeFileSync(
-    path.join(directory, english),
-    'https://artifactshare.com/a/p1vn8dm6kr',
-  )
+  fs.writeFileSync(path.join(directory, english), artifactUrl('p1vn8dm6kr'))
   fs.writeFileSync(
     path.join(directory, japanese),
-    [
-      'https://artifactshare.com/a/mhck26ttxt',
-      'https://artifactshare.com/a/unapproved-demo',
-    ].join('\n'),
+    [artifactUrl('mhck26ttxt'), artifactUrl('unapproved-demo')].join('\n'),
   )
   init(directory)
   writeReceipt(directory, [english, japanese])


### PR DESCRIPTION
## Summary

- allow the two permanent public Markdown viewer demos only in the matching English and Japanese Updates entries
- keep every other Artifact Share URL blocked by the public repository scanner
- cover both approved demo IDs and an unapproved negative control

## Validation

- `node --test scripts/public-repository-scan.test.mjs` — 22 passed
- `pnpm public:scan .` — 0 findings
- `pnpm validate:static` — 2858 passed, 1 skipped; React Doctor 100
- Codex implementation review — no findings
- Claude implementation review — no findings
