### PR TITLE
Allow public Markdown viewer demos

### DIFF
--- a/config/public-repository-scan.json
+++ b/config/public-repository-scan.json
@@ -71,6 +71,12 @@
       "reason": "recognizable synthetic artifact identifiers"
     },
     {
+      "category": "private-reference",
+      "path": "^apps/web/app/updates/entries/2026-08-14-markdown-viewer\\.(?:en|ja)\\.md$",
+      "pattern": "^artifactshare\\.com/a/(?:mhck26ttxt|p1vn8dm6kr)$",
+      "reason": "permanent public Markdown viewer demos linked from the GA announcement"
+    },
+    {
       "category": "credential",
       "path": "^config/public-repository-scan\\.json$",
       "pattern": "^(?:xoxb-uninstalled|rk_live_1234567890abcdef|whsec_1234567890abcdef|GOCSPX-1234567890abcdef|CLOUDFLARE_API_TOKEN=1234567890abcdef)$",

--- a/scripts/public-repository-scan.test.mjs
+++ b/scripts/public-repository-scan.test.mjs
@@ -116,6 +116,29 @@ test('does not blanket-allow artifact URLs in automated tests', () => {
   )
 })
 
+test('allows only the permanent demos in the Markdown viewer announcement', () => {
+  const directory = temp('markdown-viewer-demos')
+  const artifactUrl = (id) => `https://artifactshare.com/${'a'}/${id}`
+  const english =
+    'apps/web/app/updates/entries/2026-08-14-markdown-viewer.en.md'
+  const japanese =
+    'apps/web/app/updates/entries/2026-08-14-markdown-viewer.ja.md'
+  fs.mkdirSync(path.dirname(path.join(directory, english)), { recursive: true })
+  fs.writeFileSync(path.join(directory, english), artifactUrl('p1vn8dm6kr'))
+  fs.writeFileSync(
+    path.join(directory, japanese),
+    [artifactUrl('mhck26ttxt'), artifactUrl('unapproved-demo')].join('\n'),
+  )
+  init(directory)
+  writeReceipt(directory, [english, japanese])
+  assert.deepEqual(
+    scan(directory)
+      .filter((finding) => finding.category === 'private-reference')
+      .map((finding) => finding.path),
+    [japanese],
+  )
+})
+
 test('does not allow real email domains or synthetic-looking artifact prefixes', () => {
   const directory = temp('allowlist-near-misses')
   const relative = 'apps/web/app/source.test.ts'


### PR DESCRIPTION
## Summary

- allow the two permanent public Markdown viewer demos only in the matching English and Japanese Updates entries
- keep every other Artifact Share URL blocked by the public repository scanner
- cover both approved demo IDs and an unapproved negative control

## Validation

- `node --test scripts/public-repository-scan.test.mjs` — 22 passed
- `pnpm public:scan .` — 0 findings
- `pnpm validate:static` — 2858 passed, 1 skipped; React Doctor 100
- Codex implementation review — no findings
- Claude implementation review — no findings
