### PR TITLE
Improve Japanese typography fallbacks

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -18,8 +18,9 @@
 
 @theme {
   --font-sans:
-    'Geist Variable', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    'Geist Variable', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+    'Noto Sans JP', Meiryo, ui-sans-serif, system-ui, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
   /* ── space (4px base) — utility と CSS 変数の単一ソース ── */
   --spacing-0: 0;
@@ -290,6 +291,7 @@ html[data-theme='dark'] {
     @apply font-sans;
   }
   html:lang(ja) {
+    line-break: strict;
     word-break: auto-phrase;
   }
   @media (prefers-reduced-motion: no-preference) {

--- a/apps/web/app/root.locale.browser.test.tsx
+++ b/apps/web/app/root.locale.browser.test.tsx
@@ -68,6 +68,19 @@ afterEach(() => {
 })
 
 describe('Japanese home to English home navigation', () => {
+  test('applies the Japanese system-font fallback and line-breaking rules', async () => {
+    mount()
+    await vi.waitFor(() => expect(document.documentElement.lang).toBe('ja'))
+
+    const style = getComputedStyle(document.documentElement)
+    expect(style.fontFamily).toContain('Geist Variable')
+    expect(style.fontFamily).toContain('Hiragino Sans')
+    expect(style.fontFamily).toContain('Noto Sans JP')
+    expect(style.fontFamily).toContain('Meiryo')
+    expect(style.getPropertyValue('line-break')).toBe('strict')
+    expect(style.wordBreak).toBe('auto-phrase')
+  })
+
   test('revalidates the root locale without a document reload', async () => {
     mount()
     await vi.waitFor(() =>

--- a/docs/reference/design-system.md
+++ b/docs/reference/design-system.md
@@ -2,7 +2,7 @@
 
 > **値の正本**: `apps/web/app/app.css` の `@theme` / `apps/web/app/styles/tokens.css` (light / dark とも) と各部品コード
 > **部品一覧の正本**: `apps/web/app/components/catalog.ts` (何があり・いつ使い・どの variant を持ち・公式から何が違うか)
-> ステータス: 現行仕様 v0.25 (2026-07-29)
+> ステータス: 現行仕様 v0.26 (2026-08-14)
 
 この文書はデザインシステムの**語彙と意図**を定める。なぜこのスケールなのか、どの部品をいつ使い、何を避けるかを確定する。
 値 (色・余白・角丸・動き 等) は文書に規範表として持たない。値の正本は `@theme` と部品コードにあり、文書が値を二重に持つと実装と乖離するため、文書からは正本性を外す。
@@ -142,7 +142,17 @@ shadcn/ui の new-york style を**ベースに採用**しつつ、color/spacing/
 
 ### 4.1 Font stack
 
-Geist を preferred にし、無ければ system font へ fallback する。emoji は `Apple Color Emoji` / `Segoe UI Emoji` を明示して OS 任せの描画に統一する。装飾的な OpenType feature (`cv02`, `ss01` 等) は使わない (Notion はプレーン)。値は `app.css` を正本にする。
+製品 UI は Geist Variable を英数字の preferred font とし、日本語グリフは Hiragino Sans、Noto Sans JP、Meiryo の順で OS のフォントへ fallback する。日本語ページは `line-break: strict` と `word-break: auto-phrase` を併用し、禁則処理を保ちながら語句単位で改行する。文字幅を変える `palt` などの OpenType feature は全体へ適用しない。表、入力、バッジ、コード、数値表示は同じ stack を継承し、各部品が所有する既存の幅と整列を維持する。emoji は `Apple Color Emoji` / `Segoe UI Emoji` を明示して OS 任せの描画に統一する。値は `app.css` を正本にする。
+
+表示面ごとのフォント指定は、配信方法と生成環境が異なるため完全には統一しない。
+
+| 表示面 | 所有範囲と方針 |
+|---|---|
+| 製品 UI | `app.css` が Geist Variable、日本語 system fallback、locale 固有の文字組みを所有する。追加の日本語 Web フォントは配信しない |
+| ユーザー文書 | Markdown renderer またはアップロードされた文書自身が font stack と文字組みを所有し、製品 UI の指定を文書内へ注入しない |
+| PDF 書き出し | 書き出し処理が再現可能な日本語 font の埋め込みを所有する |
+| OG 画像 | preview image generator が利用可能な埋め込み font を所有する。製品 UI の OS fallback には依存しない |
+| 独立した error / embed surface | 各 surface の自己完結した CSS が所有し、製品 UI bundle の font 読み込みには依存しない |
 
 ### 4.2 Type scale
 
@@ -500,3 +510,4 @@ visual検出器の負の対照は `pnpm visual:fault-injection` で実行する�
 |---|---|---|
 | 2026-05-10 | v0.1  | 初版                                            |
 | 2026-07-29 | v0.25 | 現行の semantic token、部品規範、検証基準へ更新 |
+| 2026-08-14 | v0.26 | 日本語 system font fallback、禁則処理、表示面ごとの font 所有範囲を明文化 |

--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -49,15 +49,20 @@ export function findFontSourceViolations(appCss, rootTsx) {
   const activeAppCss = stripCssComments(appCss)
   const definitions = [...activeAppCss.matchAll(/--font-sans\s*:/g)].length
   const violations = []
+  const fontStack = activeAppCss.match(/--font-sans\s*:\s*([^;]+);/)?.[1]
   if (
     definitions !== 1 ||
     !/--font-sans\s*:\s*['"]Geist Variable['"]/.test(activeAppCss) ||
+    !fontStack ||
+    !/['"]Hiragino Sans['"]/.test(fontStack) ||
+    !/['"]Noto Sans JP['"]/.test(fontStack) ||
+    !/\bMeiryo\b/.test(fontStack) ||
     !/@import\s+['"]@fontsource-variable\/geist['"]\s*;/.test(activeAppCss)
   ) {
     violations.push({
       file: APP_CSS,
       detail:
-        "app.css must import @fontsource-variable/geist and define --font-sans once with 'Geist Variable' first",
+        "app.css must import @fontsource-variable/geist and define --font-sans once with 'Geist Variable' first, followed by the required Japanese system-font fallbacks",
     })
   }
   if (/https:\/\/fonts\.(googleapis|gstatic)\.com/i.test(rootTsx)) {
@@ -67,6 +72,25 @@ export function findFontSourceViolations(appCss, rootTsx) {
     })
   }
   return violations
+}
+
+export function findJapaneseTypographyViolations(appCss) {
+  const activeAppCss = stripCssComments(appCss)
+  const japaneseRule = activeAppCss.match(/html:lang\(ja\)\s*{([^}]+)}/)?.[1]
+  if (
+    japaneseRule &&
+    /line-break\s*:\s*strict\s*;/.test(japaneseRule) &&
+    /word-break\s*:\s*auto-phrase\s*;/.test(japaneseRule)
+  ) {
+    return []
+  }
+  return [
+    {
+      file: APP_CSS,
+      detail:
+        'html:lang(ja) must use strict line breaking and auto-phrase word breaking',
+    },
+  ]
 }
 
 export function findDesignSystemVersionViolations(document) {
@@ -1744,6 +1768,13 @@ export function runAllChecks() {
   )) {
     violations.push({
       check: 'font-source-sync',
+      file: rel(violation.file),
+      detail: violation.detail,
+    })
+  }
+  for (const violation of findJapaneseTypographyViolations(appCssContent)) {
+    violations.push({
+      check: 'japanese-typography',
       file: rel(violation.file),
       detail: violation.detail,
     })

--- a/scripts/check-design-tokens.test.mjs
+++ b/scripts/check-design-tokens.test.mjs
@@ -8,6 +8,7 @@ import {
   findBreakpointDocumentationViolations,
   findDesignSystemVersionViolations,
   findFontSourceViolations,
+  findJapaneseTypographyViolations,
   collectDefinedVariables,
   collectLayoutPrimitiveImportNames,
   collectThemeBreakpointNames,
@@ -242,7 +243,7 @@ test('design system sync checks reject stale font, version, and breakpoint sourc
       {
         file: APP_CSS,
         detail:
-          "app.css must import @fontsource-variable/geist and define --font-sans once with 'Geist Variable' first",
+          "app.css must import @fontsource-variable/geist and define --font-sans once with 'Geist Variable' first, followed by the required Japanese system-font fallbacks",
       },
       {
         file: new URL('../apps/web/app/root.tsx', import.meta.url).pathname,
@@ -273,7 +274,7 @@ test('design system sync checks reject stale font, version, and breakpoint sourc
 test('design system sync checks allow the current sources', () => {
   assert.deepEqual(
     findFontSourceViolations(
-      "@import '@fontsource-variable/geist';\n--font-sans: 'Geist Variable', system-ui;",
+      "@import '@fontsource-variable/geist';\n--font-sans: 'Geist Variable', 'Hiragino Sans', 'Noto Sans JP', Meiryo, system-ui;",
       'export const links = () => []',
     ),
     [],
@@ -287,7 +288,7 @@ test('design system sync checks allow the current sources', () => {
       {
         file: APP_CSS,
         detail:
-          "app.css must import @fontsource-variable/geist and define --font-sans once with 'Geist Variable' first",
+          "app.css must import @fontsource-variable/geist and define --font-sans once with 'Geist Variable' first, followed by the required Japanese system-font fallbacks",
       },
     ],
   )
@@ -300,16 +301,28 @@ test('design system sync checks allow the current sources', () => {
       {
         file: APP_CSS,
         detail:
-          "app.css must import @fontsource-variable/geist and define --font-sans once with 'Geist Variable' first",
+          "app.css must import @fontsource-variable/geist and define --font-sans once with 'Geist Variable' first, followed by the required Japanese system-font fallbacks",
       },
     ],
   )
   assert.deepEqual(
     findFontSourceViolations(
-      "@import '@fontsource-variable/geist';\n/* --font-sans: Inter; */\n--font-sans: 'Geist Variable', system-ui;",
+      "@import '@fontsource-variable/geist';\n/* --font-sans: Inter; */\n--font-sans: 'Geist Variable', 'Hiragino Sans', 'Noto Sans JP', Meiryo, system-ui;",
       'export const links = () => []',
     ),
     [],
+  )
+  assert.deepEqual(
+    findJapaneseTypographyViolations(
+      'html:lang(ja) { line-break: strict; word-break: auto-phrase; }',
+    ),
+    [],
+  )
+  assert.equal(
+    findJapaneseTypographyViolations(
+      'html:lang(ja) { word-break: auto-phrase; }',
+    )[0]?.detail,
+    'html:lang(ja) must use strict line breaking and auto-phrase word breaking',
   )
   assert.deepEqual(
     findDesignSystemVersionViolations(


### PR DESCRIPTION
## 現状

製品 UI は英数字に Geist Variable を使う一方、日本語グリフは汎用 system font に委ねていました。そのため、OS ごとに日本語の字面やウェイトが変わり、日本語ページの禁則処理も明示されていませんでした。

## 変更

- Geist Variable を先頭に維持し、Hiragino Sans、Noto Sans JP、Meiryo の日本語 system font fallback を明示
- 日本語ページへ strict な禁則処理と語句単位の改行を適用
- font stack と日本語文字組みの静的回帰検査、実ブラウザ検査を追加
- 製品 UI、ユーザー文書、PDF、OG 画像、独立 surface の font 所有範囲を design system に記載
- 日本語 Web font や追加の font 通信は追加していない

## 検証

- `pnpm validate:static`
- `pnpm --filter @artifactshare/web exec vitest --config vitest.visual.browser.config.ts --run app/root.locale.browser.test.tsx`
- `pnpm screens:capture -- --screen landing --screen start --label japanese-typography --audit-gaps`（日英・明暗・desktop/mobile の 16 capture、gap finding 0）
- Codex / Claude deep implementation review（blocker なし）
