### PR TITLE
Guide users through plan limit upgrades

### DIFF
--- a/apps/web/app/components/app/project-manage-dialogs.tsx
+++ b/apps/web/app/components/app/project-manage-dialogs.tsx
@@ -12,6 +12,10 @@ import {
 } from '~/components/ui/alert-dialog'
 import { Button } from '~/components/ui/button'
 import { useT } from '~/hooks/use-t'
+import {
+  UpgradeRequestPanel,
+  type UpgradeRequestView,
+} from './upgrade-request-panel'
 
 type ProjectAction = 'archive' | 'unarchive' | 'delete'
 
@@ -26,6 +30,7 @@ async function postProjectAction(
       code?: string
       limit?: number
       holderName?: string
+      upgradeRequest?: UpgradeRequestView
     }
 > {
   try {
@@ -39,7 +44,10 @@ async function postProjectAction(
       error?: {
         code?: string
         message?: string
-        details?: { holder_name?: string | null }
+        details?: {
+          holder_name?: string | null
+          upgrade_request?: UpgradeRequestView
+        }
       }
     } | null
     const code = body?.error?.code
@@ -51,6 +59,7 @@ async function postProjectAction(
       code,
       limit: limitMatch ? Number(limitMatch[1]) : undefined,
       holderName: typeof holderName === 'string' ? holderName : undefined,
+      upgradeRequest: body?.error?.details?.upgrade_request,
     }
   } catch {
     return { ok: false, status: 0 }
@@ -73,31 +82,51 @@ export function UnarchiveProjectButton({
 }: UnarchiveProjectButtonProps) {
   const { t } = useT()
   const [busy, setBusy] = useState(false)
+  const [upgradeRequest, setUpgradeRequest] =
+    useState<UpgradeRequestView | null>(null)
+  const [upgradeLimit, setUpgradeLimit] = useState<number | null>(null)
 
   const run = async () => {
     setBusy(true)
+    setUpgradeRequest(null)
+    setUpgradeLimit(null)
     const result = await postProjectAction(projectId, 'unarchive')
     setBusy(false)
     if (result.ok) {
       toast.success(t('toast.projectRestored', { name: projectName }))
       onSuccess()
     } else if (result.code === 'project-limit-reached' && result.limit) {
-      toast.error(t('toast.projectLimitReached', { limit: result.limit }))
+      if (result.upgradeRequest) {
+        setUpgradeRequest(result.upgradeRequest)
+        setUpgradeLimit(result.limit)
+      } else {
+        toast.error(t('toast.projectLimitReached', { limit: result.limit }))
+      }
     } else {
       toast.error(t('toast.projectActionFailed'))
     }
   }
 
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={busy}
-      onClick={() => void run()}
-    >
-      {children}
-    </Button>
+    <div className="space-y-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={busy}
+        onClick={() => void run()}
+      >
+        {children}
+      </Button>
+      {upgradeRequest && upgradeLimit ? (
+        <UpgradeRequestPanel
+          request={upgradeRequest}
+          existingErrorLine={t('toast.projectLimitReached', {
+            limit: upgradeLimit,
+          })}
+        />
+      ) : null}
+    </div>
   )
 }
 

--- a/apps/web/app/components/app/upgrade-request-panel.tsx
+++ b/apps/web/app/components/app/upgrade-request-panel.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react'
+import { Button } from '~/components/ui/button'
+import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert'
+import { Textarea } from '~/components/ui/textarea'
+import { useT } from '~/hooks/use-t'
+
+export type UpgradeRequestView = {
+  limit_type: 'storage' | 'projects'
+  current_plan: 'free' | 'plus'
+  recommended_plan: 'plus' | 'team'
+} & (
+  | {
+      kind: 'contact'
+      upgrade_url: string
+      owner: { name: string | null; email: string }
+      request_message: string
+    }
+  | { kind: 'billing'; upgrade_url: string; action_message: string }
+  | { kind: 'support'; support_url: string }
+)
+
+export function UpgradeRequestPanel({
+  request,
+  existingErrorLine,
+}: {
+  request: UpgradeRequestView
+  existingErrorLine: string
+}) {
+  const { t } = useT()
+  const [copied, setCopied] = useState<'idle' | 'copied' | 'failed'>('idle')
+  const copy = async () => {
+    if (request.kind !== 'contact') return
+    try {
+      await navigator.clipboard.writeText(request.request_message)
+      setCopied('copied')
+    } catch {
+      setCopied('failed')
+    }
+  }
+  return (
+    <Alert>
+      <AlertTitle>
+        {request.current_plan === 'free' ? 'Free' : 'Plus'} →{' '}
+        {request.recommended_plan === 'plus' ? 'Plus' : 'Team'}
+      </AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p>{existingErrorLine}</p>
+        {request.kind === 'contact' ? (
+          <>
+            <p>
+              {request.owner.name
+                ? `${request.owner.name} (${request.owner.email})`
+                : request.owner.email}
+            </p>
+            <Textarea readOnly value={request.request_message} rows={5} />
+            <div className="flex items-center gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={copy}>
+                {t('upgradeRequest.copy')}
+              </Button>
+              {copied === 'copied' ? (
+                <small>{t('upgradeRequest.copied')}</small>
+              ) : null}
+              {copied === 'failed' ? (
+                <small>{t('upgradeRequest.copyFailed')}</small>
+              ) : null}
+            </div>
+          </>
+        ) : request.kind === 'billing' ? (
+          <>
+            <p>{request.action_message}</p>
+            <Button asChild size="sm">
+              <a href={request.upgrade_url}>{t('upgradeRequest.billing')}</a>
+            </Button>
+          </>
+        ) : (
+          <Button asChild variant="outline" size="sm">
+            <a href={request.support_url}>{t('upgradeRequest.support')}</a>
+          </Button>
+        )}
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/apps/web/app/i18n/en.json
+++ b/apps/web/app/i18n/en.json
@@ -1200,5 +1200,10 @@
   "audienceDialog.bot.workspaceInvalid": "Bots can only join projects in their own workspace.",
   "audienceDialog.bot.targetInvalid": "A grant change did not apply. Reload the audience and retry.",
   "team.bots.error.reissue-destination-gone": "The destination project has been deleted. Create a new bot for a new destination.",
-  "team.bots.error.reissue-conflict": "The reissue hit a temporary conflict. Retry."
+  "team.bots.error.reissue-conflict": "The reissue hit a temporary conflict. Retry.",
+  "upgradeRequest.copy": "Copy request",
+  "upgradeRequest.copied": "Copied",
+  "upgradeRequest.copyFailed": "Select the text and copy it manually.",
+  "upgradeRequest.billing": "View billing",
+  "upgradeRequest.support": "Contact support"
 }

--- a/apps/web/app/i18n/ja.json
+++ b/apps/web/app/i18n/ja.json
@@ -1200,5 +1200,10 @@
   "audienceDialog.bot.workspaceInvalid": "ボットは自分のワークスペースのプロジェクトにだけ参加できます。",
   "audienceDialog.bot.targetInvalid": "変更が適用されませんでした。関係者一覧を読み込み直してからやり直してください。",
   "team.bots.error.reissue-destination-gone": "投稿先プロジェクトが削除されています。新しいボットを作成してください。",
-  "team.bots.error.reissue-conflict": "再発行が一時的に競合しました。もう一度お試しください。"
+  "team.bots.error.reissue-conflict": "再発行が一時的に競合しました。もう一度お試しください。",
+  "upgradeRequest.copy": "依頼文をコピー",
+  "upgradeRequest.copied": "コピーしました",
+  "upgradeRequest.copyFailed": "テキストを選択して手動でコピーしてください。",
+  "upgradeRequest.billing": "請求設定を開く",
+  "upgradeRequest.support": "サポートに問い合わせる"
 }

--- a/apps/web/app/lib/api-errors.ts
+++ b/apps/web/app/lib/api-errors.ts
@@ -2,8 +2,18 @@ export function errorResponse(
   code: string,
   message: string,
   status: number,
+  options?: { details?: Record<string, unknown>; headers?: HeadersInit },
 ): Response {
-  return Response.json({ error: { code, message } }, { status })
+  return Response.json(
+    {
+      error: {
+        code,
+        message,
+        ...(options?.details ? { details: options.details } : {}),
+      },
+    },
+    { status, headers: options?.headers },
+  )
 }
 
 /**

--- a/apps/web/app/routes/_home/+components/upload-artifact-dialog.tsx
+++ b/apps/web/app/routes/_home/+components/upload-artifact-dialog.tsx
@@ -4,6 +4,7 @@ import {
   useRef,
   useState,
   type ChangeEvent,
+  type RefObject,
 } from 'react'
 import { useLocation, useNavigate, useRevalidator } from 'react-router'
 import { IconFolderOpen, IconStack2 as Layers } from '@tabler/icons-react'
@@ -18,7 +19,6 @@ import {
 import { useT } from '~/hooks/use-t'
 import {
   isUploadShareableErrorCode,
-  readErrorTag,
   UPLOAD_SHAREABLE_ERROR_I18N,
   type UploadShareableErrorCode,
 } from '~/lib/api-errors'
@@ -53,6 +53,10 @@ import {
   FieldDescription,
   FieldLabel,
 } from '~/components/ui/field'
+import {
+  UpgradeRequestPanel,
+  type UpgradeRequestView,
+} from '~/components/app/upgrade-request-panel'
 
 const uploadDialogContentClassName =
   'max-w-[var(--breakpoint-phone)] sm:max-w-[var(--breakpoint-phone)]'
@@ -99,6 +103,19 @@ const uploadProjectDefaultsEmailClassName =
   'overflow-hidden text-ellipsis whitespace-nowrap'
 
 const uploadProjectDefaultsExternalClassName = 'text-xs font-semibold text-link'
+
+async function readUploadError(res: Response) {
+  const body = (await res.json().catch(() => null)) as {
+    error?: {
+      code?: string
+      details?: { upgrade_request?: UpgradeRequestView }
+    }
+  } | null
+  return {
+    code: body?.error?.code,
+    upgradeRequest: body?.error?.details?.upgrade_request ?? null,
+  }
+}
 
 export function shouldShowSlackNotification(
   hasSlackChannel: boolean | undefined,
@@ -198,6 +215,8 @@ export function UploadArtifactDialog({
   )
   const [slackNotifyDisabled, setSlackNotifyDisabled] =
     useSlackNotifyOptOut(open)
+  const [upgradeRequest, setUpgradeRequest] =
+    useState<UpgradeRequestView | null>(null)
   const currentState = resolveUploadDialogState(state, {
     defaultVisibility,
     open,
@@ -215,6 +234,7 @@ export function UploadArtifactDialog({
 
   const upload = useCallback(
     async (files: File[]) => {
+      setUpgradeRequest(null)
       const problem = validateFiles(files, t)
       if (problem) {
         toast.error(problem)
@@ -263,7 +283,8 @@ export function UploadArtifactDialog({
           return
         }
         if (!res.ok) {
-          const code = await readErrorTag(res)
+          const failure = await readUploadError(res)
+          const code = failure.code
           const key =
             staticSite && code === 'unsupported-type'
               ? 'upload.error.unsupportedBundleType'
@@ -284,6 +305,7 @@ export function UploadArtifactDialog({
                     onClick: () => void upload(files),
                   }
           toast.error(t(key), { id: toastId, ...(action && { action }) })
+          setUpgradeRequest(failure.upgradeRequest)
           return
         }
 
@@ -373,6 +395,8 @@ export function UploadArtifactDialog({
           homeDestinationLabel={homeDestinationLabel}
         />
 
+        <UploadUpgradeRequest request={upgradeRequest} />
+
         <UploadDropzone
           dragOver={currentState.dragOver}
           disabled={currentState.uploading}
@@ -387,22 +411,9 @@ export function UploadArtifactDialog({
           onDropError={() => toast.error(t('upload.error.dropReadFailed'))}
         />
 
-        <input
-          ref={inputRef}
-          className="hidden"
-          type="file"
-          aria-label={t('picker.title')}
-          accept={ACCEPTED_FILE_UPLOAD_TYPES}
-          onChange={handleInputChange}
-        />
-
-        <input
-          ref={setDirectoryInputRef}
-          className="hidden"
-          type="file"
-          aria-label={t('upload.pick.folder')}
-          multiple
-          accept={ACCEPTED_SITE_UPLOAD_TYPES}
+        <UploadFileInputs
+          inputRef={inputRef}
+          setDirectoryInputRef={setDirectoryInputRef}
           onChange={handleInputChange}
         />
 
@@ -476,6 +487,53 @@ export function UploadArtifactDialog({
       </DialogContent>
     </Dialog>
   )
+}
+
+function UploadFileInputs({
+  inputRef,
+  setDirectoryInputRef,
+  onChange,
+}: {
+  inputRef: RefObject<HTMLInputElement | null>
+  setDirectoryInputRef: (element: HTMLInputElement | null) => void
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void
+}) {
+  const { t } = useT()
+  return (
+    <>
+      <input
+        ref={inputRef}
+        className="hidden"
+        type="file"
+        aria-label={t('picker.title')}
+        accept={ACCEPTED_FILE_UPLOAD_TYPES}
+        onChange={onChange}
+      />
+      <input
+        ref={setDirectoryInputRef}
+        className="hidden"
+        type="file"
+        aria-label={t('upload.pick.folder')}
+        multiple
+        accept={ACCEPTED_SITE_UPLOAD_TYPES}
+        onChange={onChange}
+      />
+    </>
+  )
+}
+
+function UploadUpgradeRequest({
+  request,
+}: {
+  request: UpgradeRequestView | null
+}) {
+  const { t } = useT()
+  return request ? (
+    <UpgradeRequestPanel
+      request={request}
+      existingErrorLine={t('upload.error.quotaExceeded')}
+    />
+  ) : null
 }
 
 function SlackNotificationPreference({

--- a/apps/web/app/routes/_home/+components/upload-artifact-dialog.tsx
+++ b/apps/web/app/routes/_home/+components/upload-artifact-dialog.tsx
@@ -195,6 +195,16 @@ function useSlackNotifyOptOut(open: boolean) {
   return [disabled, setDisabled] as const
 }
 
+function useTransientUpgradeRequest(open: boolean) {
+  const [request, setRequest] = useState<UpgradeRequestView | null>(null)
+  const [prevOpen, setPrevOpen] = useState(open)
+  if (prevOpen !== open) {
+    setPrevOpen(open)
+    setRequest(null)
+  }
+  return [request, setRequest] as const
+}
+
 export function UploadArtifactDialog({
   open,
   onOpenChange,
@@ -215,8 +225,7 @@ export function UploadArtifactDialog({
   )
   const [slackNotifyDisabled, setSlackNotifyDisabled] =
     useSlackNotifyOptOut(open)
-  const [upgradeRequest, setUpgradeRequest] =
-    useState<UpgradeRequestView | null>(null)
+  const [upgradeRequest, setUpgradeRequest] = useTransientUpgradeRequest(open)
   const currentState = resolveUploadDialogState(state, {
     defaultVisibility,
     open,
@@ -346,6 +355,7 @@ export function UploadArtifactDialog({
       t,
       user,
       slackNotifyDisabled,
+      setUpgradeRequest,
     ],
   )
 

--- a/apps/web/app/routes/_home/_protected/projects.tsx
+++ b/apps/web/app/routes/_home/_protected/projects.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useEffectEvent, useRef, useState } from 'react'
 import {
+  data,
   Form,
   Link,
   redirect,
@@ -8,6 +9,7 @@ import {
   useOutletContext,
   useSearchParams,
 } from 'react-router'
+import { env } from 'cloudflare:workers'
 import { toast } from 'sonner'
 import { IconPlus, IconStack2 as Layers } from '@tabler/icons-react'
 import type { Route } from './+types/projects'
@@ -20,6 +22,10 @@ import {
   BreadcrumbSeparator,
 } from '~/components/ui/breadcrumb'
 import { PageBreadcrumb } from '~/components/app/page-breadcrumb'
+import {
+  UpgradeRequestPanel,
+  type UpgradeRequestView,
+} from '~/components/app/upgrade-request-panel'
 import { Alert, AlertDescription } from '~/components/ui/alert'
 import { Button } from '~/components/ui/button'
 import {
@@ -35,9 +41,11 @@ import { Input } from '~/components/ui/input'
 import { Textarea } from '~/components/ui/textarea'
 import { useT } from '~/hooks/use-t'
 import type { TKey } from '~/lib/i18n'
+import { getLocale } from '~/lib/i18n.server'
 import { checkUploadAccess } from '~/services/upload-access.server'
 import { requireUser } from '~/middleware/context'
 import { createDb } from '~/services/db.server'
+import { buildUpgradeRequest } from '~/services/upgrade-request.server'
 import {
   createProjectContainer,
   listSharedProjects,
@@ -132,11 +140,33 @@ export async function action({ request, context }: Route.ActionArgs) {
     baseVisibility,
   })
   if (result.kind === 'project-limit-reached') {
-    return {
+    const upgradeRequest =
+      result.billingWorkspaceId && result.observedPlan
+        ? await buildUpgradeRequest({
+            db,
+            actor: {
+              id: user.id,
+              workspaceId: user.workspaceId,
+              kind: user.kind,
+            },
+            billingWorkspaceId: result.billingWorkspaceId,
+            limitType: 'projects',
+            observedPlan: result.observedPlan,
+            locale: getLocale(request, user.locale),
+            appBaseUrl: env.BETTER_AUTH_URL,
+          })
+        : null
+    const value = {
       intent: 'create-project',
       errorKey: 'project.errorProjectLimitReached',
       errorVars: { limit: result.limit },
+      ...(upgradeRequest ? { upgrade_request: upgradeRequest } : {}),
     } as const
+    return upgradeRequest
+      ? data(value, {
+          headers: { 'Cache-Control': 'private, no-store' },
+        })
+      : value
   }
   return redirect(`/projects/${result.id}`)
 }
@@ -170,7 +200,13 @@ export default function ProjectsIndex({ loaderData }: Route.ComponentProps) {
   const createErrorKey =
     actionData?.intent === 'create-project' ? actionData.errorKey : null
   const createErrorVars =
-    actionData?.intent === 'create-project' ? actionData.errorVars : undefined
+    actionData?.intent === 'create-project' && 'errorVars' in actionData
+      ? actionData.errorVars
+      : undefined
+  const upgradeRequest =
+    actionData?.intent === 'create-project' && 'upgrade_request' in actionData
+      ? (actionData.upgrade_request as UpgradeRequestView)
+      : null
 
   useEffect(() => {
     if (
@@ -238,6 +274,7 @@ export default function ProjectsIndex({ loaderData }: Route.ComponentProps) {
         workspaceName={workspaceName}
         errorKey={createErrorVisible ? createErrorKey : null}
         errorVars={createErrorVisible ? createErrorVars : undefined}
+        upgradeRequest={createErrorVisible ? upgradeRequest : null}
       />
     </>
   )
@@ -249,12 +286,14 @@ function ProjectDialog({
   workspaceName,
   errorKey,
   errorVars,
+  upgradeRequest,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   workspaceName: string
   errorKey: TKey | null
   errorVars?: Record<string, string | number>
+  upgradeRequest: UpgradeRequestView | null
 }) {
   const navigation = useNavigation()
   const { t } = useT()
@@ -322,7 +361,12 @@ function ProjectDialog({
 
             <ProjectScopeField />
 
-            {errorKey ? (
+            {errorKey && upgradeRequest ? (
+              <UpgradeRequestPanel
+                request={upgradeRequest}
+                existingErrorLine={t(errorKey, errorVars)}
+              />
+            ) : errorKey ? (
               <Alert variant="destructive">
                 <AlertDescription>
                   {t(errorKey, errorVars)}

--- a/apps/web/app/routes/api.cli.projects.tsx
+++ b/apps/web/app/routes/api.cli.projects.tsx
@@ -1,3 +1,4 @@
+import { env } from 'cloudflare:workers'
 import { requireUserApiWithBearerMiddleware } from '~/middleware/auth'
 import { getCliAuthority, requireUser } from '~/middleware/context'
 import { errorResponse } from '~/lib/api-errors'
@@ -11,6 +12,7 @@ import {
   parseProjectBaseVisibility,
 } from '~/services/projects.server'
 import { checkUploadAccess } from '~/services/upload-access.server'
+import { buildUpgradeRequest } from '~/services/upgrade-request.server'
 import type { Route } from './+types/api.cli.projects'
 
 export const middleware = [requireUserApiWithBearerMiddleware]
@@ -100,6 +102,23 @@ export async function action({ request, context }: Route.ActionArgs) {
       return {
         kind: 'project-limit-reached' as const,
         limit: created.limit,
+        upgradeRequest:
+          created.billingWorkspaceId && created.observedPlan
+            ? await buildUpgradeRequest({
+                db,
+                actor: {
+                  id: user.id,
+                  workspaceId: user.workspaceId,
+                  kind: user.kind,
+                },
+                billingWorkspaceId: created.billingWorkspaceId,
+                limitType: 'projects',
+                observedPlan: created.observedPlan,
+                locale:
+                  user.kind === 'bot' || user.locale !== 'ja' ? 'en' : 'ja',
+                appBaseUrl: env.BETTER_AUTH_URL,
+              })
+            : null,
       }
     }
     return { kind: 'created' as const, id: created.id }
@@ -109,6 +128,12 @@ export async function action({ request, context }: Route.ActionArgs) {
       'project-limit-reached',
       `You've reached your plan's project limit (${result.limit} projects). Upgrade your plan or archive existing projects. See /settings/billing for upgrade options.`,
       403,
+      result.upgradeRequest
+        ? {
+            details: { upgrade_request: result.upgradeRequest },
+            headers: { 'Cache-Control': 'private, no-store' },
+          }
+        : undefined,
     )
   }
 

--- a/apps/web/app/routes/api.projects.$id.tsx
+++ b/apps/web/app/routes/api.projects.$id.tsx
@@ -1,7 +1,12 @@
+import { env } from 'cloudflare:workers'
+import type { Kysely } from 'kysely'
 import { errorResponse } from '~/lib/api-errors'
+import { getLocale } from '~/lib/i18n.server'
 import { requireUserApiMiddleware } from '~/middleware/auth'
 import { requireUser } from '~/middleware/context'
 import { createDb } from '~/services/db.server'
+import { buildUpgradeRequest } from '~/services/upgrade-request.server'
+import type { DB } from '~/types/db'
 import {
   archiveProjectContainer,
   deleteProjectContainer,
@@ -30,7 +35,10 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     )
   }
   if (op === 'unarchive') {
-    return mapUnarchiveResult(
+    return await mapUnarchiveResult(
+      db,
+      user,
+      getLocale(request, user.locale),
       await unarchiveProjectContainer(db, user.workspaceId, params.id, user.id),
     )
   }
@@ -84,12 +92,39 @@ function mapArchiveResult(result: ProjectArchiveResult): Response {
   return Response.json({ ok: true })
 }
 
-function mapUnarchiveResult(result: ProjectUnarchiveResult): Response {
+async function mapUnarchiveResult(
+  db: Kysely<DB>,
+  user: {
+    id: string
+    workspaceId: string
+    kind: 'human' | 'bot'
+  },
+  locale: 'en' | 'ja',
+  result: ProjectUnarchiveResult,
+): Promise<Response> {
   if (typeof result === 'object') {
+    const upgradeRequest =
+      result.billingWorkspaceId && result.observedPlan
+        ? await buildUpgradeRequest({
+            db,
+            actor: user,
+            billingWorkspaceId: result.billingWorkspaceId,
+            limitType: 'projects',
+            observedPlan: result.observedPlan,
+            locale,
+            appBaseUrl: env.BETTER_AUTH_URL,
+          })
+        : null
     return errorResponse(
       'project-limit-reached',
       `You've reached your plan's project limit (${result.limit} projects). Upgrade your plan or archive existing projects. See /settings/billing for upgrade options.`,
       403,
+      upgradeRequest
+        ? {
+            details: { upgrade_request: upgradeRequest },
+            headers: { 'Cache-Control': 'private, no-store' },
+          }
+        : undefined,
     )
   }
   return mapArchiveResult(result)

--- a/apps/web/app/routes/api.shareables.uploads.tsx
+++ b/apps/web/app/routes/api.shareables.uploads.tsx
@@ -8,6 +8,7 @@ import {
   MaxPartsExceededError,
   MaxTotalSizeExceededError,
 } from '@remix-run/multipart-parser'
+import { env } from 'cloudflare:workers'
 import {
   errorResponse,
   contributorGuardrailResponse,
@@ -60,6 +61,8 @@ import {
 import type { Kysely } from 'kysely'
 import type { DB } from '~/types/db'
 import type { CliAuthority } from '~/services/cli-authority.server'
+import { buildUpgradeRequest } from '~/services/upgrade-request.server'
+import { DEFAULT_LOCALE, isSupportedLocale } from '~/i18n/messages'
 import type { Route } from './+types/api.shareables.uploads'
 
 export const middleware = [requireUserApiWithBearerMiddleware]
@@ -294,7 +297,11 @@ export async function action({ request, context }: Route.ActionArgs) {
         502,
       )
     case 'quota-exceeded':
-      return errorResponse('quota-exceeded', 'Storage quota exceeded.', 413)
+      return storageQuotaExceededResponse(
+        db,
+        user,
+        authorized.destination.workspaceId,
+      )
     case 'workspace-access-revoked':
       return workspaceAccessRevokedResponse()
     case 'contributor-limit-exceeded':
@@ -356,6 +363,36 @@ export async function action({ request, context }: Route.ActionArgs) {
       )
     }
   }
+}
+
+async function storageQuotaExceededResponse(
+  db: Kysely<DB>,
+  user: Parameters<typeof buildUpgradeRequest>[0]['actor'] & {
+    locale: string | null
+  },
+  billingWorkspaceId: string,
+): Promise<Response> {
+  const workspace = await db
+    .selectFrom('workspaces')
+    .select('plan')
+    .where('id', '=', billingWorkspaceId)
+    .executeTakeFirst()
+  const observedPlan = workspace?.plan === 'free' ? 'free' : null
+  const upgradeRequest = observedPlan
+    ? await buildUpgradeRequest({
+        db,
+        actor: user,
+        billingWorkspaceId,
+        limitType: 'storage',
+        observedPlan,
+        locale: isSupportedLocale(user.locale) ? user.locale : DEFAULT_LOCALE,
+        appBaseUrl: env.BETTER_AUTH_URL,
+      })
+    : null
+  return errorResponse('quota-exceeded', 'Storage quota exceeded.', 413, {
+    ...(upgradeRequest && { details: { upgrade_request: upgradeRequest } }),
+    headers: { 'Cache-Control': 'no-store' },
+  })
 }
 
 class StaticSiteUploadRejected extends Error {

--- a/apps/web/app/routes/api.shareables.uploads.tsx
+++ b/apps/web/app/routes/api.shareables.uploads.tsx
@@ -220,6 +220,13 @@ export async function action({ request, context }: Route.ActionArgs) {
         waitUntil,
       })
       if (updated.kind !== 'ok') {
+        if (updated.kind === 'quota-exceeded') {
+          return storageQuotaExceededResponse(
+            db,
+            user,
+            authorized.destination.workspaceId,
+          )
+        }
         return createVersionFailureResponse(updated, keyKindMismatchResponse)
       }
       return Response.json({
@@ -485,6 +492,8 @@ async function uploadStaticSiteWithSession(
     emailVerified: boolean
     workspaceId: string
     hd: string | null
+    locale: string | null
+    kind: 'human' | 'bot'
   },
   publishKey: string | null,
   channel: 'web' | 'cli',
@@ -545,7 +554,7 @@ async function uploadStaticSiteWithSession(
           403,
         )
       }
-      return await runStaticSiteVersionUpload(
+      const response = await runStaticSiteVersionUpload(
         db,
         request,
         user,
@@ -560,6 +569,13 @@ async function uploadStaticSiteWithSession(
           waitUntil,
         },
       )
+      return (await hasErrorCode(response, 'quota-exceeded'))
+        ? storageQuotaExceededResponse(
+            db,
+            user,
+            authorized.destination.workspaceId,
+          )
+        : response
     }
   }
 
@@ -578,7 +594,9 @@ async function uploadStaticSiteWithSession(
           containerId,
           publishKey,
         )
-  if (begun.kind !== 'ok') return staticSiteBundleResponse(request, begun)
+  if (begun.kind !== 'ok') {
+    return staticSiteBundleResponse(request, begun)
+  }
   const { session } = begun
 
   let form: FormData
@@ -603,7 +621,13 @@ async function uploadStaticSiteWithSession(
   } catch (error) {
     if (error instanceof StaticSiteUploadRejected) {
       await session.abort()
-      return staticSiteBundleResponse(request, error.result)
+      return error.result.kind === 'quota-exceeded'
+        ? storageQuotaExceededResponse(
+            db,
+            user,
+            authorized.destination.workspaceId,
+          )
+        : staticSiteBundleResponse(request, error.result)
     }
     const response = staticSiteParseErrorResponse(error)
     if (response) {
@@ -680,11 +704,29 @@ async function uploadStaticSiteWithSession(
       sendToGa: firstPostShouldSend(request, channel),
       waitUntil,
     })
+  if (result.kind === 'quota-exceeded') {
+    return storageQuotaExceededResponse(
+      db,
+      user,
+      authorized.destination.workspaceId,
+    )
+  }
   return staticSiteBundleResponse(
     request,
     result,
     publishKey !== null ? { created: true } : {},
   )
+}
+
+async function hasErrorCode(response: Response, code: string) {
+  if (response.ok) return false
+  const body = (await response
+    .clone()
+    .json()
+    .catch(() => null)) as {
+    error?: { code?: string }
+  } | null
+  return body?.error?.code === code
 }
 
 function keyResolutionFailureResponse(

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -2361,7 +2361,7 @@ async function uploadError(
               'artifact_containers.workspace_id as workspace_id',
               'workspaces.plan as plan',
             ])
-            .where('id', '=', containerId)
+            .where('artifact_containers.id', '=', containerId)
             .executeTakeFirst()
         : { workspace_id: user.workspaceId, plan: user.plan }
       const billingWorkspaceId = destination?.workspace_id

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -80,6 +80,10 @@ import { toAgentCommentThread } from '~/services/artifact-readback.server'
 import { getArtifactReadback } from '~/services/artifact-readback-service.server'
 import { recordFirstArtifactPost } from '~/services/first-post-analytics.server'
 import { listCliArtifacts } from '~/services/cli-artifacts.server'
+import {
+  buildUpgradeRequest,
+  type UpgradeRequest,
+} from '~/services/upgrade-request.server'
 
 export {
   capSource,
@@ -580,7 +584,9 @@ export function registerArtifactTools(
           ...uploadOptionsForSlackNotify(args.slack_notify),
         },
       )
-      if (result.kind !== 'ok') return uploadError(result)
+      if (result.kind !== 'ok') {
+        return uploadError(ctx, user, result, containerId)
+      }
       await recordFirstArtifactPost(ctx.db, user, {
         channel: 'mcp',
         // MCP posts have no browser consent signal; measured as first-party.
@@ -1505,7 +1511,7 @@ export function registerArtifactTools(
         },
       )
       if (created.kind === 'project-limit-reached') {
-        return projectLimitReachedError(created.limit)
+        return projectLimitReachedError(ctx, user, created)
       }
       return jsonResult({
         id: created.id,
@@ -1589,7 +1595,7 @@ export function registerArtifactTools(
           archived: args.archived,
         },
       )
-      if (result.kind !== 'ok') return projectEditError(result)
+      if (result.kind !== 'ok') return projectEditError(ctx, user, result)
 
       const state = result.project
       return jsonResult({
@@ -1767,6 +1773,7 @@ function toolError(error: {
   message: string
   recoverable_by: 'agent' | 'human'
   hint?: string
+  upgrade_request?: UpgradeRequest
 }): ToolTextResult {
   return { isError: true, content: textContent({ error }) }
 }
@@ -1924,12 +1931,30 @@ function invalidProjectNameError(): ToolTextResult {
   })
 }
 
-function projectLimitReachedError(limit: number): ToolTextResult {
+async function projectLimitReachedError(
+  ctx: McpRequestContext,
+  user: McpUser,
+  result: {
+    limit: number
+    billingWorkspaceId: string
+    observedPlan: 'free' | 'plus'
+  },
+): Promise<ToolTextResult> {
+  const upgradeRequest = await buildUpgradeRequest({
+    db: ctx.db,
+    actor: user,
+    billingWorkspaceId: result.billingWorkspaceId,
+    limitType: 'projects',
+    observedPlan: result.observedPlan,
+    locale: isSupportedLocale(user.locale) ? user.locale : DEFAULT_LOCALE,
+    appBaseUrl: ctx.baseUrl,
+  })
   return toolError({
     code: 'project-limit-reached',
-    message: `You've reached your plan's project limit (${limit} projects). Upgrade your plan or archive existing projects. See /settings/billing for upgrade options.`,
+    message: `You've reached your plan's project limit (${result.limit} projects). Upgrade your plan or archive existing projects. See /settings/billing for upgrade options.`,
     recoverable_by: 'human',
     hint: 'Archive an existing project or upgrade the workspace plan in billing settings.',
+    ...(upgradeRequest && { upgrade_request: upgradeRequest }),
   })
 }
 
@@ -1977,9 +2002,11 @@ function tooManyAudienceError(): ToolTextResult {
   })
 }
 
-function projectEditError(
+async function projectEditError(
+  ctx: McpRequestContext,
+  user: McpUser,
   result: Exclude<EditProjectContainerSettingsResult, { kind: 'ok' }>,
-): ToolTextResult {
+): Promise<ToolTextResult> {
   switch (result.kind) {
     case 'not-found':
       return projectNotFoundError()
@@ -1988,7 +2015,7 @@ function projectEditError(
     case 'project-archived':
       return projectArchivedError()
     case 'project-limit-reached':
-      return projectLimitReachedError(result.limit)
+      return await projectLimitReachedError(ctx, user, result)
     case 'too-many-grants':
       return tooManyAudienceError()
     case 'validation-failed':
@@ -2238,9 +2265,12 @@ function permissionError(
   }
 }
 
-function uploadError(
+async function uploadError(
+  ctx: McpRequestContext,
+  user: McpUser,
   result: Exclude<UploadShareableResult, { kind: 'ok' }>,
-): ToolTextResult {
+  containerId: string | null,
+): Promise<ToolTextResult> {
   switch (result.kind) {
     case 'unsupported-type':
       return toolError({
@@ -2319,11 +2349,42 @@ function uploadError(
         hint: 'Contact the Artifact Share team for help.',
       })
     case 'quota-exceeded':
+      const destination = containerId
+        ? await ctx.db
+            .selectFrom('artifact_containers')
+            .innerJoin(
+              'workspaces',
+              'workspaces.id',
+              'artifact_containers.workspace_id',
+            )
+            .select([
+              'artifact_containers.workspace_id as workspace_id',
+              'workspaces.plan as plan',
+            ])
+            .where('id', '=', containerId)
+            .executeTakeFirst()
+        : { workspace_id: user.workspaceId, plan: user.plan }
+      const billingWorkspaceId = destination?.workspace_id
+      const upgradeRequest =
+        billingWorkspaceId && destination?.plan === 'free'
+          ? await buildUpgradeRequest({
+              db: ctx.db,
+              actor: user,
+              billingWorkspaceId,
+              limitType: 'storage',
+              observedPlan: 'free',
+              locale: isSupportedLocale(user.locale)
+                ? user.locale
+                : DEFAULT_LOCALE,
+              appBaseUrl: ctx.baseUrl,
+            })
+          : null
       return toolError({
         code: 'quota-exceeded',
         message: 'The workspace is out of storage.',
         recoverable_by: 'human',
         hint: 'Ask a workspace admin to free space or raise the plan.',
+        ...(upgradeRequest && { upgrade_request: upgradeRequest }),
       })
     case 'invalid-container':
       return invalidDestinationError()

--- a/apps/web/app/services/projects.server.test.ts
+++ b/apps/web/app/services/projects.server.test.ts
@@ -1031,7 +1031,12 @@ describe('createProjectContainer plan limits', () => {
         description: null,
         baseVisibility: 'workspace',
       }),
-    ).resolves.toEqual({ kind: 'project-limit-reached', limit: 5 })
+    ).resolves.toEqual({
+      kind: 'project-limit-reached',
+      limit: 5,
+      billingWorkspaceId: 'ws-a',
+      observedPlan: 'free',
+    })
   })
 
   test('allows the twentieth plus project and rejects the twenty-first', async () => {
@@ -1055,7 +1060,12 @@ describe('createProjectContainer plan limits', () => {
         description: null,
         baseVisibility: 'workspace',
       }),
-    ).resolves.toEqual({ kind: 'project-limit-reached', limit: 20 })
+    ).resolves.toEqual({
+      kind: 'project-limit-reached',
+      limit: 20,
+      billingWorkspaceId: 'ws-a',
+      observedPlan: 'plus',
+    })
   })
 
   test('does not limit team workspaces', async () => {
@@ -1129,7 +1139,12 @@ describe('unarchiveProjectContainer plan limits', () => {
     await seedProjects(6, 0)
     await expect(
       unarchiveProjectContainer(db, 'ws-a', 'project-0', 'u1'),
-    ).resolves.toEqual({ kind: 'project-limit-reached', limit: 5 })
+    ).resolves.toEqual({
+      kind: 'project-limit-reached',
+      limit: 5,
+      billingWorkspaceId: 'ws-a',
+      observedPlan: 'free',
+    })
     expect(
       await db
         .selectFrom('artifact_containers')

--- a/apps/web/app/services/projects.server.ts
+++ b/apps/web/app/services/projects.server.ts
@@ -25,7 +25,7 @@ import {
   isTeamWorkspaceAdmin,
   workspaceScopedProjectVisibility,
 } from '~/services/access.server'
-import { projectLimitForPlan } from '~/lib/billing-plan.server'
+import { normalizePlan, projectLimitForPlan } from '~/lib/billing-plan.server'
 import { isExternalPostingAllowedForWorkspace } from '~/lib/project-external-posting.server'
 import { resolveGrantUsersByEmail } from '~/services/grant-users.server'
 import type { DB } from '~/types/db'
@@ -1131,7 +1131,12 @@ export async function lookupProjectShareDefaultUsers(
 
 export type CreateProjectContainerResult =
   | { kind: 'ok'; id: string }
-  | { kind: 'project-limit-reached'; limit: number }
+  | {
+      kind: 'project-limit-reached'
+      limit: number
+      billingWorkspaceId: string
+      observedPlan: 'free' | 'plus'
+    }
 
 export async function createProjectContainer(
   db: Kysely<DB>,
@@ -1188,7 +1193,13 @@ export async function createProjectContainer(
       ) < ${limit}
     `.execute(db)
     if (Number(result.numAffectedRows ?? 0n) === 0) {
-      return { kind: 'project-limit-reached', limit }
+      const observedPlan = normalizePlan(workspace?.plan)
+      return {
+        kind: 'project-limit-reached',
+        limit,
+        billingWorkspaceId: workspaceId,
+        observedPlan: observedPlan === 'plus' ? 'plus' : 'free',
+      }
     }
     await insertCreatorMembershipOrRollback(db, id, createdById, now)
     return { kind: 'ok', id }
@@ -1274,7 +1285,12 @@ export type ProjectArchiveResult = 'ok' | 'not-found' | 'forbidden'
 
 export type ProjectUnarchiveResult =
   | ProjectArchiveResult
-  | { kind: 'project-limit-reached'; limit: number }
+  | {
+      kind: 'project-limit-reached'
+      limit: number
+      billingWorkspaceId: string
+      observedPlan: 'free' | 'plus'
+    }
 export type ProjectDeleteResult =
   | 'ok'
   | 'not-found'
@@ -1296,7 +1312,12 @@ export type EditProjectContainerSettingsResult =
   | { kind: 'not-found' }
   | { kind: 'forbidden' }
   | { kind: 'project-archived' }
-  | { kind: 'project-limit-reached'; limit: number }
+  | {
+      kind: 'project-limit-reached'
+      limit: number
+      billingWorkspaceId: string
+      observedPlan: 'free' | 'plus'
+    }
   | { kind: 'too-many-grants' }
   | { kind: 'validation-failed' }
   | { kind: 'bot-grant-rejected'; code: string }
@@ -1500,7 +1521,13 @@ export async function unarchiveProjectContainer(
         ) < ${limit}
     `.execute(db)
     if (Number(result.numAffectedRows ?? 0n) === 0) {
-      return { kind: 'project-limit-reached', limit }
+      const observedPlan = normalizePlan(workspace?.plan)
+      return {
+        kind: 'project-limit-reached',
+        limit,
+        billingWorkspaceId: workspaceId,
+        observedPlan: observedPlan === 'plus' ? 'plus' : 'free',
+      }
     }
     return 'ok'
   }

--- a/apps/web/app/services/upgrade-request.server.test.ts
+++ b/apps/web/app/services/upgrade-request.server.test.ts
@@ -1,0 +1,103 @@
+import type { DatabaseSync } from 'node:sqlite'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
+
+vi.mock('cloudflare:workers', () => ({ env: {} }))
+
+import { buildUpgradeRequest } from './upgrade-request.server'
+
+describe('buildUpgradeRequest', () => {
+  let sqlite: DatabaseSync
+  let db: ReturnType<typeof createMigratedInMemoryDb>['db']
+
+  beforeEach(() => {
+    ;({ sqlite, db } = createMigratedInMemoryDb())
+    seedWorkspace(sqlite, 'ws1')
+    seedUser(sqlite, 'owner', 'owner@example.com', 'human', 'owner')
+    seedUser(sqlite, 'member', 'member@example.com', 'human', 'member')
+    seedUser(sqlite, 'bot', 'bot@example.com', 'bot', 'member')
+  })
+
+  afterEach(async () => db.destroy())
+
+  test('gives a billing action to the workspace owner', async () => {
+    await expect(build('owner', 'human')).resolves.toMatchObject({
+      kind: 'billing',
+      limit_type: 'projects',
+      current_plan: 'free',
+      recommended_plan: 'plus',
+      upgrade_url:
+        'https://app.example.com/settings/billing?plan=plus&reason=project_limit',
+    })
+  })
+
+  test('gives a copyable owner request to a member or bot', async () => {
+    for (const [id, kind] of [
+      ['member', 'human'],
+      ['bot', 'bot'],
+    ] as const) {
+      await expect(build(id, kind)).resolves.toMatchObject({
+        kind: 'contact',
+        owner: { name: 'Owner', email: 'owner@example.com' },
+        request_message: expect.stringContaining('owner@example.com'),
+      })
+    }
+  })
+
+  test('suppresses enrichment across a workspace boundary', async () => {
+    await expect(
+      buildUpgradeRequest({
+        db,
+        actor: { id: 'member', workspaceId: 'ws1', kind: 'human' },
+        billingWorkspaceId: 'other',
+        limitType: 'storage',
+        observedPlan: 'free',
+        locale: 'en',
+        appBaseUrl: 'https://app.example.com',
+      }),
+    ).resolves.toBeNull()
+  })
+
+  function build(id: string, kind: 'human' | 'bot') {
+    return buildUpgradeRequest({
+      db,
+      actor: { id, workspaceId: 'ws1', kind },
+      billingWorkspaceId: 'ws1',
+      limitType: 'projects',
+      observedPlan: 'free',
+      locale: 'en',
+      appBaseUrl: 'https://app.example.com',
+    })
+  }
+})
+
+function seedWorkspace(sqlite: DatabaseSync, id: string) {
+  sqlite
+    .prepare(
+      `INSERT INTO workspaces (id, name, created_at, plan, storage_quota_bytes, storage_used_bytes, storage_updated_at)
+       VALUES (?, 'Example', ?, 'free', 100, 100, ?)`,
+    )
+    .run(id, '2026-08-14T00:00:00.000Z', '2026-08-14T00:00:00.000Z')
+}
+
+function seedUser(
+  sqlite: DatabaseSync,
+  id: string,
+  email: string,
+  kind: 'human' | 'bot',
+  role: 'owner' | 'member',
+) {
+  const now = '2026-08-14T00:00:00.000Z'
+  sqlite
+    .prepare(
+      `INSERT INTO users (id, email, email_verified, name, created_at, updated_at, workspace_id, locale, kind)
+       VALUES (?, ?, 1, ?, ?, ?, 'ws1', 'en', ?)`,
+    )
+    .run(id, email, id === 'owner' ? 'Owner' : id, now, now, kind)
+  sqlite
+    .prepare(
+      `INSERT INTO workspace_members (workspace_id, user_id, role, status, created_at, updated_at)
+       VALUES ('ws1', ?, ?, 'active', ?, ?)`,
+    )
+    .run(id, role, now, now)
+}

--- a/apps/web/app/services/upgrade-request.server.test.ts
+++ b/apps/web/app/services/upgrade-request.server.test.ts
@@ -71,6 +71,20 @@ describe('buildUpgradeRequest', () => {
     })
   })
 
+  test('falls back to support when the billing origin is unsafe', async () => {
+    await expect(
+      buildUpgradeRequest({
+        db,
+        actor: { id: 'owner', workspaceId: 'ws1', kind: 'human' },
+        billingWorkspaceId: 'ws1',
+        limitType: 'storage',
+        observedPlan: 'free',
+        locale: 'en',
+        appBaseUrl: 'http://127.0.0.1:8787',
+      }),
+    ).resolves.toMatchObject({ kind: 'support' })
+  })
+
   function build(id: string, kind: 'human' | 'bot') {
     return buildUpgradeRequest({
       db,

--- a/apps/web/app/services/upgrade-request.server.test.ts
+++ b/apps/web/app/services/upgrade-request.server.test.ts
@@ -58,6 +58,19 @@ describe('buildUpgradeRequest', () => {
     ).resolves.toBeNull()
   })
 
+  test('percent-encodes spaces in the support mail subject', async () => {
+    sqlite
+      .prepare(
+        `UPDATE workspace_members SET status = 'removed' WHERE workspace_id = 'ws1' AND user_id = 'owner'`,
+      )
+      .run()
+    await expect(build('bot', 'bot')).resolves.toMatchObject({
+      kind: 'support',
+      support_url:
+        'mailto:support@artifactshare.com?subject=Artifact%20Share%20upgrade%20help%3A%20projects',
+    })
+  })
+
   function build(id: string, kind: 'human' | 'bot') {
     return buildUpgradeRequest({
       db,

--- a/apps/web/app/services/upgrade-request.server.ts
+++ b/apps/web/app/services/upgrade-request.server.ts
@@ -198,7 +198,13 @@ export async function buildUpgradeRequest(
           input.limitType,
           mapped.recommended,
         )
-        if (!url) return null
+        if (!url) {
+          return {
+            ...base,
+            kind: 'support',
+            support_url: supportUrl(input.limitType),
+          }
+        }
         return {
           ...base,
           kind: 'billing',
@@ -227,7 +233,13 @@ export async function buildUpgradeRequest(
       input.limitType,
       mapped.recommended,
     )
-    if (!url) return null
+    if (!url) {
+      return {
+        ...base,
+        kind: 'support',
+        support_url: supportUrl(input.limitType),
+      }
+    }
     return {
       ...base,
       kind: 'contact',

--- a/apps/web/app/services/upgrade-request.server.ts
+++ b/apps/web/app/services/upgrade-request.server.ts
@@ -3,8 +3,6 @@ import type { Kysely } from 'kysely'
 import { isValidGrantEmail } from '~/lib/grant-emails'
 import type { DB } from '~/types/db'
 
-import { requireWorkspaceBillingOwner } from './team-management.server'
-
 export type UpgradeLimitType = 'storage' | 'projects'
 export type UpgradePlan = 'free' | 'plus' | 'team'
 export type UpgradeLocale = 'en' | 'ja'
@@ -153,6 +151,7 @@ async function loadOwnerContact(db: Kysely<DB>, workspaceId: string) {
     .selectFrom('workspace_members')
     .leftJoin('users', 'users.id', 'workspace_members.user_id')
     .select([
+      'workspace_members.user_id as user_id',
       'users.name as name',
       'users.email as email',
       'users.kind as kind',
@@ -165,7 +164,7 @@ async function loadOwnerContact(db: Kysely<DB>, workspaceId: string) {
   const email = owner.email?.trim() ?? ''
   if (!isValidGrantEmail(email)) return null
   const name = owner.name?.trim() || null
-  return { name, email }
+  return { userId: owner.user_id, name, email }
 }
 
 export async function buildUpgradeRequest(
@@ -190,42 +189,38 @@ export async function buildUpgradeRequest(
       recommended_plan: mapped.recommended,
     }
 
-    if (input.actor.kind === 'human') {
-      const owner = await requireWorkspaceBillingOwner(input.db, input.actor)
-      if (owner.kind === 'ok') {
-        const url = billingUrl(
-          input.appBaseUrl,
-          input.limitType,
-          mapped.recommended,
-        )
-        if (!url) {
-          return {
-            ...base,
-            kind: 'support',
-            support_url: supportUrl(input.limitType),
-          }
-        }
-        return {
-          ...base,
-          kind: 'billing',
-          upgrade_url: url,
-          action_message: actionMessage({
-            locale: input.locale,
-            limitType: input.limitType,
-            currentPlan: mapped.current,
-            recommendedPlan: mapped.recommended,
-            url,
-          }),
-        }
-      }
-    }
-
     const owner = await loadOwnerContact(input.db, input.billingWorkspaceId)
     if (!owner) {
       return {
         ...base,
         kind: 'support',
         support_url: supportUrl(input.limitType),
+      }
+    }
+    if (input.actor.kind === 'human' && owner.userId === input.actor.id) {
+      const url = billingUrl(
+        input.appBaseUrl,
+        input.limitType,
+        mapped.recommended,
+      )
+      if (!url) {
+        return {
+          ...base,
+          kind: 'support',
+          support_url: supportUrl(input.limitType),
+        }
+      }
+      return {
+        ...base,
+        kind: 'billing',
+        upgrade_url: url,
+        action_message: actionMessage({
+          locale: input.locale,
+          limitType: input.limitType,
+          currentPlan: mapped.current,
+          recommendedPlan: mapped.recommended,
+          url,
+        }),
       }
     }
     const url = billingUrl(

--- a/apps/web/app/services/upgrade-request.server.ts
+++ b/apps/web/app/services/upgrade-request.server.ts
@@ -1,0 +1,254 @@
+import type { Kysely } from 'kysely'
+
+import { isValidGrantEmail } from '~/lib/grant-emails'
+import type { DB } from '~/types/db'
+
+import { requireWorkspaceBillingOwner } from './team-management.server'
+
+export type UpgradeLimitType = 'storage' | 'projects'
+export type UpgradePlan = 'free' | 'plus' | 'team'
+export type UpgradeLocale = 'en' | 'ja'
+
+type UpgradeRequestBase = {
+  limit_type: UpgradeLimitType
+  current_plan: 'free' | 'plus'
+  recommended_plan: 'plus' | 'team'
+}
+
+export type UpgradeRequest = UpgradeRequestBase &
+  (
+    | {
+        kind: 'contact'
+        upgrade_url: string
+        owner: { name: string | null; email: string }
+        request_message: string
+      }
+    | {
+        kind: 'billing'
+        upgrade_url: string
+        action_message: string
+      }
+    | { kind: 'support'; support_url: string }
+  )
+
+type BuildUpgradeRequestInput = {
+  db: Kysely<DB>
+  actor: { id: string; workspaceId: string; kind: 'human' | 'bot' }
+  billingWorkspaceId: string
+  limitType: UpgradeLimitType
+  observedPlan: UpgradePlan
+  locale: UpgradeLocale
+  appBaseUrl: string
+}
+
+const SUPPORT_SUBJECTS: Record<UpgradeLimitType, string> = {
+  storage: 'Artifact Share upgrade help: storage',
+  projects: 'Artifact Share upgrade help: projects',
+}
+
+function recommendation(
+  limitType: UpgradeLimitType,
+  currentPlan: UpgradePlan,
+): { current: 'free' | 'plus'; recommended: 'plus' | 'team' } | null {
+  if (limitType === 'storage' && currentPlan === 'free') {
+    return { current: 'free', recommended: 'plus' }
+  }
+  if (limitType === 'projects' && currentPlan === 'free') {
+    return { current: 'free', recommended: 'plus' }
+  }
+  if (limitType === 'projects' && currentPlan === 'plus') {
+    return { current: 'plus', recommended: 'team' }
+  }
+  return null
+}
+
+function billingUrl(
+  appBaseUrl: string,
+  limitType: UpgradeLimitType,
+  recommendedPlan: 'plus' | 'team',
+): string | null {
+  try {
+    const base = new URL(appBaseUrl)
+    if (base.protocol !== 'https:' && base.hostname !== 'localhost') return null
+    const url = new URL('/settings/billing', base.origin)
+    url.searchParams.set('plan', recommendedPlan)
+    if (limitType === 'projects') {
+      url.searchParams.set('reason', 'project_limit')
+    }
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+function supportUrl(limitType: UpgradeLimitType): string {
+  const url = new URL('mailto:support@artifactshare.com')
+  url.searchParams.set('subject', SUPPORT_SUBJECTS[limitType])
+  return url.toString()
+}
+
+function planName(plan: UpgradePlan): string {
+  return plan[0]!.toUpperCase() + plan.slice(1)
+}
+
+function limitName(locale: UpgradeLocale, limitType: UpgradeLimitType): string {
+  if (locale === 'ja') {
+    return limitType === 'storage' ? '保存容量' : 'アクティブプロジェクト数'
+  }
+  return limitType === 'storage' ? 'storage capacity' : 'active project count'
+}
+
+function remedy(locale: UpgradeLocale, limitType: UpgradeLimitType): string {
+  if (locale === 'ja') {
+    return limitType === 'storage'
+      ? '不要なファイルを削除するか、アップロードを小さくする'
+      : '既存のプロジェクトをアーカイブする'
+  }
+  return limitType === 'storage'
+    ? 'free storage or reduce the upload size'
+    : 'archive an existing project'
+}
+
+function requestMessage(args: {
+  locale: UpgradeLocale
+  limitType: UpgradeLimitType
+  currentPlan: 'free' | 'plus'
+  recommendedPlan: 'plus' | 'team'
+  url: string
+  owner: { name: string | null; email: string }
+}): string {
+  const current = planName(args.currentPlan)
+  const recommended = planName(args.recommendedPlan)
+  const limit = limitName(args.locale, args.limitType)
+  const freeRemedy = remedy(args.locale, args.limitType)
+  if (args.locale === 'ja') {
+    const owner = args.owner.name
+      ? `${args.owner.name} さん (${args.owner.email})`
+      : args.owner.email
+    return `${owner}、${current} で ${limit} の制限に達しました。${recommended} への変更、または${freeRemedy}対応をお願いします: ${args.url}`
+  }
+  const owner = args.owner.name
+    ? `${args.owner.name} (${args.owner.email})`
+    : args.owner.email
+  return `${owner}, we reached the ${limit} limit on ${current}. Please move the workspace to ${recommended}, or ${freeRemedy}. Open: ${args.url}`
+}
+
+function actionMessage(args: {
+  locale: UpgradeLocale
+  limitType: UpgradeLimitType
+  currentPlan: 'free' | 'plus'
+  recommendedPlan: 'plus' | 'team'
+  url: string
+}): string {
+  const current = planName(args.currentPlan)
+  const recommended = planName(args.recommendedPlan)
+  const limit = limitName(args.locale, args.limitType)
+  const freeRemedy = remedy(args.locale, args.limitType)
+  if (args.locale === 'ja') {
+    return `${current} で ${limit} の制限に達しました。${recommended} へ変更するか、${freeRemedy}対応をしてください: ${args.url}`
+  }
+  return `You reached the ${limit} limit on ${current}. Move the workspace to ${recommended}, or ${freeRemedy}. Open: ${args.url}`
+}
+
+async function loadOwnerContact(db: Kysely<DB>, workspaceId: string) {
+  const owner = await db
+    .selectFrom('workspace_members')
+    .leftJoin('users', 'users.id', 'workspace_members.user_id')
+    .select([
+      'users.name as name',
+      'users.email as email',
+      'users.kind as kind',
+    ])
+    .where('workspace_members.workspace_id', '=', workspaceId)
+    .where('workspace_members.role', '=', 'owner')
+    .where('workspace_members.status', '=', 'active')
+    .executeTakeFirst()
+  if (owner?.kind !== 'human') return null
+  const email = owner.email?.trim() ?? ''
+  if (!isValidGrantEmail(email)) return null
+  const name = owner.name?.trim() || null
+  return { name, email }
+}
+
+export async function buildUpgradeRequest(
+  input: BuildUpgradeRequestInput,
+): Promise<UpgradeRequest | null> {
+  try {
+    if (input.actor.workspaceId !== input.billingWorkspaceId) return null
+    const membership = await input.db
+      .selectFrom('workspace_members')
+      .select('status')
+      .where('workspace_id', '=', input.billingWorkspaceId)
+      .where('user_id', '=', input.actor.id)
+      .where('status', '=', 'active')
+      .executeTakeFirst()
+    if (!membership) return null
+
+    const mapped = recommendation(input.limitType, input.observedPlan)
+    if (!mapped) return null
+    const base: UpgradeRequestBase = {
+      limit_type: input.limitType,
+      current_plan: mapped.current,
+      recommended_plan: mapped.recommended,
+    }
+
+    if (input.actor.kind === 'human') {
+      const owner = await requireWorkspaceBillingOwner(input.db, input.actor)
+      if (owner.kind === 'ok') {
+        const url = billingUrl(
+          input.appBaseUrl,
+          input.limitType,
+          mapped.recommended,
+        )
+        if (!url) return null
+        return {
+          ...base,
+          kind: 'billing',
+          upgrade_url: url,
+          action_message: actionMessage({
+            locale: input.locale,
+            limitType: input.limitType,
+            currentPlan: mapped.current,
+            recommendedPlan: mapped.recommended,
+            url,
+          }),
+        }
+      }
+    }
+
+    const owner = await loadOwnerContact(input.db, input.billingWorkspaceId)
+    if (!owner) {
+      return {
+        ...base,
+        kind: 'support',
+        support_url: supportUrl(input.limitType),
+      }
+    }
+    const url = billingUrl(
+      input.appBaseUrl,
+      input.limitType,
+      mapped.recommended,
+    )
+    if (!url) return null
+    return {
+      ...base,
+      kind: 'contact',
+      upgrade_url: url,
+      owner,
+      request_message: requestMessage({
+        locale: input.locale,
+        limitType: input.limitType,
+        currentPlan: mapped.current,
+        recommendedPlan: mapped.recommended,
+        url,
+        owner,
+      }),
+    }
+  } catch (error) {
+    console.error('upgrade_request_enrichment_failed', {
+      workspaceId: input.billingWorkspaceId,
+      cause: error instanceof Error ? error.message : 'unknown',
+    })
+    return null
+  }
+}

--- a/apps/web/app/services/upgrade-request.server.ts
+++ b/apps/web/app/services/upgrade-request.server.ts
@@ -82,9 +82,7 @@ function billingUrl(
 }
 
 function supportUrl(limitType: UpgradeLimitType): string {
-  const url = new URL('mailto:support@artifactshare.com')
-  url.searchParams.set('subject', SUPPORT_SUBJECTS[limitType])
-  return url.toString()
+  return `mailto:support@artifactshare.com?subject=${encodeURIComponent(SUPPORT_SUBJECTS[limitType])}`
 }
 
 function planName(plan: UpgradePlan): string {

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -313,6 +313,13 @@ export function mapApiError(
     })
   }
   if (apiCode === 'project-limit-reached') {
+    const apiDetails =
+      typeof body?.error === 'object' && isRecord(body.error.details)
+        ? body.error.details
+        : undefined
+    const upgradeRequest = isRecord(apiDetails?.upgrade_request)
+      ? apiDetails.upgrade_request
+      : undefined
     return cliError({
       code: 'project_limit_reached',
       message:
@@ -323,6 +330,9 @@ export function mapApiError(
       agentRecoverable: false,
       requiresHuman: true,
       recovery: { kind: 'change_input' },
+      ...(upgradeRequest
+        ? { details: { upgrade_request: upgradeRequest } }
+        : {}),
     })
   }
   if (apiCode === 'forbidden' || status === 403) {

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -117,6 +117,13 @@ export function mapApiError(
     })
   }
   if (apiCode === 'quota-exceeded') {
+    const apiDetails =
+      typeof body?.error === 'object' && isRecord(body.error.details)
+        ? body.error.details
+        : undefined
+    const upgradeRequest = isRecord(apiDetails?.upgrade_request)
+      ? apiDetails.upgrade_request
+      : undefined
     return cliError({
       code: 'storage_limit_exceeded',
       message: 'Storage quota is exceeded.',
@@ -125,6 +132,9 @@ export function mapApiError(
       agentRecoverable: false,
       requiresHuman: true,
       recovery: { kind: 'ask_human' },
+      ...(upgradeRequest
+        ? { details: { upgrade_request: upgradeRequest } }
+        : {}),
     })
   }
   if (apiCode !== null && ['too-large', 'file-too-large'].includes(apiCode)) {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -77,8 +77,22 @@ export function writeFailure(
   if (mode.json) {
     process.stderr.write(`${JSON.stringify(payload, null, 2)}\n`)
   } else {
+    const upgradeRequest = isRecord(error.details?.upgrade_request)
+      ? error.details.upgrade_request
+      : null
+    const upgradeHint =
+      upgradeRequest?.kind === 'contact' &&
+      typeof upgradeRequest.request_message === 'string'
+        ? upgradeRequest.request_message
+        : upgradeRequest?.kind === 'billing' &&
+            typeof upgradeRequest.upgrade_url === 'string'
+          ? upgradeRequest.upgrade_url
+          : upgradeRequest?.kind === 'support' &&
+              typeof upgradeRequest.support_url === 'string'
+            ? upgradeRequest.support_url
+            : null
     process.stderr.write(
-      `Error: ${error.message}\nWhy: ${error.why}\nHint: ${error.hint}\n`,
+      `Error: ${error.message}\nWhy: ${error.why}\nHint: ${error.hint}${upgradeHint ? `\n${upgradeHint}` : ''}\n`,
     )
   }
   process.exitCode = exitCode

--- a/packages/cli/src/share.test.ts
+++ b/packages/cli/src/share.test.ts
@@ -1150,6 +1150,26 @@ test('share keeps the contributor guardrail error when the API returns 403', () 
   assert.deepEqual(failure.recovery, { kind: 'ask_human' })
 })
 
+test('share preserves storage upgrade guidance from the API', () => {
+  const upgradeRequest = {
+    kind: 'billing',
+    limit_type: 'storage',
+    current_plan: 'free',
+    recommended_plan: 'plus',
+    upgrade_url: 'https://artifactshare.test/settings/billing?plan=plus',
+    action_message: 'Upgrade storage.',
+  }
+  const failure = mapApiError(413, {
+    error: {
+      code: 'quota-exceeded',
+      message: 'Storage quota exceeded.',
+      details: { upgrade_request: upgradeRequest },
+    },
+  })
+  assert.equal(failure.code, 'storage_limit_exceeded')
+  assert.deepEqual(failure.details?.upgrade_request, upgradeRequest)
+})
+
 test('share to home uses the workspace product default and server-confirmed visibility', async () => {
   const root = await mkdtemp(join(tmpdir(), 'artifactshare-cli-'))
   const target = join(root, 'report.html')


### PR DESCRIPTION
## Summary

- add structured upgrade guidance for storage and active-project limits
- show billing, owner-contact, or support actions without exposing cross-workspace owner data
- carry the same guidance through web uploads, project actions, CLI errors, and MCP tool errors

## Validation

- `pnpm validate:static`
- focused web tests for projects, uploads, MCP tools, and upgrade-request construction
- full CLI test suite
- React Doctor: 100
- public repository scan: 0 findings

## Review

- the fixed specification passed parallel Codex and Claude deep review before implementation
- the final implementation commit passed parallel Codex and Claude deep review with no unresolved blockers
- UI uses the existing Alert, Button, and Textarea primitives; Japanese and English action copy are included

## Follow-up disposition

- plan labels remain `Free`, `Plus`, and `Team` in Japanese, matching the existing billing UI
