### PR TITLE
Remind reviewers to keep fixes proportional

### DIFF
--- a/scripts/claude-review.mjs
+++ b/scripts/claude-review.mjs
@@ -3,6 +3,8 @@ import { pathToFileURL } from 'node:url'
 import { cliPackage, specReviewPrompt } from './spec-review-input.mjs'
 
 const timeoutMs = 1_800_000
+const reviewReminder =
+  'Before applying findings: what current acceptance criterion, correctness, or safety property would remain broken without this change? If none can be named concretely, do not change the artifact.'
 
 function usage() {
   return `Usage:
@@ -125,15 +127,17 @@ function review(options = {}) {
   const argv = options.argv ?? process.argv.slice(2)
   const stdout = options.stdout ?? process.stdout
   const stderr = options.stderr ?? process.stderr
+  const execute = options.run ?? run
+  const readCleanHead = options.cleanHead ?? cleanHead
   const parsed = parseArgs(argv)
   if (parsed.help) {
     stdout.write(`${usage()}\n`)
     return 0
   }
-  const head = cleanHead()
+  const head = readCleanHead()
   const started = Date.now()
   const request = invocation(parsed, head)
-  const raw = run('claude', request.args, {
+  const raw = execute('claude', request.args, {
     cwd: git(['rev-parse', '--show-toplevel']),
     input: request.input,
   })
@@ -154,8 +158,9 @@ function review(options = {}) {
   stderr.write(
     `Claude ${parsed.phase} review: ${head.slice(0, 12)}, ${Math.round((Date.now() - started) / 1000)}s\n`,
   )
-  if (cleanHead() !== head)
+  if (readCleanHead() !== head)
     throw new Error('HEAD or worktree changed during review.')
+  stdout.write(`${reviewReminder}\n`)
   return 0
 }
 
@@ -173,4 +178,4 @@ if (
   }
 }
 
-export { cliPackage, invocation, parseArgs, review, usage }
+export { cliPackage, invocation, parseArgs, review, reviewReminder, usage }

--- a/scripts/claude-review.test.mjs
+++ b/scripts/claude-review.test.mjs
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { cliPackage, invocation, parseArgs, usage } from './claude-review.mjs'
+import {
+  cliPackage,
+  invocation,
+  parseArgs,
+  review,
+  reviewReminder,
+  usage,
+} from './claude-review.mjs'
 
 test('parses the two review phases', () => {
   assert.deepEqual(parseArgs(['--phase', 'implementation']), {
@@ -66,4 +73,57 @@ test('keeps the Artifact Share CLI pin and concise usage explicit', () => {
   assert.match(cliPackage, /^@artifactshare\/cli@\d/u)
   assert.match(usage(), /phase spec/u)
   assert.match(usage(), /phase implementation/u)
+})
+
+test('prints the reminder only after a successful unchanged review', () => {
+  const head = 'a'.repeat(40)
+  const output = []
+  const code = review({
+    argv: ['--phase', 'implementation'],
+    cleanHead: () => head,
+    run: () =>
+      JSON.stringify({
+        is_error: false,
+        subtype: 'success',
+        result: 'No findings.',
+        permission_denials: [],
+      }),
+    stdout: { write: (value) => output.push(value) },
+    stderr: { write: () => {} },
+  })
+  assert.equal(code, 0)
+  assert.deepEqual(output, ['No findings.\n', `${reviewReminder}\n`])
+})
+
+test('does not print the reminder when the checkout changes', () => {
+  const output = []
+  let read = 0
+  assert.throws(
+    () =>
+      review({
+        argv: ['--phase', 'implementation'],
+        cleanHead: () => `${read++}`.repeat(40),
+        run: () =>
+          JSON.stringify({
+            is_error: false,
+            subtype: 'success',
+            result: 'No findings.',
+            permission_denials: [],
+          }),
+        stdout: { write: (value) => output.push(value) },
+        stderr: { write: () => {} },
+      }),
+    /changed during review/u,
+  )
+  assert.equal(output.includes(`${reviewReminder}\n`), false)
+})
+
+test('does not print the reminder for help', () => {
+  const output = []
+  const code = review({
+    argv: ['--help'],
+    stdout: { write: (value) => output.push(value) },
+  })
+  assert.equal(code, 0)
+  assert.equal(output.includes(`${reviewReminder}\n`), false)
 })

--- a/scripts/codex-review.mjs
+++ b/scripts/codex-review.mjs
@@ -5,6 +5,8 @@ import { specReviewPrompt } from './spec-review-input.mjs'
 
 const defaultModel = 'gpt-5.6-sol'
 const defaultBase = 'origin/main'
+const reviewReminder =
+  'Before applying findings: what current acceptance criterion, correctness, or safety property would remain broken without this change? If none can be named concretely, do not change the artifact.'
 
 function usage() {
   return `Usage:
@@ -144,6 +146,7 @@ function main({
       throw new Error(
         'Working tree or HEAD changed during review; review the current commit again.',
       )
+    log(reviewReminder)
     return 0
   } catch (error) {
     errorLog(error instanceof Error ? error.message : 'Codex review failed.')
@@ -154,4 +157,12 @@ function main({
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
   process.exitCode = main()
 
-export { defaultBase, defaultModel, main, parseArgs, reviewRequest, usage }
+export {
+  defaultBase,
+  defaultModel,
+  main,
+  parseArgs,
+  reviewReminder,
+  reviewRequest,
+  usage,
+}

--- a/scripts/codex-review.test.mjs
+++ b/scripts/codex-review.test.mjs
@@ -5,6 +5,7 @@ import {
   defaultModel,
   main,
   parseArgs,
+  reviewReminder,
   reviewRequest,
   usage,
 } from './codex-review.mjs'
@@ -98,8 +99,10 @@ test('requires a clean committed checkout before review', () => {
 
 test('runs native review and verifies the checkout did not change', () => {
   const calls = []
+  const logs = []
   const code = main({
     exec: cleanGit,
+    log: (message) => logs.push(message),
     run: (file, args, options) => {
       calls.push([file, args, options])
       return { status: 0 }
@@ -119,6 +122,7 @@ test('runs native review and verifies the checkout did not change', () => {
     input: undefined,
     stdio: ['ignore', 'inherit', 'inherit'],
   })
+  assert.deepEqual(logs, [reviewReminder])
 })
 
 test('reads the fixed spec version and runs Codex against the same clean HEAD', () => {
@@ -169,6 +173,7 @@ test('reads the fixed spec version and runs Codex against the same clean HEAD', 
 test('rejects a review result when HEAD changes', () => {
   let reads = 0
   const errors = []
+  const logs = []
   const code = main({
     exec: (_file, args) => {
       if (args[0] === 'status') return ''
@@ -177,8 +182,23 @@ test('rejects a review result when HEAD changes', () => {
       return `${(reads === 1 ? 'a' : 'b').repeat(40)}\n`
     },
     run: () => ({ status: 0 }),
+    log: (message) => logs.push(message),
     errorLog: (message) => errors.push(message),
   })
   assert.equal(code, 1)
   assert.match(errors[0], /changed during review/u)
+  assert.deepEqual(logs, [])
+})
+
+test('does not print the reminder for help or dry-run', () => {
+  for (const argv of [['--help'], ['--dry-run']]) {
+    const logs = []
+    const code = main({
+      argv,
+      exec: cleanGit,
+      log: (message) => logs.push(message),
+    })
+    assert.equal(code, 0)
+    assert.equal(logs.includes(reviewReminder), false)
+  }
 })


### PR DESCRIPTION
## Change

Print a concise scope reminder after successful Codex and Claude reviews, once checkout integrity has been verified. The reminder asks maintainers to tie each proposed fix to a current acceptance criterion, correctness property, or safety property before changing the artifact.

Keep help, dry-run, failed-review, and changed-checkout paths free of the success reminder.

## Validation

- `node --test scripts/codex-review.test.mjs scripts/claude-review.test.mjs` — 16 passed
- `pnpm public:scan .` — 0 findings
- `pnpm validate:static` — 272 test files passed, 2845 tests passed, 1 skipped; React Doctor 100; final public scan 0 findings

## Review

Codex and Claude both deeply reviewed commit `1d8db53` with no findings or unresolved blockers. No follow-ups were identified.
