### PR TITLE
feat: 管理画面を管理対象ごとのURLに分ける

### DIFF
--- a/apps/web/app/routes/_protected/settings/+components/settings-nav.tsx
+++ b/apps/web/app/routes/_protected/settings/+components/settings-nav.tsx
@@ -5,8 +5,10 @@ import {
   IconCreditCard as CreditCard,
   IconKey as KeyRound,
   IconPlug as Plug,
+  IconRobot,
   IconShare2 as Share2,
   IconSettings as Settings2,
+  IconTerminal2,
   IconUsers as Users,
 } from '@tabler/icons-react'
 import { useEffect, useRef, type ReactNode } from 'react'
@@ -18,6 +20,7 @@ import { TabNav, TabNavLink } from '~/components/app/tab-nav'
 const ITEMS: ReadonlyArray<{
   to: string
   end?: boolean
+  adminOnly?: boolean
   icon: typeof Users
   label: TKey
 }> = [
@@ -28,8 +31,23 @@ const ITEMS: ReadonlyArray<{
     label: 'team.externalAccess',
   },
   { to: '/settings', end: true, icon: Users, label: 'team.members' },
+  {
+    to: '/settings/bots',
+    adminOnly: true,
+    icon: IconRobot,
+    label: 'team.bots',
+  },
   { to: '/settings/usage', icon: BarChart3, label: 'team.usage' },
-  { to: '/settings/tokens', icon: KeyRound, label: 'team.tokens' },
+  {
+    to: '/settings/tokens',
+    icon: KeyRound,
+    label: 'team.tokens.api.title',
+  },
+  {
+    to: '/settings/cli-sessions',
+    icon: IconTerminal2,
+    label: 'team.tokens.cli.title',
+  },
   { to: '/settings/integrations', icon: Plug, label: 'team.integrations' },
   { to: '/settings/billing', icon: CreditCard, label: 'team.billing' },
 ]
@@ -60,16 +78,18 @@ export function SettingsNav({
         style={{ top: 'calc(45px + var(--spacing-4))' }}
       >
         <TabNav aria-label={t('team.nav.label')} orientation="responsive">
-          {ITEMS.map(({ to, end, icon: Icon, label }) => (
-            <TabNavLink
-              key={to}
-              to={to}
-              end={end}
-              icon={Icon}
-              label={t(label)}
-              orientation="responsive"
-            />
-          ))}
+          {ITEMS.map(({ to, end, adminOnly, icon: Icon, label }) =>
+            adminOnly && !currentUserIsAdmin ? null : (
+              <TabNavLink
+                key={to}
+                to={to}
+                end={end}
+                icon={Icon}
+                label={t(label)}
+                orientation="responsive"
+              />
+            ),
+          )}
           {currentUserIsAdmin ? (
             <TabNavLink
               to="/settings/activity"

--- a/apps/web/app/routes/_protected/settings/bots.test.ts
+++ b/apps/web/app/routes/_protected/settings/bots.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('cloudflare:workers', () => ({ env: {} }))
+
+const services = vi.hoisted(() => ({
+  loadSettingsShell: vi.fn(),
+  listWorkspaceBots: vi.fn(),
+  isBotMembersEnabled: vi.fn(),
+}))
+
+const db = vi.hoisted(() => ({
+  selectFrom: vi.fn(() => ({
+    select: vi.fn(() => ({
+      where: vi.fn(() => ({
+        where: vi.fn(() => ({
+          where: vi.fn(() => ({
+            orderBy: vi.fn(() => ({ execute: vi.fn(() => []) })),
+          })),
+        })),
+      })),
+    })),
+  })),
+}))
+
+vi.mock('~/services/db.server', () => ({ createDb: () => db }))
+vi.mock('~/middleware/context', () => ({
+  requireUser: () => ({ id: 'user-1', workspaceId: 'workspace-1' }),
+}))
+vi.mock('~/services/team-management.server', () => ({
+  loadSettingsShell: services.loadSettingsShell,
+}))
+vi.mock('~/lib/bot-members-flag.server', () => ({
+  isBotMembersEnabled: services.isBotMembersEnabled,
+}))
+vi.mock('~/services/bot-members.server', () => ({
+  listWorkspaceBots: services.listWorkspaceBots,
+  cancelWorkspaceBot: vi.fn(),
+  createWorkspaceBot: vi.fn(),
+  reissueWorkspaceBotCredential: vi.fn(),
+  stopWorkspaceBot: vi.fn(),
+}))
+
+import { loader } from './bots'
+
+describe('/settings/bots loader', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  test('does not expose bot inventory to a non-admin direct request', async () => {
+    services.loadSettingsShell.mockResolvedValue({ currentUserIsAdmin: false })
+
+    await expect(loader({ context: new Map() } as never)).rejects.toMatchObject(
+      { status: 403 },
+    )
+    expect(services.listWorkspaceBots).not.toHaveBeenCalled()
+  })
+
+  test('loads bot inventory for an admin', async () => {
+    services.loadSettingsShell.mockResolvedValue({ currentUserIsAdmin: true })
+    services.listWorkspaceBots.mockResolvedValue([{ id: 'bot-1' }])
+    services.isBotMembersEnabled.mockResolvedValue(true)
+
+    await expect(
+      loader({ context: new Map() } as never),
+    ).resolves.toMatchObject({
+      bots: [{ id: 'bot-1' }],
+      botCreationEnabled: true,
+    })
+  })
+})

--- a/apps/web/app/routes/_protected/settings/bots.tsx
+++ b/apps/web/app/routes/_protected/settings/bots.tsx
@@ -4,10 +4,14 @@ import { requireUser } from '~/middleware/context'
 import {
   cancelWorkspaceBot,
   createWorkspaceBot,
+  listWorkspaceBots,
   reissueWorkspaceBotCredential,
   stopWorkspaceBot,
 } from '~/services/bot-members.server'
 import { createDb } from '~/services/db.server'
+import { loadSettingsShell } from '~/services/team-management.server'
+import { SettingsPage } from '~/components/form/settings-page'
+import { BotSection, type BotProjectOption } from './+components/bot-section'
 import type { Route } from './+types/bots'
 
 // Dedicated JSON action for bot management. Tokens are returned only in this
@@ -15,8 +19,47 @@ import type { Route } from './+types/bots'
 // parameters, or logs. The bot-members feature flag gates creation only:
 // stop/reissue keep working for existing bots regardless of the flag.
 
-export function loader() {
-  return new Response('Method Not Allowed', { status: 405 })
+export async function loader({ context }: Route.LoaderArgs) {
+  const user = requireUser(context)
+  const db = createDb()
+  const shell = await loadSettingsShell(db, user)
+  if (!shell.currentUserIsAdmin) {
+    throw new Response('Forbidden', { status: 403 })
+  }
+  const [bots, botCreationEnabled, projects] = await Promise.all([
+    listWorkspaceBots(db, user.workspaceId),
+    isBotMembersEnabled(user.workspaceId),
+    loadBotDestinationOptions(db, user.workspaceId),
+  ])
+  return { bots, botCreationEnabled, projects }
+}
+
+// Creation candidates: every non-archived project in the workspace
+// (workspace-visible and private alike).
+async function loadBotDestinationOptions(
+  db: ReturnType<typeof createDb>,
+  workspaceId: string,
+): Promise<BotProjectOption[]> {
+  return await db
+    .selectFrom('artifact_containers')
+    .select(['id', 'name'])
+    .where('workspace_id', '=', workspaceId)
+    .where('kind', '=', 'project')
+    .where('archived_at', 'is', null)
+    .orderBy('name', 'asc')
+    .execute()
+}
+
+export default function BotsPage({ loaderData }: Route.ComponentProps) {
+  return (
+    <SettingsPage>
+      <BotSection
+        bots={loaderData.bots}
+        projects={loaderData.projects}
+        canCreate={loaderData.botCreationEnabled}
+      />
+    </SettingsPage>
+  )
 }
 
 export async function action({ request, context }: Route.ActionArgs) {

--- a/apps/web/app/routes/_protected/settings/cli-sessions.test.tsx
+++ b/apps/web/app/routes/_protected/settings/cli-sessions.test.tsx
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('cloudflare:workers', () => ({ env: {} }))
+
+const services = vi.hoisted(() => ({
+  revokeAllCliRefreshCredentialFamilies: vi.fn(),
+  revokeCliRefreshCredentialFamily: vi.fn(),
+}))
+
+vi.mock('~/services/db.server', () => ({ createDb: () => ({}) }))
+vi.mock('~/middleware/context', () => ({
+  requireUser: () => ({ id: 'current-user' }),
+}))
+vi.mock('~/services/cli-refresh-credentials.server', () => ({
+  listCliRefreshCredentialFamilies: vi.fn(),
+  revokeAllCliRefreshCredentialFamilies:
+    services.revokeAllCliRefreshCredentialFamilies,
+  revokeCliRefreshCredentialFamily: services.revokeCliRefreshCredentialFamily,
+}))
+
+import { action } from './cli-sessions'
+
+function request(values: Record<string, string>) {
+  const form = new FormData()
+  for (const [key, value] of Object.entries(values)) form.set(key, value)
+  return new Request('https://example.test/settings/cli-sessions', {
+    method: 'POST',
+    body: form,
+  })
+}
+
+describe('/settings/cli-sessions actions', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  test('revokes one family for the current user', async () => {
+    services.revokeCliRefreshCredentialFamily.mockResolvedValue('ok')
+    await action({
+      request: request({ intent: 'revoke-cli-family', familyId: 'family-a' }),
+      context: new Map(),
+    } as never)
+
+    expect(services.revokeCliRefreshCredentialFamily).toHaveBeenCalledWith(
+      {},
+      'current-user',
+      'family-a',
+    )
+  })
+
+  test('does not dispatch a family revoke without a family id', async () => {
+    await action({
+      request: request({ intent: 'revoke-cli-family' }),
+      context: new Map(),
+    } as never)
+
+    expect(services.revokeCliRefreshCredentialFamily).not.toHaveBeenCalled()
+  })
+
+  test('revokes all families for the current user', async () => {
+    await action({
+      request: request({ intent: 'revoke-all-cli-families' }),
+      context: new Map(),
+    } as never)
+
+    expect(services.revokeAllCliRefreshCredentialFamilies).toHaveBeenCalledWith(
+      {},
+      'current-user',
+    )
+  })
+})

--- a/apps/web/app/routes/_protected/settings/cli-sessions.tsx
+++ b/apps/web/app/routes/_protected/settings/cli-sessions.tsx
@@ -1,0 +1,222 @@
+import { useState, type ReactNode } from 'react'
+import { Form, useActionData, useNavigation } from 'react-router'
+import { SettingsPage } from '~/components/form/settings-page'
+import { SettingsSection } from '~/components/form/settings-section'
+import { TableEmptyRow } from '~/components/form/table-empty-row'
+import { TeamMuted } from '~/components/form/team-muted'
+import { Button } from '~/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/ui/table'
+import { useT } from '~/hooks/use-t'
+import type { Locale } from '~/i18n/messages'
+import { formatRelative } from '~/lib/datetime'
+import { stringValue } from '~/lib/form'
+import { requireUser } from '~/middleware/context'
+import {
+  listCliRefreshCredentialFamilies,
+  revokeAllCliRefreshCredentialFamilies,
+  revokeCliRefreshCredentialFamily,
+  type CliRefreshCredentialFamily,
+} from '~/services/cli-refresh-credentials.server'
+import { createDb } from '~/services/db.server'
+import { ConfirmActionDialog } from './+components/confirm-action-dialog'
+import { TeamActions } from './+components/team-actions'
+import { TeamUser } from './+components/team-user'
+import type { Route } from './+types/cli-sessions'
+
+type ActionData = { kind: 'cli-revoke-noop' } | null
+
+export async function loader({ context }: Route.LoaderArgs) {
+  const user = requireUser(context)
+  const cliFamilies = await listCliRefreshCredentialFamilies(
+    createDb(),
+    user.id,
+  )
+  return { cliFamilies }
+}
+
+export async function action({
+  request,
+  context,
+}: Route.ActionArgs): Promise<ActionData> {
+  const user = requireUser(context)
+  const form = await request.formData()
+  const intent = stringValue(form.get('intent'))
+  const db = createDb()
+
+  if (intent === 'revoke-cli-family') {
+    const familyId = stringValue(form.get('familyId'))
+    if (!familyId) return null
+    const result = await revokeCliRefreshCredentialFamily(db, user.id, familyId)
+    return result === 'noop' ? { kind: 'cli-revoke-noop' } : null
+  }
+  if (intent === 'revoke-all-cli-families') {
+    await revokeAllCliRefreshCredentialFamilies(db, user.id)
+  }
+  return null
+}
+
+export default function CliSessionsPage({ loaderData }: Route.ComponentProps) {
+  const actionData = useActionData<typeof action>()
+  const navigation = useNavigation()
+  const [revokeAllOpen, setRevokeAllOpen] = useState(false)
+  const { locale, t } = useT()
+
+  return (
+    <SettingsPage>
+      <SettingsSection
+        title={t('team.tokens.cli.title')}
+        description={t('team.tokens.cli.body')}
+      >
+        {actionData?.kind === 'cli-revoke-noop' ? (
+          <p role="status" className="text-muted-foreground text-sm">
+            {t('team.tokens.cli.alreadyRevoked')}
+          </p>
+        ) : null}
+        {loaderData.cliFamilies.length > 0 ? (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              type="button"
+              onClick={() => setRevokeAllOpen(true)}
+            >
+              {t('team.tokens.cli.revokeAll')}
+            </Button>
+            <Form
+              method="post"
+              action="/settings/cli-sessions"
+              id="revoke-all-cli-families-form"
+              className="hidden"
+            >
+              <input
+                type="hidden"
+                name="intent"
+                value="revoke-all-cli-families"
+              />
+            </Form>
+            <ConfirmActionDialog
+              open={revokeAllOpen}
+              onOpenChange={setRevokeAllOpen}
+              title={t('team.tokens.cli.revokeAllConfirm.title')}
+              description={t('team.tokens.cli.revokeAllConfirm.body')}
+              action={t('team.tokens.cli.revokeAll')}
+              pending={
+                navigation.state !== 'idle' &&
+                navigation.formData?.get('intent') === 'revoke-all-cli-families'
+              }
+              onConfirm={() => {
+                const form = document.getElementById(
+                  'revoke-all-cli-families-form',
+                )
+                if (form instanceof HTMLFormElement) form.requestSubmit()
+              }}
+            />
+          </>
+        ) : null}
+        <CredentialTable empty={loaderData.cliFamilies.length === 0}>
+          {loaderData.cliFamilies.map((family) => (
+            <CliFamilyRow
+              key={family.familyId}
+              family={family}
+              locale={locale}
+            />
+          ))}
+        </CredentialTable>
+      </SettingsSection>
+    </SettingsPage>
+  )
+}
+
+function CredentialTable({
+  children,
+  empty,
+}: {
+  children: ReactNode
+  empty: boolean
+}) {
+  const { t } = useT()
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>{t('team.tokens.table.name')}</TableHead>
+          <TableHead className="max-phone:hidden">
+            {t('team.tokens.table.created')}
+          </TableHead>
+          <TableHead className="max-nav:hidden">
+            {t('team.tokens.table.lastUsed')}
+          </TableHead>
+          <TableHead className="text-right">
+            {t('team.tokens.table.actions')}
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {children}
+        {empty ? (
+          <TableEmptyRow colSpan={4}>
+            {t('team.tokens.cli.empty')}
+          </TableEmptyRow>
+        ) : null}
+      </TableBody>
+    </Table>
+  )
+}
+
+function CliFamilyRow({
+  family,
+  locale,
+}: {
+  family: CliRefreshCredentialFamily
+  locale: Locale
+}) {
+  const navigation = useNavigation()
+  const { t } = useT()
+  const pending =
+    navigation.state !== 'idle' &&
+    navigation.formData?.get('intent') === 'revoke-cli-family' &&
+    navigation.formData.get('familyId') === family.familyId
+  return (
+    <TableRow>
+      <TableCell>
+        <div
+          className="max-w-96 min-w-0 truncate"
+          title={family.deviceName ?? t('team.tokens.cli.session')}
+        >
+          <TeamUser name={family.deviceName ?? t('team.tokens.cli.session')} />
+        </div>
+      </TableCell>
+      <TableCell className="max-phone:hidden">
+        <TeamMuted>{formatRelative(family.createdAt, locale)}</TeamMuted>
+      </TableCell>
+      <TableCell className="max-nav:hidden">
+        <TeamMuted>
+          {family.lastUsedAt ? formatRelative(family.lastUsedAt, locale) : '—'}
+        </TeamMuted>
+      </TableCell>
+      <TableCell>
+        <TeamActions>
+          <Form method="post" action="/settings/cli-sessions">
+            <input type="hidden" name="intent" value="revoke-cli-family" />
+            <input type="hidden" name="familyId" value={family.familyId} />
+            <Button
+              variant="outline"
+              size="sm"
+              type="submit"
+              disabled={pending}
+            >
+              {t('team.tokens.revoke')}
+            </Button>
+          </Form>
+        </TeamActions>
+      </TableCell>
+    </TableRow>
+  )
+}

--- a/apps/web/app/routes/_protected/settings/index.test.tsx
+++ b/apps/web/app/routes/_protected/settings/index.test.tsx
@@ -237,6 +237,7 @@ vi.mock('./+components/upgrade-notice', () => ({ UpgradeNotice: () => null }))
 
 import { action } from './index'
 import TeamMembersPage from './index'
+import BotsPage from './bots'
 import { TransferOwnerDialog } from './+components/transfer-owner-dialog'
 
 function postForm(fields: Record<string, string>) {
@@ -440,7 +441,7 @@ describe('TransferOwnerDialog', () => {
   })
 })
 
-describe('/settings bot section', () => {
+describe('/settings/bots page', () => {
   function renderWithBots(bots: unknown[]) {
     pageState.navigation = { formData: undefined }
     pageState.context = {
@@ -456,20 +457,13 @@ describe('/settings bot section', () => {
       currentUserRole: 'owner',
     }
     const loaderData = {
-      membersPage: { members: [], total: 0, page: 1 },
-      removedMembers: [],
-      currentUserRole: 'owner',
-      currentUserIsAdmin: true,
-      filters: { query: '', role: 'all', activity: 'all', page: 1 },
       bots,
       botCreationEnabled: true,
-      botProjects: [{ id: 'proj1', name: 'Project 1' }],
+      projects: [{ id: 'proj1', name: 'Project 1' }],
     }
     return renderToStaticMarkup(
-      <TeamMembersPage
-        {...({ loaderData } as unknown as Parameters<
-          typeof TeamMembersPage
-        >[0])}
+      <BotsPage
+        {...({ loaderData } as unknown as Parameters<typeof BotsPage>[0])}
       />,
     )
   }

--- a/apps/web/app/routes/_protected/settings/index.tsx
+++ b/apps/web/app/routes/_protected/settings/index.tsx
@@ -68,9 +68,6 @@ import {
   type WorkspaceMemberRole,
 } from '~/lib/team-management'
 import { requireUser } from '~/middleware/context'
-import { isBotMembersEnabled } from '~/lib/bot-members-flag.server'
-import { BotSection, type BotProjectOption } from './+components/bot-section'
-import { listWorkspaceBots } from '~/services/bot-members.server'
 import { createDb } from '~/services/db.server'
 import {
   grantWorkspaceAdmin,
@@ -90,30 +87,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   const filters = parseMembersPageFilters(new URL(request.url).searchParams)
   const db = createDb()
   const data = await loadMembersPageData(db, user, filters)
-  const [bots, botCreationEnabled, botProjects] = data.currentUserIsAdmin
-    ? await Promise.all([
-        listWorkspaceBots(db, user.workspaceId),
-        isBotMembersEnabled(user.workspaceId),
-        loadBotDestinationOptions(db, user.workspaceId),
-      ])
-    : [[], false, [] as BotProjectOption[]]
-  return { ...data, filters, bots, botCreationEnabled, botProjects }
-}
-
-// Creation candidates: every non-archived project in the workspace
-// (workspace-visible and private alike).
-async function loadBotDestinationOptions(
-  db: ReturnType<typeof createDb>,
-  workspaceId: string,
-): Promise<BotProjectOption[]> {
-  return await db
-    .selectFrom('artifact_containers')
-    .select(['id', 'name'])
-    .where('workspace_id', '=', workspaceId)
-    .where('kind', '=', 'project')
-    .where('archived_at', 'is', null)
-    .orderBy('name', 'asc')
-    .execute()
+  return { ...data, filters }
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
@@ -226,14 +200,6 @@ export default function TeamMembersPage({ loaderData }: Route.ComponentProps) {
         canManage={canManage}
         currentUserRole={loaderData.currentUserRole}
       />
-
-      {canManage ? (
-        <BotSection
-          bots={loaderData.bots ?? []}
-          projects={loaderData.botProjects ?? []}
-          canCreate={loaderData.botCreationEnabled ?? false}
-        />
-      ) : null}
 
       {canManage ? (
         <RemovedMemberSection

--- a/apps/web/app/routes/_protected/settings/tokens.test.tsx
+++ b/apps/web/app/routes/_protected/settings/tokens.test.tsx
@@ -6,9 +6,6 @@ const services = vi.hoisted(() => ({
   createApiToken: vi.fn(),
   listApiTokens: vi.fn(),
   revokeApiToken: vi.fn(),
-  listCliRefreshCredentialFamilies: vi.fn(),
-  revokeAllCliRefreshCredentialFamilies: vi.fn(),
-  revokeCliRefreshCredentialFamily: vi.fn(),
 }))
 
 vi.mock('~/services/db.server', () => ({ createDb: () => ({}) }))
@@ -19,12 +16,6 @@ vi.mock('~/services/api-tokens.server', () => ({
   createApiToken: services.createApiToken,
   listApiTokens: services.listApiTokens,
   revokeApiToken: services.revokeApiToken,
-}))
-vi.mock('~/services/cli-refresh-credentials.server', () => ({
-  listCliRefreshCredentialFamilies: services.listCliRefreshCredentialFamilies,
-  revokeAllCliRefreshCredentialFamilies:
-    services.revokeAllCliRefreshCredentialFamilies,
-  revokeCliRefreshCredentialFamily: services.revokeCliRefreshCredentialFamily,
 }))
 
 import { action } from './tokens'
@@ -41,37 +32,25 @@ function request(values: Record<string, string>) {
 describe('/settings/tokens actions', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  test('revokes one family for the current user', async () => {
+  test('revokes one API token for the current user', async () => {
     await action({
-      request: request({ intent: 'revoke-cli-family', familyId: 'family-a' }),
+      request: request({ intent: 'revoke', tokenId: 'token-a' }),
       context: new Map(),
     } as never)
 
-    expect(services.revokeCliRefreshCredentialFamily).toHaveBeenCalledWith(
+    expect(services.revokeApiToken).toHaveBeenCalledWith(
       {},
       'current-user',
-      'family-a',
+      'token-a',
     )
   })
 
-  test('does not dispatch a family revoke without a family id', async () => {
+  test('does not dispatch a revoke without a token id', async () => {
     await action({
-      request: request({ intent: 'revoke-cli-family' }),
+      request: request({ intent: 'revoke' }),
       context: new Map(),
     } as never)
 
-    expect(services.revokeCliRefreshCredentialFamily).not.toHaveBeenCalled()
-  })
-
-  test('revokes all families for the current user', async () => {
-    await action({
-      request: request({ intent: 'revoke-all-cli-families' }),
-      context: new Map(),
-    } as never)
-
-    expect(services.revokeAllCliRefreshCredentialFamilies).toHaveBeenCalledWith(
-      {},
-      'current-user',
-    )
+    expect(services.revokeApiToken).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/app/routes/_protected/settings/tokens.tsx
+++ b/apps/web/app/routes/_protected/settings/tokens.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, type ReactNode } from 'react'
 import { Form, useActionData, useFetcher, useNavigation } from 'react-router'
 import { InlineFields } from '~/components/form/inline-fields'
 import { SettingsPage } from '~/components/form/settings-page'
@@ -16,7 +16,6 @@ import {
 } from '~/components/ui/table'
 import { TableEmptyRow } from '~/components/form/table-empty-row'
 import { CreatedTokenPanel } from './+components/created-token-panel'
-import { ConfirmActionDialog } from './+components/confirm-action-dialog'
 import { TeamActions } from './+components/team-actions'
 import { TeamMuted } from '~/components/form/team-muted'
 import { TeamUser } from './+components/team-user'
@@ -33,12 +32,6 @@ import {
   type ApiTokenListItem,
 } from '~/services/api-tokens.server'
 import { createDb } from '~/services/db.server'
-import {
-  listCliRefreshCredentialFamilies,
-  revokeAllCliRefreshCredentialFamilies,
-  revokeCliRefreshCredentialFamily,
-  type CliRefreshCredentialFamily,
-} from '~/services/cli-refresh-credentials.server'
 import { isDevScreenStateRequest } from '~/services/dev-screen-state.server'
 import { Link } from 'react-router'
 import { withLang } from '~/lib/connect-link'
@@ -49,22 +42,18 @@ type ActionData =
   | { kind: 'created'; token: string; name: string }
   | { kind: 'name-required' }
   | { kind: 'name-too-long' }
-  | { kind: 'cli-revoke-noop' }
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   const user = requireUser(context)
   const db = createDb()
-  const [tokens, cliFamilies] = await Promise.all([
-    listApiTokens(db, user.id),
-    listCliRefreshCredentialFamilies(db, user.id),
-  ])
+  const tokens = await listApiTokens(db, user.id)
   const createdToken = isDevScreenStateRequest(
     request,
     'settings-tokens/created-secret',
   )
     ? { name: 'CLI deploy', token: 'as_dev_screen_created_secret' }
     : null
-  return { tokens, cliFamilies, createdToken }
+  return { tokens, createdToken }
 }
 
 export async function action({
@@ -91,19 +80,6 @@ export async function action({
     return null
   }
 
-  if (intent === 'revoke-cli-family') {
-    const familyId = stringValue(form.get('familyId'))
-    if (!familyId) return null
-    const result = await revokeCliRefreshCredentialFamily(db, user.id, familyId)
-    if (result === 'noop') return { kind: 'cli-revoke-noop' }
-    return null
-  }
-
-  if (intent === 'revoke-all-cli-families') {
-    await revokeAllCliRefreshCredentialFamilies(db, user.id)
-    return null
-  }
-
   return null
 }
 
@@ -111,7 +87,6 @@ export default function ApiTokensPage({ loaderData }: Route.ComponentProps) {
   const actionData = useActionData<typeof action>()
   const navigation = useNavigation()
   const createFormRef = useRef<HTMLFormElement>(null)
-  const [revokeAllOpen, setRevokeAllOpen] = useState(false)
   const createdToken = useMemo(
     () =>
       actionData?.kind === 'created'
@@ -198,69 +173,6 @@ export default function ApiTokensPage({ loaderData }: Route.ComponentProps) {
           </Link>
         </p>
       </SettingsSection>
-      <SettingsSection
-        title={t('team.tokens.cli.title')}
-        description={t('team.tokens.cli.body')}
-      >
-        {actionData?.kind === 'cli-revoke-noop' ? (
-          <p role="status" className="text-muted-foreground text-sm">
-            {t('team.tokens.cli.alreadyRevoked')}
-          </p>
-        ) : null}
-        {loaderData.cliFamilies.length > 0 ? (
-          <>
-            <Button
-              variant="outline"
-              size="sm"
-              type="button"
-              onClick={() => setRevokeAllOpen(true)}
-            >
-              {t('team.tokens.cli.revokeAll')}
-            </Button>
-            <Form
-              method="post"
-              action="/settings/tokens"
-              id="revoke-all-cli-families-form"
-              className="hidden"
-            >
-              <input
-                type="hidden"
-                name="intent"
-                value="revoke-all-cli-families"
-              />
-            </Form>
-            <ConfirmActionDialog
-              open={revokeAllOpen}
-              onOpenChange={setRevokeAllOpen}
-              title={t('team.tokens.cli.revokeAllConfirm.title')}
-              description={t('team.tokens.cli.revokeAllConfirm.body')}
-              action={t('team.tokens.cli.revokeAll')}
-              pending={
-                navigation.state !== 'idle' &&
-                navigation.formData?.get('intent') === 'revoke-all-cli-families'
-              }
-              onConfirm={() => {
-                const form = document.getElementById(
-                  'revoke-all-cli-families-form',
-                )
-                if (form instanceof HTMLFormElement) form.requestSubmit()
-              }}
-            />
-          </>
-        ) : null}
-        <CredentialTable
-          empty={loaderData.cliFamilies.length === 0}
-          emptyMessage={t('team.tokens.cli.empty')}
-        >
-          {loaderData.cliFamilies.map((family) => (
-            <CliFamilyRow
-              key={family.familyId}
-              family={family}
-              locale={locale}
-            />
-          ))}
-        </CredentialTable>
-      </SettingsSection>
     </SettingsPage>
   )
 }
@@ -298,57 +210,6 @@ function CredentialTable({
         ) : null}
       </TableBody>
     </Table>
-  )
-}
-
-function CliFamilyRow({
-  family,
-  locale,
-}: {
-  family: CliRefreshCredentialFamily
-  locale: Locale
-}) {
-  const navigation = useNavigation()
-  const { t } = useT()
-  const pending =
-    navigation.state !== 'idle' &&
-    navigation.formData?.get('intent') === 'revoke-cli-family' &&
-    navigation.formData.get('familyId') === family.familyId
-  return (
-    <TableRow>
-      <TableCell>
-        <div
-          className="max-w-96 min-w-0 truncate"
-          title={family.deviceName ?? t('team.tokens.cli.session')}
-        >
-          <TeamUser name={family.deviceName ?? t('team.tokens.cli.session')} />
-        </div>
-      </TableCell>
-      <TableCell className="max-phone:hidden">
-        <TeamMuted>{formatRelative(family.createdAt, locale)}</TeamMuted>
-      </TableCell>
-      <TableCell className="max-nav:hidden">
-        <TeamMuted>
-          {family.lastUsedAt ? formatRelative(family.lastUsedAt, locale) : '—'}
-        </TeamMuted>
-      </TableCell>
-      <TableCell>
-        <TeamActions>
-          <Form method="post" action="/settings/tokens">
-            <input type="hidden" name="intent" value="revoke-cli-family" />
-            <input type="hidden" name="familyId" value={family.familyId} />
-            <Button
-              variant="outline"
-              size="sm"
-              type="submit"
-              disabled={pending}
-            >
-              {t('team.tokens.revoke')}
-            </Button>
-          </Form>
-        </TeamActions>
-      </TableCell>
-    </TableRow>
   )
 }
 

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -447,8 +447,18 @@ export const screens = [
     metric: 'チーム運用の継続率を高める',
     role: 'メンバーと権限を管理する',
     primaryAction: 'メンバーを管理する',
+    states: [defaultState('メンバー管理')],
+  },
+  {
+    id: 'settings-bots',
+    route: { en: '/settings/bots' },
+    auth: 'team-owner',
+    loop: 'support',
+    metric: 'Bot運用の安全性を高める',
+    role: 'Botを棚卸し認証情報を管理する',
+    primaryAction: 'Botを管理する',
     states: [
-      defaultState('メンバー管理'),
+      defaultState('Bot管理'),
       {
         id: 'with-bots',
         description:
@@ -596,6 +606,18 @@ export const screens = [
         description: '作成直後のシークレットを表示する状態',
         setup: { scenario: 'settings-tokens/created-secret' },
       },
+    ],
+  },
+  {
+    id: 'settings-cli-sessions',
+    route: { en: '/settings/cli-sessions' },
+    auth: 'team-owner',
+    loop: 'support',
+    metric: 'CLI利用の安全性を高める',
+    role: 'CLIセッションを棚卸し失効する',
+    primaryAction: 'CLIセッションを管理する',
+    states: [
+      defaultState('CLIセッション管理'),
       {
         id: 'active-cli',
         description: '有効なCLIセッションを表示する状態',
@@ -663,10 +685,6 @@ export const excludedRoutes = [
   {
     file: '_protected/projects.$id.slack.install.tsx',
     reason: 'プロジェクトの Slack 通知認可への無条件 redirect',
-  },
-  {
-    file: '_protected/settings/bots.tsx',
-    reason: 'Bot管理のJSON action専用routeでUIを描画しない',
   },
   {
     file: '_protected/settings/billing-preview.tsx',


### PR DESCRIPTION
## 現状

ワークスペース管理画面で、メンバー、Bot、APIトークン、CLIセッションが同じページに縦並びになっていました。

## 変更

- Bot管理を `/settings/bots` へ分離しました。
- CLIセッション管理を `/settings/cli-sessions` へ分離しました。
- メンバー、Bot、APIトークン、CLIセッションを独立したナビゲーション項目としました。
- Bot管理はナビゲーションと loader の両方で管理者に限定しました。
- 新しいURLに合わせて画面キャプチャ台帳を更新しました。

## 検証

- `pnpm validate:static`
- Codex / Claude implementation review: blocker なし
- 対象画面のデスクトップ・モバイル、ライト・ダークを含む40枚の画面キャプチャ
