### PR TITLE
Require UI critique confirmation before Ready

### DIFF
--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -61,7 +61,7 @@ Record the commands and results in the pull request. If the affected surface is 
 6. Start Codex and Claude deep reviews of the committed Ready candidate in parallel, wait for both, classify every finding together, and repeat both reviews in parallel on each new commit until the latest commit has no unresolved blocker.
 7. Publish a Draft PR with `pnpm pr:publish -- --body-file <path> --title <title>`. Further fixes use normal commits and pushes; the pre-push boundary guard scans every push.
 8. If UI changed, capture every affected state and repeat UI critique after material visual fixes. Commit any resulting change and return to the implementation gate.
-9. Push the final commit normally and run `pnpm pr:ready`. It verifies the Draft targets `main`, the remote PR head equals local `HEAD`, and required PR checks have succeeded before calling `gh pr ready`.
+9. Push the final commit normally and run `pnpm pr:ready`. It verifies the Draft targets `main`, the remote PR head equals local `HEAD`, and required PR checks have succeeded before calling `gh pr ready`. When the diff contains UI changes, it stops until you confirm that affected states were captured, the captures and relevant source were critiqued, and no UI changed afterward; after those checks, rerun it with `pnpm pr:ready -- --ui-gate-complete`.
 10. Use the merge queue. Its unit, CLI, browser, build, integration, runtime, and visual lanes are the final validation record. A queue entry runs the snapshot taken when it was added: after pushing a fix to a PR that failed in the queue, rebuild the entry with `gh pr merge <pr> --disable-auto` followed by `gh pr merge <pr> --auto` — an "already queued" response may still point at the old snapshot.
 
 ## UI critique

--- a/scripts/pr-ready.mjs
+++ b/scripts/pr-ready.mjs
@@ -7,9 +7,42 @@ function output(exec, file, args) {
 
 function parseArgs(args) {
   const normalized = args[0] === '--' ? args.slice(1) : args
-  if (normalized.some((arg) => arg !== '--dry-run'))
-    throw new Error('Usage: pnpm pr:ready -- [--dry-run]')
-  return { dryRun: normalized.includes('--dry-run') }
+  const allowed = new Set(['--dry-run', '--ui-gate-complete'])
+  if (normalized.some((arg) => !allowed.has(arg)))
+    throw new Error('Usage: pnpm pr:ready -- [--dry-run] [--ui-gate-complete]')
+  return {
+    dryRun: normalized.includes('--dry-run'),
+    uiGateComplete: normalized.includes('--ui-gate-complete'),
+  }
+}
+
+function isUiFile(file) {
+  if (file.startsWith('apps/web/public/')) return true
+  if (/^apps\/web\/app\/.*\.css$/u.test(file)) return true
+  if (/^apps\/web\/app\/i18n\/[^/]+\.json$/u.test(file)) return true
+  if (/^apps\/web\/app\/(?:guides|legal|updates\/entries)\/.*\.md$/u.test(file))
+    return true
+  if (
+    /^apps\/web\/app\/(?:components|hooks|lib)\/.*\.ts$/u.test(file) ||
+    /^apps\/web\/app\/routes\/.*\/(?:\+components|\+hooks)\/.*\.ts$/u.test(file)
+  )
+    return !/\.(?:(?:test|spec)|server)\.ts$/u.test(file)
+  if (!/^apps\/web\/app\/.*\.tsx$/u.test(file)) return false
+  if (/\.(?:test|spec)\.tsx$/u.test(file)) return false
+  if (file === 'apps/web/app/entry.server.tsx') return false
+  return !/^apps\/web\/app\/routes\/api\./u.test(file)
+}
+
+function uiFiles(exec, base) {
+  return output(exec, 'git', [
+    'diff',
+    '--name-only',
+    '--diff-filter=ACDMRTUXB',
+    `origin/${base}...HEAD`,
+  ])
+    .split('\n')
+    .filter(Boolean)
+    .filter(isUiFile)
 }
 
 function ready({
@@ -41,6 +74,18 @@ function ready({
     )
   if (pr.headRefOid !== head)
     throw new Error('Push the current HEAD before making the PR ready.')
+  const changedUiFiles = uiFiles(exec, pr.baseRefName)
+  if (changedUiFiles.length > 0 && !parsed.uiGateComplete)
+    throw new Error(
+      [
+        'UI changes detected. Ready was not changed.',
+        'Before retrying, confirm all of the following:',
+        '- Every affected screen state has been captured.',
+        '- UI critique using the captures and relevant source is complete; captures alone are not sufficient.',
+        '- HEAD has no UI changes after that critique. If it does, recapture and repeat the critique.',
+        'Then run: pnpm pr:ready -- --ui-gate-complete',
+      ].join('\n'),
+    )
   exec('gh', ['pr', 'checks', String(pr.number), '--required'])
   if (!parsed.dryRun) exec('gh', ['pr', 'ready', String(pr.number)])
   return { number: pr.number, head, dryRun: parsed.dryRun }
@@ -63,4 +108,4 @@ if (
   }
 }
 
-export { parseArgs, ready }
+export { isUiFile, parseArgs, ready }

--- a/scripts/pr-ready.test.mjs
+++ b/scripts/pr-ready.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { parseArgs, ready } from './pr-ready.mjs'
+import { isUiFile, parseArgs, ready } from './pr-ready.mjs'
 
 const head = 'a'.repeat(40)
 
@@ -9,6 +9,7 @@ function harness({
   draft = true,
   base = 'main',
   dirty = false,
+  changedFiles = [],
 } = {}) {
   const calls = []
   const exec = (file, args) => {
@@ -16,6 +17,7 @@ function harness({
     if (file === 'git' && args[0] === 'branch') return 'topic\n'
     if (file === 'git' && args[0] === 'rev-parse') return `${head}\n`
     if (file === 'git' && args[0] === 'status') return dirty ? ' M file' : ''
+    if (file === 'git' && args[0] === 'diff') return changedFiles.join('\n')
     if (file === 'gh' && args[1] === 'list')
       return JSON.stringify([
         {
@@ -32,9 +34,84 @@ function harness({
 }
 
 test('needs no reviewer SHA arguments', () => {
-  assert.deepEqual(parseArgs([]), { dryRun: false })
-  assert.deepEqual(parseArgs(['--', '--dry-run']), { dryRun: true })
+  assert.deepEqual(parseArgs([]), {
+    dryRun: false,
+    uiGateComplete: false,
+  })
+  assert.deepEqual(parseArgs(['--', '--dry-run', '--ui-gate-complete']), {
+    dryRun: true,
+    uiGateComplete: true,
+  })
   assert.throws(() => parseArgs(['--codex-go', head]), /Usage/u)
+})
+
+test('classifies user-visible web files without treating tests or API routes as UI', () => {
+  for (const file of [
+    'apps/web/app/components/button.tsx',
+    'apps/web/app/components/app/landing-styles.ts',
+    'apps/web/app/hooks/use-hydrated.ts',
+    'apps/web/app/routes/pricing.tsx',
+    'apps/web/app/routes/_home/+components/home-view.ts',
+    'apps/web/app/app.css',
+    'apps/web/app/lib/app-theme.ts',
+    'apps/web/app/lib/markdown-render.ts',
+    'apps/web/app/lib/mermaid-render.client.ts',
+    'apps/web/app/i18n/ja.json',
+    'apps/web/app/guides/workspace-owner.en.md',
+    'apps/web/app/legal/privacy.ja.md',
+    'apps/web/app/updates/entries/example.en.md',
+    'apps/web/public/landing/hero.svg',
+  ])
+    assert.equal(isUiFile(file), true, file)
+
+  for (const file of [
+    'apps/web/app/components/button.test.tsx',
+    'apps/web/app/components/catalog.test.ts',
+    'apps/web/app/routes/api.artifacts.tsx',
+    'apps/web/app/services/project.server.ts',
+    'apps/web/app/lib/app-theme.server.ts',
+    'packages/cli/src/index.ts',
+  ])
+    assert.equal(isUiFile(file), false, file)
+})
+
+test('blocks UI changes until capture and source-based critique are confirmed', () => {
+  const h = harness({ changedFiles: ['apps/web/app/routes/pricing.tsx'] })
+  assert.throws(
+    () =>
+      ready({
+        exec: h.exec,
+        parsed: { dryRun: false, uiGateComplete: false },
+      }),
+    (error) => {
+      assert.match(
+        error.message,
+        /Every affected screen state has been captured/u,
+      )
+      assert.match(error.message, /relevant source/u)
+      assert.match(error.message, /captures alone are not sufficient/u)
+      assert.match(error.message, /recapture and repeat the critique/u)
+      return true
+    },
+  )
+  assert.equal(
+    h.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
+    false,
+  )
+})
+
+test('allows confirmed UI changes and does not gate non-UI changes', () => {
+  for (const [changedFiles, uiGateComplete] of [
+    [['apps/web/app/components/button.tsx'], true],
+    [['packages/cli/src/index.ts'], false],
+  ]) {
+    const h = harness({ changedFiles })
+    ready({ exec: h.exec, parsed: { dryRun: false, uiGateComplete } })
+    assert.equal(
+      h.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
+      true,
+    )
+  }
 })
 
 test('checks required status then makes the pushed Draft ready', () => {


### PR DESCRIPTION
## 現状

UI を変更した PR でも、画面キャプチャと関連ソースを使った UI 批評を確認せずに Ready 化できました。

## 変更

- `pr:ready` が Web UI の表示ソースを変更差分から検出するようにしました。
- UI 変更時は、影響画面のキャプチャ、キャプチャと関連ソースを使った批評、批評後に UI 変更がないことの確認を案内して停止します。
- 確認後は `--ui-gate-complete` を指定した場合だけ既存の Ready 化チェックへ進みます。
- test、server-only、API route、CLI などの非 UI 変更には追加確認を求めません。

## 検証

- `pnpm validate:static`
- `node --test scripts/pr-ready.test.mjs`
- Codex / Claude implementation deep review（最新コミットに未解決 Blocker なし）
