### PR TITLE
Clarify combined review disposition reminder

### DIFF
--- a/scripts/claude-review.mjs
+++ b/scripts/claude-review.mjs
@@ -3,8 +3,14 @@ import { pathToFileURL } from 'node:url'
 import { cliPackage, specReviewPrompt } from './spec-review-input.mjs'
 
 const timeoutMs = 1_800_000
-const reviewReminder =
-  'Before applying findings: what current acceptance criterion, correctness, or safety property would remain broken without this change? If none can be named concretely, do not change the artifact.'
+const reviewReminder = [
+  'Before applying findings:',
+  '- Wait for both Codex and Claude reviews to finish, then classify all findings together.',
+  '- For each finding, state in one sentence what current acceptance criterion, correctness, or safety property would remain broken without a fix.',
+  '- If no such breakage can be named concretely, classify it as follow-up or non-actionable, not a blocker.',
+  '- Fix all blockers together in one pass after considering both reviews.',
+  '- Do not add future reuse, generalization, or defenses for unreachable cases to the current change.',
+].join('\n')
 
 function usage() {
   return `Usage:

--- a/scripts/claude-review.test.mjs
+++ b/scripts/claude-review.test.mjs
@@ -95,6 +95,12 @@ test('prints the reminder only after a successful unchanged review', () => {
   assert.deepEqual(output, ['No findings.\n', `${reviewReminder}\n`])
 })
 
+test('uses the same combined-review classification guidance as Codex', async () => {
+  const { reviewReminder: codexReviewReminder } =
+    await import('./codex-review.mjs')
+  assert.equal(reviewReminder, codexReviewReminder)
+})
+
 test('does not print the reminder when the checkout changes', () => {
   const output = []
   let read = 0

--- a/scripts/codex-review.mjs
+++ b/scripts/codex-review.mjs
@@ -5,8 +5,14 @@ import { specReviewPrompt } from './spec-review-input.mjs'
 
 const defaultModel = 'gpt-5.6-sol'
 const defaultBase = 'origin/main'
-const reviewReminder =
-  'Before applying findings: what current acceptance criterion, correctness, or safety property would remain broken without this change? If none can be named concretely, do not change the artifact.'
+const reviewReminder = [
+  'Before applying findings:',
+  '- Wait for both Codex and Claude reviews to finish, then classify all findings together.',
+  '- For each finding, state in one sentence what current acceptance criterion, correctness, or safety property would remain broken without a fix.',
+  '- If no such breakage can be named concretely, classify it as follow-up or non-actionable, not a blocker.',
+  '- Fix all blockers together in one pass after considering both reviews.',
+  '- Do not add future reuse, generalization, or defenses for unreachable cases to the current change.',
+].join('\n')
 
 function usage() {
   return `Usage:

--- a/scripts/codex-review.test.mjs
+++ b/scripts/codex-review.test.mjs
@@ -125,6 +125,18 @@ test('runs native review and verifies the checkout did not change', () => {
   assert.deepEqual(logs, [reviewReminder])
 })
 
+test('reminds maintainers to combine both reviews and limit blockers to current breakage', () => {
+  assert.match(reviewReminder, /Wait for both Codex and Claude/u)
+  assert.match(reviewReminder, /classify all findings together/u)
+  assert.match(
+    reviewReminder,
+    /in one sentence what current acceptance criterion/u,
+  )
+  assert.match(reviewReminder, /follow-up or non-actionable, not a blocker/u)
+  assert.match(reviewReminder, /Fix all blockers together in one pass/u)
+  assert.match(reviewReminder, /future reuse, generalization/u)
+})
+
 test('reads the fixed spec version and runs Codex against the same clean HEAD', () => {
   const calls = []
   const code = main({


### PR DESCRIPTION
## 現状

レビューコマンドの完了時リマインダーは、個々の指摘が現在の受け入れ条件、正しさ、安全性のどれを守るか確認するよう促していましたが、両レビューを待ってまとめて判断・修正する手順までは表示していませんでした。

## 変更

- CodexとClaudeのレビュー完了時に、両方の結果を待ってから指摘をまとめて分類するよう表示します。
- blockerには、未対応の場合に現在の受け入れ条件、正しさ、安全性の何が壊れるかを一文で示すよう促します。
- 具体的な破損を示せない指摘はfollow-upまたはnon-actionableとし、blockerを一度に修正するよう表示します。
- 将来の再利用、一般化、到達不能なケースへの備えを現在の変更へ混ぜないよう表示します。
- 両レビューで同一の文面を使うことをテストします。

## 検証

- `node --test scripts/codex-review.test.mjs scripts/claude-review.test.mjs`
- `pnpm format`
- `pnpm lint`
- `pnpm validate:static`
- Codex deep review: unresolved blockerなし
- Claude deep review: unresolved blockerなし

Follow-upおよびnon-actionable findingはありません。
