### PR TITLE
Fail closed when screen captures are not reviewable

### DIFF
--- a/apps/web/app/components/app/unavailable.tsx
+++ b/apps/web/app/components/app/unavailable.tsx
@@ -18,6 +18,7 @@ export type UnavailableReason =
 interface UnavailableProps {
   user: UserInfo | null
   reason: UnavailableReason
+  screenCaptureError?: string
 }
 
 const MESSAGES = {
@@ -43,7 +44,11 @@ const MESSAGES = {
   },
 } as const
 
-export function Unavailable({ user, reason }: UnavailableProps) {
+export function Unavailable({
+  user,
+  reason,
+  screenCaptureError,
+}: UnavailableProps) {
   const { t } = useT()
   const { title: titleKey, body: bodyKey } = MESSAGES[reason]
 
@@ -53,6 +58,7 @@ export function Unavailable({ user, reason }: UnavailableProps) {
       icon={<BrokenFileIcon />}
       title={t(titleKey)}
       body={t(bodyKey)}
+      screenCaptureError={screenCaptureError}
       actions={
         <Button asChild>
           <Link to="/">{t('unavailable.back')}</Link>

--- a/apps/web/app/components/app/viewer-error-shell.tsx
+++ b/apps/web/app/components/app/viewer-error-shell.tsx
@@ -10,6 +10,7 @@ interface ViewerErrorShellProps {
   title: string
   body: React.ReactNode
   actions: React.ReactNode
+  screenCaptureError?: string
   regressionRegions?: {
     header?: string
     main?: string
@@ -22,6 +23,7 @@ export function ViewerErrorShell({
   title,
   body,
   actions,
+  screenCaptureError,
   regressionRegions,
 }: ViewerErrorShellProps) {
   // viewer-brand-placement.md: エラー topbar は grid 領域を明示し、
@@ -47,6 +49,7 @@ export function ViewerErrorShell({
       )}
       <main
         className="flex min-h-0 flex-1"
+        data-screen-capture-error={screenCaptureError}
         data-regression-region={regressionRegions?.main}
       >
         <DeniedPanel icon={icon} title={title} body={body} actions={actions} />

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -181,7 +181,10 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   }
 
   return (
-    <main className="mx-auto w-full max-w-5xl p-4 pt-16">
+    <main
+      data-screen-capture-error="route-error-boundary"
+      className="mx-auto w-full max-w-5xl p-4 pt-16"
+    >
       <h1>{message}</h1>
       <p>{details}</p>
       {stack && (

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -120,6 +120,7 @@ export function SandboxFrame(props: SandboxFrameProps) {
   return (
     <ViewerBodySurface>
       <div
+        data-sandbox-state={controller.loadState}
         className="bg-background relative block h-full w-full overflow-hidden"
         style={{
           viewTransitionName: controller.isTransitioning

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -1233,7 +1233,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   const rootData = useRouteLoaderData<{ user: SessionUser | null }>('root')
   if (!rootData?.user) {
     return (
-      <main>
+      <main data-screen-capture-error="viewer-route-error-boundary">
         <Empty>
           <EmptyContent>
             <Button asChild>
@@ -1249,6 +1249,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
     <Unavailable
       user={toUserInfo(rootData.user)}
       reason={is404 ? 'missing' : 'open-error'}
+      screenCaptureError="viewer-route-error-boundary"
     />
   )
 }

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -1093,7 +1093,13 @@ export default function ViewerRoute({ loaderData }: Route.ComponentProps) {
         </ViewerShell>
       )
     case 'unavailable':
-      return <Unavailable reason="missing" user={loaderData.user} />
+      return (
+        <Unavailable
+          reason="missing"
+          user={loaderData.user}
+          screenCaptureError="viewer-unavailable"
+        />
+      )
     case 'ok':
       return (
         <>

--- a/docs/reference/screen-capture.md
+++ b/docs/reference/screen-capture.md
@@ -23,8 +23,16 @@ Each selected ledger entry expands across its declared locales and states, deskt
 Output is written to `screen-captures/<label>/`:
 
 - one full-page PNG for each matrix item;
-- `manifest.json` with the exact capture metadata;
+- `manifest.json` with the exact capture metadata and a `success` or `failed`
+  status for every matrix item;
 - `index.html` for visual browsing.
+
+Before a capture is marked successful, the harness rejects the shared route
+error boundary and waits for any screen-specific `ready` condition declared in
+the screen ledger. Failed entries distinguish navigation, rendered screen
+errors, readiness timeouts, missing interaction prerequisites, and interaction
+failures. When possible, a `--failed.png` diagnostic image is retained, but it
+is never counted as a successful review capture.
 
 The output directory is untracked. A new run removes only the selected label directory before writing it.
 

--- a/scripts/check-screen-ledger.test.mjs
+++ b/scripts/check-screen-ledger.test.mjs
@@ -4,6 +4,7 @@ import { checkScreenLedger, hasDefaultExport } from './check-screen-ledger.mjs'
 import {
   CaptureFailure,
   assertNoRouteError,
+  waitForInteractionTarget,
   captureFailure,
   screenStateRequestHeaders,
   waitForReady,
@@ -240,6 +241,42 @@ test('classifies an unmet screen readiness contract', async () => {
       error.kind === 'readiness_timeout' &&
       error.details.condition === 'viewer ready' &&
       error.details.timeoutMs === 25,
+  )
+})
+
+test('waits for a delayed interaction target before acting', async () => {
+  let waitOptions
+  const page = {
+    locator: () => ({
+      waitFor: (options) => {
+        waitOptions = options
+        return Promise.resolve()
+      },
+    }),
+  }
+
+  await waitForInteractionTarget(page, {
+    action: 'click',
+    selector: '[aria-label="Updates"]',
+  })
+  assert.deepEqual(waitOptions, { state: 'visible' })
+})
+
+test('classifies a missing interaction target as a precondition failure', async () => {
+  const page = {
+    locator: () => ({ waitFor: () => Promise.reject(new Error('timeout')) }),
+  }
+
+  await assert.rejects(
+    waitForInteractionTarget(page, {
+      action: 'hover',
+      selector: '[data-help]',
+    }),
+    (error) =>
+      error instanceof CaptureFailure &&
+      error.kind === 'interaction_precondition' &&
+      error.details.action === 'hover' &&
+      error.details.selector === '[data-help]',
   )
 })
 

--- a/scripts/check-screen-ledger.test.mjs
+++ b/scripts/check-screen-ledger.test.mjs
@@ -4,6 +4,7 @@ import { checkScreenLedger, hasDefaultExport } from './check-screen-ledger.mjs'
 import {
   CaptureFailure,
   assertNoRouteError,
+  navigateForCapture,
   waitForInteractionTarget,
   captureFailure,
   screenStateRequestHeaders,
@@ -196,13 +197,16 @@ test('preserves typed capture failures for manifest reporting', () => {
 
 test('classifies a rendered route error without exposing its stack', async () => {
   const textLocator = (text) => ({
+    count: () => Promise.resolve(1),
     first: () => textLocator(text),
     innerText: () => Promise.resolve(text),
   })
   const root = {
     getAttribute: () => Promise.resolve('route-error-boundary'),
     locator: (selector) =>
-      selector === 'h1' ? textLocator('Oops!') : textLocator('Bad Request'),
+      selector.includes('heading')
+        ? textLocator('Oops!')
+        : textLocator('Bad Request'),
   }
   const page = {
     locator: () => ({
@@ -218,6 +222,52 @@ test('classifies a rendered route error without exposing its stack', async () =>
       error.kind === 'screen_error' &&
       error.message ===
         'screen rendered route-error-boundary: Oops! — Bad Request',
+  )
+})
+
+test('classifies a marker without heading or details immediately', async () => {
+  const root = {
+    getAttribute: () => Promise.resolve('viewer-route-error-boundary'),
+    locator: () => ({ count: () => Promise.resolve(0) }),
+  }
+  const page = {
+    locator: () => ({
+      count: () => Promise.resolve(1),
+      first: () => root,
+    }),
+  }
+
+  await assert.rejects(
+    assertNoRouteError(page),
+    (error) =>
+      error instanceof CaptureFailure &&
+      error.kind === 'screen_error' &&
+      error.message === 'screen rendered viewer-route-error-boundary',
+  )
+})
+
+test('classifies rejected and unsuccessful navigation', async () => {
+  await assert.rejects(
+    navigateForCapture(
+      { goto: () => Promise.reject(new Error('connection refused')) },
+      'https://localhost/',
+    ),
+    (error) =>
+      error instanceof CaptureFailure &&
+      error.kind === 'navigation_failure' &&
+      error.message === 'navigation failed: connection refused',
+  )
+  await assert.rejects(
+    navigateForCapture(
+      {
+        goto: () => Promise.resolve({ ok: () => false, status: () => 503 }),
+      },
+      'https://localhost/',
+    ),
+    (error) =>
+      error instanceof CaptureFailure &&
+      error.kind === 'navigation_failure' &&
+      error.message === 'navigation failed: HTTP 503',
   )
 })
 

--- a/scripts/check-screen-ledger.test.mjs
+++ b/scripts/check-screen-ledger.test.mjs
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { checkScreenLedger, hasDefaultExport } from './check-screen-ledger.mjs'
-import { screenStateRequestHeaders } from './screen-capture.mjs'
+import {
+  CaptureFailure,
+  assertNoRouteError,
+  captureFailure,
+  screenStateRequestHeaders,
+  waitForReady,
+} from './screen-capture.mjs'
 import {
   screenScenarioAllowlist,
   screens as ledgerScreens,
@@ -116,6 +122,126 @@ test('rejects an unknown screen scenario', () =>
       ]),
     /unknown scenario: unknown\/scenario/,
   ))
+
+test('accepts a declared screen readiness condition', () =>
+  assert.equal(
+    validateLedger([
+      {
+        ...ledgerScreen([{ id: 'default', setup: {} }]),
+        ready: {
+          selector: '[data-state="ready"]',
+          description: 'viewer ready',
+          timeoutMs: 5_000,
+        },
+      },
+    ]),
+    true,
+  ))
+
+test('rejects incomplete or invalid readiness conditions', () => {
+  const state = [{ id: 'default', setup: {} }]
+  assert.throws(
+    () =>
+      validateLedger([
+        {
+          ...ledgerScreen(state),
+          ready: { selector: '', description: 'ready' },
+        },
+      ]),
+    /ready selector required/,
+  )
+  assert.throws(
+    () =>
+      validateLedger([
+        {
+          ...ledgerScreen(state),
+          ready: { selector: '.ready', description: '', timeoutMs: 0 },
+        },
+      ]),
+    /ready description required/,
+  )
+  assert.throws(
+    () =>
+      validateLedger([
+        {
+          ...ledgerScreen(state),
+          ready: { selector: '.ready', description: 'ready', timeoutMs: 0 },
+        },
+      ]),
+    /ready timeout must be positive/,
+  )
+})
+
+test('preserves typed capture failures for manifest reporting', () => {
+  assert.deepEqual(
+    captureFailure(
+      new CaptureFailure('readiness_timeout', 'viewer not ready', {
+        condition: 'sandbox frame ready',
+        timeoutMs: 30_000,
+      }),
+    ),
+    {
+      kind: 'readiness_timeout',
+      message: 'viewer not ready',
+      condition: 'sandbox frame ready',
+      timeoutMs: 30_000,
+    },
+  )
+  assert.deepEqual(captureFailure(new Error('unknown failure')), {
+    kind: 'capture_failure',
+    message: 'unknown failure',
+  })
+})
+
+test('classifies a rendered route error without exposing its stack', async () => {
+  const textLocator = (text) => ({
+    first: () => textLocator(text),
+    innerText: () => Promise.resolve(text),
+  })
+  const root = {
+    getAttribute: () => Promise.resolve('route-error-boundary'),
+    locator: (selector) =>
+      selector === 'h1' ? textLocator('Oops!') : textLocator('Bad Request'),
+  }
+  const page = {
+    locator: () => ({
+      count: () => Promise.resolve(1),
+      first: () => root,
+    }),
+  }
+
+  await assert.rejects(
+    assertNoRouteError(page),
+    (error) =>
+      error instanceof CaptureFailure &&
+      error.kind === 'screen_error' &&
+      error.message ===
+        'screen rendered route-error-boundary: Oops! — Bad Request',
+  )
+})
+
+test('classifies an unmet screen readiness contract', async () => {
+  const page = {
+    locator: (selector) => ({
+      count: () =>
+        Promise.resolve(selector === '[data-screen-capture-error]' ? 0 : 1),
+      waitFor: () => Promise.reject(new Error('timeout')),
+    }),
+  }
+
+  await assert.rejects(
+    waitForReady(page, {
+      selector: '[data-state="ready"]',
+      description: 'viewer ready',
+      timeoutMs: 25,
+    }),
+    (error) =>
+      error instanceof CaptureFailure &&
+      error.kind === 'readiness_timeout' &&
+      error.details.condition === 'viewer ready' &&
+      error.details.timeoutMs === 25,
+  )
+})
 
 test('adds the scenario header only to a seeded state job', () => {
   assert.deepEqual(screenStateRequestHeaders({ setup: {} }), {})

--- a/scripts/screen-capture.mjs
+++ b/scripts/screen-capture.mjs
@@ -17,6 +17,64 @@ const VIEWPORTS = {
   mobile: { width: 390, height: 844 },
 }
 const THEMES = ['light', 'dark']
+const ROUTE_ERROR_SELECTOR = '[data-screen-capture-error]'
+
+export class CaptureFailure extends Error {
+  constructor(kind, message, details = {}) {
+    super(message)
+    this.name = 'CaptureFailure'
+    this.kind = kind
+    this.details = details
+  }
+}
+
+export function captureFailure(error) {
+  if (error instanceof CaptureFailure)
+    return {
+      kind: error.kind,
+      message: error.message,
+      ...error.details,
+    }
+  return {
+    kind: 'capture_failure',
+    message: error instanceof Error ? error.message : String(error),
+  }
+}
+
+export async function assertNoRouteError(page) {
+  const error = page.locator(ROUTE_ERROR_SELECTOR)
+  if ((await error.count()) === 0) return
+  const root = error.first()
+  const marker = await root.getAttribute('data-screen-capture-error')
+  const heading = await root.locator('h1').first().innerText()
+  const details = await root.locator('p').first().innerText()
+  throw new CaptureFailure(
+    'screen_error',
+    `screen rendered ${marker ?? 'an error boundary'}: ${heading} — ${details}`,
+    { condition: marker ?? ROUTE_ERROR_SELECTOR },
+  )
+}
+
+export async function waitForReady(page, ready) {
+  if (!ready) return
+  try {
+    await page.locator(ready.selector).waitFor({
+      state: 'visible',
+      timeout: ready.timeoutMs ?? 30_000,
+    })
+  } catch {
+    await assertNoRouteError(page)
+    throw new CaptureFailure(
+      'readiness_timeout',
+      `ready condition was not met: ${ready.description}`,
+      {
+        condition: ready.description,
+        selector: ready.selector,
+        timeoutMs: ready.timeoutMs ?? 30_000,
+      },
+    )
+  }
+}
 
 const usage = () =>
   'Usage: pnpm screens:capture -- [--screen <id>...] [--all] [--label <name>] [--audit-gaps]'
@@ -314,13 +372,15 @@ export async function captureScreens({
       reducedMotion: 'reduce',
       extraHTTPHeaders: screenStateRequestHeaders(state),
     })
+    let page
+    let url
     try {
       if (cookie)
         await context.addCookies(
           cookie.cookies.map((item) => ({ ...item, url: baseUrl })),
         )
-      const page = await context.newPage()
-      const url = new URL(pathFor(screen, locale, seeds, state), baseUrl)
+      page = await context.newPage()
+      url = new URL(pathFor(screen, locale, seeds, state), baseUrl)
       url.searchParams.set('theme', theme)
       const query = state.setup?.query
       if (query)
@@ -331,19 +391,44 @@ export async function captureScreens({
         waitUntil: 'networkidle',
       })
       if (!navigation || !navigation.ok())
-        throw new Error(
+        throw new CaptureFailure(
+          'navigation_failure',
           `navigation failed: HTTP ${navigation?.status() ?? 'none'}`,
         )
+      await assertNoRouteError(page)
+      await waitForReady(page, state.setup?.ready ?? screen.ready)
       const interactions = state.setup?.interactions ?? []
       for (const interaction of interactions) {
-        if (interaction.action === 'hover')
-          await page.hover(interaction.selector)
-        else if (interaction.action === 'click')
-          await page.click(interaction.selector)
+        if ((await page.locator(interaction.selector).count()) === 0)
+          throw new CaptureFailure(
+            'interaction_precondition',
+            `interaction target was not found: ${interaction.selector}`,
+            {
+              action: interaction.action,
+              selector: interaction.selector,
+            },
+          )
+        try {
+          if (interaction.action === 'hover')
+            await page.hover(interaction.selector)
+          else if (interaction.action === 'click')
+            await page.click(interaction.selector)
+        } catch (error) {
+          throw new CaptureFailure(
+            'interaction_failure',
+            `interaction failed: ${interaction.action} ${interaction.selector}: ${error instanceof Error ? error.message : String(error)}`,
+            {
+              action: interaction.action,
+              selector: interaction.selector,
+            },
+          )
+        }
         await page.waitForTimeout(400)
       }
       // goto already waited for networkidle; only re-settle after interactions.
       if (interactions.length > 0) await page.waitForLoadState('networkidle')
+      await assertNoRouteError(page)
+      await waitForReady(page, state.setup?.ready ?? screen.ready)
       await page.screenshot({
         path: join(outDir, file),
         fullPage: true,
@@ -365,6 +450,7 @@ export async function captureScreens({
         })
       manifest.push({
         order,
+        status: 'success',
         screen: screen.id,
         state: state.id,
         viewport,
@@ -383,8 +469,31 @@ export async function captureScreens({
       })
     } catch (error) {
       failures++
+      const failure = captureFailure(error)
+      const diagnosticFile = file.replace(/\.png$/, '--failed.png')
+      let savedDiagnostic = false
+      if (page)
+        try {
+          await page.screenshot({
+            path: join(outDir, diagnosticFile),
+            fullPage: true,
+          })
+          savedDiagnostic = true
+        } catch {}
+      manifest.push({
+        order,
+        status: 'failed',
+        screen: screen.id,
+        state: state.id,
+        viewport,
+        theme,
+        locale,
+        url: url?.toString() ?? null,
+        ...(savedDiagnostic ? { diagnosticFile } : {}),
+        failure,
+      })
       console.error(
-        `capture failed: ${screen.id}/${state.id}/${viewport}/${theme}/${locale}: ${error.message}`,
+        `capture failed: ${screen.id}/${state.id}/${viewport}/${theme}/${locale} [${failure.kind}]: ${failure.message}`,
       )
     } finally {
       await context.close()
@@ -425,10 +534,13 @@ export async function captureScreens({
       (screen) =>
         `<section><h2>${screen.id}</h2><div class="grid">${manifest
           .filter((item) => item.screen === screen.id)
-          .map(
-            (item) =>
-              `<a href="${item.file}"><img src="${item.file}" loading="lazy"><span>${item.state} · ${item.viewport} · ${item.theme} · ${item.locale}</span></a>`,
-          )
+          .map((item) => {
+            const file = item.file ?? item.diagnosticFile
+            const displayLabel = `${item.state} · ${item.viewport} · ${item.theme} · ${item.locale}`
+            if (!file)
+              return `<article><span>${displayLabel} · failed: ${item.failure.kind}</span></article>`
+            return `<a href="${file}"><img src="${file}" loading="lazy"><span>${displayLabel}${item.status === 'failed' ? ` · failed: ${item.failure.kind}` : ''}</span></a>`
+          })
           .join('')}</div></section>`,
     )
     .join('')
@@ -436,8 +548,9 @@ export async function captureScreens({
     join(outDir, 'index.html'),
     `<!doctype html><meta charset="utf-8"><title>Screen captures: ${label}</title><style>body{font:14px system-ui;margin:24px;background:#eee}section{margin:24px 0}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px}a{color:#111;text-decoration:none;background:white;padding:8px}img{width:100%;height:180px;object-fit:contain;background:#ddd;display:block}span{display:block;padding:8px 0}</style>${groups}`,
   )
+  const successes = manifest.filter((item) => item.status === 'success').length
   console.log(
-    `Screen captures: ${manifest.length} succeeded, ${failures} failed. Output: ${outDir}`,
+    `Screen captures: ${successes} succeeded, ${failures} failed. Output: ${outDir}`,
   )
   if (gapFailures.length)
     console.error(

--- a/scripts/screen-capture.mjs
+++ b/scripts/screen-capture.mjs
@@ -41,18 +41,44 @@ export function captureFailure(error) {
   }
 }
 
+async function optionalText(root, selector) {
+  const locator = root.locator(selector)
+  return (await locator.count()) > 0 ? await locator.first().innerText() : null
+}
+
 export async function assertNoRouteError(page) {
   const error = page.locator(ROUTE_ERROR_SELECTOR)
   if ((await error.count()) === 0) return
   const root = error.first()
   const marker = await root.getAttribute('data-screen-capture-error')
-  const heading = await root.locator('h1').first().innerText()
-  const details = await root.locator('p').first().innerText()
+  const heading = await optionalText(
+    root,
+    'h1, [role="heading"], [data-slot="empty-title"]',
+  )
+  const details = await optionalText(root, 'p, [data-slot="empty-description"]')
+  const summary = [heading, details].filter(Boolean).join(' — ')
   throw new CaptureFailure(
     'screen_error',
-    `screen rendered ${marker ?? 'an error boundary'}: ${heading} — ${details}`,
+    `screen rendered ${marker ?? 'an error boundary'}${summary ? `: ${summary}` : ''}`,
     { condition: marker ?? ROUTE_ERROR_SELECTOR },
   )
+}
+
+export async function navigateForCapture(page, url) {
+  let navigation
+  try {
+    navigation = await page.goto(url, { waitUntil: 'networkidle' })
+  } catch (error) {
+    throw new CaptureFailure(
+      'navigation_failure',
+      `navigation failed: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+  if (!navigation || !navigation.ok())
+    throw new CaptureFailure(
+      'navigation_failure',
+      `navigation failed: HTTP ${navigation?.status() ?? 'none'}`,
+    )
 }
 
 export async function waitForReady(page, ready) {
@@ -402,14 +428,7 @@ export async function captureScreens({
         new URLSearchParams(query.replace(/^\?/, '')).forEach((value, key) =>
           url.searchParams.set(key, value),
         )
-      const navigation = await page.goto(url.toString(), {
-        waitUntil: 'networkidle',
-      })
-      if (!navigation || !navigation.ok())
-        throw new CaptureFailure(
-          'navigation_failure',
-          `navigation failed: HTTP ${navigation?.status() ?? 'none'}`,
-        )
+      await navigateForCapture(page, url.toString())
       await assertNoRouteError(page)
       await waitForReady(page, state.setup?.ready ?? screen.ready)
       const interactions = state.setup?.interactions ?? []

--- a/scripts/screen-capture.mjs
+++ b/scripts/screen-capture.mjs
@@ -430,7 +430,7 @@ export async function captureScreens({
         )
       await navigateForCapture(page, url.toString())
       await assertNoRouteError(page)
-      await waitForReady(page, state.setup?.ready ?? screen.ready)
+      await waitForReady(page, screen.ready)
       const interactions = state.setup?.interactions ?? []
       for (const interaction of interactions) {
         await waitForInteractionTarget(page, interaction)
@@ -454,7 +454,7 @@ export async function captureScreens({
       // goto already waited for networkidle; only re-settle after interactions.
       if (interactions.length > 0) await page.waitForLoadState('networkidle')
       await assertNoRouteError(page)
-      await waitForReady(page, state.setup?.ready ?? screen.ready)
+      await waitForReady(page, screen.ready)
       await page.screenshot({
         path: join(outDir, file),
         fullPage: true,

--- a/scripts/screen-capture.mjs
+++ b/scripts/screen-capture.mjs
@@ -76,6 +76,21 @@ export async function waitForReady(page, ready) {
   }
 }
 
+export async function waitForInteractionTarget(page, interaction) {
+  try {
+    await page.locator(interaction.selector).waitFor({ state: 'visible' })
+  } catch {
+    throw new CaptureFailure(
+      'interaction_precondition',
+      `interaction target was not found: ${interaction.selector}`,
+      {
+        action: interaction.action,
+        selector: interaction.selector,
+      },
+    )
+  }
+}
+
 const usage = () =>
   'Usage: pnpm screens:capture -- [--screen <id>...] [--all] [--label <name>] [--audit-gaps]'
 
@@ -399,15 +414,7 @@ export async function captureScreens({
       await waitForReady(page, state.setup?.ready ?? screen.ready)
       const interactions = state.setup?.interactions ?? []
       for (const interaction of interactions) {
-        if ((await page.locator(interaction.selector).count()) === 0)
-          throw new CaptureFailure(
-            'interaction_precondition',
-            `interaction target was not found: ${interaction.selector}`,
-            {
-              action: interaction.action,
-              selector: interaction.selector,
-            },
-          )
+        await waitForInteractionTarget(page, interaction)
         try {
           if (interaction.action === 'hover')
             await page.hover(interaction.selector)

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -229,6 +229,11 @@ export const screens = [
     metric: '共有成果物の閲覧と反応を増やす',
     role: '共有された成果物を閲覧する',
     primaryAction: '成果物を確認する',
+    ready: {
+      selector: '[data-sandbox-state="ready"]',
+      description: 'sandbox frame ready',
+      timeoutMs: 30_000,
+    },
     states: [
       defaultState('通常閲覧'),
       {
@@ -722,6 +727,18 @@ export function validateLedger(
       throw new Error(`invalid loop for ${screen.id}`)
     if (!Array.isArray(screen.states) || screen.states.length === 0)
       throw new Error(`states required for ${screen.id}`)
+    if (screen.ready) {
+      if (!screen.ready.selector?.trim())
+        throw new Error(`ready selector required for ${screen.id}`)
+      if (!screen.ready.description?.trim())
+        throw new Error(`ready description required for ${screen.id}`)
+      if (
+        screen.ready.timeoutMs !== undefined &&
+        (!Number.isInteger(screen.ready.timeoutMs) ||
+          screen.ready.timeoutMs < 1)
+      )
+        throw new Error(`ready timeout must be positive for ${screen.id}`)
+    }
     const stateIds = new Set()
     for (const state of screen.states) {
       if (stateIds.has(state.id))


### PR DESCRIPTION
## 現状

画面撮影が route error や viewer の loading 状態を成功成果物として残し、UI 批評が「正常」と「検査不能」を区別できませんでした。

## 変更

- route error と screen-specific ready 条件を撮影前後に検証
- navigation、screen error、readiness timeout、interaction failure を manifest で分類
- 失敗時の診断 PNG を保持し、成功件数から除外
- viewer の ready 契約、台帳検証、回帰テスト、運用ドキュメントを追加

## 検証

- `pnpm test:scripts`
- `pnpm public:scan .`
- `pnpm validate:static`
- `pnpm screens:capture -- --screen project-detail --screen viewer --label validity-gate-check`
  - 9 success、16 screen_error、3 readiness_timeout
  - エラー画面と未準備状態を成功として記録しないことを確認
- Codex / Claude implementation review: findings なし
