### PR TITLE
Preserve local action origins through the Vite bridge

### DIFF
--- a/apps/web/workers/app.test.ts
+++ b/apps/web/workers/app.test.ts
@@ -649,6 +649,54 @@ describe('app worker maintenance mode', () => {
     await expect(response.text()).resolves.toBe('app')
   })
 
+  test('restores the development action port removed by the Vite bridge', async () => {
+    const response = await app.fetch(
+      workerRequest('https://localhost/projects/project-1.data', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          origin: 'https://localhost:5173',
+        },
+        body: 'intent=seen',
+      }),
+      { APP_ENV: 'development' } as unknown as Cloudflare.Env,
+      executionContext(),
+    )
+
+    expect(response.status).toBe(200)
+    const forwarded = requestHandlerMock.mock.calls.at(-1)?.[0]
+    expect(forwarded?.url).toBe(
+      'https://localhost:5173/projects/project-1.data',
+    )
+    await expect(forwarded?.text()).resolves.toBe('intent=seen')
+  })
+
+  test('does not rewrite production or cross-host action requests', async () => {
+    for (const sample of [
+      {
+        url: 'https://artifactshare.com/projects/project-1.data',
+        origin: 'https://artifactshare.com:5173',
+        env: { APP_ENV: 'production' },
+      },
+      {
+        url: 'https://localhost/projects/project-1.data',
+        origin: 'https://other.localhost:5173',
+        env: { APP_ENV: 'development' },
+      },
+    ]) {
+      await app.fetch(
+        workerRequest(sample.url, {
+          method: 'POST',
+          headers: { origin: sample.origin },
+        }),
+        sample.env as unknown as Cloudflare.Env,
+        executionContext(),
+      )
+      const forwarded = requestHandlerMock.mock.calls.at(-1)?.[0]
+      expect(forwarded?.url).toBe(sample.url)
+    }
+  })
+
   test('does not forward spoofed maintenance markers when maintenance is disabled', async () => {
     const response = await app.fetch(
       workerRequest('https://artifactshare.com/', {

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -194,7 +194,10 @@ export default {
 
     const context = new RouterContextProvider()
     context.set(ctxContext, ctx)
-    return requestHandler(handlerRequest, context)
+    return requestHandler(
+      requestWithDevelopmentOriginPort(handlerRequest, env),
+      context,
+    )
   },
 } satisfies ExportedHandler<Cloudflare.Env>
 
@@ -382,6 +385,35 @@ function requestWithoutMaintenanceHeader(request: Request): Request {
   const headers = new Headers(request.headers)
   headers.delete(MAINTENANCE_REQUEST_HEADER)
   return new Request(request, { headers })
+}
+
+function requestWithDevelopmentOriginPort(
+  request: Request,
+  env: { APP_ENV: string },
+): Request {
+  if (
+    isProduction(env) ||
+    request.method === 'GET' ||
+    request.method === 'HEAD'
+  )
+    return request
+  const origin = request.headers.get('origin')
+  if (!origin) return request
+  let originUrl: URL
+  try {
+    originUrl = new URL(origin)
+  } catch {
+    return request
+  }
+  const requestUrl = new URL(request.url)
+  if (
+    requestUrl.hostname !== originUrl.hostname ||
+    requestUrl.port ||
+    !originUrl.port
+  )
+    return request
+  requestUrl.port = originUrl.port
+  return new Request(requestUrl, request)
 }
 
 function requestWithoutAuthCookies(request: Request): Request {


### PR DESCRIPTION
## 現状

ローカル開発環境では、Vite/Workers bridgeがReact Routerへ渡すrequest URLからportを落とす一方、ブラウザのOriginにはportが残っていた。この不一致によりUI actionがCSRF検査で400になり、project detailがエラー画面へ遷移していた。

## 変更

- development時に限り、request URLとOriginが同じhostnameで、request URLにportが欠けている場合だけOriginのportを復元
- production、safe method、cross-host、既にportを持つrequestは変更しない
- request bodyを維持した補正と非補正境界の回帰テストを追加

## 検証

- `pnpm validate:static`
- `pnpm --filter @artifactshare/web exec vitest --config vitest.config.ts workers/app.test.ts --run`
- `pnpm screens:capture -- --screen project-detail --label project-detail-origin-port-fix`
  - 16 success、0 failed
- Codex / Claude implementation review: findingsなし
