### PR TITLE
Make UI capture states deterministic

### DIFF
--- a/apps/web/app/root.test.tsx
+++ b/apps/web/app/root.test.tsx
@@ -203,6 +203,26 @@ describe('root maintenance', () => {
   })
 })
 
+describe('root screen states', () => {
+  test('keeps the updates menu fixture independent of notice publication dates', async () => {
+    const context = {
+      get: vi.fn(() => ({ id: 'user-1', locale: null })),
+    }
+
+    const result = await loader(
+      loaderArgs('https://localhost/', 'en', context, {
+        'X-ArtifactShare-Dev-Screen-State': 'home/updates-menu-open',
+      }),
+    )
+
+    expect(result.updatesNotice).toEqual({
+      slug: 'dev-screen-updates-notice',
+      dot: true,
+      new: true,
+    })
+  })
+})
+
 function loaderArgs(
   url: string,
   acceptLanguage: string,

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -41,6 +41,7 @@ import {
   readUpdatesNotice,
   updatesNoticePresentation,
 } from '~/lib/updates-notice.server'
+import { isDevScreenStateRequest } from '~/services/dev-screen-state.server'
 export { shouldRevalidate } from '~/lib/root-locale'
 
 export const links: Route.LinksFunction = () => [
@@ -70,6 +71,12 @@ export async function loader({ request, url, context }: Route.LoaderArgs) {
   const appTheme = getAppTheme(request)
   const notice = user ? await getLatestVisibleNotice() : undefined
   const noticeState = readUpdatesNotice(request)
+  const updatesNotice = isDevScreenStateRequest(
+    request,
+    'home/updates-menu-open',
+  )
+    ? { slug: 'dev-screen-updates-notice', dot: true, new: true }
+    : updatesNoticePresentation(noticeState, notice?.slug)
   const analyticsMeasurementId: string | null = env.GA4_MEASUREMENT_ID
     ? env.GA4_MEASUREMENT_ID
     : null
@@ -108,7 +115,7 @@ export async function loader({ request, url, context }: Route.LoaderArgs) {
     locale,
     user,
     appTheme,
-    updatesNotice: updatesNoticePresentation(noticeState, notice?.slug),
+    updatesNotice,
     maintenance: isMaintenanceRequest(request),
     lastLoginMethod: readLastLoginMethod(request.headers.get('cookie')),
     analyticsConsent,

--- a/apps/web/app/services/dev-screen-state.server.ts
+++ b/apps/web/app/services/dev-screen-state.server.ts
@@ -101,7 +101,9 @@ export async function seedDevScreenState(
   now: string,
 ): Promise<{ containerId: string | null; containerKind: 'inbox' | 'project' }> {
   const seedsRepresentativeFeed =
-    scenario === 'home/content-rich' || scenario === 'project-detail/with-files'
+    scenario === 'home/content-rich' ||
+    scenario === 'home/updates-menu-open' ||
+    scenario === 'project-detail/with-files'
   const needsProject =
     scenario.startsWith('project-detail/') ||
     scenario === 'projects-archived/with-archived-project'
@@ -150,6 +152,7 @@ export async function seedDevScreenState(
 
   if (
     scenario === 'home/content-rich' ||
+    scenario === 'home/updates-menu-open' ||
     scenario === 'home/first-file' ||
     scenario === 'recent/content-rich' ||
     scenario === 'project-detail/with-files' ||

--- a/docs/reference/screen-capture.md
+++ b/docs/reference/screen-capture.md
@@ -14,7 +14,7 @@ pnpm screens:capture -- --screen about --label before
 pnpm screens:capture -- --all --audit-gaps
 ```
 
-`SCREEN_CAPTURE_BASE_URL` overrides the default `https://localhost:5173`. `SCREEN_CAPTURE_CONCURRENCY` controls parallel pages and must be a positive integer. `PLAYWRIGHT_CHANNEL=chrome` uses an installed Chrome; otherwise install Chromium from the web workspace.
+`SCREEN_CAPTURE_BASE_URL` overrides the default `https://localhost:5173`. `SCREEN_CAPTURE_CONCURRENCY` controls parallel pages and must be a positive integer. A screen may declare a lower concurrency limit when its matrix shares a runtime resource; the viewer is captured serially because every state loads the same seeded artifact. `PLAYWRIGHT_CHANNEL=chrome` uses an installed Chrome; otherwise install Chromium from the web workspace.
 
 ## Matrix and output
 

--- a/scripts/check-screen-ledger.test.mjs
+++ b/scripts/check-screen-ledger.test.mjs
@@ -140,6 +140,18 @@ test('accepts a declared screen readiness condition', () =>
     true,
   ))
 
+test('validates a screen capture concurrency limit', () => {
+  const state = [{ id: 'default', setup: {} }]
+  assert.equal(
+    validateLedger([{ ...ledgerScreen(state), captureConcurrency: 1 }]),
+    true,
+  )
+  assert.throws(
+    () => validateLedger([{ ...ledgerScreen(state), captureConcurrency: 0 }]),
+    /capture concurrency must be positive for fixture/,
+  )
+})
+
 test('rejects incomplete or invalid readiness conditions', () => {
   const state = [{ id: 'default', setup: {} }]
   assert.throws(

--- a/scripts/screen-capture.mjs
+++ b/scripts/screen-capture.mjs
@@ -538,13 +538,23 @@ export async function captureScreens({
   }
 
   const concurrency = validatedConcurrency
+  const runPhase = async (pool) => {
+    const regular = pool.filter((job) => !job.screen.captureConcurrency)
+    await runPool(regular, concurrency)
+    for (const screen of selected)
+      if (screen.captureConcurrency)
+        await runPool(
+          pool.filter((job) => job.screen === screen),
+          Math.min(concurrency, screen.captureConcurrency),
+        )
+  }
   try {
     // Seeded states run strictly after the plain pass, and their data
     // mutation happens once, serially, before their own parallel captures.
     const plainJobs = jobs.filter((job) => !job.state.setup?.scenario)
     const seededJobs = jobs.filter((job) => job.state.setup?.scenario)
-    await runPool(plainJobs, concurrency)
-    await runPool(seededJobs, concurrency)
+    await runPhase(plainJobs)
+    await runPhase(seededJobs)
   } finally {
     await browser.close()
   }

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -229,6 +229,7 @@ export const screens = [
     metric: '共有成果物の閲覧と反応を増やす',
     role: '共有された成果物を閲覧する',
     primaryAction: '成果物を確認する',
+    captureConcurrency: 1,
     ready: {
       selector: '[data-sandbox-state="ready"]',
       description: 'sandbox frame ready',
@@ -290,6 +291,7 @@ export const screens = [
         id: 'updates-menu-open',
         description: '新着の更新情報をアバターメニューで確認した状態',
         setup: {
+          scenario: 'home/updates-menu-open',
           interactions: [
             {
               action: 'click',
@@ -727,6 +729,12 @@ export function validateLedger(
       throw new Error(`invalid loop for ${screen.id}`)
     if (!Array.isArray(screen.states) || screen.states.length === 0)
       throw new Error(`states required for ${screen.id}`)
+    if (
+      screen.captureConcurrency !== undefined &&
+      (!Number.isInteger(screen.captureConcurrency) ||
+        screen.captureConcurrency < 1)
+    )
+      throw new Error(`capture concurrency must be positive for ${screen.id}`)
     if (screen.ready) {
       if (!screen.ready.selector?.trim())
         throw new Error(`ready selector required for ${screen.id}`)

--- a/scripts/screen-scenarios.json
+++ b/scripts/screen-scenarios.json
@@ -1,5 +1,6 @@
 [
   "home/content-rich",
+  "home/updates-menu-open",
   "home/empty",
   "home/first-file",
   "recent/content-rich",


### PR DESCRIPTION
## 現状

UI批評用の画面撮影で、更新通知の表示が公開日からの日数に依存していました。また、viewerの各状態が同じseed artifactを並列に読み込むと、sandbox ready handshakeが不安定になることがありました。

## 変更

- 更新通知メニューを期限に依存しないdev screen scenarioで固定
- viewerに画面固有のcapture concurrency 1を宣言
- concurrencyの検証、capture scheduler、回帰テスト、参照ドキュメントを更新

## 検証

- `pnpm validate:static`
- UI批評対象5画面のcapture: 64 succeeded, 0 failed
- Codex implementation review: 指摘なし
- Claude implementation review: 指摘なし
