### PR TITLE
Complete recent-return dev scenario

### DIFF
--- a/apps/web/app/routes/dev.sign-in.test.tsx
+++ b/apps/web/app/routes/dev.sign-in.test.tsx
@@ -64,6 +64,14 @@ describe('/dev/sign-in loader', () => {
     })
   })
 
+  test('keeps an explicit Home next path', async () => {
+    const result = await loader({
+      request: new Request('https://artifactshare.test/dev/sign-in?next=%2F'),
+    } as never)
+
+    expect(result.next).toBe('/')
+  })
+
   test('sanitizes an unsafe next path to general settings', async () => {
     isViteDevMock.mockReturnValueOnce(true)
 

--- a/apps/web/app/routes/dev.sign-in.tsx
+++ b/apps/web/app/routes/dev.sign-in.tsx
@@ -16,8 +16,9 @@ import scenarioIds from '../../../../scripts/screen-scenarios.json'
 const DEFAULT_NEXT = '/settings/general'
 
 function safeDevSignInTarget(next: unknown): string {
+  if (next == null) return DEFAULT_NEXT
   const path = safeInternalNext(next)
-  return path === '/' ? DEFAULT_NEXT : path
+  return path === '/' && next !== '/' ? DEFAULT_NEXT : path
 }
 
 function appendSetCookies(from: Response, headers: Headers): void {

--- a/apps/web/app/services/auth.server.ts
+++ b/apps/web/app/services/auth.server.ts
@@ -69,6 +69,7 @@ import {
   devScreenUserEmail,
   ensureDevScreenState,
   isScreenScenario,
+  seedDevScreenArtifactBodies,
   seedDevScreenState,
 } from './dev-screen-state.server'
 
@@ -1676,6 +1677,14 @@ export async function ensureDevSignInUser(
   const seed = scenario
     ? await seedDevScreenState(db, scenario, workspaceId, userId, now)
     : { containerId: null, containerKind: null }
+  if (scenario) {
+    await seedDevScreenArtifactBodies(
+      (env as { BUCKET?: R2Bucket }).BUCKET,
+      scenario,
+      workspaceId,
+      userId,
+    )
+  }
   return {
     userId,
     workspaceId,

--- a/apps/web/app/services/dev-screen-state.server.test.ts
+++ b/apps/web/app/services/dev-screen-state.server.test.ts
@@ -10,6 +10,7 @@ import {
   ensureDevScreenState,
   isDevScreenStateRequest,
   isScreenScenario,
+  seedDevScreenArtifactBodies,
   seedDevScreenState,
 } from './dev-screen-state.server'
 import {
@@ -47,6 +48,98 @@ describe('recent content-rich dev screen state', () => {
 
   afterEach(async () => {
     await db?.destroy()
+  })
+
+  test('stores viewer bodies only for the successful task artifacts', async () => {
+    const put = vi.fn().mockResolvedValue(undefined)
+
+    await seedDevScreenArtifactBodies(
+      { put } as unknown as Pick<R2Bucket, 'put'>,
+      'recent/content-rich',
+      'workspace',
+      'viewer',
+    )
+
+    expect(put.mock.calls.map(([key]) => key)).toEqual([
+      'dev-screen/workspace-viewer-file-1-v1',
+      'dev-screen/workspace-viewer-file-21-v1',
+      'dev-screen/workspace-viewer-file-21-v2',
+    ])
+    expect(put.mock.calls[2][1]).toContain('今回の更新')
+    expect(put.mock.calls[2][2]).toEqual({
+      httpMetadata: { contentType: 'text/html; charset=utf-8' },
+    })
+
+    put.mockClear()
+    await seedDevScreenArtifactBodies(
+      { put } as unknown as Pick<R2Bucket, 'put'>,
+      'home/content-rich',
+      'workspace',
+      'viewer',
+    )
+    expect(put).not.toHaveBeenCalled()
+  })
+
+  test('distinguishes a working two-version artifact from missing body and source states', async () => {
+    ;({ db } = createMigratedInMemoryDb())
+    const now = '2026-07-31T12:00:00.000Z'
+    const { workspaceId } = await ensureDevScreenState(
+      db,
+      'recent/content-rich',
+      now,
+      'plus',
+    )
+    const userId = `${workspaceId}-user`
+    await db
+      .insertInto('users')
+      .values({
+        id: userId,
+        email: 'dev-user@example.com',
+        email_verified: 1,
+        name: 'Viewer',
+        image: null,
+        created_at: now,
+        updated_at: now,
+        workspace_id: workspaceId,
+        locale: null,
+      })
+      .execute()
+
+    await seedDevScreenState(
+      db,
+      'recent/content-rich',
+      workspaceId,
+      userId,
+      now,
+    )
+
+    const shareableIds = [19, 20, 21].map(
+      (number) => `${workspaceId}-${userId}-file-${number}`,
+    )
+    const shareables = await db
+      .selectFrom('shareables')
+      .select(['id', 'current_version_id'])
+      .where('id', 'in', shareableIds)
+      .orderBy('id')
+      .execute()
+    const versions = await db
+      .selectFrom('versions')
+      .select(['id', 'shareable_id', 'published_at'])
+      .where('shareable_id', 'in', shareableIds)
+      .orderBy('id')
+      .execute()
+
+    expect(shareables).toEqual([
+      { id: shareableIds[0], current_version_id: null },
+      { id: shareableIds[1], current_version_id: `${shareableIds[1]}-v1` },
+      { id: shareableIds[2], current_version_id: `${shareableIds[2]}-v2` },
+    ])
+    expect(versions.map(({ id }) => id)).toEqual([
+      `${shareableIds[1]}-v1`,
+      `${shareableIds[2]}-v1`,
+      `${shareableIds[2]}-v2`,
+    ])
+    expect(versions.at(-1)?.published_at).toBe('2026-07-31T11:30:00.000Z')
   })
 
   test('seeds unread comments and resets recency and comment data on reseed', async () => {
@@ -98,12 +191,12 @@ describe('recent content-rich dev screen state', () => {
       status: 'published',
       entrypoint_path: '/index.html',
       r2_key: `dev-screen/${shareableId}-v1`,
-      size_bytes: 1,
       sha256: `${shareableId}-v1`,
       created_by_id: userId,
       created_at: '2026-07-31T12:00:00.000Z',
       published_at: '2026-07-31T12:00:00.000Z',
     })
+    expect(version.size_bytes).toBeGreaterThan(1)
     expect(shareable.current_version_id).toBe(`${shareableId}-v1`)
     const recency = await db
       .selectFrom('shareable_viewer_recency')

--- a/apps/web/app/services/dev-screen-state.server.ts
+++ b/apps/web/app/services/dev-screen-state.server.ts
@@ -40,6 +40,66 @@ export function devScreenUserEmail(persona: string, scenario: string): string {
   return `dev-${persona}+${scenario.replaceAll('/', '-')}@artifactshare.local`
 }
 
+const RECENT_CONTENT_RICH_BODIES = {
+  quarterlyReport: {
+    version: 'v1',
+    html: `<!doctype html><html lang="ja"><head><meta charset="utf-8"><title>Quarterly report</title></head><body><main><h1>Quarterly report</h1><p>第2四半期の結果と、次の四半期に向けた見通しをまとめています。</p><h2>部門別の推移</h2><p>プロダクト部門は前月比12%増、営業部門は前月比8%増でした。</p></main></body></html>`,
+  },
+  archivedReview21: [
+    {
+      version: 'v1',
+      html: `<!doctype html><html lang="ja"><head><meta charset="utf-8"><title>Archived review 21</title></head><body><main><h1>Archived review 21</h1><p>前回閲覧時のレビュー記録です。</p><h2>確認事項</h2><p>公開前に担当者と日程を確認します。</p></main></body></html>`,
+    },
+    {
+      version: 'v2',
+      html: `<!doctype html><html lang="ja"><head><meta charset="utf-8"><title>Archived review 21</title></head><body><main><h1>Archived review 21</h1><p>前回閲覧後に更新されたレビュー記録です。</p><h2>確認事項</h2><p>担当者の確認が完了し、公開日を8月20日に決定しました。</p><h2>今回の更新</h2><p>公開日と最終確認の結果を追記しました。</p></main></body></html>`,
+    },
+  ],
+} as const
+
+function recentContentRichBody(
+  index: number,
+  version: 'v1' | 'v2',
+): string | null {
+  if (index === 0 && version === 'v1')
+    return RECENT_CONTENT_RICH_BODIES.quarterlyReport.html
+  if (index === 20)
+    return (
+      RECENT_CONTENT_RICH_BODIES.archivedReview21.find(
+        (entry) => entry.version === version,
+      )?.html ?? null
+    )
+  return null
+}
+
+/** Stores the deterministic viewer bodies owned by the recent task scenario. */
+export async function seedDevScreenArtifactBodies(
+  bucket: Pick<R2Bucket, 'put'> | undefined,
+  scenario: string,
+  workspaceId: string,
+  userId: string,
+): Promise<void> {
+  if (!bucket || scenario !== 'recent/content-rich') return
+  const shareablePrefix = `${workspaceId}-${userId}-file`
+  const bodies = [
+    {
+      key: `dev-screen/${shareablePrefix}-1-${RECENT_CONTENT_RICH_BODIES.quarterlyReport.version}`,
+      html: RECENT_CONTENT_RICH_BODIES.quarterlyReport.html,
+    },
+    ...RECENT_CONTENT_RICH_BODIES.archivedReview21.map(({ version, html }) => ({
+      key: `dev-screen/${shareablePrefix}-21-${version}`,
+      html,
+    })),
+  ]
+  await Promise.all(
+    bodies.map(({ key, html }) =>
+      bucket.put(key, html, {
+        httpMetadata: { contentType: 'text/html; charset=utf-8' },
+      }),
+    ),
+  )
+}
+
 /** Creates the isolated workspace anchor used by screen-capture scenarios. */
 export async function ensureDevScreenState(
   db: Kysely<DB>,
@@ -214,41 +274,67 @@ export async function seedDevScreenState(
           .onConflict((oc) => oc.column('id').doNothing())
           .execute()
         if (scenario === 'recent/content-rich') {
-          if (index === 0) {
-            const versionId = `${shareableId}-v1`
-            await db
-              .insertInto('versions')
-              .values({
-                id: versionId,
-                shareable_id: shareableId,
-                artifact_kind: 'html_page',
-                status: 'published',
-                entrypoint_path: '/index.html',
-                r2_key: `dev-screen/${versionId}`,
-                size_bytes: 1,
-                sha256: versionId,
-                created_by_id: userId,
-                created_at: timestamp,
-                published_at: timestamp,
-              })
-              .onConflict((oc) =>
-                oc.column('id').doUpdateSet({
+          const versionNames =
+            index === 20
+              ? (['v1', 'v2'] as const)
+              : index === 0 || index === 19
+                ? (['v1'] as const)
+                : []
+          if (versionNames.length > 0) {
+            for (const versionName of versionNames) {
+              const versionId = `${shareableId}-${versionName}`
+              const isUpdatedVersion = index === 20 && versionName === 'v2'
+              const versionTimestamp = isUpdatedVersion
+                ? new Date(Date.parse(now) - 30 * 60_000).toISOString()
+                : timestamp
+              const body = recentContentRichBody(index, versionName)
+              const sizeBytes = body
+                ? new TextEncoder().encode(body).byteLength
+                : 1
+              await db
+                .insertInto('versions')
+                .values({
+                  id: versionId,
                   shareable_id: shareableId,
                   artifact_kind: 'html_page',
                   status: 'published',
                   entrypoint_path: '/index.html',
                   r2_key: `dev-screen/${versionId}`,
-                  size_bytes: 1,
+                  size_bytes: sizeBytes,
                   sha256: versionId,
                   created_by_id: userId,
-                  created_at: timestamp,
-                  published_at: timestamp,
-                }),
-              )
-              .execute()
+                  created_at: versionTimestamp,
+                  published_at: versionTimestamp,
+                })
+                .onConflict((oc) =>
+                  oc.column('id').doUpdateSet({
+                    shareable_id: shareableId,
+                    artifact_kind: 'html_page',
+                    status: 'published',
+                    entrypoint_path: '/index.html',
+                    r2_key: `dev-screen/${versionId}`,
+                    size_bytes: sizeBytes,
+                    sha256: versionId,
+                    created_by_id: userId,
+                    created_at: versionTimestamp,
+                    published_at: versionTimestamp,
+                  }),
+                )
+                .execute()
+            }
+            const currentVersionId = `${shareableId}-${versionNames.at(-1)}`
             await db
               .updateTable('shareables')
-              .set({ current_version_id: versionId })
+              .set({
+                current_version_id: currentVersionId,
+                ...(index === 20
+                  ? {
+                      updated_at: new Date(
+                        Date.parse(now) - 30 * 60_000,
+                      ).toISOString(),
+                    }
+                  : {}),
+              })
               .where('id', '=', shareableId)
               .execute()
           }

--- a/apps/web/dev.mjs
+++ b/apps/web/dev.mjs
@@ -1,5 +1,9 @@
 import { spawn } from 'node:child_process'
-import { prepareDevEnvironment } from '../../scripts/dev-setup.mjs'
+import {
+  DEV_SERVICES,
+  prepareDevEnvironment,
+  selectMissingDevServices,
+} from '../../scripts/dev-setup.mjs'
 
 const environment = prepareDevEnvironment({ reset: false })
 if (!environment.ok) {
@@ -11,17 +15,21 @@ if (!environment.ok) {
 }
 environment.actions.forEach((action) => console.log(action))
 
-const commands = [
-  ['og-image', ['pnpm', 'dev:og-image']],
-  ['app', ['pnpm', 'dev:app']],
-  ['sandbox', ['pnpm', 'dev:sandbox']],
-]
+const { missing, reused } = await selectMissingDevServices(DEV_SERVICES)
+for (const service of reused) {
+  console.log(`Reusing ${service.name} at ${service.origin}`)
+}
 
 const children = new Set()
+const reuseOnlyHeartbeat =
+  missing.length === 0 ? setInterval(() => {}, 60_000) : null
 let shuttingDown = false
 let exitCode = 0
 
-for (const [name, [command, ...args]] of commands) {
+for (const {
+  name,
+  command: [command, ...args],
+} of missing) {
   const child = spawn(command, args, {
     stdio: 'inherit',
     env: process.env,
@@ -75,6 +83,7 @@ function stopChildren(except) {
 
 function maybeExit() {
   if (children.size === 0) {
+    if (reuseOnlyHeartbeat) clearInterval(reuseOnlyHeartbeat)
     process.exit(exitCode)
   }
 }

--- a/docs/reference/local-dev-harness.md
+++ b/docs/reference/local-dev-harness.md
@@ -16,6 +16,11 @@ The command prepares local inputs and then starts three HTTPS services:
 | Artifact sandbox | `https://*.sandbox.localhost:5174` |
 | Open Graph image worker | `https://localhost:5175` |
 
+If one or more of these services already responds on its expected origin, the
+launcher reuses it and starts only the missing siblings. Stopping that launcher
+terminates only the processes it started, so starting a missing sandbox does not
+replace or stop an existing application process.
+
 Local bindings are forced local with `remoteBindings: false`. Development must not depend on a Cloudflare login or production resources.
 
 Before starting a worker, the launcher runs the same preparation as `pnpm dev:setup`:

--- a/scripts/dev-setup.mjs
+++ b/scripts/dev-setup.mjs
@@ -1,5 +1,7 @@
 import { randomBytes } from 'node:crypto'
 import { execFileSync } from 'node:child_process'
+import { request } from 'node:https'
+import { connect } from 'node:net'
 import {
   mkdtempSync,
   existsSync,
@@ -41,6 +43,127 @@ const RECOVERY_COMMANDS = {
 const ROOT = resolve(import.meta.dirname, '..')
 const APP = join(ROOT, 'apps/web')
 const SCHEMA = join(APP, 'db/schema.sql')
+
+export const DEV_SERVICES = [
+  {
+    name: 'og-image',
+    origin: 'https://localhost:5175',
+    path: '/',
+    expected: { status: 404, contentType: 'text/plain', body: 'not found' },
+    command: ['pnpm', 'dev:og-image'],
+  },
+  {
+    name: 'app',
+    origin: 'https://localhost:5173',
+    path: '/dev/sign-in',
+    expected: {
+      status: 200,
+      contentType: 'text/html',
+      body: 'Local dev sign-in',
+    },
+    command: ['pnpm', 'dev:app'],
+  },
+  {
+    name: 'sandbox',
+    origin: 'https://localhost:5174',
+    path: '/',
+    headers: { 'mf-original-hostname': 'probe.sandbox.localhost' },
+    expected: {
+      status: 401,
+      contentType: 'text/plain',
+      body: 'Invalid token',
+    },
+    command: ['pnpm', 'dev:sandbox'],
+  },
+]
+
+export async function selectMissingDevServices(services, probe = probeHttps) {
+  const states = await Promise.all(
+    services.map(async (service) => ({
+      service,
+      available: await probe(service),
+    })),
+  )
+  return states.reduce(
+    (result, { service, available }) => {
+      result[available ? 'reused' : 'missing'].push(service)
+      return result
+    },
+    { missing: [], reused: [] },
+  )
+}
+
+function probeHttps(service) {
+  return new Promise((finish, reject) => {
+    const req = request(
+      new URL(service.path, service.origin),
+      {
+        method: 'GET',
+        rejectUnauthorized: false,
+        headers: service.headers,
+        timeout: 1_000,
+      },
+      (response) => {
+        response.setEncoding('utf8')
+        let body = ''
+        response.on('data', (chunk) => {
+          body += chunk
+        })
+        response.on('end', () => {
+          const actual = {
+            status: response.statusCode,
+            contentType: response.headers['content-type'],
+            body,
+          }
+          if (serviceIdentityMatches(service.expected, actual)) finish(true)
+          else
+            reject(
+              new Error(
+                `${service.name} origin ${service.origin} is occupied by an unexpected HTTPS service`,
+              ),
+            )
+        })
+      },
+    )
+    req.on('timeout', () => req.destroy())
+    req.on('error', async () => {
+      if (await portIsOpen(service.origin))
+        reject(
+          new Error(
+            `${service.name} origin ${service.origin} is occupied but did not answer as the expected HTTPS service`,
+          ),
+        )
+      else finish(false)
+    })
+    req.end()
+  })
+}
+
+export function serviceIdentityMatches(expected, actual) {
+  return (
+    actual.status === expected.status &&
+    actual.contentType?.startsWith(expected.contentType) === true &&
+    actual.body.includes(expected.body)
+  )
+}
+
+function portIsOpen(origin) {
+  const url = new URL(origin)
+  return new Promise((finish) => {
+    const socket = connect(Number(url.port), url.hostname)
+    socket.setTimeout(250)
+    socket.on('connect', () => {
+      socket.destroy()
+      finish(true)
+    })
+    socket.on('timeout', () => {
+      socket.destroy()
+      finish(false)
+    })
+    socket.on('error', () => finish(false))
+  })
+}
+
 function normalizeSql(sql) {
   return withoutSqlComments(sql).replace(/\s+/g, ' ').trim()
 }

--- a/scripts/dev-setup.test.mjs
+++ b/scripts/dev-setup.test.mjs
@@ -21,8 +21,65 @@ import {
   assertSupportedSchema,
   normalizeDefinition,
   configArgs,
+  DEV_SERVICES,
   parseCliArgs,
+  selectMissingDevServices,
+  serviceIdentityMatches,
 } from './dev-setup.mjs'
+
+test('dev launcher reuses healthy services and starts only missing siblings', async () => {
+  const { missing, reused } = await selectMissingDevServices(
+    DEV_SERVICES,
+    ({ name }) => name === 'app',
+  )
+
+  assert.deepEqual(
+    reused.map(({ name }) => name),
+    ['app'],
+  )
+  assert.deepEqual(
+    missing.map(({ name }) => name),
+    ['og-image', 'sandbox'],
+  )
+})
+
+test('dev launcher starts the complete topology when no service is running', async () => {
+  const { missing, reused } = await selectMissingDevServices(
+    DEV_SERVICES,
+    () => false,
+  )
+
+  assert.equal(reused.length, 0)
+  assert.deepEqual(
+    missing.map(({ name }) => name),
+    ['og-image', 'app', 'sandbox'],
+  )
+})
+
+test('dev launcher accepts only the expected service identity', () => {
+  const expected = {
+    status: 200,
+    contentType: 'text/html',
+    body: 'Local dev sign-in',
+  }
+
+  assert.equal(
+    serviceIdentityMatches(expected, {
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: '<h1>Local dev sign-in</h1>',
+    }),
+    true,
+  )
+  assert.equal(
+    serviceIdentityMatches(expected, {
+      status: 200,
+      contentType: 'text/html',
+      body: '<h1>Another application</h1>',
+    }),
+    false,
+  )
+})
 
 test('configArgs uses the shared default persist directory', () => {
   assert.deepEqual(configArgs('app'), [


### PR DESCRIPTION
## Summary

- make the `recent/content-rich` development scenario exercise viewer bodies, version history, comments, and intentional unavailable states
- preserve an explicit Home return target during development sign-in
- reuse verified local development services and stop only processes started by the current launcher

## Verification

- `pnpm validate:static`
- dual implementation review on the final commit
- manually verified partial and fully reused `pnpm dev` topologies
- confirmed app and sandbox remain available after stopping the reuse launcher
