### PR TITLE
Capture viewer return states

### DIFF
--- a/scripts/check-screen-ledger.test.mjs
+++ b/scripts/check-screen-ledger.test.mjs
@@ -4,7 +4,9 @@ import { checkScreenLedger, hasDefaultExport } from './check-screen-ledger.mjs'
 import {
   CaptureFailure,
   assertNoRouteError,
+  browserLaunchOptions,
   navigateForCapture,
+  pathFor,
   waitForInteractionTarget,
   captureFailure,
   screenStateRequestHeaders,
@@ -124,6 +126,59 @@ test('rejects an unknown screen scenario', () =>
       ]),
     /unknown scenario: unknown\/scenario/,
   ))
+
+test('requires a valid scenario for a scenario artifact index', () => {
+  assert.throws(
+    () =>
+      validateLedger([
+        ledgerScreen([{ id: 'default', setup: { scenarioArtifactIndex: 1 } }]),
+      ]),
+    /scenario artifact index requires a scenario and a positive integer/,
+  )
+  assert.throws(
+    () =>
+      validateLedger([
+        ledgerScreen([
+          {
+            id: 'default',
+            setup: {
+              scenario: 'recent/content-rich',
+              scenarioArtifactIndex: 0,
+            },
+          },
+        ]),
+      ]),
+    /scenario artifact index requires a scenario and a positive integer/,
+  )
+})
+
+test('routes a seeded state to its scenario artifact', () => {
+  const path = pathFor(
+    { route: { en: '/a/{seed:artifact}' }, auth: 'free-owner' },
+    'en',
+    {
+      artifact: 'generic-artifact',
+      project: null,
+      update: 'latest',
+      scenarioCookies: {
+        'free-owner:recent/content-rich': {
+          workspaceId: 'workspace',
+          userId: 'viewer',
+          containerKind: 'inbox',
+          containerId: 'container',
+        },
+      },
+    },
+    {
+      setup: {
+        scenario: 'recent/content-rich',
+        scenarioArtifactIndex: 21,
+      },
+    },
+  )
+
+  assert.equal(path, '/a/workspace-viewer-file-21')
+})
 
 test('accepts a declared screen readiness condition', () =>
   assert.equal(
@@ -352,6 +407,16 @@ test('adds the scenario header only to a seeded state job', () => {
       'X-ArtifactShare-Dev-Screen-State': 'settings-billing/subscribed',
     },
   )
+})
+
+test('maps local sandbox hostnames for both bundled and installed browsers', () => {
+  assert.deepEqual(browserLaunchOptions(undefined), {
+    args: ['--host-resolver-rules=MAP *.sandbox.localhost 127.0.0.1'],
+  })
+  assert.deepEqual(browserLaunchOptions('chrome'), {
+    channel: 'chrome',
+    args: ['--host-resolver-rules=MAP *.sandbox.localhost 127.0.0.1'],
+  })
 })
 
 test('keeps the scenario allowlist and ledger references in sync', () => {

--- a/scripts/screen-capture.mjs
+++ b/scripts/screen-capture.mjs
@@ -126,6 +126,13 @@ export function screenStateRequestHeaders(state) {
     : {}
 }
 
+export function browserLaunchOptions(channel) {
+  return {
+    ...(channel ? { channel } : {}),
+    args: ['--host-resolver-rules=MAP *.sandbox.localhost 127.0.0.1'],
+  }
+}
+
 // The local dev server uses a self-signed certificate; global fetch rejects it.
 const requireFromCli = createRequire(
   join(dirname(fileURLToPath(import.meta.url)), '../packages/cli/package.json'),
@@ -154,6 +161,7 @@ async function signIn(baseUrl, persona, scenario) {
     cookie,
     cookies,
     cookieHeader: cookieHeader(cookies),
+    userId: body?.userId ?? null,
     workspaceId: body?.workspaceId ?? null,
     containerId: body?.containerId ?? null,
     containerKind: body?.containerKind ?? null,
@@ -305,7 +313,7 @@ function parseArgs(argv) {
   return { selected, label, auditGaps }
 }
 
-function pathFor(screen, locale, seeds, state) {
+export function pathFor(screen, locale, seeds, state) {
   const scenarioContainer = state.setup?.scenario
     ? seeds.scenarioCookies?.[`${screen.auth}:${state.setup.scenario}`]
     : null
@@ -315,8 +323,12 @@ function pathFor(screen, locale, seeds, state) {
     scenarioContainer?.containerKind === 'project'
       ? scenarioContainer.containerId
       : seeds.project
+  const scenarioArtifactIndex = state.setup?.scenarioArtifactIndex
+  const artifactId = scenarioArtifactIndex
+    ? `${scenarioContainer.workspaceId}-${scenarioContainer.userId}-file-${scenarioArtifactIndex}`
+    : seeds.artifact
   return screen.route[locale]
-    .replace('{seed:artifact}', seeds.artifact)
+    .replace('{seed:artifact}', artifactId)
     .replace('{seed:project}', projectId)
     .replace('{seed:update}', seeds.update)
 }
@@ -360,9 +372,7 @@ export async function captureScreens({
   let browser
   try {
     browser = await playwright.chromium.launch(
-      process.env.PLAYWRIGHT_CHANNEL
-        ? { channel: process.env.PLAYWRIGHT_CHANNEL }
-        : undefined,
+      browserLaunchOptions(process.env.PLAYWRIGHT_CHANNEL),
     )
   } catch (error) {
     if (

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -261,6 +261,42 @@ export const screens = [
           ],
         },
       },
+      {
+        id: 'comments-open',
+        description: '最近見た成果物のコメントパネルを開いた状態',
+        setup: {
+          scenario: 'recent/content-rich',
+          scenarioArtifactIndex: 1,
+          interactions: [
+            {
+              action: 'click',
+              selector: 'button[aria-label="Comments"]',
+            },
+          ],
+        },
+      },
+      {
+        id: 'updated-return',
+        description: '前回閲覧後に更新された2版の成果物へ戻った状態',
+        setup: {
+          scenario: 'recent/content-rich',
+          scenarioArtifactIndex: 21,
+        },
+      },
+      {
+        id: 'updated-version-menu',
+        description: '前回閲覧後に更新された成果物の版メニューを開いた状態',
+        setup: {
+          scenario: 'recent/content-rich',
+          scenarioArtifactIndex: 21,
+          interactions: [
+            {
+              action: 'click',
+              selector: 'button[aria-label="Version status: v2"]',
+            },
+          ],
+        },
+      },
     ],
   },
   {
@@ -759,6 +795,15 @@ export function validateLedger(
       stateIds.add(state.id)
       if (state.setup?.scenario && !scenarioAllowlist.has(state.setup.scenario))
         throw new Error(`unknown scenario: ${state.setup.scenario}`)
+      if (
+        state.setup?.scenarioArtifactIndex !== undefined &&
+        (!state.setup.scenario ||
+          !Number.isInteger(state.setup.scenarioArtifactIndex) ||
+          state.setup.scenarioArtifactIndex < 1)
+      )
+        throw new Error(
+          `scenario artifact index requires a scenario and a positive integer: ${screen.id}/${state.id}`,
+        )
     }
   }
   return true


### PR DESCRIPTION
## Summary

- let registered viewer captures target deterministic artifacts from a development scenario
- add comment-open, updated-return, and updated-version-menu viewer states
- map local sandbox hostnames explicitly so long scenario artifact hosts render in capture Chromium

## Verification

- `pnpm validate:static`
- `pnpm screens:capture -- --screen viewer --label viewer-return-states` (24 succeeded, 0 failed)
- Codex and Claude implementation reviews
