### PR TITLE
Expire CLI rotation rollout compatibility

### DIFF
--- a/apps/web/app/services/cli-refresh-credentials.server.test.ts
+++ b/apps/web/app/services/cli-refresh-credentials.server.test.ts
@@ -649,7 +649,7 @@ describe('cli-refresh-credentials service', () => {
     )
   })
 
-  test('keeps live and incomplete replay rows fail closed', async () => {
+  test('keeps live replay rows and clears expired partial replay material', async () => {
     const issued = await issueCliRefreshCredential(db, 'u1')
     const rotated = await refreshCliSession(
       db,
@@ -677,7 +677,7 @@ describe('cli-refresh-credentials service', () => {
       .run()
     await expect(
       cleanupExpiredCliRotationReplays(db, '2026-08-09T00:00:00.000Z'),
-    ).resolves.toBe(0)
+    ).resolves.toBe(1)
     const incomplete = sqlite
       .prepare(
         `SELECT rotation_request_hash, rotation_retry_until
@@ -685,8 +685,8 @@ describe('cli-refresh-credentials service', () => {
          WHERE replaced_by_id IS NOT NULL`,
       )
       .get() as Record<string, string | null>
-    expect(incomplete.rotation_request_hash).not.toBeNull()
-    expect(incomplete.rotation_retry_until).not.toBeNull()
+    expect(incomplete.rotation_request_hash).toBeNull()
+    expect(incomplete.rotation_retry_until).toBeNull()
   })
 
   test('concurrent refreshes with one rotation id converge on one credential', async () => {
@@ -794,7 +794,7 @@ describe('cli-refresh-credentials service', () => {
     })
   })
 
-  test('revokes pre-link CLI sessions without revoking browser or other-family sessions', async () => {
+  test('single-family revoke only deletes sessions linked to that family', async () => {
     const first = await issueCliRefreshCredential(db, 'u1')
     const second = await issueCliRefreshCredential(db, 'u1')
     const secondSession = await refreshCliSession(
@@ -818,13 +818,18 @@ describe('cli-refresh-credentials service', () => {
       .run()
 
     expect(await revokeCliRefreshCredential(db, first.refreshToken)).toBe('ok')
-    expect(
-      sqlite.prepare('SELECT token FROM sessions ORDER BY token').all(),
-    ).toEqual([
-      { token: secondSession.sessionToken },
-      { token: 'browser-session' },
-      { token: 'pending-device-login' },
-    ])
+    const remainingSessions = sqlite
+      .prepare('SELECT token FROM sessions ORDER BY token')
+      .all()
+    expect(remainingSessions).toHaveLength(4)
+    expect(remainingSessions).toEqual(
+      expect.arrayContaining([
+        { token: 'ass_pre_link' },
+        { token: secondSession.sessionToken },
+        { token: 'browser-session' },
+        { token: 'pending-device-login' },
+      ]),
+    )
   })
 
   test('fails closed when legacy data has a null family id', async () => {
@@ -914,7 +919,7 @@ describe('cli-refresh-credentials service', () => {
     expect(readActiveRefreshFamilies(sqlite)).toHaveLength(0)
   })
 
-  test('revoking one listed family removes unattributable legacy sessions', async () => {
+  test('revoking one listed family preserves unattributable sessions', async () => {
     await issueCliRefreshCredential(db, 'u1')
     const [familyId] = readRefreshFamilies(sqlite)
     sqlite
@@ -928,7 +933,9 @@ describe('cli-refresh-credentials service', () => {
 
     await revokeCliRefreshCredentialFamily(db, 'u1', familyId!)
 
-    expect(sqlite.prepare('SELECT token FROM sessions').all()).toEqual([])
+    expect(sqlite.prepare('SELECT token FROM sessions').all()).toEqual([
+      { token: 'ass_legacy_other' },
+    ])
   })
 
   test('revokes all of the current user families', async () => {

--- a/apps/web/app/services/cli-refresh-credentials.server.ts
+++ b/apps/web/app/services/cli-refresh-credentials.server.ts
@@ -66,8 +66,6 @@ export async function cleanupExpiredCliRotationReplays(
     })
     .where('rotation_retry_until', '<=', now)
     .where('rotation_request_hash', 'is not', null)
-    .where('rotation_session_id', 'is not', null)
-    .where('replaced_by_id', 'is not', null)
     .where('revoked_at', 'is not', null)
     .executeTakeFirst()
   return Number(result.numUpdatedRows)
@@ -884,7 +882,6 @@ export async function revokeCliRefreshCredential(
     reason: 'logout',
     auditSubjectId: row.id,
     auditSubjectType: 'cli_refresh_credential',
-    deleteUnlinkedSessions: true,
   })
   return 'ok'
 }
@@ -943,7 +940,6 @@ export async function revokeCliRefreshCredentialFamily(
     targetUserId: userId,
     familyId,
     reason: 'self',
-    deleteUnlinkedSessions: true,
   })
 }
 
@@ -1008,7 +1004,6 @@ type SingleFamilyRevokeInput = {
   reason: CliCredentialRevokeReason
   auditSubjectId?: string
   auditSubjectType?: string
-  deleteUnlinkedSessions?: boolean
 }
 
 function authorizedTargetQuery(
@@ -1245,32 +1240,6 @@ async function revokeCliRefreshCredentialFamilyAtomic(
         .where('family_id', '=', input.familyId),
     )
     .where(({ exists }) => exists(matchingFamily))
-  const unlinkedSessions = db
-    .deleteFrom('sessions')
-    // A device-login session belongs to a future family, so a single-family
-    // revoke must not terminate another machine between login and linking.
-    .where(
-      'id',
-      'in',
-      db
-        .selectFrom('sessions')
-        .select('sessions.id')
-        .where('sessions.user_id', '=', input.targetUserId)
-        .where(
-          sql<boolean>`substr(sessions.token, 1, 4) = ${SESSION_TOKEN_PREFIX}`,
-        )
-        .where((eb) =>
-          eb.not(
-            eb.exists(
-              eb
-                .selectFrom('cli_refresh_sessions')
-                .select('session_id')
-                .whereRef('session_id', '=', 'sessions.id'),
-            ),
-          ),
-        ),
-    )
-    .where(({ exists }) => exists(matchingFamily))
   const credentials = db
     .updateTable('cli_refresh_credentials')
     .set({ revoked_at: now })
@@ -1280,7 +1249,6 @@ async function revokeCliRefreshCredentialFamilyAtomic(
     .where(({ exists }) => exists(matchingFamily))
   const statements = [
     credentialRevokeAudit(db, input, now),
-    ...(input.deleteUnlinkedSessions ? [unlinkedSessions] : []),
     linkedSessions,
     credentials,
   ]

--- a/apps/web/app/test/migrations.test.ts
+++ b/apps/web/app/test/migrations.test.ts
@@ -2543,6 +2543,24 @@ describe('database migrations', () => {
     })
   })
 
+  test('0085 indexes only rows that may contain expired replay material', () => {
+    sqlite = new DatabaseSync(':memory:')
+    sqlite.exec('PRAGMA foreign_keys = ON')
+    applyMigrations(sqlite)
+
+    const index = sqlite
+      .prepare(
+        `SELECT sql FROM sqlite_master
+         WHERE type = 'index'
+           AND name = 'cli_refresh_credentials_rotation_retry_until'`,
+      )
+      .get() as { sql: string }
+
+    expect(index.sql).toContain('rotation_retry_until')
+    expect(index.sql).toContain('rotation_request_hash IS NOT NULL')
+    expect(index.sql).toContain('revoked_at IS NOT NULL')
+  })
+
   describe('0084 bot users', () => {
     function migrateUpTo0084(seedBefore?: (db: DatabaseSync) => void) {
       const db = new DatabaseSync(':memory:')

--- a/apps/web/db/migrations/0085_cli_rotation_replay_cleanup.sql
+++ b/apps/web/db/migrations/0085_cli_rotation_replay_cleanup.sql
@@ -1,0 +1,11 @@
+-- Migration: 0085_cli_rotation_replay_cleanup
+-- Created: 2026-08-16
+-- Description: Keep bounded rotation replay cleanup indexed after rollout.
+-- Mirrors db/schema.sql; keep both in sync.
+-- Refresh-session linkage shipped on 2026-08-09. Its seven-day session TTL
+-- elapsed before this rollout cleanup removed the pre-link revoke fallback.
+
+CREATE INDEX cli_refresh_credentials_rotation_retry_until
+  ON cli_refresh_credentials(rotation_retry_until)
+  WHERE rotation_request_hash IS NOT NULL
+    AND revoked_at IS NOT NULL;

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -318,6 +318,10 @@ CREATE TABLE cli_refresh_credentials (
 );
 CREATE INDEX cli_refresh_credentials_user_id ON cli_refresh_credentials(user_id);
 CREATE INDEX cli_refresh_credentials_family_id ON cli_refresh_credentials(family_id);
+CREATE INDEX cli_refresh_credentials_rotation_retry_until
+  ON cli_refresh_credentials(rotation_retry_until)
+  WHERE rotation_request_hash IS NOT NULL
+    AND revoked_at IS NOT NULL;
 CREATE TABLE cli_refresh_sessions (
   session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
   credential_id TEXT NOT NULL REFERENCES cli_refresh_credentials(id) ON DELETE CASCADE,


### PR DESCRIPTION
## 現状

CLI refresh credential rotation は10分間の再送窓を持ちますが、期限切れ replay 行の保守 query は部分状態の導出材料を残し、対象 index もありませんでした。また、session linkage の rollout 用に single-family revoke が未 link の CLI session を user-wide に削除していました。

## 変更

- 期限切れ replay 行は、session/replacement 参照が欠けていても request hash、retry deadline、session 参照を冪等に消去
- cleanup predicate に対応する partial index と migration test を追加
- 7日間の session rollout 期間満了後、single-family revoke の未 link session fallback を撤去
- linked session、family lineage、revoke-all の device-login cleanup は維持

## 検証

- `pnpm public:scan .`
- `pnpm validate:static`
- `pnpm build`
- `pnpm build:og-image`
- `pnpm integration:test:run`（30 tests）
- service / migration focused tests（74 tests）
- Codex / Claude deep review（blocker なし）
