### PR TITLE
Improve restricted rows in Recent

### DIFF
--- a/apps/web/app/i18n/en.json
+++ b/apps/web/app/i18n/en.json
@@ -41,6 +41,7 @@
   "recent.next": "Next",
   "recent.page": "Page {page} / {totalPages}",
   "recent.restricted": "You do not have permission to view this file",
+  "recent.restrictedShort": "No access",
   "recent.viewedDate": "Viewed: {date}",
   "recent.unavailableTitle": "Title unavailable",
   "recent.unknownOwner": "Unknown owner",

--- a/apps/web/app/i18n/ja.json
+++ b/apps/web/app/i18n/ja.json
@@ -41,6 +41,7 @@
   "recent.next": "次へ",
   "recent.page": "{page} / {totalPages} ページ",
   "recent.restricted": "閲覧権限がありません",
+  "recent.restrictedShort": "権限なし",
   "recent.viewedDate": "閲覧日: {date}",
   "recent.unavailableTitle": "タイトルを表示できません",
   "recent.unknownOwner": "所有者不明",

--- a/apps/web/app/routes/_home/+components/file-list-styles.ts
+++ b/apps/web/app/routes/_home/+components/file-list-styles.ts
@@ -34,7 +34,7 @@ export const homeCompactLostAccessColumns = 'grid-cols-[minmax(0,1fr)]'
 export const dateRailFilesColumns =
   '@max-recent-rail-collapse:grid-cols-[minmax(0,1fr)_40px] @min-recent-rail-collapse:@max-recent-rail-wide:grid-cols-[3.5rem_minmax(0,1fr)_40px] @min-recent-rail-wide:grid-cols-[6rem_minmax(0,1fr)_9rem_5.5rem_76px]'
 export const dateRailRestrictedColumns =
-  '@max-recent-rail-collapse:grid-cols-[minmax(0,1fr)] @min-recent-rail-collapse:@max-recent-rail-wide:grid-cols-[3.5rem_minmax(0,1fr)] @min-recent-rail-wide:grid-cols-[6rem_minmax(0,1fr)]'
+  '@max-recent-rail-collapse:grid-cols-[minmax(0,1fr)] @min-recent-rail-collapse:@max-recent-rail-wide:grid-cols-[3.5rem_minmax(0,1fr)] @min-recent-rail-wide:grid-cols-[6rem_minmax(0,1fr)_calc(9rem+5.5rem+76px+2rem)]'
 // Project detail row — icon+title cell, stats, actions.
 export const projectFileColumns =
   'grid-cols-[minmax(0,1fr)_auto_76px] max-wide:grid-cols-[minmax(0,1fr)_auto_76px]'

--- a/apps/web/app/routes/_home/+components/recent-content.test.tsx
+++ b/apps/web/app/routes/_home/+components/recent-content.test.tsx
@@ -134,7 +134,7 @@ test('renders restricted rows without links or action buttons and with a day hea
   expect(html).toMatch(/<h2>[^<]+<\/h2>/)
 })
 
-test('recent restricted rows preserve the existing two-column layout', () => {
+test('recent restricted rows align their main content and keep status visible', () => {
   const html = renderToStaticMarkup(
     <MemoryRouter>
       <RecentContent
@@ -157,7 +157,10 @@ test('recent restricted rows preserve the existing two-column layout', () => {
       />
     </MemoryRouter>,
   )
-  expect(html).toContain('max-wide:grid-cols-[minmax(0,1fr)_auto]')
+  expect(html).toContain('data-slot="restricted-recent-row"')
+  expect(html).toContain('line-clamp-2')
+  expect(html).toContain('rounded-full')
+  expect(html).toContain('recent.restrictedShort')
   expect(html).not.toContain('max-stack:px-0')
 })
 
@@ -181,7 +184,8 @@ test('home restricted rows use the same compact edge alignment as file rows', ()
   )
   expect(html).toContain('max-stack:px-0')
   expect(html).toContain('grid-cols-[minmax(0,1fr)]')
-  expect(html).toContain('Other Owner · recent.restricted')
+  expect(html).toContain('Other Owner</span><span')
+  expect(html).toContain('recent.restricted')
 })
 
 test.each([0, 1, 3, 5, 20])(

--- a/apps/web/app/routes/_home/+components/recent-content.tsx
+++ b/apps/web/app/routes/_home/+components/recent-content.tsx
@@ -1,5 +1,6 @@
 import type { RefObject } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
+import { IconLock } from '@tabler/icons-react'
 import type { FileRowData } from './file-data'
 import type { RecentRow, RestrictedRecentRow } from '~/lib/recent-row'
 import { EmptyState } from './empty-state'
@@ -474,12 +475,13 @@ function RestrictedRow({
   const { t } = useT()
   return (
     <div
+      data-slot="restricted-recent-row"
       data-gap-audit-allow-touch={dateRail ? '' : undefined}
-      className={`${dateRail ? dateRailRestrictedColumns : homeCompact ? homeCompactLostAccessColumns : fileTableColumnsActions} border-divider text-muted-foreground ${dateRail ? 'max-stack:px-0 px-3' : homeCompact ? 'max-wide:grid-cols-[minmax(0,1fr)] max-stack:px-0' : 'max-wide:grid-cols-[minmax(0,1fr)_auto]'} grid min-h-12 items-center gap-4 border-b px-3.5 py-2.5 text-sm last:border-b-0`}
+      className={`${dateRail ? dateRailRestrictedColumns : homeCompact ? homeCompactLostAccessColumns : fileTableColumnsActions} border-divider text-muted-foreground ${dateRail ? 'max-stack:px-0 px-3' : homeCompact ? 'max-wide:grid-cols-[minmax(0,1fr)] max-stack:px-0' : 'max-wide:grid-cols-[minmax(0,1fr)]'} grid min-h-15.5 items-center gap-4 border-b px-3.5 py-2.5 text-sm last:border-b-0`}
     >
       {dateRail ? <RestrictedDateCell presentation={dateRail} /> : null}
       <span
-        className="flex min-w-0 flex-col"
+        className="inline-flex min-w-0 items-center gap-3"
         data-recent-main-cell={dateRail ? '' : undefined}
       >
         {dateRail?.fullDate ? (
@@ -487,40 +489,44 @@ function RestrictedRow({
             {t('recent.viewedDate', { date: dateRail.fullDate })}
           </span>
         ) : null}
-        <span
-          className="truncate"
-          data-recent-title-line={dateRail ? '' : undefined}
-        >
-          {row.title}
+        <span className="bg-muted text-faint flex size-5 shrink-0 items-center justify-center rounded-sm">
+          <IconLock size={14} aria-hidden="true" />
         </span>
-        <span className="flex min-w-0 items-start truncate text-xs">
-          {dateRail?.compactLabel ? (
-            <span
-              aria-hidden="true"
-              className="@min-recent-rail-collapse:hidden flex shrink-0 flex-col"
-            >
-              {dateRail.compactLabel.split('\n').map((line) => (
-                <span key={line}>{line}</span>
-              ))}
+        <span className="flex min-w-0 flex-1 flex-col gap-1 overflow-hidden">
+          <span
+            className="text-foreground line-clamp-2 font-medium"
+            title={row.title}
+            data-recent-title-line={dateRail ? '' : undefined}
+          >
+            {row.title}
+          </span>
+          <span className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 text-xs">
+            <span className="min-w-0 truncate">
+              {dateRail?.compactLabel ? (
+                <span
+                  aria-hidden="true"
+                  className="@min-recent-rail-collapse:hidden"
+                >
+                  {dateRail.compactLabel.replace('\n', ' ')} ·{' '}
+                </span>
+              ) : null}
+              {row.ownerName ?? t('recent.unknownOwner')}
             </span>
-          ) : null}
-          {dateRail?.compactLabel ? (
             <span
-              aria-hidden="true"
-              className="@min-recent-rail-collapse:hidden shrink-0"
+              className={`${dateRail ? '@min-recent-rail-wide:hidden' : 'max-wide:inline-flex hidden'} border-divider bg-muted/60 shrink-0 rounded-full border px-2 py-0.5 leading-tight`}
+              title={t('recent.restricted')}
             >
-              &nbsp;·&nbsp;
+              {t('recent.restrictedShort')}
             </span>
-          ) : null}
-          <span className="min-w-0 truncate">
-            {row.ownerName ?? t('recent.unknownOwner')}
-            {homeCompact ? ` · ${t('recent.restricted')}` : null}
           </span>
         </span>
       </span>
-      {!homeCompact && !dateRail ? (
-        <span className="text-xs">{t('recent.restricted')}</span>
-      ) : null}
+      <span
+        className={`${dateRail ? '@max-recent-rail-wide:hidden @min-recent-rail-wide:inline-flex' : 'max-wide:hidden'} border-divider bg-muted/60 w-fit items-center rounded-full border px-2 py-0.5 text-xs leading-tight`}
+        title={t('recent.restricted')}
+      >
+        {t('recent.restrictedShort')}
+      </span>
     </div>
   )
 }

--- a/apps/web/app/routes/_home/files-recent-structure.behavior.browser.test.tsx
+++ b/apps/web/app/routes/_home/files-recent-structure.behavior.browser.test.tsx
@@ -267,9 +267,12 @@ test('restricted recent rows expose only owner and unavailable state', async () 
     />,
   )
   expect(host.textContent).toContain('Other Owner')
-  expect(host.textContent).toContain(
-    'You do not have permission to view this file',
-  )
+  expect(host.textContent).toContain('No access')
+  expect(
+    host.querySelector(
+      '[title="You do not have permission to view this file"]',
+    ),
+  ).not.toBeNull()
   expect(host.textContent).toContain('Secret title')
   expect(host.querySelector('a[href="/a/restricted-file"]')).toBeNull()
   expect(host.querySelector('button')).toBeNull()


### PR DESCRIPTION
## 現状

Recent の閲覧権限を失った履歴行は、通常行と異なる構造で表示され、タイトル・所有者・権限状態を一覧の流れの中で判別しにくい状態でした。

## 変更

- 権限なし行にロックアイコンを加え、通常行と同じタイトル走査ラインへ揃えました
- タイトルを2行まで表示し、所有者と短い権限状態チップを同時に読める構造へ変更しました
- デスクトップでは状態チップを通常行の状態列へ配置しました
- 行は引き続きリンク・ボタンを持たず、非インタラクティブな状態を維持します
- 日英の短い権限状態文言と、構造・非操作性の回帰テストを追加しました

## 検証

- `pnpm validate:static`
- 対象 unit test: 16 passed
- 対象 browser behavior test: 4 passed
- `pnpm screens:capture -- --screen recent --label after-restricted-row-final`: 12/12 succeeded（desktop/mobile × light/dark を含む）
- React Doctor: score 100、warnings 0、errors 0
- Codex / Claude deep review: blocker なし

UI キャプチャと関連 source を確認し、通常行との走査ライン、長文時の情報優先度、非インタラクティブ性、ライト／ダークテーマでのコントラストに問題がないことを確認しました。
