### PR TITLE
Keep required gates active until completion

### DIFF
--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -36,6 +36,8 @@ Do not promote a finding to blocker merely because it would make the design more
 
 Changing the specification after its gate invalidates that gate. Changing the implementation after its gate invalidates that gate. Finish mechanical corrections before the final review; if the version or commit changes afterward, start both deep reviews again in parallel against the new target. Do not stop or restart one reviewer merely because the other finishes first or reports a blocker: wait for both results so one correction pass can address the complete finding set. Keep dispositions in the normal task or reviewer session, and summarize the final gate and any follow-ups in the pull request. Do not create receipts, digests, locks, attempt logs, or review-specific push guards.
 
+A required review or validation remains unfinished while its command is running or its result is pending. Keep the task active and do not give a final response such as "waiting for review" before every required gate has completed and its result has been evaluated. If a required process disappears before producing a result, treat the gate as incomplete and run that process again; absence of a result is never success.
+
 ## Choose local validation
 
 Run the smallest command set that can detect a plausible defect in the changed area:


### PR DESCRIPTION
## 現状

必須レビューや検証が進行中でも、待機を作業の区切りとして扱う余地がありました。また、実行中プロセスが結果を残さず消失した場合の扱いが明記されていませんでした。

## 変更

- 必須レビューまたは検証の実行中・結果待ちは未完了であり、タスクを継続することを明記しました。
- 必須ゲートの評価前に「レビュー待ち」などの最終回答を返さないことを明記しました。
- 必須プロセスが結果なしに消失した場合は成功扱いせず、再実行することを明記しました。

## 検証

- `pnpm format`
- `pnpm public:scan .`
- `pnpm validate:static`
- Codex / Claude implementation deep review: 指摘なし
