### PR TITLE
Rate limit public viewer entry routes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,12 @@ Relevant actors include unauthenticated viewers; holders of link-sharing URLs; w
 
 No system can guarantee that arbitrary uploaded content is harmless, that a bearer URL reached only its intended recipient, or that an external service will handle data under Artifact Share's controls. Do not place secrets in public or link-shared content, and review the destination before sending content to an integration or external AI service.
 
+## Link-viewer trial control
+
+Viewer and Open Graph image requests share a Cloudflare Workers Rate Limiting binding keyed by the Cloudflare-provided client IP. The initial limit is 300 requests per 60 seconds per Cloudflare location. A rejected request returns `429` with `Retry-After: 60` before artifact lookup.
+
+The limiter is an abuse and database-load backstop, not the bearer credential itself. Binding failures fail open so an infrastructure fault does not revoke working share links; the application logs the binding failure without the requested URL. Local requests without the Cloudflare client-IP header or binding are not limited.
+
 ## Report a vulnerability privately
 
 Use GitHub Private Vulnerability Reporting for this repository. If that channel is unavailable, email `support@artifactshare.com`.

--- a/apps/web/app/services/viewer-rate-limit.server.test.ts
+++ b/apps/web/app/services/viewer-rate-limit.server.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  checkViewerRateLimit,
+  isViewerRateLimitedPath,
+  type ViewerRateLimiter,
+} from './viewer-rate-limit.server'
+
+describe('checkViewerRateLimit', () => {
+  test('uses the Cloudflare client IP as the counter key', async () => {
+    const limit = vi.fn().mockResolvedValue({ success: true })
+    const response = await checkViewerRateLimit(
+      request('GET', '203.0.113.10'),
+      { limit },
+    )
+
+    expect(response).toBeNull()
+    expect(limit).toHaveBeenCalledWith({ key: '203.0.113.10' })
+  })
+
+  test('returns a non-cacheable 429 without artifact details', async () => {
+    const response = await checkViewerRateLimit(
+      request('GET', '203.0.113.10'),
+      denyLimiter(),
+    )
+
+    expect(response?.status).toBe(429)
+    expect(response?.headers.get('retry-after')).toBe('60')
+    expect(response?.headers.get('cache-control')).toBe('private, no-store')
+    await expect(response?.text()).resolves.toBe('Not found')
+  })
+
+  test('returns no body for a rate-limited HEAD request', async () => {
+    const response = await checkViewerRateLimit(
+      request('HEAD', '203.0.113.10'),
+      denyLimiter(),
+    )
+
+    expect(response?.status).toBe(429)
+    await expect(response?.text()).resolves.toBe('')
+  })
+
+  test('disables the limit when the binding or Cloudflare IP is absent', async () => {
+    const limit = vi.fn().mockResolvedValue({ success: false })
+
+    await expect(
+      checkViewerRateLimit(request('GET', null), { limit }),
+    ).resolves.toBeNull()
+    await expect(
+      checkViewerRateLimit(request('GET', '203.0.113.10'), undefined),
+    ).resolves.toBeNull()
+    expect(limit).not.toHaveBeenCalled()
+  })
+
+  test('fails open and logs without request credentials', async () => {
+    const error = new Error('binding unavailable')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const limiter: ViewerRateLimiter = {
+      limit: vi.fn().mockRejectedValue(error),
+    }
+
+    await expect(
+      checkViewerRateLimit(request('GET', '203.0.113.10'), limiter),
+    ).resolves.toBeNull()
+    expect(consoleError).toHaveBeenCalledWith('viewer_rate_limit_failed', {
+      error,
+    })
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('/a/')
+    consoleError.mockRestore()
+  })
+})
+
+describe('isViewerRateLimitedPath', () => {
+  test.each([
+    ['GET', '/a/example'],
+    ['HEAD', '/a/example'],
+    ['GET', '/a/example/og-image'],
+    ['HEAD', '/a/example/og-image/'],
+    ['GET', '/%61/example'],
+    ['GET', '/a/example/%6fg-image'],
+    ['GET', '/a/example%ZZ'],
+    ['GET', '/a/example%2Fchild'],
+  ])('includes %s %s', (method, pathname) => {
+    expect(
+      isViewerRateLimitedPath(
+        new Request(`https://artifactshare.test${pathname}`, { method }),
+      ),
+    ).toBe(true)
+  })
+
+  test.each([
+    ['POST', '/a/example'],
+    ['GET', '/api/shareables/example'],
+    ['GET', '/a/example/versions'],
+    ['GET', '/a/example/%2Fversions'],
+    ['GET', '/a/example/%ZZ'],
+    ['GET', '/about'],
+  ])('excludes %s %s', (method, pathname) => {
+    expect(
+      isViewerRateLimitedPath(
+        new Request(`https://artifactshare.test${pathname}`, { method }),
+      ),
+    ).toBe(false)
+  })
+})
+
+function request(method: string, clientIp: string | null): Request {
+  return new Request('https://artifactshare.test/a/example~credential', {
+    method,
+    headers: clientIp ? { 'cf-connecting-ip': clientIp } : undefined,
+  })
+}
+
+function denyLimiter(): ViewerRateLimiter {
+  return { limit: vi.fn().mockResolvedValue({ success: false }) }
+}

--- a/apps/web/app/services/viewer-rate-limit.server.ts
+++ b/apps/web/app/services/viewer-rate-limit.server.ts
@@ -1,0 +1,55 @@
+export interface ViewerRateLimiter {
+  limit(input: { key: string }): Promise<{ success: boolean }>
+}
+
+const RETRY_AFTER_SECONDS = 60
+
+export function isViewerRateLimitedPath(request: Request): boolean {
+  if (request.method !== 'GET' && request.method !== 'HEAD') return false
+  let segments: string[]
+  try {
+    segments = new URL(request.url).pathname.split('/')
+  } catch {
+    return false
+  }
+  if (segments.at(-1) === '') segments.pop()
+  if (segments[0] !== '' || decodeSegment(segments[1]) !== 'a') return false
+  if (!segments[2]) return false
+  return (
+    segments.length === 3 ||
+    (segments.length === 4 && decodeSegment(segments[3]) === 'og-image')
+  )
+}
+
+function decodeSegment(segment: string | undefined): string | undefined {
+  if (segment === undefined) return undefined
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return segment
+  }
+}
+
+export async function checkViewerRateLimit(
+  request: Request,
+  limiter: ViewerRateLimiter | undefined,
+): Promise<Response | null> {
+  const clientIp = request.headers.get('cf-connecting-ip')
+  if (!clientIp || !limiter) return null
+
+  try {
+    const { success } = await limiter.limit({ key: clientIp })
+    if (success) return null
+  } catch (error) {
+    console.error('viewer_rate_limit_failed', { error })
+    return null
+  }
+
+  return new Response(request.method === 'HEAD' ? null : 'Not found', {
+    status: 429,
+    headers: {
+      'cache-control': 'private, no-store',
+      'retry-after': String(RETRY_AFTER_SECONDS),
+    },
+  })
+}

--- a/apps/web/app/types/env.d.ts
+++ b/apps/web/app/types/env.d.ts
@@ -18,6 +18,7 @@ declare namespace Cloudflare {
     D1_BACKUP_WORKFLOW: Workflow
     D1_REST_API_TOKEN: string
     VIEW_DEDUP: KVNamespace
+    VIEWER_RATELIMIT?: import('../services/viewer-rate-limit.server').ViewerRateLimiter
     ARTIFACT_LIVE: DurableObjectNamespace<
       import('../../workers/artifact-live-room').ArtifactLiveRoom
     >

--- a/apps/web/workers/app.test.ts
+++ b/apps/web/workers/app.test.ts
@@ -228,6 +228,29 @@ describe('app worker workflow spike route', () => {
   })
 })
 
+describe('app worker viewer rate limit', () => {
+  test.each(['/a/share123', '/a/share123/og-image'])(
+    'rejects %s before the application handler',
+    async (pathname) => {
+      const limit = vi.fn().mockResolvedValue({ success: false })
+      const response = await app.fetch(
+        workerRequest(`https://artifactshare.com${pathname}`, {
+          headers: { 'cf-connecting-ip': '203.0.113.10' },
+        }),
+        {
+          ...productionEnv({ maintenance: false }),
+          VIEWER_RATELIMIT: { limit },
+        } as unknown as Cloudflare.Env,
+        executionContext(),
+      )
+
+      expect(response.status).toBe(429)
+      expect(requestHandlerMock).not.toHaveBeenCalled()
+      expect(limit).toHaveBeenCalledWith({ key: '203.0.113.10' })
+    },
+  )
+})
+
 describe('app worker D1 backup workflow route', () => {
   test('hides the D1 backup workflow route in production', async () => {
     const response = await app.fetch(

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -33,6 +33,10 @@ import {
 } from '../app/services/slack-notifications.server'
 import { nanoid } from 'nanoid'
 import { cleanupExpiredCliRotationReplays } from '../app/services/cli-refresh-credentials.server'
+import {
+  checkViewerRateLimit,
+  isViewerRateLimitedPath,
+} from '../app/services/viewer-rate-limit.server'
 
 export { ArtifactLiveRoom } from './artifact-live-room'
 export { D1BackupWorkflow } from './d1-backup-workflow'
@@ -108,6 +112,11 @@ export default {
     )
   },
   async fetch(request, env, ctx) {
+    if (isViewerRateLimitedPath(request)) {
+      const limited = await checkViewerRateLimit(request, env.VIEWER_RATELIMIT)
+      if (limited) return limited
+    }
+
     // Lazy initialization (better-auth init, React Router server build) is
     // driven by whichever request touches it first. Anchor both to waitUntil
     // once per isolate so a client abort cannot leave a permanently pending

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -55,6 +55,11 @@
       "namespace_id": "1002",
       "simple": { "limit": 60, "period": 60 },
     },
+    {
+      "name": "VIEWER_RATELIMIT",
+      "namespace_id": "1003",
+      "simple": { "limit": 300, "period": 60 },
+    },
   ],
   "vars": {
     "APP_ENV": "development",

--- a/apps/web/wrangler.production.jsonc
+++ b/apps/web/wrangler.production.jsonc
@@ -73,6 +73,11 @@
       "namespace_id": "1002",
       "simple": { "limit": 60, "period": 60 },
     },
+    {
+      "name": "VIEWER_RATELIMIT",
+      "namespace_id": "1003",
+      "simple": { "limit": 300, "period": 60 },
+    },
   ],
   "vars": {
     "APP_ENV": "production",


### PR DESCRIPTION
## 現状

公開 viewer と共有 artifact の Open Graph image route は、artifact lookup より前の application-layer 試行制御を持っていませんでした。

## 変更

- viewer と共有 OG image に共通の Cloudflare Rate Limiting binding を追加しました。
- Cloudflare の client IP ごとに、両 route 合計で 300 request / 60 秒を上限とします。
- 制限超過は artifact lookup 前に `429` と `Retry-After: 60` を返します。
- binding 不在または障害時は既存 link の可用性を維持するため fail open し、request URL を記録しません。
- 公開 security policy に運用上の境界を記載しました。

## 検証

- `pnpm validate:static`
- `pnpm public:scan .`
- viewer rate-limit service / Worker entrypoint: 56 tests passed
- `pnpm test:scripts`: 317 tests passed
- Codex / Claude implementation review: unresolved blocker なし
