### PR TITLE
Keep long comments within the viewer panel

### DIFF
--- a/apps/web/app/routes/a.$id/+components/comment-message-item.tsx
+++ b/apps/web/app/routes/a.$id/+components/comment-message-item.tsx
@@ -80,15 +80,15 @@ export function CommentMessageItem({
   }
 
   return (
-    <div className={cn('relative grid gap-1.5 p-0', className)}>
-      <div className="flex items-center justify-between gap-2">
-        <div className="text-muted-foreground gap-comment-gap flex min-w-0 items-center text-xs">
+    <div className={cn('relative grid min-w-0 gap-1.5 p-0', className)}>
+      <div className="flex min-w-0 items-start justify-between gap-2">
+        <div className="text-muted-foreground gap-comment-gap flex min-w-0 flex-1 flex-wrap items-center text-xs">
           <CommentAvatar
             id={message.author.id}
             image={message.author.image}
             label={message.author.name ?? message.author.email}
           />
-          <strong className="text-foreground overflow-hidden font-semibold text-ellipsis whitespace-nowrap">
+          <strong className="text-foreground min-w-0 flex-1 overflow-hidden font-semibold text-ellipsis whitespace-nowrap">
             {message.author.name ?? message.author.email}
           </strong>
           <UserKindBadge kind={message.author.kind} />
@@ -97,12 +97,16 @@ export function CommentMessageItem({
               {message.agent}
             </span>
           ) : null}
-          <span>{formatRelative(message.createdAt, locale)}</span>
+          <span className="shrink-0 whitespace-nowrap">
+            {formatRelative(message.createdAt, locale)}
+          </span>
           {message.updatedAt !== message.createdAt ? (
-            <span>{t('comments.edited')}</span>
+            <span className="shrink-0 whitespace-nowrap">
+              {t('comments.edited')}
+            </span>
           ) : null}
         </div>
-        <div className="min-h-control-sm inline-flex items-center">
+        <div className="min-h-control-sm inline-flex shrink-0 items-center">
           {message.canEdit || message.canDelete ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/apps/web/app/routes/a.$id/+components/comment-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/comment-panel.tsx
@@ -481,7 +481,7 @@ function ThreadCard({
     <article
       ref={threadRef}
       className={cn(
-        'bg-background scroll-m-scroll-anchor-sm has-[[data-comment-thread-hitarea]:focus-visible]:ring-ring/50 border-border has-[[data-comment-thread-hitarea]:focus-visible]:border-link relative grid flex-none gap-2 overflow-hidden rounded-[var(--r-lg)] border p-3 has-[[data-comment-thread-hitarea]:focus-visible]:ring-3',
+        'bg-background scroll-m-scroll-anchor-sm has-[[data-comment-thread-hitarea]:focus-visible]:ring-ring/50 border-border has-[[data-comment-thread-hitarea]:focus-visible]:border-link relative grid max-w-full min-w-0 flex-none gap-2 overflow-hidden rounded-[var(--r-lg)] border p-3 has-[[data-comment-thread-hitarea]:focus-visible]:ring-3',
         canNavigateToText &&
           'cursor-pointer [&>[data-thread-content]]:relative [&>[data-thread-content]]:z-1',
         target &&
@@ -505,11 +505,11 @@ function ThreadCard({
         />
       ) : null}
       <div
-        className="flex items-center justify-between gap-2.5"
+        className="flex min-w-0 items-center justify-between gap-2.5"
         data-thread-content=""
       >
         <CommentStatusBadge status={thread.status} />
-        <div className="inline-flex items-center gap-1">
+        <div className="inline-flex shrink-0 items-center gap-1">
           {thread.canResolve ? (
             <CommentResolveButton
               status={thread.status}
@@ -542,7 +542,7 @@ function ThreadCard({
         <ThreadSubject thread={thread} />
       </div>
       {firstMessage ? (
-        <div data-thread-content="">
+        <div className="min-w-0" data-thread-content="">
           <CommentMessageItem
             message={firstMessage}
             locale={locale}
@@ -554,7 +554,7 @@ function ThreadCard({
       ) : null}
       {replyMessages.length > 0 ? (
         <div
-          className="before:top-timeline-top before:left-timeline-offset border-border relative mt-0.5 grid gap-2.5 border-t pt-2.5 pl-5 before:absolute before:bottom-0.5 before:w-0.5 before:rounded-full before:bg-[color-mix(in_srgb,var(--link)_22%,var(--divider))]"
+          className="before:top-timeline-top before:left-timeline-offset border-border relative mt-0.5 grid min-w-0 gap-2.5 border-t pt-2.5 pl-5 before:absolute before:bottom-0.5 before:w-0.5 before:rounded-full before:bg-[color-mix(in_srgb,var(--link)_22%,var(--divider))]"
           data-thread-content=""
         >
           {hiddenReplyCount > 0 ? (

--- a/apps/web/app/services/dev-screen-state.server.ts
+++ b/apps/web/app/services/dev-screen-state.server.ts
@@ -478,8 +478,8 @@ export async function seedDevScreenState(
               .values({
                 id: latestMessageId,
                 thread_id: latestThreadId,
-                body: '部門別でも見られると助かります。特に第2四半期の数値について、前月との比較も確認したいです。次回の更新で補足をお願いします。',
-                agent: null,
+                body: '部門別でも見られると助かります。特に第2四半期の数値について、前月との比較も確認したいです。次回の更新で補足をお願いします。 https://example.com/reports/quarterly/this-is-a-deliberately-long-unbroken-reference-that-must-wrap-inside-the-comment-card',
+                agent: 'Research Assistant for Q4 Data',
                 created_by_id: commenterId,
                 created_at: latestCommentAt,
                 updated_at: latestCommentAt,
@@ -487,7 +487,8 @@ export async function seedDevScreenState(
               .onConflict((oc) =>
                 oc.column('id').doUpdateSet({
                   thread_id: latestThreadId,
-                  body: '部門別でも見られると助かります。特に第2四半期の数値について、前月との比較も確認したいです。次回の更新で補足をお願いします。',
+                  body: '部門別でも見られると助かります。特に第2四半期の数値について、前月との比較も確認したいです。次回の更新で補足をお願いします。 https://example.com/reports/quarterly/this-is-a-deliberately-long-unbroken-reference-that-must-wrap-inside-the-comment-card',
+                  agent: 'Research Assistant for Q4 Data',
                   created_by_id: commenterId,
                   created_at: latestCommentAt,
                   updated_at: latestCommentAt,

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -263,7 +263,8 @@ export const screens = [
       },
       {
         id: 'comments-open',
-        description: '最近見た成果物のコメントパネルを開いた状態',
+        description:
+          '長い投稿者名、エージェント名、本文を含むコメントパネルを開いた状態',
         setup: {
           scenario: 'recent/content-rich',
           scenarioArtifactIndex: 1,


### PR DESCRIPTION
## 現状

Viewer のコメントカードは、長い投稿者名とエージェント名が並ぶと、時刻や操作領域がパネル幅の外へ押し出されることがありました。改行のない長い本文も、カードと返信タイムラインの幅を広げる要因になります。

## 変更

- 投稿者情報を折り返し可能な可変領域にし、時刻とメッセージ操作を縮まない領域にしました。
- カードと返信領域の grid/flex 子要素がパネル幅の中で縮めるようにしました。
- UX ハーネスのコメント状態に、長い投稿者名、上限に近いエージェント名、改行のない長い参照文字列を追加しました。

## 検証

- `pnpm validate:static`
- `pnpm --filter @artifactshare/web typecheck`
- `pnpm exec vitest run app/services/dev-screen-state.server.test.ts`
- `pnpm check:task-ledger`
- React Doctor: 100/100, 0 findings
- `pnpm screens:capture -- --screen viewer --label comment-overflow --audit-gaps`: 24/24 captures succeeded。今回対象の横あふれ指摘は 0。既存のヘッダー/タブ間隔の gap audit 指摘でコマンド自体は exit 1。
- desktop/mobile、light/dark の対象キャプチャをソースと照合し、時刻、返信、解決、メニュー、閉じる操作と本文の折り返しを確認。
- Codex / Claude deep implementation review: blocker なし。
