### PR TITLE
Fix sandbox preflight for screen capture

### DIFF
--- a/scripts/check-screen-ledger.test.mjs
+++ b/scripts/check-screen-ledger.test.mjs
@@ -5,6 +5,7 @@ import {
   CaptureFailure,
   assertNoRouteError,
   browserLaunchOptions,
+  needsLocalSandbox,
   navigateForCapture,
   pathFor,
   waitForInteractionTarget,
@@ -417,6 +418,21 @@ test('maps local sandbox hostnames for both bundled and installed browsers', () 
     channel: 'chrome',
     args: ['--host-resolver-rules=MAP *.sandbox.localhost 127.0.0.1'],
   })
+})
+
+test('requires the local sandbox only for local captures that render it', () => {
+  const sandboxScreen = {
+    ready: { selector: '[data-sandbox-state="ready"]' },
+  }
+  assert.equal(
+    needsLocalSandbox('https://localhost:5173', [sandboxScreen]),
+    true,
+  )
+  assert.equal(needsLocalSandbox('https://localhost:5173', screens), false)
+  assert.equal(
+    needsLocalSandbox('https://preview.example.com', [sandboxScreen]),
+    false,
+  )
 })
 
 test('keeps the scenario allowlist and ledger references in sync', () => {

--- a/scripts/screen-capture.mjs
+++ b/scripts/screen-capture.mjs
@@ -11,6 +11,7 @@ import {
   cookieHeader,
   cookiesFromHeaders,
 } from './lib/dev-sign-in.mjs'
+import { DEV_SERVICES, selectMissingDevServices } from './dev-setup.mjs'
 
 const VIEWPORTS = {
   desktop: { width: 1440, height: 900 },
@@ -131,6 +132,15 @@ export function browserLaunchOptions(channel) {
     ...(channel ? { channel } : {}),
     args: ['--host-resolver-rules=MAP *.sandbox.localhost 127.0.0.1'],
   }
+}
+
+export function needsLocalSandbox(baseUrl, selectedScreens) {
+  return (
+    new URL(baseUrl).origin === 'https://localhost:5173' &&
+    selectedScreens.some(
+      (screen) => screen.ready?.selector === '[data-sandbox-state="ready"]',
+    )
+  )
 }
 
 // The local dev server uses a self-signed certificate; global fetch rejects it.
@@ -354,8 +364,16 @@ export async function captureScreens({
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
   } catch {
     throw new Error(
-      `Dev server is unreachable at ${baseUrl}. Please start it with pnpm --filter @artifactshare/web dev:app`,
+      `App dev server is unreachable at ${baseUrl}. Please start the local development services with pnpm dev`,
     )
+  }
+  if (needsLocalSandbox(baseUrl, selected)) {
+    const sandbox = DEV_SERVICES.filter((service) => service.name === 'sandbox')
+    const { missing } = await selectMissingDevServices(sandbox)
+    if (missing.length > 0)
+      throw new Error(
+        'Sandbox dev server is unreachable at https://localhost:5174. Please start the local development services with pnpm dev',
+      )
   }
   let playwright
   try {


### PR DESCRIPTION
## Summary

- preflight the local sandbox service before Viewer screen captures
- direct maintainers to `pnpm dev` when either required local service is unavailable
- keep non-sandbox and remote captures unaffected

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm test:scripts` (322 passed)
- `pnpm validate:static` (2,893 passed, 1 skipped; React Doctor clean)
- `pnpm public:scan .` (0 findings)
- missing-sandbox smoke test exits in 1.8s with the `pnpm dev` recovery instruction
- Codex and Claude implementation reviews: no findings
