### PR TITLE
Let viewers open published historical versions

### DIFF
--- a/apps/web/app/i18n/en.json
+++ b/apps/web/app/i18n/en.json
@@ -670,6 +670,8 @@
   "history.updateShort": "Update",
   "history.updateAvailable": "A new version is available",
   "history.showLatest": "Show latest",
+  "history.viewingVersion": "Viewing {version}",
+  "history.returnCurrent": "Return to current",
   "history.dropTitle": "Add new version",
   "history.dropCaption": "Drop here, or use the button below",
   "history.pickFile": "Choose file...",

--- a/apps/web/app/i18n/ja.json
+++ b/apps/web/app/i18n/ja.json
@@ -670,6 +670,8 @@
   "history.updateShort": "更新あり",
   "history.updateAvailable": "新しい版があります",
   "history.showLatest": "最新を見る",
+  "history.viewingVersion": "{version} を表示中",
+  "history.returnCurrent": "現在に戻る",
   "history.dropTitle": "新しい版を追加",
   "history.dropCaption": "ここにドロップ、または下のボタンから",
   "history.pickFile": "ファイルを選択…",

--- a/apps/web/app/routes/a.$id/+components/history-panel.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/history-panel.test.tsx
@@ -17,6 +17,8 @@ vi.mock('~/hooks/use-t', () => ({
         'history.updateShort': 'Update',
         'history.updateAvailable': 'A new version is available',
         'history.showLatest': 'Show latest',
+        'history.viewingVersion': `Viewing ${vars?.version ?? ''}`,
+        'history.returnCurrent': 'Return to current',
         'history.dropTitle': 'Add new version',
         'history.dropCaption': 'Drop here, or use the button below',
         'history.pickFile': 'Choose file...',
@@ -33,6 +35,9 @@ vi.mock('~/hooks/use-t', () => ({
 }))
 
 vi.mock('react-router', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
   useRevalidator: () => ({ revalidate: vi.fn() }),
 }))
 
@@ -192,6 +197,37 @@ describe('HistoryPanel', () => {
     expect(html).toContain('Updated v1')
     expect(html).toContain('2 new comments')
     expect(html).toContain('Activity and version status')
+  })
+
+  test('historical mode identifies the selected version and links back to current', () => {
+    const html = renderToStaticMarkup(
+      <VersionWidget
+        artifactId="artifact-1"
+        displayedVersionId="version-1"
+        displayedVersionOrdinal={1}
+        versions={[
+          {
+            id: 'version-2',
+            ordinal: 2,
+            createdAt,
+            sizeBytes: 2048,
+            isCurrent: true,
+          },
+          {
+            id: 'version-1',
+            ordinal: 1,
+            createdAt,
+            sizeBytes: 1024,
+            isCurrent: false,
+          },
+        ]}
+        onOpenHistory={() => {}}
+      />,
+    )
+
+    expect(html).toContain('Viewing v1')
+    expect(html).toContain('Return to current')
+    expect(html).toContain('href="/a/artifact-1"')
   })
 
   test('static site replacement mode accepts multiple bundle files', () => {

--- a/apps/web/app/routes/a.$id/+components/history-panel.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/history-panel.test.tsx
@@ -133,6 +133,7 @@ describe('HistoryPanel', () => {
     expect(html).not.toContain('Add new version')
     expect(html).not.toContain('Choose file...')
     expect(html).not.toContain('data-panel-dropzone')
+    expect(html).not.toContain('href=')
   })
 
   test('closed panel omits sheet content', () => {

--- a/apps/web/app/routes/a.$id/+components/history-panel.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/history-panel.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, test, vi } from 'vitest'
 import { HistoryPanel, HistoryPanelBody, VersionWidget } from './history-panel'
 import { hasLocalFiles } from './drag-files'
+import { VersionRows } from './version-rows'
 
 vi.mock('~/hooks/use-t', () => ({
   useT: () => ({
@@ -229,6 +230,37 @@ describe('HistoryPanel', () => {
     expect(html).toContain('Viewing v1')
     expect(html).toContain('Return to current')
     expect(html).toContain('href="/a/artifact-1"')
+  })
+
+  test('links only historical file kinds supported by the viewer', () => {
+    const html = renderToStaticMarkup(
+      <VersionRows
+        artifactId="artifact-1"
+        locale="en"
+        t={t}
+        versions={[
+          {
+            id: 'html-version',
+            ordinal: 2,
+            createdAt,
+            sizeBytes: 2048,
+            isCurrent: true,
+            artifactKind: 'html_page',
+          },
+          {
+            id: 'site-version',
+            ordinal: 1,
+            createdAt,
+            sizeBytes: 1024,
+            isCurrent: false,
+            artifactKind: 'static_site',
+          },
+        ]}
+      />,
+    )
+
+    expect(html).toContain('href="/a/artifact-1"')
+    expect(html).not.toContain('version=site-version')
   })
 
   test('static site replacement mode accepts multiple bundle files', () => {

--- a/apps/web/app/routes/a.$id/+components/history-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/history-panel.tsx
@@ -20,6 +20,8 @@ export type { VersionRow } from './version-history-types'
 export { VersionWidget } from './version-widget'
 
 interface HistoryPanelProps {
+  artifactId?: string
+  displayedVersionId?: string | null
   versions: ReadonlyArray<VersionRow>
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -32,6 +34,8 @@ interface HistoryPanelProps {
 }
 
 export function HistoryPanel({
+  artifactId,
+  displayedVersionId,
   versions,
   open,
   onOpenChange,
@@ -96,6 +100,9 @@ export function HistoryPanel({
           submitFiles={submitFiles}
           locale={locale}
           t={t}
+          artifactId={artifactId}
+          displayedVersionId={displayedVersionId}
+          onVersionSelect={() => onOpenChange(false)}
         />
       </SheetContent>
     </Sheet>
@@ -113,6 +120,9 @@ export function HistoryPanelBody({
   submitFiles,
   locale,
   t,
+  artifactId,
+  displayedVersionId,
+  onVersionSelect,
 }: {
   versions: ReadonlyArray<VersionRow>
   canReplaceFile: boolean
@@ -124,11 +134,21 @@ export function HistoryPanelBody({
   submitFiles: (files: FileList | File[] | null) => void
   locale: Parameters<typeof formatRelative>[1]
   t: ReturnType<typeof useT>['t']
+  artifactId?: string
+  displayedVersionId?: string | null
+  onVersionSelect?: () => void
 }) {
   return (
     <>
       <div className="flex min-h-0 flex-1 flex-col gap-3.5 overflow-y-auto p-3.5">
-        <VersionRows versions={versions} locale={locale} t={t} />
+        <VersionRows
+          versions={versions}
+          locale={locale}
+          t={t}
+          artifactId={artifactId}
+          displayedVersionId={displayedVersionId}
+          onVersionSelect={onVersionSelect}
+        />
       </div>
 
       {canReplaceFile ? (

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -95,6 +95,7 @@ async function renderMermaidRequest(message: MermaidRenderRequestMessage) {
 
 type SandboxFrameProps = {
   shareableId: string
+  versionId?: string | null
   url: string
   name: string
   mermaidEnabled: boolean
@@ -271,6 +272,7 @@ function SandboxState({
 
 function useSandboxFrameController({
   shareableId,
+  versionId,
   url,
   name,
   mermaidEnabled,
@@ -427,7 +429,11 @@ function useSandboxFrameController({
         )
         if (outcome === 'reachable') {
           setLoadState('resuming')
-          const next = await refreshSandboxFrameUrl(shareableId, frameUrl)
+          const next = await refreshSandboxFrameUrl(
+            shareableId,
+            frameUrl,
+            versionId,
+          )
           if (
             !shouldAcceptNavigationResult(
               generation,
@@ -466,7 +472,7 @@ function useSandboxFrameController({
         window.clearTimeout(timeout)
       }
     },
-    [frameUrl, reportBlock, shareableId],
+    [frameUrl, reportBlock, shareableId, versionId],
   )
 
   const markFrameReadyFromMessage = useEffectEvent(() => {
@@ -540,7 +546,7 @@ function useSandboxFrameController({
           setFrameUrl(action.url)
           return
         }
-        void refreshSandboxFrameUrl(shareableId, action.url).then(
+        void refreshSandboxFrameUrl(shareableId, action.url, versionId).then(
           (nextFrameUrl) => {
             if (navigationId !== frameNavigationIdRef.current) return
             if (!nextFrameUrl) {
@@ -790,6 +796,7 @@ function useSandboxFrameController({
 async function refreshSandboxFrameUrl(
   shareableId: string,
   targetUrl: string,
+  versionId?: string | null,
 ): Promise<string | null> {
   let result: {
     response: Response
@@ -799,7 +806,9 @@ async function refreshSandboxFrameUrl(
     result = await fetchJsonWithViewerTimeout<{
       sandboxUrl?: unknown
       renderType?: unknown
-    }>(`/api/shareables/${encodeURIComponent(shareableId)}/sandbox-token`)
+    }>(
+      `/api/shareables/${encodeURIComponent(shareableId)}/sandbox-token${versionId ? `?version=${encodeURIComponent(versionId)}` : ''}`,
+    )
   } catch (error) {
     logViewerNetworkEvent({
       channel: 'fetch',

--- a/apps/web/app/routes/a.$id/+components/version-history-types.ts
+++ b/apps/web/app/routes/a.$id/+components/version-history-types.ts
@@ -4,5 +4,6 @@ export interface VersionRow {
   createdAt: string
   sizeBytes: number
   isCurrent: boolean
+  artifactKind?: string | null
   createdByLabel?: string | null
 }

--- a/apps/web/app/routes/a.$id/+components/version-rows.tsx
+++ b/apps/web/app/routes/a.$id/+components/version-rows.tsx
@@ -59,16 +59,7 @@ export function VersionRows({
                   : undefined
               }
               className="text-foreground hover:bg-accent -m-1 flex rounded-[var(--r-sm)] p-1 no-underline"
-              onClick={(event) => {
-                if (
-                  displayedVersionId === version.id ||
-                  (!displayedVersionId && version.isCurrent)
-                ) {
-                  event.preventDefault()
-                  return
-                }
-                onVersionSelect?.()
-              }}
+              onClick={onVersionSelect}
             >
               <VersionRowContent version={version} locale={locale} t={t} />
             </Link>

--- a/apps/web/app/routes/a.$id/+components/version-rows.tsx
+++ b/apps/web/app/routes/a.$id/+components/version-rows.tsx
@@ -2,6 +2,7 @@ import { useT } from '~/hooks/use-t'
 import { formatRelative } from '~/lib/datetime'
 import { formatBytes } from '~/lib/format'
 import { cn } from '~/lib/utils'
+import { Link } from 'react-router'
 import type { VersionRow } from './version-history-types'
 
 export function VersionRows({
@@ -9,11 +10,17 @@ export function VersionRows({
   locale,
   t,
   density = 'panel',
+  artifactId,
+  displayedVersionId,
+  onVersionSelect,
 }: {
   versions: ReadonlyArray<VersionRow>
   locale: Parameters<typeof formatRelative>[1]
   t: ReturnType<typeof useT>['t']
   density?: 'panel' | 'popover'
+  artifactId?: string
+  displayedVersionId?: string | null
+  onVersionSelect?: () => void
 }) {
   if (versions.length === 0) {
     return (
@@ -38,27 +45,72 @@ export function VersionRows({
           )}
           key={version.id}
         >
-          <div className="flex items-center gap-1.5 text-sm">
-            <strong>v{version.ordinal}</strong>
-            {version.isCurrent ? (
-              <span className="bg-link-soft text-link rounded-full px-1.5 py-px text-xs">
-                {t('history.current')}
-              </span>
-            ) : null}
-          </div>
-          <div className="text-muted-foreground flex gap-1.5 text-xs">
-            {version.createdByLabel ? (
-              <>
-                <span>{version.createdByLabel}</span>
-                <span aria-hidden="true">·</span>
-              </>
-            ) : null}
-            <span>{formatRelative(version.createdAt, locale)}</span>
-            <span aria-hidden="true">·</span>
-            <span>{formatBytes(version.sizeBytes)}</span>
-          </div>
+          {artifactId ? (
+            <Link
+              to={
+                version.isCurrent
+                  ? `/a/${encodeURIComponent(artifactId)}`
+                  : `/a/${encodeURIComponent(artifactId)}?version=${encodeURIComponent(version.id)}`
+              }
+              aria-current={
+                displayedVersionId === version.id ||
+                (!displayedVersionId && version.isCurrent)
+                  ? 'page'
+                  : undefined
+              }
+              className="text-foreground hover:bg-accent -m-1 flex rounded-[var(--r-sm)] p-1 no-underline"
+              onClick={(event) => {
+                if (
+                  displayedVersionId === version.id ||
+                  (!displayedVersionId && version.isCurrent)
+                ) {
+                  event.preventDefault()
+                  return
+                }
+                onVersionSelect?.()
+              }}
+            >
+              <VersionRowContent version={version} locale={locale} t={t} />
+            </Link>
+          ) : (
+            <VersionRowContent version={version} locale={locale} t={t} />
+          )}
         </li>
       ))}
     </ul>
+  )
+}
+
+function VersionRowContent({
+  version,
+  locale,
+  t,
+}: {
+  version: VersionRow
+  locale: Parameters<typeof formatRelative>[1]
+  t: ReturnType<typeof useT>['t']
+}) {
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+      <div className="flex items-center gap-1.5 text-sm">
+        <strong>v{version.ordinal}</strong>
+        {version.isCurrent ? (
+          <span className="bg-link-soft text-link rounded-full px-1.5 py-px text-xs">
+            {t('history.current')}
+          </span>
+        ) : null}
+      </div>
+      <div className="text-muted-foreground flex gap-1.5 text-xs">
+        {version.createdByLabel ? (
+          <>
+            <span>{version.createdByLabel}</span>
+            <span aria-hidden="true">·</span>
+          </>
+        ) : null}
+        <span>{formatRelative(version.createdAt, locale)}</span>
+        <span aria-hidden="true">·</span>
+        <span>{formatBytes(version.sizeBytes)}</span>
+      </div>
+    </div>
   )
 }

--- a/apps/web/app/routes/a.$id/+components/version-rows.tsx
+++ b/apps/web/app/routes/a.$id/+components/version-rows.tsx
@@ -45,7 +45,9 @@ export function VersionRows({
           )}
           key={version.id}
         >
-          {artifactId ? (
+          {artifactId &&
+          (version.artifactKind === 'html_page' ||
+            version.artifactKind === 'markdown_page') ? (
             <Link
               to={
                 version.isCurrent

--- a/apps/web/app/routes/a.$id/+components/version-widget.tsx
+++ b/apps/web/app/routes/a.$id/+components/version-widget.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react'
 import { toast } from 'sonner'
+import { Link } from 'react-router'
 import { Button } from '~/components/ui/button'
 import { IconButton } from '~/components/app/icon-button'
 import { useT } from '~/hooks/use-t'
@@ -17,7 +18,10 @@ import type { VersionRow } from './version-history-types'
 import { VersionRows } from './version-rows'
 
 interface VersionWidgetProps {
+  artifactId?: string
   versions: ReadonlyArray<VersionRow>
+  displayedVersionId?: string | null
+  displayedVersionOrdinal?: number | null
   canReplaceFile?: boolean
   onSubmit?: (files: File[]) => void
   replaceMode?: 'single' | 'static_site'
@@ -40,7 +44,10 @@ interface VersionWidgetProps {
 }
 
 export function VersionWidget({
+  artifactId,
   versions,
+  displayedVersionId,
+  displayedVersionOrdinal,
   canReplaceFile = false,
   onSubmit,
   replaceMode = 'single',
@@ -159,6 +166,9 @@ export function VersionWidget({
             locale={locale}
             t={t}
             density="popover"
+            artifactId={artifactId}
+            displayedVersionId={displayedVersionId}
+            onVersionSelect={() => setOpen(false)}
           />
           <button
             type="button"
@@ -194,6 +204,24 @@ export function VersionWidget({
               t={t}
             />
           ) : null}
+        </div>
+      ) : null}
+      {artifactId && displayedVersionId && displayedVersionOrdinal ? (
+        <div
+          role="status"
+          className="bg-background text-foreground border-border pointer-events-auto flex items-center gap-2 rounded-[var(--r-md)] border px-2 py-1.5 text-sm shadow-sm"
+        >
+          <span>
+            {t('history.viewingVersion', {
+              version: `v${displayedVersionOrdinal}`,
+            })}
+          </span>
+          <Link
+            to={`/a/${encodeURIComponent(artifactId)}`}
+            className="text-link hover:text-link-hover font-semibold no-underline"
+          >
+            {t('history.returnCurrent')}
+          </Link>
         </div>
       ) : null}
       {showVersionClue || showCommentClue ? (
@@ -257,12 +285,18 @@ export function VersionWidget({
         aria-controls={open ? popoverId : undefined}
         aria-expanded={open}
         aria-label={t('vw.versionStatusWithVersion', {
-          version: currentLabel,
+          version: displayedVersionOrdinal
+            ? `v${displayedVersionOrdinal}`
+            : currentLabel,
         })}
         onClick={() => setOpen((value) => !value)}
       >
         <HistoryIcon aria-hidden="true" strokeWidth={2.5} />
-        <span>{currentLabel}</span>
+        <span>
+          {displayedVersionOrdinal
+            ? `v${displayedVersionOrdinal}`
+            : currentLabel}
+        </span>
         {hasNewerVersion ? (
           <strong className="text-link text-xs font-semibold">
             {t('history.updateShort')}

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
@@ -142,6 +142,7 @@ interface ViewerChromeProps {
     options?: { returnFocusTo?: HTMLElement | null },
   ) => void
   commentCount?: number
+  commentsEnabled?: boolean
   presence?: ReadonlyArray<ViewerPresence>
   onCommentsOpen?: (returnFocusTo?: HTMLElement | null) => void
   onCopyMarkdown?: () => void
@@ -159,6 +160,7 @@ export function ViewerChrome({
   renderType,
   onHistoryOpenChange,
   commentCount = 0,
+  commentsEnabled = true,
   presence = emptyPresence,
   onCommentsOpen,
   onCopyMarkdown,
@@ -181,7 +183,8 @@ export function ViewerChrome({
   const currentVisibility = isVisibility(artifact.visibility)
     ? artifact.visibility
     : null
-  const commentsAvailable = artifactSupportsComments(renderType)
+  const commentsAvailable =
+    commentsEnabled && artifactSupportsComments(renderType)
   const canChangeVisibility =
     user !== null &&
     artifact.canChangeVisibility === true &&

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -1420,7 +1420,7 @@ function useLatestVersionNotice({
   }, [checkLatestVersion, enabled, liveAvailable])
 
   return {
-    hasNewerVersion: notice.hasNewerVersion,
+    hasNewerVersion: enabled && notice.hasNewerVersion,
     markVersionChanged,
     reconcile: useCallback(
       () => checkLatestVersion({ kind: 'reconcile' }),

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -74,6 +74,8 @@ export type ViewerShellArtifact = {
   canReplaceFile?: boolean
   canViewHistory?: boolean
   currentVersionId?: string | null
+  displayedVersionId?: string | null
+  displayedVersionOrdinal?: number | null
   versions?: ReadonlyArray<VersionRow>
   comments?: ReadonlyArray<CommentThreadView>
   revisitContext?: {
@@ -1235,10 +1237,12 @@ function useLatestVersionNotice({
   artifactId,
   currentVersionId,
   liveAvailable,
+  enabled = true,
 }: {
   artifactId: string
   currentVersionId: string | null
   liveAvailable: boolean
+  enabled?: boolean
 }) {
   const currentVersionIdRef = useRef(currentVersionId)
   const liveAvailableRef = useRef(liveAvailable)
@@ -1296,7 +1300,7 @@ function useLatestVersionNotice({
         kind: 'fallback',
       },
     ) {
-      if (!currentVersionIdRef.current) return
+      if (!enabled || !currentVersionIdRef.current) return
       if (liveAvailableRef.current && options.kind !== 'reconcile') return
       const now = Date.now()
       const elapsed = now - latestCheckStartedAtRef.current
@@ -1368,7 +1372,7 @@ function useLatestVersionNotice({
       if (seq !== latestCheckSeqRef.current) return
       markVersionChanged(body.currentVersionId)
     },
-    [artifactId, clearLatestVersionRetry, markVersionChanged],
+    [artifactId, clearLatestVersionRetry, enabled, markVersionChanged],
   )
 
   useEffect(() => {
@@ -1398,7 +1402,7 @@ function useLatestVersionNotice({
   }, [abortLatestVersionCheck, clearLatestVersionRetry, liveAvailable])
 
   useEffect(() => {
-    if (liveAvailable) return
+    if (!enabled || liveAvailable) return
     void checkLatestVersion({ kind: 'fallback' })
     const interval = window.setInterval(() => {
       void checkLatestVersion({ kind: 'fallback' })
@@ -1413,7 +1417,7 @@ function useLatestVersionNotice({
       window.clearInterval(interval)
       document.removeEventListener('visibilitychange', onVisibilityChange)
     }
-  }, [checkLatestVersion, liveAvailable])
+  }, [checkLatestVersion, enabled, liveAvailable])
 
   return {
     hasNewerVersion: notice.hasNewerVersion,
@@ -1463,7 +1467,9 @@ function useViewerShellController({
     viewerShellReducer,
     initialViewerShellState,
   )
-  const canReplaceFile = user !== null && artifact.canReplaceFile === true
+  const historical = Boolean(artifact.displayedVersionId)
+  const canReplaceFile =
+    !historical && user !== null && artifact.canReplaceFile === true
   const canViewHistory = artifact.canViewHistory === true
   const replaceMode: 'single' | 'static_site' =
     renderType === 'static_site' ? 'static_site' : 'single'
@@ -1476,12 +1482,14 @@ function useViewerShellController({
   // comments-changed) はコメント可能な種別で有効化する。接続は本文を抱える
   // sandbox iframe ではなく apex 側の閲覧画面から張るため、static_site でも
   // sandbox の隔離に触れない。
-  const commentsEnabled = user !== null && artifactSupportsComments(renderType)
+  const commentsEnabled =
+    !historical && user !== null && artifactSupportsComments(renderType)
   const [liveConnected, setLiveConnected] = useState(false)
   const latestVersion = useLatestVersionNotice({
     artifactId: artifact.id,
     currentVersionId: artifact.currentVersionId ?? null,
     liveAvailable: commentsEnabled && liveConnected,
+    enabled: !historical,
   })
   const initialCommentThreads = artifact.comments ?? emptyCommentThreads
   const [viewCountState, setViewCountState] = useState(() => ({
@@ -1509,7 +1517,8 @@ function useViewerShellController({
   }, [])
   // 本文範囲コメントは本文の選択を要するため html / md のみ。static_site の本文は
   // 別オリジンの sandbox iframe にあり選択を取得できない。
-  const textAnchorsEnabled = renderType === 'html' || renderType === 'md'
+  const textAnchorsEnabled =
+    !historical && (renderType === 'html' || renderType === 'md')
   // 全体コメントの新規作成 composer は static_site のみ。html / md は本文選択で付ける。
   const newThreadComposerEnabled = renderType === 'static_site'
   const comments = useViewerComments({
@@ -1525,7 +1534,7 @@ function useViewerShellController({
     onLiveConnectionChanged: setLiveConnected,
     onPanelOpened: handleCommentsPanelOpened,
   })
-  const exportSupported = artifactSupportsExport(renderType)
+  const exportSupported = !historical && artifactSupportsExport(renderType)
   const initialExportPath = useMemo(
     () => defaultExportPath(artifact.entrypointPath, renderType),
     [artifact.entrypointPath, renderType],
@@ -1773,6 +1782,7 @@ function useViewerShellController({
     dispatch,
     canReplaceFile,
     canViewHistory,
+    historical,
     frameTitle,
     historyReturnFocusRef,
     latestVersion,
@@ -1821,6 +1831,7 @@ function ViewerShellView({
   dispatch,
   canReplaceFile,
   canViewHistory,
+  historical,
   frameTitle,
   historyReturnFocusRef,
   latestVersion,
@@ -1838,7 +1849,9 @@ function ViewerShellView({
   handleDownloadMarkdown,
   handleDownloadPdf,
 }: ViewerShellController) {
-  const showExportActions = Boolean(user && artifactSupportsExport(renderType))
+  const showExportActions = Boolean(
+    !historical && user && artifactSupportsExport(renderType),
+  )
 
   return (
     <div className="bg-surface-warm fixed inset-x-0 top-0 bottom-[var(--consent-banner-height)] flex flex-col overflow-hidden overscroll-none">
@@ -1855,8 +1868,9 @@ function ViewerShellView({
           dispatch({ type: 'history-open-changed', open })
         }}
         commentCount={comments.totalCount}
+        commentsEnabled={commentsEnabled}
         presence={comments.presence}
-        onCommentsOpen={comments.openPanel}
+        onCommentsOpen={commentsEnabled ? comments.openPanel : undefined}
         collapsible={sandboxUrl !== null}
         collapsed={state.chromeCollapsed}
         onCollapsedChange={(collapsed) =>
@@ -1871,8 +1885,9 @@ function ViewerShellView({
       />
       {sandboxUrl ? (
         <SandboxFrame
-          key={`${artifact.id}:${artifact.currentVersionId ?? ''}:${renderType ?? ''}`}
+          key={`${artifact.id}:${artifact.displayedVersionId ?? artifact.currentVersionId ?? ''}:${renderType ?? ''}`}
           shareableId={artifact.id}
+          versionId={artifact.displayedVersionId}
           url={sandboxUrl}
           name={frameTitle}
           mermaidEnabled={renderType === 'md'}
@@ -1926,7 +1941,10 @@ function ViewerShellView({
       )}
       {canViewHistory ? (
         <VersionWidget
+          artifactId={artifact.id}
           versions={artifact.versions ?? []}
+          displayedVersionId={artifact.displayedVersionId}
+          displayedVersionOrdinal={artifact.displayedVersionOrdinal}
           canReplaceFile={canReplaceFile}
           onSubmit={canReplaceFile ? submitReplaceVersion : undefined}
           replaceMode={replaceMode}
@@ -1947,6 +1965,8 @@ function ViewerShellView({
       ) : null}
       {canViewHistory ? (
         <HistoryPanel
+          artifactId={artifact.id}
+          displayedVersionId={artifact.displayedVersionId}
           versions={artifact.versions ?? []}
           open={state.historyOpen}
           onOpenChange={(open) => {

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -1852,6 +1852,8 @@ function ViewerShellView({
   const showExportActions = Boolean(
     !historical && user && artifactSupportsExport(renderType),
   )
+  const historyNavigationArtifactId =
+    renderType === 'html' || renderType === 'md' ? artifact.id : undefined
 
   return (
     <div className="bg-surface-warm fixed inset-x-0 top-0 bottom-[var(--consent-banner-height)] flex flex-col overflow-hidden overscroll-none">
@@ -1941,7 +1943,7 @@ function ViewerShellView({
       )}
       {canViewHistory ? (
         <VersionWidget
-          artifactId={artifact.id}
+          artifactId={historyNavigationArtifactId}
           versions={artifact.versions ?? []}
           displayedVersionId={artifact.displayedVersionId}
           displayedVersionOrdinal={artifact.displayedVersionOrdinal}
@@ -1965,7 +1967,7 @@ function ViewerShellView({
       ) : null}
       {canViewHistory ? (
         <HistoryPanel
-          artifactId={artifact.id}
+          artifactId={historyNavigationArtifactId}
           displayedVersionId={artifact.displayedVersionId}
           versions={artifact.versions ?? []}
           open={state.historyOpen}

--- a/apps/web/app/routes/a.$id/index.test.tsx
+++ b/apps/web/app/routes/a.$id/index.test.tsx
@@ -168,8 +168,9 @@ describe('/a/:id loader', () => {
       await loader({
         params: { id: 'html123abc' },
         request: new Request(
-          'https://artifactshare.com/a/html123abc?version=v2',
+          'https://artifactshare.com/a/html123abc.data?version=v2&_routes=routes%2Fa.%24id%2Findex',
         ),
+        url: new URL('https://artifactshare.com/a/html123abc?version=v2'),
         context,
       } as never)
     } catch (error) {

--- a/apps/web/app/routes/a.$id/index.test.tsx
+++ b/apps/web/app/routes/a.$id/index.test.tsx
@@ -182,6 +182,31 @@ describe('/a/:id loader', () => {
     expect((thrown as Response).headers.get('Location')).toBe('/a/html123abc')
   })
 
+  test('does not reveal a private artifact current version through redirects', async () => {
+    dbMock.selectFrom.mockReturnValue(
+      shareableQuery({
+        id: 'html123abc',
+        visibility: 'private',
+        current_version_id: 'v2',
+        r2_key: 'artifacts/html123abc/v2/index.html',
+      }),
+    )
+    const context = new Map()
+    context.set(userContext, null)
+
+    const result = await loader({
+      params: { id: 'html123abc' },
+      request: new Request('https://artifactshare.com/a/html123abc?version=v2'),
+      url: new URL('https://artifactshare.com/a/html123abc?version=v2'),
+      context,
+    } as never)
+
+    expect(result).toMatchObject({
+      kind: 'preauth',
+      canonicalUrl: 'https://artifactshare.com/a/html123abc?version=v2',
+    })
+  })
+
   test('returns static_site loader data with a signed sandbox URL', async () => {
     const shareable = {
       id: 'abc123def4',

--- a/apps/web/app/routes/a.$id/index.test.tsx
+++ b/apps/web/app/routes/a.$id/index.test.tsx
@@ -151,6 +151,36 @@ describe('/a/:id loader', () => {
     expect(viewerDisplayCheckMock).not.toHaveBeenCalled()
   })
 
+  test('redirects an anonymous current-version URL to the public canonical URL', async () => {
+    dbMock.selectFrom.mockReturnValue(
+      shareableQuery({
+        id: 'html123abc',
+        visibility: 'link',
+        current_version_id: 'v2',
+        r2_key: 'artifacts/html123abc/v2/index.html',
+      }),
+    )
+    const context = new Map()
+    context.set(userContext, null)
+
+    let thrown: unknown
+    try {
+      await loader({
+        params: { id: 'html123abc' },
+        request: new Request(
+          'https://artifactshare.com/a/html123abc?version=v2',
+        ),
+        context,
+      } as never)
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Response)
+    expect((thrown as Response).status).toBe(302)
+    expect((thrown as Response).headers.get('Location')).toBe('/a/html123abc')
+  })
+
   test('returns static_site loader data with a signed sandbox URL', async () => {
     const shareable = {
       id: 'abc123def4',

--- a/apps/web/app/routes/a.$id/index.test.tsx
+++ b/apps/web/app/routes/a.$id/index.test.tsx
@@ -124,6 +124,33 @@ describe('/a/:id loader', () => {
     expect(viewerDisplayCheckMock).not.toHaveBeenCalled()
   })
 
+  test('preserves a requested historical version through sign-in', async () => {
+    const shareable = {
+      id: 'html123abc',
+      visibility: 'link',
+      current_version_id: 'v2',
+      r2_key: 'artifacts/html123abc/v2/index.html',
+    }
+    dbMock.selectFrom.mockImplementation((table: string) => {
+      if (table === 'shareables') return shareableQuery(shareable)
+      throw new Error(`unexpected table ${table}`)
+    })
+    const context = new Map()
+    context.set(userContext, null)
+
+    const result = await loader({
+      params: { id: 'html123abc' },
+      request: new Request('https://artifactshare.com/a/html123abc?version=v1'),
+      context,
+    } as never)
+
+    expect(result).toMatchObject({
+      kind: 'preauth',
+      canonicalUrl: 'https://artifactshare.com/a/html123abc?version=v1',
+    })
+    expect(viewerDisplayCheckMock).not.toHaveBeenCalled()
+  })
+
   test('returns static_site loader data with a signed sandbox URL', async () => {
     const shareable = {
       id: 'abc123def4',

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -310,6 +310,14 @@ export async function loader({
     throw new Response('Not found', { status: 404 })
   }
 
+  if (requestedVersionId === shareable.current_version_id) {
+    const currentUrl = new URL(request.url)
+    currentUrl.searchParams.delete('version')
+    throw redirect(
+      `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`,
+    )
+  }
+
   if (!user) {
     if (requestedVersionId) {
       const requestedUrl = new URL(canonicalUrl)
@@ -425,14 +433,6 @@ export async function loader({
       })
     }
     return forbidden({ kind: 'unavailable', user: userInfo })
-  }
-
-  if (requestedVersionId === shareable.current_version_id) {
-    const currentUrl = new URL(request.url)
-    currentUrl.searchParams.delete('version')
-    throw redirect(
-      `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`,
-    )
   }
 
   const selectedVersion = requestedVersionId

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -231,8 +231,10 @@ export async function loader({
   params,
   context,
   request,
+  url,
 }: Route.LoaderArgs): Promise<LoaderData> {
   const db = createDb()
+  const normalizedUrl = url ?? new URL(request.url)
 
   // versions は leftJoin。version 行欠落 (NULL current_version_id か
   // dangling FK) のとき owner には source-missing を返したい。owner
@@ -295,8 +297,8 @@ export async function loader({
     throw new Response('Not found', { status: 404 })
   }
 
-  const canonicalUrl = new URL(`/a/${shareable.id}`, request.url).toString()
-  const requestedVersionId = new URL(request.url).searchParams.get('version')
+  const canonicalUrl = new URL(`/a/${shareable.id}`, normalizedUrl).toString()
+  const requestedVersionId = normalizedUrl.searchParams.get('version')
   const user = context.get(userContext)
 
   if (!shareable.r2_key) {
@@ -311,7 +313,7 @@ export async function loader({
   }
 
   if (requestedVersionId === shareable.current_version_id) {
-    const currentUrl = new URL(request.url)
+    const currentUrl = new URL(normalizedUrl)
     currentUrl.searchParams.delete('version')
     throw redirect(
       `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`,

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -312,15 +312,13 @@ export async function loader({
     throw new Response('Not found', { status: 404 })
   }
 
-  if (requestedVersionId === shareable.current_version_id) {
-    const currentUrl = new URL(normalizedUrl)
-    currentUrl.searchParams.delete('version')
-    throw redirect(
-      `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`,
-    )
-  }
-
   if (!user) {
+    if (
+      shareable.visibility === 'link' &&
+      requestedVersionId === shareable.current_version_id
+    ) {
+      throw redirectToCurrentVersion(normalizedUrl)
+    }
     if (requestedVersionId) {
       const requestedUrl = new URL(canonicalUrl)
       requestedUrl.searchParams.set('version', requestedVersionId)
@@ -435,6 +433,10 @@ export async function loader({
       })
     }
     return forbidden({ kind: 'unavailable', user: userInfo })
+  }
+
+  if (requestedVersionId === shareable.current_version_id) {
+    throw redirectToCurrentVersion(normalizedUrl)
   }
 
   const selectedVersion = requestedVersionId
@@ -723,6 +725,14 @@ export async function loader({
     sandboxUrl,
     canonicalUrl,
   }
+}
+
+function redirectToCurrentVersion(url: URL): Response {
+  const currentUrl = new URL(url)
+  currentUrl.searchParams.delete('version')
+  return redirect(
+    `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`,
+  )
 }
 
 async function buildLinkAnonymousResponse(

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -1068,6 +1068,7 @@ async function loadHistoryVersions(
       .leftJoin('users', 'users.id', 'versions.created_by_id')
       .select([
         'versions.id',
+        'versions.artifact_kind as artifactKind',
         'versions.published_at as createdAt',
         'versions.size_bytes as sizeBytes',
         'users.email as createdByEmail',
@@ -1089,6 +1090,7 @@ async function loadHistoryVersions(
     createdAt: row.createdAt!,
     sizeBytes: row.sizeBytes,
     isCurrent: row.id === currentVersionId,
+    artifactKind: row.artifactKind,
     createdByLabel: row.createdByName ?? row.createdByEmail,
   }))
 }

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -5,6 +5,7 @@ import {
   data,
   isRouteErrorResponse,
   Link,
+  redirect,
   useRouteLoaderData,
 } from 'react-router'
 import { Button } from '~/components/ui/button'
@@ -111,6 +112,8 @@ interface ArtifactSummary {
   workspaceMsTenantId: string | null
   availableVisibilities: ReadonlyArray<EditableVisibility>
   currentVersionId: string | null
+  displayedVersionId?: string | null
+  displayedVersionOrdinal?: number | null
   versions: ReadonlyArray<VersionRow>
   grants: ReadonlyArray<GrantEntry>
   comments: ReadonlyArray<CommentThreadView>
@@ -293,6 +296,7 @@ export async function loader({
   }
 
   const canonicalUrl = new URL(`/a/${shareable.id}`, request.url).toString()
+  const requestedVersionId = new URL(request.url).searchParams.get('version')
   const user = context.get(userContext)
 
   if (!shareable.r2_key) {
@@ -307,6 +311,21 @@ export async function loader({
   }
 
   if (!user) {
+    if (requestedVersionId) {
+      const requestedUrl = new URL(canonicalUrl)
+      requestedUrl.searchParams.set('version', requestedVersionId)
+      return {
+        kind: 'preauth',
+        artifact: {
+          id: shareable.id,
+          name: null,
+          derivedTitle: null,
+          titleOverride: null,
+          description: null,
+        },
+        canonicalUrl: requestedUrl.toString(),
+      }
+    }
     if (shareable.visibility === 'link') {
       return await buildLinkAnonymousResponse(
         db,
@@ -408,6 +427,22 @@ export async function loader({
     return forbidden({ kind: 'unavailable', user: userInfo })
   }
 
+  if (requestedVersionId === shareable.current_version_id) {
+    const currentUrl = new URL(request.url)
+    currentUrl.searchParams.delete('version')
+    throw redirect(
+      `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`,
+    )
+  }
+
+  const selectedVersion = requestedVersionId
+    ? await loadPublishedViewerVersion(db, shareable.id, requestedVersionId)
+    : null
+  if (requestedVersionId && !selectedVersion) {
+    throw new Response('Not found', { status: 404 })
+  }
+  const historical = selectedVersion !== null
+
   const {
     modifiedTime,
     name: fileName,
@@ -417,17 +452,23 @@ export async function loader({
   const nameStale = fileName !== shareable.name
   const isOwner = shareable.owner_user_id === user.id
   const isPrefetch = isPrefetchRequest(request)
-  const shouldRecordView = !isPrefetch
+  const shouldRecordView = !isPrefetch && !historical
   const preserveRevisitFixture = isDevScreenStateRequest(
     request,
     'viewer/revisit-context',
   )
-  const canTrackView = !isPrefetch
+  const canTrackView = !isPrefetch && !historical
   const canViewHistory = true
-  const isStaticSite = shareable.version_artifact_kind === 'static_site'
+  const selectedArtifactKind =
+    selectedVersion?.artifact_kind ?? shareable.version_artifact_kind
+  const isStaticSite = selectedArtifactKind === 'static_site'
   const detectedRenderType = isStaticSite
     ? 'static_site'
-    : detectArtifactType(mimeType, fileName)
+    : selectedArtifactKind === 'markdown_page'
+      ? 'md'
+      : selectedArtifactKind === 'html_page'
+        ? 'html'
+        : detectArtifactType(mimeType, fileName)
   const canReplaceFile = isOwner
   const canReturnToProject =
     shareable.return_project_id !== null &&
@@ -440,6 +481,9 @@ export async function loader({
     shareable.id,
     shareable.current_version_id,
   )
+  const displayedVersionOrdinal = selectedVersion
+    ? await loadPublishedVersionOrdinal(db, shareable.id, selectedVersion)
+    : null
   // creator なら visibility に関わらず grants を pre-load する。
   // private / workspace の切り替え時に、既存の個別許可を最初から見せる。
   const grants = isOwner
@@ -456,9 +500,13 @@ export async function loader({
     r2Key: shareable.r2_key,
   })
   const [comments, latestCommentCreatedAt, revisitContext] = await Promise.all([
-    loadCommentThreads(db, commentAccess, user),
-    latestOtherCommentCreatedAt(db, shareable.id, user.id),
-    detectedRenderType
+    historical
+      ? Promise.resolve([])
+      : loadCommentThreads(db, commentAccess, user),
+    historical
+      ? Promise.resolve(null)
+      : latestOtherCommentCreatedAt(db, shareable.id, user.id),
+    detectedRenderType && !historical
       ? loadViewerRevisitContext(db, {
           shareableId: shareable.id,
           viewerUserId: user.id,
@@ -479,12 +527,13 @@ export async function loader({
   )
   const baseArtifact = {
     id: shareable.id,
-    storageKey,
+    storageKey: selectedVersion?.r2_key ?? storageKey,
     name: fileName,
     derivedTitle: shareable.derived_title,
     titleOverride: shareable.title_override,
     description: shareable.description,
-    entrypointPath: shareable.entrypoint_path,
+    entrypointPath:
+      selectedVersion?.entrypoint_path ?? shareable.entrypoint_path,
     ownerId: shareable.owner_user_id,
     ownerEmail: ownerEmail ?? shareable.owner_email,
     ownerName: shareable.owner_name,
@@ -614,8 +663,8 @@ export async function loader({
       uid: user.id,
       wid: shareable.workspace_id,
       aid: shareable.id,
-      vid: shareable.current_version_id!,
-      fid: storageKey,
+      vid: selectedVersion?.id ?? shareable.current_version_id!,
+      fid: selectedVersion?.r2_key ?? storageKey,
       mt: modifiedTime,
       t: renderType,
       jti: nanoid(),
@@ -647,7 +696,7 @@ export async function loader({
     env,
     shareable.id,
     token,
-    shareable.entrypoint_path ?? undefined,
+    selectedVersion?.entrypoint_path ?? shareable.entrypoint_path ?? undefined,
   )
 
   return {
@@ -661,6 +710,8 @@ export async function loader({
       canChangeVisibility: isOwner,
       availableVisibilities,
       currentVersionId: shareable.current_version_id,
+      displayedVersionId: selectedVersion?.id ?? null,
+      displayedVersionOrdinal,
       versions,
       grants,
       comments,
@@ -997,19 +1048,23 @@ async function loadHistoryVersions(
       .selectFrom('versions')
       .select((eb) => eb.fn.count<number>('id').as('count'))
       .where('shareable_id', '=', shareableId)
+      .where('status', '=', 'published')
+      .where('published_at', 'is not', null)
       .executeTakeFirst(),
     db
       .selectFrom('versions')
       .leftJoin('users', 'users.id', 'versions.created_by_id')
       .select([
         'versions.id',
-        'versions.created_at as createdAt',
+        'versions.published_at as createdAt',
         'versions.size_bytes as sizeBytes',
         'users.email as createdByEmail',
         'users.name as createdByName',
       ])
       .where('versions.shareable_id', '=', shareableId)
-      .orderBy('versions.created_at', 'desc')
+      .where('versions.status', '=', 'published')
+      .where('versions.published_at', 'is not', null)
+      .orderBy('versions.published_at', 'desc')
       .orderBy('versions.id', 'desc')
       .limit(50)
       .execute(),
@@ -1019,11 +1074,67 @@ async function loadHistoryVersions(
   return rows.map((row, index) => ({
     id: row.id,
     ordinal: total - index,
-    createdAt: row.createdAt,
+    createdAt: row.createdAt!,
     sizeBytes: row.sizeBytes,
     isCurrent: row.id === currentVersionId,
     createdByLabel: row.createdByName ?? row.createdByEmail,
   }))
+}
+
+type PublishedViewerVersion = {
+  id: string
+  artifact_kind: 'html_page' | 'markdown_page'
+  entrypoint_path: string
+  r2_key: string
+  published_at: string
+}
+
+async function loadPublishedViewerVersion(
+  db: ReturnType<typeof createDb>,
+  shareableId: string,
+  versionId: string,
+): Promise<PublishedViewerVersion | null> {
+  const version = await db
+    .selectFrom('versions')
+    .select([
+      'id',
+      'artifact_kind',
+      'entrypoint_path',
+      'r2_key',
+      'published_at',
+    ])
+    .where('id', '=', versionId)
+    .where('shareable_id', '=', shareableId)
+    .where('status', '=', 'published')
+    .where('published_at', 'is not', null)
+    .where('artifact_kind', 'in', ['html_page', 'markdown_page'])
+    .executeTakeFirst()
+  if (!version?.published_at) return null
+  return version as PublishedViewerVersion
+}
+
+async function loadPublishedVersionOrdinal(
+  db: ReturnType<typeof createDb>,
+  shareableId: string,
+  version: Pick<PublishedViewerVersion, 'id' | 'published_at'>,
+): Promise<number> {
+  const row = await db
+    .selectFrom('versions')
+    .select((eb) => eb.fn.count<number>('id').as('count'))
+    .where('shareable_id', '=', shareableId)
+    .where('status', '=', 'published')
+    .where('published_at', 'is not', null)
+    .where((eb) =>
+      eb.or([
+        eb('published_at', '<', version.published_at),
+        eb.and([
+          eb('published_at', '=', version.published_at),
+          eb('id', '<=', version.id),
+        ]),
+      ]),
+    )
+    .executeTakeFirst()
+  return Number(row?.count ?? 0)
 }
 
 export function meta({ loaderData }: Route.MetaArgs) {
@@ -1185,7 +1296,8 @@ function PreauthFallback({ canonicalUrl }: { canonicalUrl: string }) {
   const { t } = useT()
   const cliCommand = buildPreauthCliOpenCommand(canonicalUrl)
   const [agentHelpOpen, setAgentHelpOpen] = useState(false)
-  const returnPath = new URL(canonicalUrl).pathname
+  const returnUrl = new URL(canonicalUrl)
+  const returnPath = `${returnUrl.pathname}${returnUrl.search}`
   const signInHref = `/sign-in?method=email&next=${encodeURIComponent(returnPath)}`
   return (
     <Stack gap="0" align="center" justify="center" asChild>

--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.test.ts
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.test.ts
@@ -156,6 +156,76 @@ describe('/api/shareables/:id/sandbox-token', () => {
     expect(body.sandboxUrl).not.toContain('as_next=')
   })
 
+  test('returns a token for a requested published historical version', async () => {
+    dbMock.selectFrom
+      .mockReturnValueOnce(
+        shareableQuery({
+          id: 'html123abc',
+          workspace_id: 'ws1',
+          owner_user_id: 'owner1',
+          name: 'demo.html',
+          visibility: 'private',
+          container_id: null,
+          current_version_id: 'v2',
+          project_container_kind: null,
+          project_container_base_visibility: null,
+          r2_key: 'ws1/html123abc/v2/demo.html',
+          entrypoint_path: '/demo.html',
+          artifact_kind: 'html_page',
+          version_artifact_kind: 'html_page',
+        }),
+      )
+      .mockReturnValueOnce(
+        shareableQuery({
+          id: 'v1',
+          r2_key: 'ws1/html123abc/v1/demo.html',
+          entrypoint_path: '/demo.html',
+          artifact_kind: 'html_page',
+        }),
+      )
+
+    const response = await loader(loaderArgs('html123abc', 'v1'))
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { sandboxUrl: string }
+    const token = new URL(body.sandboxUrl).searchParams.get('t')
+    await expect(
+      verifySandboxToken(token!, 'test-secret-with-enough-entropy-for-hmac'),
+    ).resolves.toMatchObject({
+      uid: 'u1',
+      aid: 'html123abc',
+      vid: 'v1',
+      fid: 'ws1/html123abc/v1/demo.html',
+      t: 'html',
+    })
+  })
+
+  test('does not expose requested historical versions anonymously', async () => {
+    requireUserMock.mockReturnValue(null)
+    dbMock.selectFrom.mockReturnValue(
+      shareableQuery({
+        id: 'html123abc',
+        workspace_id: 'ws1',
+        owner_user_id: 'owner1',
+        name: 'demo.html',
+        visibility: 'link',
+        container_id: null,
+        current_version_id: 'v2',
+        project_container_kind: null,
+        project_container_base_visibility: null,
+        r2_key: 'ws1/html123abc/v2/demo.html',
+        entrypoint_path: '/demo.html',
+        artifact_kind: 'html_page',
+        version_artifact_kind: 'html_page',
+      }),
+    )
+
+    const response = await loader(loaderArgs('html123abc', 'v1'))
+
+    expect(response.status).toBe(404)
+    expect(dbMock.selectFrom).toHaveBeenCalledTimes(1)
+  })
+
   test('does not return a token when access is denied', async () => {
     dbMock.selectFrom.mockReturnValue(
       shareableQuery({
@@ -182,7 +252,7 @@ describe('/api/shareables/:id/sandbox-token', () => {
   })
 })
 
-function loaderArgs(id = 'abc123def4') {
+function loaderArgs(id = 'abc123def4', versionId?: string) {
   const ctx = new Map()
   const user = requireUserMock()
   if (user) ctx.set(userContextSymbol, user)
@@ -190,7 +260,7 @@ function loaderArgs(id = 'abc123def4') {
     context: ctx,
     params: { id },
     request: new Request(
-      `https://artifactshare.test/api/shareables/${id}/sandbox-token`,
+      `https://artifactshare.test/api/shareables/${id}/sandbox-token${versionId ? `?version=${versionId}` : ''}`,
     ),
   } as never
 }

--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
@@ -11,7 +11,7 @@ import {
 import { createDb } from '~/services/db.server'
 import type { Route } from './+types/api.shareables.$id.sandbox-token'
 
-export async function loader({ context, params }: Route.LoaderArgs) {
+export async function loader({ context, params, request }: Route.LoaderArgs) {
   const user = context.get(userContext)
   const db = createDb()
   const shareable = await db
@@ -39,16 +39,7 @@ export async function loader({ context, params }: Route.LoaderArgs) {
     ])
     .where('shareables.id', '=', params.id)
     .executeTakeFirst()
-  const artifactKind = shareable?.version_artifact_kind
-  const renderType =
-    artifactKind === 'static_site'
-      ? 'static_site'
-      : artifactKind === 'html_page'
-        ? renderTypeFromKind(artifactKind)
-        : artifactKind === 'markdown_page'
-          ? renderTypeFromKind(artifactKind)
-          : null
-  if (!shareable?.r2_key || !shareable.current_version_id || !renderType) {
+  if (!shareable?.r2_key || !shareable.current_version_id) {
     return Response.json({ error: 'not-found' }, { status: 404 })
   }
 
@@ -84,13 +75,48 @@ export async function loader({ context, params }: Route.LoaderArgs) {
     return Response.json({ error: 'not-found' }, { status: 404 })
   }
 
+  const requestedVersionId = new URL(request.url).searchParams.get('version')
+  if (requestedVersionId && !user) {
+    return Response.json({ error: 'not-found' }, { status: 404 })
+  }
+  const requestedVersion = requestedVersionId
+    ? await db
+        .selectFrom('versions')
+        .select(['id', 'r2_key', 'entrypoint_path', 'artifact_kind'])
+        .where('id', '=', requestedVersionId)
+        .where('shareable_id', '=', shareable.id)
+        .where('status', '=', 'published')
+        .where('published_at', 'is not', null)
+        .where('artifact_kind', 'in', ['html_page', 'markdown_page'])
+        .executeTakeFirst()
+    : null
+  if (requestedVersionId && !requestedVersion) {
+    return Response.json({ error: 'not-found' }, { status: 404 })
+  }
+  const version = requestedVersion ?? {
+    id: shareable.current_version_id,
+    r2_key: shareable.r2_key,
+    entrypoint_path: shareable.entrypoint_path,
+    artifact_kind: shareable.version_artifact_kind,
+  }
+  const artifactKind = version.artifact_kind
+  const renderType =
+    artifactKind === 'static_site'
+      ? 'static_site'
+      : artifactKind === 'html_page' || artifactKind === 'markdown_page'
+        ? renderTypeFromKind(artifactKind)
+        : null
+  if (!renderType) {
+    return Response.json({ error: 'not-found' }, { status: 404 })
+  }
+
   const token = await signSandboxToken(
     {
       uid: user?.id ?? null,
       wid: shareable.workspace_id,
       aid: shareable.id,
-      vid: shareable.current_version_id,
-      fid: shareable.r2_key,
+      vid: version.id,
+      fid: version.r2_key,
       mt: check.meta.modifiedTime,
       t: renderType,
       jti: nanoid(),
@@ -102,9 +128,7 @@ export async function loader({ context, params }: Route.LoaderArgs) {
     env,
     shareable.id,
     token,
-    renderType === 'static_site'
-      ? (shareable.entrypoint_path ?? undefined)
-      : undefined,
+    version.entrypoint_path ?? undefined,
   )
   return Response.json({ sandboxUrl, renderType })
 }

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -1722,6 +1722,31 @@ describe('handleArtifactSandboxRequest', () => {
     const second = await handleArtifactSandboxRequest(new Request(url))
     expect(second.status).toBe(200)
     expect(consumeJtiMock).not.toHaveBeenCalled()
+
+    await dbRef
+      .current!.insertInto('versions')
+      .values({
+        id: 'v-embed-next',
+        shareable_id: 'embed12345',
+        artifact_kind: 'html_page',
+        status: 'published',
+        entrypoint_path: '/index.html',
+        r2_key: 'artifacts/embed12345/v-embed-next/index.html',
+        size_bytes: 10,
+        sha256: 'sha-embed-next',
+        created_by_id: 'owner-1',
+        created_at: '2026-05-23T00:00:00.000Z',
+        published_at: '2026-05-23T00:00:00.000Z',
+      })
+      .execute()
+    await dbRef
+      .current!.updateTable('shareables')
+      .set({ current_version_id: 'v-embed-next' })
+      .where('id', '=', 'embed12345')
+      .execute()
+
+    const stale = await handleArtifactSandboxRequest(new Request(url))
+    expect(stale.status).toBe(401)
   })
 
   test('a normal single-file token keeps frame-ancestors locked to our origin', async () => {

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -448,6 +448,77 @@ describe('violation reporter injection handler', () => {
       vi.unstubAllGlobals()
     }
   })
+
+  test('serves an authenticated published historical single-file version', async () => {
+    await dbRef
+      .current!.insertInto('shareables')
+      .values({
+        id: 'html-history',
+        workspace_id: 'ws-a',
+        owner_user_id: 'owner-1',
+        slug: null,
+        name: 'report.html',
+        derived_title: null,
+        title_override: null,
+        description: null,
+        artifact_kind: 'html_page',
+        visibility: 'private',
+        current_version_id: 'v-history-current',
+        container_id: 'owner-inbox',
+        created_at: '2026-05-22T00:00:00.000Z',
+        updated_at: '2026-05-23T00:00:00.000Z',
+        last_accessed_at: null,
+      })
+      .execute()
+    await dbRef
+      .current!.insertInto('versions')
+      .values([
+        {
+          id: 'v-history-old',
+          shareable_id: 'html-history',
+          artifact_kind: 'html_page',
+          status: 'published',
+          entrypoint_path: '/report.html',
+          r2_key: 'history-old-key',
+          size_bytes: 10,
+          sha256: 'sha-history-old',
+          created_by_id: 'owner-1',
+          created_at: '2026-05-22T00:00:00.000Z',
+          published_at: '2026-05-22T00:00:00.000Z',
+        },
+        {
+          id: 'v-history-current',
+          shareable_id: 'html-history',
+          artifact_kind: 'html_page',
+          status: 'published',
+          entrypoint_path: '/report.html',
+          r2_key: 'history-current-key',
+          size_bytes: 10,
+          sha256: 'sha-history-current',
+          created_by_id: 'owner-1',
+          created_at: '2026-05-23T00:00:00.000Z',
+          published_at: '2026-05-23T00:00:00.000Z',
+        },
+      ])
+      .execute()
+    storageMock.getArtifact.mockResolvedValue(
+      storedArtifact('<!doctype html><body>Old</body>', 'text/html'),
+    )
+    const token = await singleFileToken({
+      id: 'html-history',
+      versionId: 'v-history-old',
+      r2Key: 'history-old-key',
+      renderType: 'html',
+    })
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`https://localhost:5173/report.html?t=${token}`),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toContain('Old')
+    expect(storageMock.getArtifact).toHaveBeenCalledWith({}, 'history-old-key')
+  })
 })
 
 async function seedOwnerInbox(db: Kysely<DB>) {

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -285,19 +285,26 @@ async function currentEntrypoint(
 
   const version = await db
     .selectFrom('shareables')
-    .innerJoin('versions', 'versions.id', 'shareables.current_version_id')
+    .innerJoin('versions', 'versions.shareable_id', 'shareables.id')
     .select([
+      'shareables.current_version_id',
       'versions.artifact_kind',
       'versions.entrypoint_path',
       'versions.r2_key',
     ])
     .where('shareables.id', '=', payload.aid)
     .where('shareables.workspace_id', '=', payload.wid)
-    .where('shareables.current_version_id', '=', payload.vid)
     .where('versions.id', '=', payload.vid)
+    .where('versions.status', '=', 'published')
+    .where('versions.published_at', 'is not', null)
     .where('versions.artifact_kind', '=', expectedKind)
     .executeTakeFirst()
-  if (!version || version.entrypoint_path !== path) return null
+  if (
+    !version ||
+    version.entrypoint_path !== path ||
+    (payload.uid === null && version.current_version_id !== payload.vid)
+  )
+    return null
 
   if (payload.t !== 'static_site') {
     if (version.r2_key !== payload.fid) return null

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -302,7 +302,8 @@ async function currentEntrypoint(
   if (
     !version ||
     version.entrypoint_path !== path ||
-    (payload.uid === null && version.current_version_id !== payload.vid)
+    ((payload.uid === null || payload.emb === true) &&
+      version.current_version_id !== payload.vid)
   )
     return null
 


### PR DESCRIPTION
## Summary

- let signed-in viewers open published HTML and Markdown versions from version history
- keep the selected version in the URL and provide a clear return to the current version
- suppress current-version comments, replacement, export, live updates, view tracking, and revisit side effects while viewing history
- validate the selected published version in both the Viewer and sandbox worker

## Validation

- `pnpm validate:static`
- targeted Viewer, sandbox-token, bundle-sandbox, history UI, and viewer-shell tests
- React Doctor: 100
- desktop and mobile historical-version captures reviewed against the relevant source; no unresolved visual issue
- Codex and Claude implementation reviews: no unresolved blockers on `a433cf6`

## Scope

- historical static-site bundles and content diffs remain separate work
