### PR TITLE
Scope sandbox origins to published versions

### DIFF
--- a/apps/web/app/lib/hosts.test.ts
+++ b/apps/web/app/lib/hosts.test.ts
@@ -3,6 +3,8 @@ import {
   artifactSandboxUrl,
   MCP_EMBED_FRAME_ANCESTORS,
   requestHostname,
+  sandboxVersionIdentityFromHostname,
+  sandboxVersionLabel,
 } from './hosts'
 
 describe('artifactSandboxUrl', () => {
@@ -10,23 +12,27 @@ describe('artifactSandboxUrl', () => {
     const url = artifactSandboxUrl(
       { APP_ENV: 'development' },
       'abc123def4',
+      'version_1-test',
       'token',
       '/index.html',
     )
 
-    expect(url).toBe('https://abc123def4.sandbox.localhost:5174/?t=token')
+    expect(url).toBe(
+      'https://abc123def4--v-76657273696f6e5f312d74657374.sandbox.localhost:5174/?t=token',
+    )
   })
 
   test('uses the sandbox dev server without an app path prefix', () => {
     const url = artifactSandboxUrl(
       { APP_ENV: 'development' },
       'abc123def4',
+      'version_1-test',
       'token',
       '/CLAUDE.md',
     )
 
     expect(url).toBe(
-      'https://abc123def4.sandbox.localhost:5174/CLAUDE.md?t=token',
+      'https://abc123def4--v-76657273696f6e5f312d74657374.sandbox.localhost:5174/CLAUDE.md?t=token',
     )
   })
 
@@ -34,13 +40,35 @@ describe('artifactSandboxUrl', () => {
     const url = artifactSandboxUrl(
       { APP_ENV: 'production' },
       'abc123def4',
+      'version_1-test',
       'token',
       '/docs/50% off.html',
     )
 
     expect(url).toBe(
-      'https://abc123def4.sandbox.artifactshare.com/docs/50%25%20off.html?t=token',
+      'https://abc123def4--v-76657273696f6e5f312d74657374.sandbox.artifactshare.com/docs/50%25%20off.html?t=token',
     )
+  })
+})
+
+describe('sandbox version identity', () => {
+  test('round trips DNS-unsafe version ids through a version-scoped hostname', () => {
+    const label = sandboxVersionLabel('abc123def4', 'version_1-test')
+    expect(
+      sandboxVersionIdentityFromHostname(`${label}.sandbox.artifactshare.com`, {
+        APP_ENV: 'production',
+      }),
+    ).toEqual({ shareableId: 'abc123def4', versionId: 'version_1-test' })
+  })
+
+  test('rejects malformed and oversized identities', () => {
+    expect(
+      sandboxVersionIdentityFromHostname(
+        'abc123def4--v-0g.sandbox.artifactshare.com',
+        { APP_ENV: 'production' },
+      ),
+    ).toBeNull()
+    expect(() => sandboxVersionLabel('abc123def4', 'x'.repeat(26))).toThrow()
   })
 })
 

--- a/apps/web/app/lib/hosts.ts
+++ b/apps/web/app/lib/hosts.ts
@@ -61,22 +61,58 @@ export const APP_DEV_PORT = 5173
 export const BUNDLE_SANDBOX_DEV_PORT = 5174
 
 /**
- * Build the iframe src URL for an artifact's sandboxed entrypoint.
- * Precondition: `shareableId` must be a non-empty lowercase alphanumeric label
- * (no `-`, no `_`, no uppercase). Enforced by the nanoid alphabet in
- * `app/services/shareables.server.ts`; the helper does not re-validate.
+ * Build the iframe src URL for a published version's sandboxed entrypoint.
+ * The hostname is scoped to both the shareable and the exact version. Version
+ * ids use nanoid's DNS-unsafe alphabet, so encode their UTF-8 bytes as hex.
  */
 export function artifactSandboxUrl(
   env: { APP_ENV: string },
   shareableId: string,
+  versionId: string,
   token: string,
   entrypointPath = '/index.html',
 ): string {
   const path = browserEntrypointPath(entrypointPath)
   const query = `?t=${encodeURIComponent(token)}`
+  const label = sandboxVersionLabel(shareableId, versionId)
   return isProduction(env)
-    ? `https://${shareableId}.${SANDBOX_HOST}${path}${query}`
-    : `https://${shareableId}.sandbox.localhost:${BUNDLE_SANDBOX_DEV_PORT}${path}${query}`
+    ? `https://${label}.${SANDBOX_HOST}${path}${query}`
+    : `https://${label}.sandbox.localhost:${BUNDLE_SANDBOX_DEV_PORT}${path}${query}`
+}
+
+export function sandboxVersionLabel(
+  shareableId: string,
+  versionId: string,
+): string {
+  const encodedVersion = Array.from(
+    new TextEncoder().encode(versionId),
+    (byte) => byte.toString(16).padStart(2, '0'),
+  ).join('')
+  const label = `${shareableId}--v-${encodedVersion}`
+  if (!/^[a-z0-9]{10}--v-[a-f0-9]+$/.test(label) || label.length > 63) {
+    throw new Error('Invalid sandbox version identity')
+  }
+  return label
+}
+
+export function sandboxVersionIdentityFromHostname(
+  hostname: string,
+  env: { APP_ENV: string },
+): { shareableId: string; versionId: string } | null {
+  const suffix = isProduction(env) ? `.${SANDBOX_HOST}` : '.sandbox.localhost'
+  if (!hostname.endsWith(suffix)) return null
+  const label = hostname.slice(0, -suffix.length)
+  const match = /^([a-z0-9]{10})--v-([a-f0-9]+)$/.exec(label)
+  if (!match || match[2].length % 2 !== 0) return null
+  try {
+    const bytes = new Uint8Array(
+      match[2].match(/../g)?.map((byte) => Number.parseInt(byte, 16)) ?? [],
+    )
+    const versionId = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+    return versionId ? { shareableId: match[1], versionId } : null
+  } catch {
+    return null
+  }
 }
 
 function browserEntrypointPath(path: string): string {

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -56,7 +56,7 @@ import {
   shouldStartLivenessProbe,
 } from '~/lib/sandbox-frame-state'
 
-// The per-artifact sandbox origin is the trust boundary for messages. The
+// The version-scoped sandbox origin is the trust boundary for messages. The
 // source check keeps sibling frames on the same page from spoofing reports.
 interface ViolationEntry extends CspViolationMessage {
   id: string

--- a/apps/web/app/routes/a.$id/index.test.tsx
+++ b/apps/web/app/routes/a.$id/index.test.tsx
@@ -190,7 +190,7 @@ describe('/a/:id loader', () => {
     if (result.kind !== 'static_site') return
     expect(result.artifact.canReplaceFile).toBe(true)
     expect(result.sandboxUrl).toMatch(
-      /^https:\/\/abc123def4\.sandbox\.artifactshare\.com\/index\.md\?t=/,
+      /^https:\/\/abc123def4--v-7631\.sandbox\.artifactshare\.com\/index\.md\?t=/,
     )
     expect(result.bundlePaths).toEqual(['/index.md', '/other.md'])
     expect(result.fallbackToIndex).toBe(false)
@@ -298,7 +298,7 @@ describe('/a/:id loader', () => {
     expect(result.kind).toBe('static_site')
     if (result.kind !== 'static_site') return
     expect(result.sandboxUrl).toMatch(
-      /^https:\/\/site123abc\.sandbox\.artifactshare\.com\/\?t=/,
+      /^https:\/\/site123abc--v-7631\.sandbox\.artifactshare\.com\/\?t=/,
     )
     expect(result.bundlePaths).toEqual(['/index.md', '/other.md'])
     expect(result.fallbackToIndex).toBe(true)
@@ -318,7 +318,7 @@ describe('/a/:id loader', () => {
     })
   })
 
-  test('returns single-file html loader data on the per-artifact sandbox origin', async () => {
+  test('returns single-file html loader data on the version-scoped sandbox origin', async () => {
     const { context, waitUntil } = setupHtmlShareable()
     recordViewAndNotifyViewCountMock.mockResolvedValue(undefined)
 
@@ -331,7 +331,7 @@ describe('/a/:id loader', () => {
     expect(result.kind).toBe('ok')
     if (result.kind !== 'ok') return
     expect(result.sandboxUrl).toMatch(
-      /^https:\/\/html123abc\.sandbox\.artifactshare\.com\/demo\.html\?t=/,
+      /^https:\/\/html123abc--v-7631\.sandbox\.artifactshare\.com\/demo\.html\?t=/,
     )
     const token = new URL(result.sandboxUrl).searchParams.get('t')
     expect(token).toBeTruthy()

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -578,6 +578,7 @@ export async function loader({
       sandboxUrl: buildArtifactSandboxUrl(
         env,
         shareable.id,
+        shareable.current_version_id!,
         token,
         shareable.entrypoint_path ?? undefined,
       ),
@@ -646,6 +647,7 @@ export async function loader({
   const sandboxUrl = buildArtifactSandboxUrl(
     env,
     shareable.id,
+    shareable.current_version_id!,
     token,
     shareable.entrypoint_path ?? undefined,
   )
@@ -853,6 +855,7 @@ async function buildLinkAnonymousResponse(
         sandboxUrl: buildArtifactSandboxUrl(
           env,
           shareable.id,
+          shareable.current_version_id!,
           token,
           shareable.entrypoint_path ?? undefined,
         ),
@@ -879,6 +882,7 @@ async function buildLinkAnonymousResponse(
       sandboxUrl: buildArtifactSandboxUrl(
         env,
         shareable.id,
+        shareable.current_version_id!,
         token,
         shareable.entrypoint_path ?? undefined,
       ),

--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.test.ts
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.test.ts
@@ -107,7 +107,7 @@ describe('/api/shareables/:id/sandbox-token', () => {
     expect(response.status).toBe(200)
     const body = (await response.json()) as { sandboxUrl: string }
     expect(body.sandboxUrl).toMatch(
-      /^https:\/\/abc123def4\.sandbox\.artifactshare\.com\/\?t=/,
+      /^https:\/\/abc123def4--v-7631\.sandbox\.artifactshare\.com\/\?t=/,
     )
     const token = new URL(body.sandboxUrl).searchParams.get('t')
     expect(token).toBeTruthy()

--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
@@ -101,6 +101,7 @@ export async function loader({ context, params }: Route.LoaderArgs) {
   const sandboxUrl = artifactSandboxUrl(
     env,
     shareable.id,
+    shareable.current_version_id,
     token,
     renderType === 'static_site'
       ? (shareable.entrypoint_path ?? undefined)

--- a/apps/web/app/services/cli-resolve.server.ts
+++ b/apps/web/app/services/cli-resolve.server.ts
@@ -336,7 +336,9 @@ function resolveArtifactIdFromUrl(value: string): string | null {
       return null
     }
   }
-  const sandboxMatch = url.hostname.match(/^([A-Za-z0-9]+)\.sandbox\./)
+  const sandboxMatch = url.hostname.match(
+    /^([A-Za-z0-9]+)(?:--v-[a-f0-9]+)?\.sandbox\./,
+  )
   if (sandboxMatch?.[1]) return sandboxMatch[1]
   const shareMatch = url.pathname.match(/^\/a\/([A-Za-z0-9]+)(?:[./]|$)/)
   return shareMatch?.[1] ?? null

--- a/apps/web/app/services/dev-screen-state.server.test.ts
+++ b/apps/web/app/services/dev-screen-state.server.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, test } from 'vitest'
 import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
 import type { DB } from '~/types/db'
 import {
+  devShareableId,
   ensureDevScreenState,
   isDevScreenStateRequest,
   isScreenScenario,
@@ -82,7 +83,7 @@ describe('viewer revisit-context dev screen state', () => {
       userId,
       now,
     )
-    const shareableId = `${workspaceId}-${userId}-file-1`
+    const shareableId = devShareableId(`${workspaceId}-${userId}-file-1`)
 
     await expect(
       loadViewerRevisitContext(db, {
@@ -120,9 +121,9 @@ describe('recent content-rich dev screen state', () => {
     )
 
     expect(put.mock.calls.map(([key]) => key)).toEqual([
-      'dev-screen/workspace-viewer-file-1-v1',
-      'dev-screen/workspace-viewer-file-21-v1',
-      'dev-screen/workspace-viewer-file-21-v2',
+      `dev-screen/${devShareableId('workspace-viewer-file-1')}-v1`,
+      `dev-screen/${devShareableId('workspace-viewer-file-21')}-v1`,
+      `dev-screen/${devShareableId('workspace-viewer-file-21')}-v2`,
     ])
     expect(put.mock.calls[2][1]).toContain('今回の更新')
     expect(put.mock.calls[2][2]).toEqual({
@@ -172,8 +173,8 @@ describe('recent content-rich dev screen state', () => {
       now,
     )
 
-    const shareableIds = [19, 20, 21].map(
-      (number) => `${workspaceId}-${userId}-file-${number}`,
+    const shareableIds = [19, 20, 21].map((number) =>
+      devShareableId(`${workspaceId}-${userId}-file-${number}`),
     )
     const shareables = await db
       .selectFrom('shareables')
@@ -234,7 +235,7 @@ describe('recent content-rich dev screen state', () => {
       now,
     )
 
-    const shareableId = `${workspaceId}-${userId}-file-1`
+    const shareableId = devShareableId(`${workspaceId}-${userId}-file-1`)
     const version = await db
       .selectFrom('versions')
       .selectAll()

--- a/apps/web/app/services/dev-screen-state.server.ts
+++ b/apps/web/app/services/dev-screen-state.server.ts
@@ -1,6 +1,24 @@
 import scenarioIds from '../../../../scripts/screen-scenarios.json'
 import type { Kysely } from 'kysely'
 import type { DB } from '~/types/db'
+
+export function devShareableId(seed: string): string {
+  let first = 0x811c9dc5
+  let second = 0x9e3779b9
+  for (const char of seed) {
+    const code = char.codePointAt(0) ?? 0
+    first = Math.imul(first ^ code, 0x01000193) >>> 0
+    second = Math.imul(second ^ code, 0x85ebca6b) >>> 0
+  }
+  const ordinal = /-file-(\d+)$/.exec(seed)?.[1]
+  const prefix = ordinal
+    ? Number.parseInt(ordinal, 10).toString(36).padStart(2, '0').slice(-2)
+    : 'zz'
+  return `${prefix}${first.toString(36).padStart(7, '0')}${second.toString(36).padStart(7, '0')}`.slice(
+    0,
+    10,
+  )
+}
 import { INBOX_CONTAINER_NAME } from './projects.server'
 
 const SCREEN_SCENARIO_IDS = scenarioIds as readonly string[]
@@ -82,7 +100,7 @@ export async function seedDevScreenArtifactBodies(
 ): Promise<void> {
   if (!bucket) return
   if (scenario === 'viewer/revisit-context') {
-    const shareableId = `${workspaceId}-${userId}-file-1`
+    const shareableId = devShareableId(`${workspaceId}-${userId}-file-1`)
     await Promise.all(
       (['v1', 'v2'] as const).map((version) =>
         bucket.put(
@@ -95,14 +113,13 @@ export async function seedDevScreenArtifactBodies(
     return
   }
   if (scenario !== 'recent/content-rich') return
-  const shareablePrefix = `${workspaceId}-${userId}-file`
   const bodies = [
     {
-      key: `dev-screen/${shareablePrefix}-1-${RECENT_CONTENT_RICH_BODIES.quarterlyReport.version}`,
+      key: `dev-screen/${devShareableId(`${workspaceId}-${userId}-file-1`)}-${RECENT_CONTENT_RICH_BODIES.quarterlyReport.version}`,
       html: RECENT_CONTENT_RICH_BODIES.quarterlyReport.html,
     },
     ...RECENT_CONTENT_RICH_BODIES.archivedReview21.map(({ version, html }) => ({
-      key: `dev-screen/${shareablePrefix}-21-${version}`,
+      key: `dev-screen/${devShareableId(`${workspaceId}-${userId}-file-21`)}-${version}`,
       html,
     })),
   ]
@@ -274,9 +291,11 @@ export async function seedDevScreenState(
     const commentAt = new Date(Date.parse(now) - 3_600_000).toISOString()
     await Promise.all(
       names.map(async (name, index) => {
-        const shareableId = needsProject
-          ? `${workspaceId}-file-${index + 1}`
-          : `${workspaceId}-${userId}-file-${index + 1}`
+        const shareableId = devShareableId(
+          needsProject
+            ? `${workspaceId}-file-${index + 1}`
+            : `${workspaceId}-${userId}-file-${index + 1}`,
+        )
         const minutesAgo = seedsRepresentativeFeed
           ? index === 2
             ? 5
@@ -823,7 +842,7 @@ export async function seedDevScreenState(
   if (scenario === 'viewer/revisit-context') {
     const ownerId = `${workspaceId}-revisit-owner`
     const ownerContainerId = `${ownerId}-container`
-    const shareableId = `${workspaceId}-${userId}-file-1`
+    const shareableId = devShareableId(`${workspaceId}-${userId}-file-1`)
     const v1At = new Date(Date.parse(now) - 2 * 3_600_000).toISOString()
     const openingAt = new Date(Date.parse(now) - 90 * 60_000).toISOString()
     const boundaryAt = new Date(Date.parse(now) - 60 * 60_000).toISOString()
@@ -1682,7 +1701,7 @@ async function seedViewedVersionRange(
   },
 ) {
   const ownerId = `${workspaceId}-version-owner`
-  const shareableId = `${workspaceId}-viewed-version-range`
+  const shareableId = devShareableId(`${workspaceId}-viewed-version-range`)
   const at = (minutesAgo: number) =>
     new Date(Date.parse(now) - minutesAgo * 60_000).toISOString()
   await db

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -1954,7 +1954,8 @@ describe('headless publish wiring', () => {
     )
     // A single-file artifact gets a cookie-free sandbox embed URL with a token.
     const previewUrl = result.structuredContent?.preview_url ?? ''
-    expect(previewUrl).toContain(`${published.id}.sandbox.`)
+    expect(previewUrl).toContain(`${published.id}--v-`)
+    expect(previewUrl).toContain('.sandbox.')
     expect(previewUrl).toContain('t=')
     expect(typeof result.structuredContent?.locale).toBe('string')
     // The reusable embed token must not leak into the model-facing text channel.

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -1079,6 +1079,7 @@ export function registerArtifactTools(
         previewUrl = artifactSandboxUrl(
           env,
           args.id,
+          access.currentVersionId,
           token,
           access.entrypointPath ?? undefined,
         )

--- a/apps/web/integration/harness.test.ts
+++ b/apps/web/integration/harness.test.ts
@@ -187,7 +187,7 @@ async function applyProductionD1Schema() {
 
 function sandboxUrlFromHtml(html: string, shareableId: string): URL {
   const escaped = new RegExp(
-    `https://${shareableId}\\.sandbox\\.localhost:5174/(?:\\\\.|[^"'\\s<])*`,
+    `https://${shareableId}--v-[a-f0-9]+\\.sandbox\\.localhost:5174/(?:\\\\.|[^"'\\s<])*`,
   ).exec(html)?.[0]
   if (!escaped) throw new Error('Viewer response did not include sandbox URL')
   const decoded = JSON.parse(`"${escaped.replaceAll('&amp;', '&')}"`) as string

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -37,6 +37,7 @@ vi.mock('../app/services/sandbox-jti.server', () => ({
 }))
 
 import { signSandboxToken } from '../app/lib/sandbox-token'
+import { sandboxVersionLabel } from '../app/lib/hosts'
 import {
   VIOLATION_REPORTER_SHA256,
   VIOLATION_REPORTER_TAG,
@@ -112,20 +113,24 @@ const youtubeFrameCspSources =
 const expectedPermissionsPolicy =
   'fullscreen=(self "https://www.youtube-nocookie.com" "https://www.youtube.com"), clipboard-write=(self), camera=(), microphone=(), geolocation=(), display-capture=(), payment=(), usb=(), serial=(), hid=(), midi=()'
 
+function sandboxOrigin(
+  versionId = 'v-bundle',
+  shareableId = 'abc123def4',
+): string {
+  return `https://${sandboxVersionLabel(shareableId, versionId)}.sandbox.localhost:5174`
+}
+
 describe('sandbox probe', () => {
   test('returns the fixed response without touching storage, DB, or JTI', async () => {
     dbRef.current = null
     const requests = [
-      new Request(
-        `https://abc123def4.sandbox.artifactshare.com${SANDBOX_PROBE_PATH}`,
-        {
-          headers: {
-            Origin: 'https://artifactshare.com',
-            Cookie: 'as_bnd=secret',
-            authorization: 'Bearer secret',
-          },
+      new Request(`${sandboxOrigin()}${SANDBOX_PROBE_PATH}`, {
+        headers: {
+          Origin: 'https://artifactshare.com',
+          Cookie: 'as_bnd=secret',
+          authorization: 'Bearer secret',
         },
-      ),
+      }),
       new Request(
         `https://not-an-id.sandbox.artifactshare.com${SANDBOX_PROBE_PATH}`,
         {
@@ -176,24 +181,18 @@ describe('sandbox probe', () => {
     ['https://localhost:5173', 'https://localhost:5173'],
   ])('allows only the app origin %s', async (origin, expected) => {
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174${SANDBOX_PROBE_PATH}`,
-        {
-          headers: { Origin: origin },
-        },
-      ),
+      new Request(`${sandboxOrigin()}${SANDBOX_PROBE_PATH}`, {
+        headers: { Origin: origin },
+      }),
     )
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe(expected)
   })
 
   test('omits ACAO for disallowed origins and normal responses', async () => {
     const probe = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174${SANDBOX_PROBE_PATH}`,
-        {
-          headers: { Origin: 'https://evil.example' },
-        },
-      ),
+      new Request(`${sandboxOrigin()}${SANDBOX_PROBE_PATH}`, {
+        headers: { Origin: 'https://evil.example' },
+      }),
     )
     expect(probe.headers.has('Access-Control-Allow-Origin')).toBe(false)
     expect(probe.headers.has('Access-Control-Expose-Headers')).toBe(false)
@@ -281,9 +280,7 @@ describe('violation reporter injection handler', () => {
       )
       const token = await entrypointToken()
       const response = await handleArtifactSandboxRequest(
-        new Request(
-          `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-        ),
+        new Request(`${sandboxOrigin()}/index.html?t=${token}`),
       )
 
       expect(response.status).toBe(200)
@@ -328,9 +325,7 @@ describe('violation reporter injection handler', () => {
         jti: 'j-node-md',
       })
       const response = await handleArtifactSandboxRequest(
-        new Request(
-          `https://abc123def4.sandbox.localhost:5174/index.md?t=${token}`,
-        ),
+        new Request(`${sandboxOrigin('v-node-md')}/index.md?t=${token}`),
       )
 
       const body = await response.text()
@@ -351,9 +346,7 @@ describe('violation reporter injection handler', () => {
       )
       const token = await entrypointToken()
       const response = await handleArtifactSandboxRequest(
-        new Request(
-          `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-        ),
+        new Request(`${sandboxOrigin()}/index.html?t=${token}`),
       )
       const body = await response.text()
       expect(body.indexOf(VIOLATION_REPORTER_TAG)).toBeLessThan(
@@ -373,9 +366,7 @@ describe('violation reporter injection handler', () => {
       )
       const token = await entrypointToken()
       await handleArtifactSandboxRequest(
-        new Request(
-          `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-        ),
+        new Request(`${sandboxOrigin()}/index.html?t=${token}`),
       )
 
       const rewriter = HtmlRewriterStub.instances.at(-1)!
@@ -396,7 +387,7 @@ describe('violation reporter injection handler', () => {
       await dbRef
         .current!.insertInto('shareables')
         .values({
-          id: 'md-single',
+          id: 'mdsingle01',
           workspace_id: 'ws-a',
           owner_user_id: 'owner-1',
           slug: null,
@@ -417,7 +408,7 @@ describe('violation reporter injection handler', () => {
         .current!.insertInto('versions')
         .values({
           id: 'v-md-single',
-          shareable_id: 'md-single',
+          shareable_id: 'mdsingle01',
           artifact_kind: 'markdown_page',
           status: 'published',
           entrypoint_path: '/readme.md',
@@ -433,13 +424,15 @@ describe('violation reporter injection handler', () => {
         storedArtifact('# Readme', 'text/markdown'),
       )
       const token = await singleFileToken({
-        id: 'md-single',
+        id: 'mdsingle01',
         versionId: 'v-md-single',
         r2Key: 'md-key',
         renderType: 'md',
       })
       const response = await handleArtifactSandboxRequest(
-        new Request(`https://localhost:5173/readme.md?t=${token}`),
+        new Request(
+          `${sandboxOrigin('v-md-single', 'mdsingle01')}/readme.md?t=${token}`,
+        ),
       )
       expect(response.status).toBe(200)
       expect(HtmlRewriterStub.instances).toHaveLength(1)
@@ -837,9 +830,7 @@ describe('handleArtifactSandboxRequest', () => {
     const token = await entrypointToken()
 
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
 
     expect(response.status).toBe(200)
@@ -880,9 +871,7 @@ describe('handleArtifactSandboxRequest', () => {
       const token = await anonymousEntrypointToken()
 
       const response = await handleArtifactSandboxRequest(
-        new Request(
-          `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-        ),
+        new Request(`${sandboxOrigin()}/index.html?t=${token}`),
       )
 
       expect(response.status).toBe(401)
@@ -899,9 +888,7 @@ describe('handleArtifactSandboxRequest', () => {
     const token = await anonymousEntrypointToken()
 
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/style.css?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/style.css?t=${token}`),
     )
 
     expect(response.status).toBe(401)
@@ -921,7 +908,11 @@ describe('handleArtifactSandboxRequest', () => {
     const token = await entrypointToken()
 
     const entrypoint = await handleArtifactSandboxRequest(
-      new Request(`https://localhost:5173/index.html?t=${token}`),
+      new Request(`https://localhost:5173/index.html?t=${token}`, {
+        headers: {
+          host: `${sandboxVersionLabel('abc123def4', 'v-bundle')}.sandbox.localhost:5174`,
+        },
+      }),
     )
     const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
 
@@ -931,7 +922,10 @@ describe('handleArtifactSandboxRequest', () => {
 
     const asset = await handleArtifactSandboxRequest(
       new Request('https://localhost:5173/style.css', {
-        headers: { Cookie: cookie ?? '' },
+        headers: {
+          Cookie: cookie ?? '',
+          host: `${sandboxVersionLabel('abc123def4', 'v-bundle')}.sandbox.localhost:5174`,
+        },
       }),
     )
 
@@ -949,9 +943,7 @@ describe('handleArtifactSandboxRequest', () => {
       )
     const token = await entrypointToken()
     const entrypoint = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
     expect(
       cspDirective(
@@ -963,7 +955,7 @@ describe('handleArtifactSandboxRequest', () => {
     const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/style.css', {
+      new Request(`${sandboxOrigin()}/style.css`, {
         headers: { Cookie: cookie ?? '' },
       }),
     )
@@ -983,7 +975,7 @@ describe('handleArtifactSandboxRequest', () => {
 
     const response = await handleArtifactSandboxRequest(
       new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}&as_next=%2Fdocs%2Fintro.html%3Ftab%3Done%23top`,
+        `${sandboxOrigin()}/index.html?t=${token}&as_next=%2Fdocs%2Fintro.html%3Ftab%3Done%23top`,
       ),
     )
 
@@ -1017,7 +1009,7 @@ describe('handleArtifactSandboxRequest', () => {
 
     const response = await handleArtifactSandboxRequest(
       new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}&as_next=%2F%E6%A6%82%E8%A6%81.html`,
+        `${sandboxOrigin()}/index.html?t=${token}&as_next=%2F%E6%A6%82%E8%A6%81.html`,
       ),
     )
 
@@ -1035,7 +1027,7 @@ describe('handleArtifactSandboxRequest', () => {
 
     const response = await handleArtifactSandboxRequest(
       new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}&as_next=https%3A%2F%2Fevil.example%2F`,
+        `${sandboxOrigin()}/index.html?t=${token}&as_next=https%3A%2F%2Fevil.example%2F`,
       ),
     )
 
@@ -1060,14 +1052,12 @@ describe('handleArtifactSandboxRequest', () => {
       )
     const token = await entrypointToken()
     const entrypoint = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
     const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/projects/alpha', {
+      new Request(`${sandboxOrigin()}/projects/alpha`, {
         headers: { Cookie: cookie ?? '' },
       }),
     )
@@ -1091,19 +1081,14 @@ describe('handleArtifactSandboxRequest', () => {
     )
     const token = await entrypointToken()
     const entrypoint = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
     const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
 
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        'https://abc123def4.sandbox.localhost:5174/assets/missing.js',
-        {
-          headers: { Cookie: cookie ?? '' },
-        },
-      ),
+      new Request(`${sandboxOrigin()}/assets/missing.js`, {
+        headers: { Cookie: cookie ?? '' },
+      }),
     )
 
     expect(response.status).toBe(404)
@@ -1118,14 +1103,12 @@ describe('handleArtifactSandboxRequest', () => {
     )
     const token = await entrypointToken()
     const entrypoint = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
     const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/projects/alpha', {
+      new Request(`${sandboxOrigin()}/projects/alpha`, {
         headers: { Cookie: cookie ?? '' },
       }),
     )
@@ -1177,19 +1160,14 @@ describe('handleArtifactSandboxRequest', () => {
         jti: `j-${sample.versionId}`,
       })
       const entrypoint = await handleArtifactSandboxRequest(
-        new Request(
-          `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-        ),
+        new Request(`${sandboxOrigin(sample.versionId)}/index.html?t=${token}`),
       )
       const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
 
       const response = await handleArtifactSandboxRequest(
-        new Request(
-          `https://abc123def4.sandbox.localhost:5174${sample.requestPath}`,
-          {
-            headers: { Cookie: cookie ?? '' },
-          },
-        ),
+        new Request(`${sandboxOrigin(sample.versionId)}${sample.requestPath}`, {
+          headers: { Cookie: cookie ?? '' },
+        }),
       )
 
       expect(response.status).toBe(200)
@@ -1211,20 +1189,15 @@ describe('handleArtifactSandboxRequest', () => {
     )
     const token = await entrypointToken()
     const first = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
     const cookie = first.headers.get('Set-Cookie')?.split(';')[0]
     consumeJtiMock.mockResolvedValueOnce(false)
 
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-        {
-          headers: { Cookie: cookie ?? '' },
-        },
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`, {
+        headers: { Cookie: cookie ?? '' },
+      }),
     )
 
     expect(response.status).toBe(200)
@@ -1240,9 +1213,7 @@ describe('handleArtifactSandboxRequest', () => {
     consumeJtiMock.mockResolvedValue(false)
 
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
 
     expect(response.status).toBe(401)
@@ -1256,9 +1227,7 @@ describe('handleArtifactSandboxRequest', () => {
     consumeJtiMock.mockResolvedValue(false)
 
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
 
     expect(response.status).toBe(401)
@@ -1292,9 +1261,7 @@ describe('handleArtifactSandboxRequest', () => {
     )
 
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
 
     expect(response.status).toBe(401)
@@ -1334,19 +1301,14 @@ describe('handleArtifactSandboxRequest', () => {
       )
     const token = await entrypointToken()
     const entrypoint = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
     const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
 
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        'https://abc123def4.sandbox.localhost:5174/assets/cafe%CC%81.html',
-        {
-          headers: { Cookie: cookie ?? '' },
-        },
-      ),
+      new Request(`${sandboxOrigin()}/assets/cafe%CC%81.html`, {
+        headers: { Cookie: cookie ?? '' },
+      }),
     )
 
     expect(response.status).toBe(200)
@@ -1386,9 +1348,7 @@ describe('handleArtifactSandboxRequest', () => {
     })
 
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.md?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin('v-md-entry')}/index.md?t=${token}`),
     )
 
     expect(response.status).toBe(200)
@@ -1449,9 +1409,7 @@ describe('handleArtifactSandboxRequest', () => {
     })
 
     const entrypoint = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.md?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin('v-md-links')}/index.md?t=${token}`),
     )
     const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
     const entrypointBody = await entrypoint.text()
@@ -1462,7 +1420,7 @@ describe('handleArtifactSandboxRequest', () => {
     expect(cookie).toContain('as_bnd=')
 
     const linkedPage = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/other.md', {
+      new Request(`${sandboxOrigin('v-md-links')}/other.md`, {
         headers: { Cookie: cookie ?? '' },
       }),
     )
@@ -1492,7 +1450,7 @@ describe('handleArtifactSandboxRequest', () => {
     )
 
     const image = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/logo.png', {
+      new Request(`${sandboxOrigin('v-md-links')}/logo.png`, {
         headers: { Cookie: cookie ?? '' },
       }),
     )
@@ -1525,9 +1483,7 @@ describe('handleArtifactSandboxRequest', () => {
       )
     const token = await entrypointToken()
     const entrypoint = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
     const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
     await dbRef
@@ -1537,7 +1493,7 @@ describe('handleArtifactSandboxRequest', () => {
       .execute()
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/style.css', {
+      new Request(`${sandboxOrigin()}/style.css`, {
         headers: { Cookie: cookie ?? '' },
       }),
     )
@@ -1550,7 +1506,50 @@ describe('handleArtifactSandboxRequest', () => {
     )
   })
 
-  test('serves a single html file from the per-artifact sandbox origin without a bundle cookie', async () => {
+  test('serves a published historical static-site entrypoint on its own origin', async () => {
+    await seedStaticSiteVersion(dbRef.current!, {
+      versionId: 'v-next',
+      entrypointPath: '/index.html',
+      entrypointR2Key: 'ws-a/abc123def4/v-next/index.html',
+      files: [
+        {
+          id: 'vf-next-index',
+          path: '/index.html',
+          r2Key: 'ws-a/abc123def4/v-next/index.html',
+          mimeType: 'text/html; charset=utf-8',
+        },
+      ],
+    })
+    await dbRef
+      .current!.updateTable('shareables')
+      .set({ current_version_id: 'v-next' })
+      .where('id', '=', 'abc123def4')
+      .execute()
+    storageMock.getArtifact.mockResolvedValue(
+      storedArtifact('<!doctype html><body>Historical</body>', 'text/html'),
+    )
+    const token = await entrypointToken()
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin('v-bundle')}/?t=${token}`),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toContain('Historical')
+  })
+
+  test('rejects a valid token presented on a different version origin', async () => {
+    const token = await entrypointToken()
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin('v-other')}/?t=${token}`),
+    )
+
+    expect(response.status).toBe(401)
+    expect(storageMock.getArtifact).not.toHaveBeenCalled()
+  })
+
+  test('serves a single html file from the version-scoped sandbox origin without a bundle cookie', async () => {
     await seedSingleFile(dbRef.current!, {
       id: 'html123abc',
       versionId: 'v-html',
@@ -1570,7 +1569,7 @@ describe('handleArtifactSandboxRequest', () => {
 
     const response = await handleArtifactSandboxRequest(
       new Request(
-        `https://html123abc.sandbox.localhost:5174/demo.html?t=${token}`,
+        `${sandboxOrigin('v-html', 'html123abc')}/demo.html?t=${token}`,
       ),
     )
 
@@ -1636,7 +1635,7 @@ describe('handleArtifactSandboxRequest', () => {
       'test-secret',
       1800,
     )
-    const url = `https://embed12345.sandbox.localhost:5174/index.html?t=${token}`
+    const url = `${sandboxOrigin('v-embed', 'embed12345')}/index.html?t=${token}`
 
     const first = await handleArtifactSandboxRequest(new Request(url))
     expect(first.status).toBe(200)
@@ -1673,7 +1672,7 @@ describe('handleArtifactSandboxRequest', () => {
 
     const response = await handleArtifactSandboxRequest(
       new Request(
-        `https://locked1234.sandbox.localhost:5174/index.html?t=${token}`,
+        `${sandboxOrigin('v-locked', 'locked1234')}/index.html?t=${token}`,
       ),
     )
     expect(response.status).toBe(200)
@@ -1705,9 +1704,7 @@ describe('handleArtifactSandboxRequest', () => {
     })
 
     const response = await handleArtifactSandboxRequest(
-      new Request(
-        `https://md123abcde.sandbox.localhost:5174/notes.md?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin('v-md', 'md123abcde')}/notes.md?t=${token}`),
     )
 
     expect(response.status).toBe(200)
@@ -1755,7 +1752,7 @@ describe('handleArtifactSandboxRequest', () => {
 
     const response = await handleArtifactSandboxRequest(
       new Request(
-        `https://mdutf8abcd.sandbox.localhost:5174/notes.md?t=${token}`,
+        `${sandboxOrigin('v-md-utf8', 'mdutf8abcd')}/notes.md?t=${token}`,
       ),
     )
 
@@ -1777,14 +1774,12 @@ describe('handleArtifactSandboxRequest', () => {
       )
     const token = await entrypointToken()
     const entrypoint = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
     const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/style.css', {
+      new Request(`${sandboxOrigin()}/style.css`, {
         headers: { Cookie: cookie ?? '' },
       }),
     )
@@ -1799,7 +1794,7 @@ describe('handleArtifactSandboxRequest', () => {
 
   test('rejects static-site asset requests without a bundle cookie', async () => {
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/style.css'),
+      new Request(`${sandboxOrigin()}/style.css`),
     )
 
     expect(response.status).toBe(401)
@@ -1817,7 +1812,7 @@ describe('handleArtifactSandboxRequest', () => {
     )
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/style.css'),
+      new Request(`${sandboxOrigin()}/style.css`),
     )
 
     expect(response.status).toBe(200)
@@ -1841,7 +1836,7 @@ describe('handleArtifactSandboxRequest', () => {
     )
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/style.css', {
+      new Request(`${sandboxOrigin()}/style.css`, {
         headers: { Cookie: 'as_bnd=invalid' },
       }),
     )
@@ -1871,7 +1866,7 @@ describe('handleArtifactSandboxRequest', () => {
       .execute()
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/style.css'),
+      new Request(`${sandboxOrigin()}/style.css`),
     )
 
     expect(response.status).toBe(401)
@@ -1894,7 +1889,7 @@ describe('handleArtifactSandboxRequest', () => {
     )
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/projects/alpha'),
+      new Request(`${sandboxOrigin()}/projects/alpha`),
     )
 
     expect(response.status).toBe(200)
@@ -1916,7 +1911,7 @@ describe('handleArtifactSandboxRequest', () => {
         .execute()
 
       const response = await handleArtifactSandboxRequest(
-        new Request('https://abc123def4.sandbox.localhost:5174/style.css'),
+        new Request(`${sandboxOrigin()}/style.css`),
       )
 
       expect(response.status).toBe(401)
@@ -1947,11 +1942,11 @@ describe('handleArtifactSandboxRequest', () => {
     })
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://abc123def4.sandbox.localhost:5174/old-only.css'),
+      new Request(`${sandboxOrigin('v-old')}/old-only.css`),
     )
 
-    expect(response.status).toBe(404)
-    await expect(response.text()).resolves.toBe('This artifact is unavailable.')
+    expect(response.status).toBe(401)
+    await expect(response.text()).resolves.toBe('Invalid token')
     expect(storageMock.getArtifact).not.toHaveBeenCalled()
     expect(consumeJtiMock).not.toHaveBeenCalled()
   })
@@ -1962,14 +1957,12 @@ describe('handleArtifactSandboxRequest', () => {
     )
     const token = await entrypointToken()
     const entrypoint = await handleArtifactSandboxRequest(
-      new Request(
-        `https://abc123def4.sandbox.localhost:5174/index.html?t=${token}`,
-      ),
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
     )
     const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
 
     const response = await handleArtifactSandboxRequest(
-      new Request('https://zzz123def4.sandbox.localhost:5174/style.css', {
+      new Request(`${sandboxOrigin('v-bundle', 'zzz123def4')}/style.css`, {
         headers: { Cookie: cookie ?? '' },
       }),
     )

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -8,6 +8,7 @@ import {
   isProduction,
   MCP_EMBED_FRAME_ANCESTORS,
   requestHostname,
+  sandboxVersionIdentityFromHostname,
   SANDBOX_HOST,
   WWW_HOST,
 } from '../app/lib/hosts'
@@ -60,25 +61,24 @@ export async function handleArtifactSandboxRequest(
   _ctx?: ExecutionContext,
 ): Promise<Response> {
   const url = new URL(request.url)
-  const production = isProduction(env)
   const hostname = requestHostname(request, env)
-  const shareableId = shareableIdFromHostname(hostname, env)
-  if (!shareableId && production) {
+  const identity = sandboxVersionIdentityFromHostname(hostname, env)
+  if (url.pathname === SANDBOX_PROBE_PATH) return sandboxProbeResponse(request)
+  if (!identity) {
     return deniedResponse('bad_hostname', 'Not found', 404, { hostname })
   }
 
-  if (url.pathname === SANDBOX_PROBE_PATH) return sandboxProbeResponse(request)
   const path = requestPath(url)
   if (!path) {
     return deniedResponse('bad_path', 'Not found', 404, {
-      aid: shareableId,
+      aid: identity?.shareableId,
       pathname: url.pathname,
     })
   }
 
   const token = url.searchParams.get('t')
   if (token) {
-    return await handleEntrypointRequest(request, url, shareableId, path, token)
+    return await handleEntrypointRequest(request, url, identity, path, token)
   }
 
   const cookie = await verifyBundleCookie(
@@ -86,14 +86,18 @@ export async function handleArtifactSandboxRequest(
     env.BETTER_AUTH_SECRET,
   )
   if (!cookie) {
-    if (shareableId !== null) {
-      return await serveAnonymousLinkBundleAsset(shareableId, path)
+    if (identity !== null) {
+      return await serveAnonymousLinkBundleAsset(identity, path)
     }
     return deniedResponse('no_bundle_cookie', 'Invalid token', 401, { path })
   }
-  if (shareableId !== null && cookie.aid !== shareableId) {
-    return deniedResponse('cookie_aid_mismatch', 'Invalid token', 401, {
-      aid: shareableId,
+  if (
+    identity !== null &&
+    (cookie.aid !== identity.shareableId || cookie.vid !== identity.versionId)
+  ) {
+    return deniedResponse('cookie_identity_mismatch', 'Invalid token', 401, {
+      aid: identity.shareableId,
+      vid: identity.versionId,
       cookieAid: cookie.aid,
       path,
     })
@@ -137,7 +141,7 @@ export function sandboxNotFoundResponse(hostname: string): Response {
 async function handleEntrypointRequest(
   request: Request,
   url: URL,
-  shareableId: string | null,
+  identity: { shareableId: string; versionId: string },
   path: string,
   token: string,
 ): Promise<Response> {
@@ -147,15 +151,19 @@ async function handleEntrypointRequest(
   )
   if (!verified.ok) {
     return deniedResponse(`token_${verified.failure}`, 'Invalid token', 401, {
-      aid: shareableId,
+      aid: identity.shareableId,
       path,
       expiredBySeconds: verified.expiredBySeconds,
     })
   }
   const payload = verified.payload
-  if (shareableId !== null && payload.aid !== shareableId) {
-    return deniedResponse('token_aid_mismatch', 'Invalid token', 401, {
-      aid: shareableId,
+  if (
+    payload.aid !== identity.shareableId ||
+    payload.vid !== identity.versionId
+  ) {
+    return deniedResponse('token_identity_mismatch', 'Invalid token', 401, {
+      aid: identity.shareableId,
+      vid: identity.versionId,
       tokenAid: payload.aid,
       path,
     })
@@ -174,7 +182,7 @@ async function handleEntrypointRequest(
         path,
       })
     }
-    const entrypoint = await currentEntrypoint(db, payload, path)
+    const entrypoint = await publishedEntrypoint(db, payload, path, true)
     if (!entrypoint) {
       return deniedResponse('anon_version_mismatch', 'Invalid token', 401, {
         aid: payload.aid,
@@ -211,7 +219,12 @@ async function handleEntrypointRequest(
     }
   }
 
-  const entrypoint = await currentEntrypoint(db, payload, path)
+  const entrypoint = await publishedEntrypoint(
+    db,
+    payload,
+    path,
+    payload.emb === true,
+  )
   if (!entrypoint) {
     return deniedResponse('version_mismatch', 'Invalid token', 401, {
       aid: payload.aid,
@@ -275,29 +288,32 @@ interface Entrypoint {
   contentType: string | null
 }
 
-async function currentEntrypoint(
+async function publishedEntrypoint(
   db: Kysely<DB>,
   payload: SandboxPayload,
   path: string,
+  requireCurrent: boolean,
 ): Promise<Entrypoint | null> {
   const expectedKind = artifactKindForToken(payload.t)
   if (!expectedKind) return null
 
   const version = await db
     .selectFrom('shareables')
-    .innerJoin('versions', 'versions.id', 'shareables.current_version_id')
+    .innerJoin('versions', 'versions.shareable_id', 'shareables.id')
     .select([
       'versions.artifact_kind',
       'versions.entrypoint_path',
       'versions.r2_key',
+      'shareables.current_version_id',
     ])
     .where('shareables.id', '=', payload.aid)
     .where('shareables.workspace_id', '=', payload.wid)
-    .where('shareables.current_version_id', '=', payload.vid)
     .where('versions.id', '=', payload.vid)
+    .where('versions.status', '=', 'published')
     .where('versions.artifact_kind', '=', expectedKind)
     .executeTakeFirst()
   if (!version || version.entrypoint_path !== path) return null
+  if (requireCurrent && version.current_version_id !== payload.vid) return null
 
   if (payload.t !== 'static_site') {
     if (version.r2_key !== payload.fid) return null
@@ -391,6 +407,7 @@ async function serveBundleAsset(
     .where('shareables.id', '=', bundle.aid)
     .where('shareables.workspace_id', '=', bundle.wid)
     .where('versions.id', '=', bundle.vid)
+    .where('versions.status', '=', 'published')
     .where('versions.artifact_kind', '=', 'static_site')
     .where('version_files.path', 'in', candidatePaths)
     .execute()
@@ -413,7 +430,7 @@ async function serveBundleAsset(
 }
 
 async function serveAnonymousLinkBundleAsset(
-  shareableId: string,
+  identity: { shareableId: string; versionId: string },
   path: string,
 ): Promise<Response> {
   const db = createDb()
@@ -427,13 +444,15 @@ async function serveAnonymousLinkBundleAsset(
       'shareables.name',
       'versions.id as vid',
     ])
-    .where('shareables.id', '=', shareableId)
+    .where('shareables.id', '=', identity.shareableId)
+    .where('versions.id', '=', identity.versionId)
+    .where('versions.status', '=', 'published')
     .where('shareables.visibility', '=', 'link')
     .where('versions.artifact_kind', '=', 'static_site')
     .executeTakeFirst()
   if (!bundle) {
     return deniedResponse('anon_bundle_not_link', 'Invalid token', 401, {
-      aid: shareableId,
+      aid: identity.shareableId,
       path,
     })
   }
@@ -462,7 +481,7 @@ async function serveAnonymousLinkBundleAsset(
   )
   if (check.kind !== 'access-granted') {
     return deniedResponse('anon_bundle_unavailable', 'Invalid token', 401, {
-      aid: shareableId,
+      aid: identity.shareableId,
       path,
     })
   }
@@ -504,19 +523,6 @@ async function serveBundleFile(file: {
 function hasFileExtension(path: string): boolean {
   const lastSegment = path.split('/').at(-1) ?? ''
   return /\.[^./]+$/.test(lastSegment)
-}
-
-function shareableIdFromHostname(
-  hostname: string,
-  envLike: { APP_ENV: string },
-): string | null {
-  const suffix = isProduction(envLike)
-    ? `.${SANDBOX_HOST}`
-    : '.sandbox.localhost'
-  if (!hostname.endsWith(suffix)) return null
-  const label = hostname.slice(0, -suffix.length)
-  if (!/^[a-z0-9]{10}$/.test(label)) return null
-  return label
 }
 
 function requestPath(url: URL): string | null {

--- a/scripts/dev-setup.mjs
+++ b/scripts/dev-setup.mjs
@@ -67,7 +67,9 @@ export const DEV_SERVICES = [
     name: 'sandbox',
     origin: 'https://localhost:5174',
     path: '/',
-    headers: { 'mf-original-hostname': 'probe.sandbox.localhost' },
+    headers: {
+      'mf-original-hostname': 'probe00000--v-70726f6265.sandbox.localhost',
+    },
     expected: {
       status: 401,
       contentType: 'text/plain',


### PR DESCRIPTION
## Summary

- scope sandbox iframe origins to the exact published artifact version
- require hostname, sandbox token, bundle cookie, and database version identity to agree
- keep anonymous and embed access current-version-only while allowing authenticated tokens to resolve published historical versions
- preserve CLI resolution for both existing and version-scoped sandbox URLs

## Validation

- `pnpm validate:static`
- `pnpm --filter @artifactshare/web test:behavior-browser`
- `pnpm --filter @artifactshare/web build`
- `pnpm integration:test:run`
- `pnpm build:sandbox`
- `pnpm public:scan .`

## Review

- Codex implementation review: no actionable findings
- Claude implementation review: one non-actionable rollout observation about already-issued legacy embed URLs; no unresolved blockers
