### PR TITLE
Let viewers open published history

### DIFF
--- a/apps/web/app/i18n/en.json
+++ b/apps/web/app/i18n/en.json
@@ -563,6 +563,8 @@
   "vw.more": "More",
   "vw.versionHistory": "History & add new version",
   "vw.versionHistoryReadonly": "Version history",
+  "history.viewingVersion": "Viewing {version}",
+  "history.backToCurrent": "Back to current version",
   "vw.history": "History",
   "vw.homeLink": "Artifact Share home",
   "vw.productSummary": "A service for sharing HTML files safely within your company.",

--- a/apps/web/app/i18n/ja.json
+++ b/apps/web/app/i18n/ja.json
@@ -563,6 +563,8 @@
   "vw.more": "その他",
   "vw.versionHistory": "履歴と新しい版の追加",
   "vw.versionHistoryReadonly": "版の履歴",
+  "history.viewingVersion": "{version} を表示中",
+  "history.backToCurrent": "現在の版に戻る",
   "vw.history": "履歴",
   "vw.homeLink": "Artifact Share のホーム",
   "vw.productSummary": "HTML ファイルを、社内で安全に共有するサービスです。",

--- a/apps/web/app/routes/a.$id/+components/history-panel.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/history-panel.test.tsx
@@ -166,6 +166,33 @@ describe('HistoryPanel', () => {
     expect(html).toContain('aria-label="Version status: v2"')
   })
 
+  test('version widget labels the displayed historical version', () => {
+    const html = renderToStaticMarkup(
+      <VersionWidget
+        versions={[
+          {
+            id: 'v2',
+            ordinal: 2,
+            createdAt,
+            sizeBytes: 2048,
+            isCurrent: true,
+          },
+          {
+            id: 'v1',
+            ordinal: 1,
+            createdAt,
+            sizeBytes: 1024,
+            isCurrent: false,
+            isDisplayed: true,
+          },
+        ]}
+        onOpenHistory={() => {}}
+      />,
+    )
+
+    expect(html).toContain('aria-label="Version status: v1"')
+  })
+
   test('version widget renders the combined revisit clues', () => {
     const html = renderToStaticMarkup(
       <VersionWidget

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -95,6 +95,7 @@ async function renderMermaidRequest(message: MermaidRenderRequestMessage) {
 
 type SandboxFrameProps = {
   shareableId: string
+  versionId: string
   url: string
   name: string
   mermaidEnabled: boolean
@@ -271,6 +272,7 @@ function SandboxState({
 
 function useSandboxFrameController({
   shareableId,
+  versionId,
   url,
   name,
   mermaidEnabled,
@@ -427,7 +429,11 @@ function useSandboxFrameController({
         )
         if (outcome === 'reachable') {
           setLoadState('resuming')
-          const next = await refreshSandboxFrameUrl(shareableId, frameUrl)
+          const next = await refreshSandboxFrameUrl(
+            shareableId,
+            versionId,
+            frameUrl,
+          )
           if (
             !shouldAcceptNavigationResult(
               generation,
@@ -466,7 +472,7 @@ function useSandboxFrameController({
         window.clearTimeout(timeout)
       }
     },
-    [frameUrl, reportBlock, shareableId],
+    [frameUrl, reportBlock, shareableId, versionId],
   )
 
   const markFrameReadyFromMessage = useEffectEvent(() => {
@@ -540,7 +546,7 @@ function useSandboxFrameController({
           setFrameUrl(action.url)
           return
         }
-        void refreshSandboxFrameUrl(shareableId, action.url).then(
+        void refreshSandboxFrameUrl(shareableId, versionId, action.url).then(
           (nextFrameUrl) => {
             if (navigationId !== frameNavigationIdRef.current) return
             if (!nextFrameUrl) {
@@ -789,6 +795,7 @@ function useSandboxFrameController({
 
 async function refreshSandboxFrameUrl(
   shareableId: string,
+  versionId: string,
   targetUrl: string,
 ): Promise<string | null> {
   let result: {
@@ -799,7 +806,9 @@ async function refreshSandboxFrameUrl(
     result = await fetchJsonWithViewerTimeout<{
       sandboxUrl?: unknown
       renderType?: unknown
-    }>(`/api/shareables/${encodeURIComponent(shareableId)}/sandbox-token`)
+    }>(
+      `/api/shareables/${encodeURIComponent(shareableId)}/sandbox-token?version=${encodeURIComponent(versionId)}`,
+    )
   } catch (error) {
     logViewerNetworkEvent({
       channel: 'fetch',

--- a/apps/web/app/routes/a.$id/+components/version-history-types.ts
+++ b/apps/web/app/routes/a.$id/+components/version-history-types.ts
@@ -4,5 +4,6 @@ export interface VersionRow {
   createdAt: string
   sizeBytes: number
   isCurrent: boolean
+  isDisplayed?: boolean
   createdByLabel?: string | null
 }

--- a/apps/web/app/routes/a.$id/+components/version-rows.tsx
+++ b/apps/web/app/routes/a.$id/+components/version-rows.tsx
@@ -28,37 +28,49 @@ export function VersionRows({
         density === 'popover' ? 'gap-1' : 'gap-1.5',
       )}
     >
-      {versions.map((version) => (
-        <li
-          className={cn(
-            'flex flex-col gap-0.5 rounded-[var(--r-md)] border',
-            density === 'popover'
-              ? 'py-version-row-pad-block border-divider px-2'
-              : 'border-border px-2.5 py-2',
-          )}
-          key={version.id}
-        >
-          <div className="flex items-center gap-1.5 text-sm">
-            <strong>v{version.ordinal}</strong>
-            {version.isCurrent ? (
-              <span className="bg-link-soft text-link rounded-full px-1.5 py-px text-xs">
-                {t('history.current')}
-              </span>
-            ) : null}
-          </div>
-          <div className="text-muted-foreground flex gap-1.5 text-xs">
-            {version.createdByLabel ? (
-              <>
-                <span>{version.createdByLabel}</span>
+      {versions.map((version) => {
+        const destination = version.isCurrent
+          ? '?'
+          : `?version=${encodeURIComponent(version.id)}`
+        return (
+          <li
+            className={cn(
+              'flex flex-col gap-0.5 rounded-[var(--r-md)] border',
+              density === 'popover'
+                ? 'py-version-row-pad-block border-divider px-2'
+                : 'border-border px-2.5 py-2',
+              version.isDisplayed && 'border-link bg-link-soft',
+            )}
+            key={version.id}
+          >
+            <a
+              href={destination}
+              className="text-foreground -m-1 flex flex-col gap-0.5 rounded-[var(--r-sm)] p-1 no-underline"
+              aria-current={version.isDisplayed ? 'page' : undefined}
+            >
+              <div className="flex items-center gap-1.5 text-sm">
+                <strong>v{version.ordinal}</strong>
+                {version.isCurrent ? (
+                  <span className="bg-link-soft text-link rounded-full px-1.5 py-px text-xs">
+                    {t('history.current')}
+                  </span>
+                ) : null}
+              </div>
+              <div className="text-muted-foreground flex gap-1.5 text-xs">
+                {version.createdByLabel ? (
+                  <>
+                    <span>{version.createdByLabel}</span>
+                    <span aria-hidden="true">·</span>
+                  </>
+                ) : null}
+                <span>{formatRelative(version.createdAt, locale)}</span>
                 <span aria-hidden="true">·</span>
-              </>
-            ) : null}
-            <span>{formatRelative(version.createdAt, locale)}</span>
-            <span aria-hidden="true">·</span>
-            <span>{formatBytes(version.sizeBytes)}</span>
-          </div>
-        </li>
-      ))}
+                <span>{formatBytes(version.sizeBytes)}</span>
+              </div>
+            </a>
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/apps/web/app/routes/a.$id/+components/version-widget.tsx
+++ b/apps/web/app/routes/a.$id/+components/version-widget.tsx
@@ -67,7 +67,9 @@ export function VersionWidget({
     string | null
   >(null)
   const currentVersion = versions.find((version) => version.isCurrent)
-  const currentLabel = currentVersion ? `v${currentVersion.ordinal}` : 'v-'
+  const displayedVersion =
+    versions.find((version) => version.isDisplayed) ?? currentVersion
+  const currentLabel = displayedVersion ? `v${displayedVersion.ordinal}` : 'v-'
   const showVersionClue = Boolean(
     revisitContext?.version &&
     dismissedVersionFor !== revisitContext?.entryCurrentVersionId &&

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
@@ -181,7 +181,8 @@ export function ViewerChrome({
   const currentVisibility = isVisibility(artifact.visibility)
     ? artifact.visibility
     : null
-  const commentsAvailable = artifactSupportsComments(renderType)
+  const commentsAvailable =
+    artifactSupportsComments(renderType) && onCommentsOpen !== undefined
   const canChangeVisibility =
     user !== null &&
     artifact.canChangeVisibility === true &&

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -64,6 +64,7 @@ import {
   viewerFetchFailureReason,
 } from '~/lib/viewer-network'
 import { cn } from '~/lib/utils'
+import { Link } from 'react-router'
 
 export type ViewerShellArtifact = {
   id: string
@@ -74,6 +75,9 @@ export type ViewerShellArtifact = {
   canReplaceFile?: boolean
   canViewHistory?: boolean
   currentVersionId?: string | null
+  displayedVersionId?: string
+  displayedVersionOrdinal?: number
+  isHistoricalVersion?: boolean
   versions?: ReadonlyArray<VersionRow>
   comments?: ReadonlyArray<CommentThreadView>
   revisitContext?: {
@@ -1464,6 +1468,8 @@ function useViewerShellController({
     initialViewerShellState,
   )
   const canReplaceFile = user !== null && artifact.canReplaceFile === true
+  const isHistoricalVersion = artifact.isHistoricalVersion === true
+  const canReplaceCurrentFile = canReplaceFile && !isHistoricalVersion
   const canViewHistory = artifact.canViewHistory === true
   const replaceMode: 'single' | 'static_site' =
     renderType === 'static_site' ? 'static_site' : 'single'
@@ -1476,11 +1482,16 @@ function useViewerShellController({
   // comments-changed) はコメント可能な種別で有効化する。接続は本文を抱える
   // sandbox iframe ではなく apex 側の閲覧画面から張るため、static_site でも
   // sandbox の隔離に触れない。
-  const commentsEnabled = user !== null && artifactSupportsComments(renderType)
+  const commentsEnabled =
+    user !== null &&
+    !isHistoricalVersion &&
+    artifactSupportsComments(renderType)
   const [liveConnected, setLiveConnected] = useState(false)
   const latestVersion = useLatestVersionNotice({
     artifactId: artifact.id,
-    currentVersionId: artifact.currentVersionId ?? null,
+    currentVersionId: isHistoricalVersion
+      ? null
+      : (artifact.currentVersionId ?? null),
     liveAvailable: commentsEnabled && liveConnected,
   })
   const initialCommentThreads = artifact.comments ?? emptyCommentThreads
@@ -1493,8 +1504,8 @@ function useViewerShellController({
       ? Math.max(viewCountState.viewCount, artifact.viewCount)
       : artifact.viewCount
   const artifactForChrome = useMemo(
-    () => ({ ...artifact, viewCount }),
-    [artifact, viewCount],
+    () => ({ ...artifact, viewCount, canReplaceFile: canReplaceCurrentFile }),
+    [artifact, canReplaceCurrentFile, viewCount],
   )
   const handleViewCountChanged = useCallback(
     (nextViewCount: number) => {
@@ -1509,7 +1520,8 @@ function useViewerShellController({
   }, [])
   // 本文範囲コメントは本文の選択を要するため html / md のみ。static_site の本文は
   // 別オリジンの sandbox iframe にあり選択を取得できない。
-  const textAnchorsEnabled = renderType === 'html' || renderType === 'md'
+  const textAnchorsEnabled =
+    !isHistoricalVersion && (renderType === 'html' || renderType === 'md')
   // 全体コメントの新規作成 composer は static_site のみ。html / md は本文選択で付ける。
   const newThreadComposerEnabled = renderType === 'static_site'
   const comments = useViewerComments({
@@ -1525,7 +1537,8 @@ function useViewerShellController({
     onLiveConnectionChanged: setLiveConnected,
     onPanelOpened: handleCommentsPanelOpened,
   })
-  const exportSupported = artifactSupportsExport(renderType)
+  const exportSupported =
+    !isHistoricalVersion && artifactSupportsExport(renderType)
   const initialExportPath = useMemo(
     () => defaultExportPath(artifact.entrypointPath, renderType),
     [artifact.entrypointPath, renderType],
@@ -1700,7 +1713,7 @@ function useViewerShellController({
   )
 
   useEffect(() => {
-    if (!canReplaceFile || state.uploading) return
+    if (!canReplaceCurrentFile || state.uploading) return
 
     function onDragEnter(event: DragEvent) {
       if (!hasLocalFiles(event.dataTransfer)) return
@@ -1737,7 +1750,13 @@ function useViewerShellController({
         capture: true,
       })
     }
-  }, [canReplaceFile, comments.changePanelOpen, state.uploading])
+  }, [canReplaceCurrentFile, comments.changePanelOpen, state.uploading])
+
+  const currentVersionParams = new URLSearchParams(routerLocation.search)
+  currentVersionParams.delete('version')
+  const currentVersionHref = `${routerLocation.pathname}${
+    currentVersionParams.toString() ? `?${currentVersionParams}` : ''
+  }`
 
   const handleFiles = (files: FileList | File[]) => {
     const list = Array.from(files)
@@ -1771,8 +1790,10 @@ function useViewerShellController({
     children,
     state,
     dispatch,
-    canReplaceFile,
+    canReplaceFile: canReplaceCurrentFile,
     canViewHistory,
+    isHistoricalVersion,
+    currentVersionHref,
     frameTitle,
     historyReturnFocusRef,
     latestVersion,
@@ -1821,6 +1842,8 @@ function ViewerShellView({
   dispatch,
   canReplaceFile,
   canViewHistory,
+  isHistoricalVersion,
+  currentVersionHref,
   frameTitle,
   historyReturnFocusRef,
   latestVersion,
@@ -1838,7 +1861,10 @@ function ViewerShellView({
   handleDownloadMarkdown,
   handleDownloadPdf,
 }: ViewerShellController) {
-  const showExportActions = Boolean(user && artifactSupportsExport(renderType))
+  const { t } = useT()
+  const showExportActions = Boolean(
+    user && !isHistoricalVersion && artifactSupportsExport(renderType),
+  )
 
   return (
     <div className="bg-surface-warm fixed inset-x-0 top-0 bottom-[var(--consent-banner-height)] flex flex-col overflow-hidden overscroll-none">
@@ -1856,7 +1882,7 @@ function ViewerShellView({
         }}
         commentCount={comments.totalCount}
         presence={comments.presence}
-        onCommentsOpen={comments.openPanel}
+        onCommentsOpen={commentsEnabled ? comments.openPanel : undefined}
         collapsible={sandboxUrl !== null}
         collapsed={state.chromeCollapsed}
         onCollapsedChange={(collapsed) =>
@@ -1869,10 +1895,29 @@ function ViewerShellView({
         }
         onDownloadPdf={showExportActions ? handleDownloadPdf : undefined}
       />
+      {isHistoricalVersion ? (
+        <div className="border-border bg-background flex min-h-11 items-center justify-between gap-3 border-b px-3 py-2 text-sm">
+          <strong>
+            {t('history.viewingVersion', {
+              version: `v${artifact.displayedVersionOrdinal ?? '-'}`,
+            })}
+          </strong>
+          <Link
+            to={currentVersionHref}
+            preventScrollReset
+            className="text-link font-medium no-underline hover:underline"
+          >
+            {t('history.backToCurrent')}
+          </Link>
+        </div>
+      ) : null}
       {sandboxUrl ? (
         <SandboxFrame
-          key={`${artifact.id}:${artifact.currentVersionId ?? ''}:${renderType ?? ''}`}
+          key={`${artifact.id}:${artifact.displayedVersionId ?? artifact.currentVersionId ?? ''}:${renderType ?? ''}`}
           shareableId={artifact.id}
+          versionId={
+            artifact.displayedVersionId ?? artifact.currentVersionId ?? ''
+          }
           url={sandboxUrl}
           name={frameTitle}
           mermaidEnabled={renderType === 'md'}

--- a/apps/web/app/routes/a.$id/index.test.tsx
+++ b/apps/web/app/routes/a.$id/index.test.tsx
@@ -124,6 +124,143 @@ describe('/a/:id loader', () => {
     expect(viewerDisplayCheckMock).not.toHaveBeenCalled()
   })
 
+  test('preserves a requested version through anonymous sign-in', async () => {
+    const shareable = {
+      id: 'html123abc',
+      visibility: 'link',
+      current_version_id: 'v2',
+      r2_key: 'artifacts/html123abc/v2/index.html',
+    }
+    dbMock.selectFrom.mockImplementation((table: string) => {
+      if (table === 'shareables') return shareableQuery(shareable)
+      throw new Error(`unexpected table ${table}`)
+    })
+    const context = new Map()
+    context.set(userContext, null)
+
+    const result = await loader({
+      params: { id: 'html123abc' },
+      request: new Request('https://artifactshare.com/a/html123abc?version=v1'),
+      context,
+    } as never)
+
+    expect(result.kind).toBe('preauth')
+    if (result.kind !== 'preauth') return
+    expect(result.canonicalUrl).toBe(
+      'https://artifactshare.com/a/html123abc?version=v1',
+    )
+    expect(viewerDisplayCheckMock).not.toHaveBeenCalled()
+  })
+
+  test('renders a published historical version without recording a view', async () => {
+    const shareable = {
+      id: 'html123abc',
+      workspace_id: 'ws1',
+      owner_user_id: 'u1',
+      name: 'demo.html',
+      artifact_kind: 'html_page',
+      derived_title: null,
+      title_override: null,
+      description: null,
+      visibility: 'private',
+      current_version_id: 'v2',
+      current_published_at: '2026-05-25T00:00:00Z',
+      owner_email: 'owner@example.com',
+      owner_name: 'Owner',
+      owner_image: null,
+      owner_kind: 'human',
+      r2_key: 'artifacts/html123abc/v2/index.html',
+      entrypoint_path: '/index.html',
+      fallback_to_index: 0,
+      version_artifact_kind: 'html_page',
+      view_count: 2,
+      updated_at: '2026-05-25T00:00:00Z',
+    }
+    let versionQueryCount = 0
+    dbMock.selectFrom.mockImplementation((table: string) => {
+      if (table === 'shareables') return shareableQuery(shareable)
+      if (table === 'versions') {
+        versionQueryCount += 1
+        if (versionQueryCount === 1) {
+          return chain({
+            executeTakeFirst: vi.fn().mockResolvedValue({
+              id: 'v1',
+              artifact_kind: 'html_page',
+              entrypoint_path: '/index.html',
+              r2_key: 'artifacts/html123abc/v1/index.html',
+              fallback_to_index: 0,
+              published_at: '2026-05-24T00:00:00Z',
+            }),
+          })
+        }
+        return chain({
+          executeTakeFirst: vi.fn().mockResolvedValue({ count: 2 }),
+          execute: vi.fn().mockResolvedValue([
+            {
+              id: 'v2',
+              createdAt: '2026-05-25T00:00:00Z',
+              sizeBytes: 256,
+            },
+            {
+              id: 'v1',
+              createdAt: '2026-05-24T00:00:00Z',
+              sizeBytes: 128,
+            },
+          ]),
+        })
+      }
+      if (table === 'workspaces' || table === 'workspace_members') {
+        return emptyFirstQuery()
+      }
+      throw new Error(`unexpected table ${table}`)
+    })
+    viewerDisplayCheckMock.mockResolvedValue({
+      kind: 'ok',
+      meta: {
+        modifiedTime: '2026-05-25T00:00:00Z',
+        name: 'demo.html',
+        mimeType: 'text/html',
+        ownerEmail: 'owner@example.com',
+      },
+    })
+    listGrantsMock.mockResolvedValue({ kind: 'ok', grants: [] })
+    const context = new Map()
+    context.set(userContext, {
+      id: 'u1',
+      email: 'owner@example.com',
+      name: 'Owner',
+      image: null,
+      workspaceId: 'ws1',
+      hd: 'example.com',
+      locale: 'en',
+    })
+    context.set(ctxContext, { waitUntil: vi.fn() })
+
+    const result = await loader({
+      params: { id: 'html123abc' },
+      request: new Request('https://artifactshare.com/a/html123abc?version=v1'),
+      context,
+    } as never)
+
+    expect(result.kind).toBe('ok')
+    if (result.kind !== 'ok') return
+    expect(result.artifact).toMatchObject({
+      currentVersionId: 'v2',
+      displayedVersionId: 'v1',
+      displayedVersionOrdinal: 1,
+      isHistoricalVersion: true,
+      canReplaceFile: true,
+    })
+    expect(result.canTrackView).toBe(false)
+    expect(result.sandboxUrl).toContain(
+      'html123abc--v-7631.sandbox.artifactshare.com',
+    )
+    expect(
+      result.artifact.versions.find((version) => version.id === 'v1'),
+    ).toMatchObject({ isDisplayed: true, isCurrent: false })
+    expect(recordViewAndNotifyViewCountMock).not.toHaveBeenCalled()
+  })
+
   test('returns static_site loader data with a signed sandbox URL', async () => {
     const shareable = {
       id: 'abc123def4',

--- a/apps/web/app/routes/a.$id/index.test.tsx
+++ b/apps/web/app/routes/a.$id/index.test.tsx
@@ -605,7 +605,7 @@ describe('/a/:id loader', () => {
     await expect(waitUntil.mock.calls[0]?.[0]).resolves.toEqual([undefined])
   })
 
-  test('records anonymous link views with live notification follow-up', async () => {
+  test('keeps the explicit current version available to anonymous link viewers', async () => {
     const shareable = {
       id: 'link123abc',
       workspace_id: 'ws1',
@@ -655,7 +655,7 @@ describe('/a/:id loader', () => {
 
     const result = await loader({
       params: { id: 'link123abc' },
-      request: new Request('https://artifactshare.com/a/link123abc'),
+      request: new Request('https://artifactshare.com/a/link123abc?version=v1'),
       context,
     } as never)
 

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -1,5 +1,6 @@
 import { env } from 'cloudflare:workers'
 import { nanoid } from 'nanoid'
+import { sql } from 'kysely'
 import { useState } from 'react'
 import {
   data,
@@ -111,6 +112,9 @@ interface ArtifactSummary {
   workspaceMsTenantId: string | null
   availableVisibilities: ReadonlyArray<EditableVisibility>
   currentVersionId: string | null
+  displayedVersionId: string
+  displayedVersionOrdinal: number
+  isHistoricalVersion: boolean
   versions: ReadonlyArray<VersionRow>
   grants: ReadonlyArray<GrantEntry>
   comments: ReadonlyArray<CommentThreadView>
@@ -200,6 +204,9 @@ type LoaderData =
         workspaceHd: string | null
         availableVisibilities: ReadonlyArray<EditableVisibility>
         currentVersionId: string | null
+        displayedVersionId: string
+        displayedVersionOrdinal: number
+        isHistoricalVersion: boolean
         versions: ReadonlyArray<VersionRow>
         grants: ReadonlyArray<GrantEntry>
         comments: ReadonlyArray<CommentThreadView>
@@ -292,7 +299,13 @@ export async function loader({
     throw new Response('Not found', { status: 404 })
   }
 
-  const canonicalUrl = new URL(`/a/${shareable.id}`, request.url).toString()
+  const requestUrl = new URL(request.url)
+  const requestedVersionId = requestUrl.searchParams.get('version')?.trim()
+  const canonicalUrl = new URL(`/a/${shareable.id}`, request.url)
+  if (requestedVersionId) {
+    canonicalUrl.searchParams.set('version', requestedVersionId)
+  }
+  const canonicalUrlString = canonicalUrl.toString()
   const user = context.get(userContext)
 
   if (!shareable.r2_key) {
@@ -307,13 +320,13 @@ export async function loader({
   }
 
   if (!user) {
-    if (shareable.visibility === 'link') {
+    if (shareable.visibility === 'link' && !requestedVersionId) {
       return await buildLinkAnonymousResponse(
         db,
         { ...shareable, r2_key: shareable.r2_key! },
         request,
         context,
-        canonicalUrl,
+        canonicalUrlString,
       )
     }
     return {
@@ -325,7 +338,7 @@ export async function loader({
         titleOverride: null,
         description: null,
       },
-      canonicalUrl,
+      canonicalUrl: canonicalUrlString,
     }
   }
 
@@ -408,6 +421,37 @@ export async function loader({
     return forbidden({ kind: 'unavailable', user: userInfo })
   }
 
+  const displayedVersion = requestedVersionId
+    ? await db
+        .selectFrom('versions')
+        .select([
+          'id',
+          'artifact_kind',
+          'entrypoint_path',
+          'r2_key',
+          'fallback_to_index',
+          'published_at',
+        ])
+        .where('shareable_id', '=', shareable.id)
+        .where('id', '=', requestedVersionId)
+        .where('status', '=', 'published')
+        .where('published_at', 'is not', null)
+        .executeTakeFirst()
+    : {
+        id: shareable.current_version_id!,
+        artifact_kind:
+          shareable.version_artifact_kind ?? shareable.artifact_kind,
+        entrypoint_path: shareable.entrypoint_path!,
+        r2_key: shareable.r2_key!,
+        fallback_to_index: shareable.fallback_to_index ?? 0,
+        published_at: shareable.current_published_at,
+      }
+  if (!displayedVersion) {
+    throw new Response('Not found', { status: 404 })
+  }
+  const isHistoricalVersion =
+    displayedVersion.id !== shareable.current_version_id
+
   const {
     modifiedTime,
     name: fileName,
@@ -417,17 +461,21 @@ export async function loader({
   const nameStale = fileName !== shareable.name
   const isOwner = shareable.owner_user_id === user.id
   const isPrefetch = isPrefetchRequest(request)
-  const shouldRecordView = !isPrefetch
+  const shouldRecordView = !isPrefetch && !isHistoricalVersion
   const preserveRevisitFixture = isDevScreenStateRequest(
     request,
     'viewer/revisit-context',
   )
-  const canTrackView = !isPrefetch
+  const canTrackView = !isPrefetch && !isHistoricalVersion
   const canViewHistory = true
-  const isStaticSite = shareable.version_artifact_kind === 'static_site'
+  const isStaticSite = displayedVersion.artifact_kind === 'static_site'
   const detectedRenderType = isStaticSite
     ? 'static_site'
-    : detectArtifactType(mimeType, fileName)
+    : displayedVersion.artifact_kind === 'markdown_page'
+      ? 'md'
+      : displayedVersion.artifact_kind === 'html_page'
+        ? 'html'
+        : detectArtifactType(mimeType, fileName)
   const canReplaceFile = isOwner
   const canReturnToProject =
     shareable.return_project_id !== null &&
@@ -435,11 +483,20 @@ export async function loader({
     shareable.return_project_workspace_id === user.workspaceId &&
     shareable.return_project_kind === 'project' &&
     shareable.return_project_archived_at === null
-  const versions = await loadHistoryVersions(
-    db,
-    shareable.id,
-    shareable.current_version_id,
-  )
+  const versions = (
+    await loadHistoryVersions(
+      db,
+      shareable.id,
+      shareable.current_version_id,
+      displayedVersion.id,
+    )
+  ).map((version) => ({
+    ...version,
+    isDisplayed: version.id === displayedVersion.id,
+  }))
+  const displayedVersionOrdinal = versions.find(
+    (version) => version.id === displayedVersion.id,
+  )!.ordinal
   // creator なら visibility に関わらず grants を pre-load する。
   // private / workspace の切り替え時に、既存の個別許可を最初から見せる。
   const grants = isOwner
@@ -456,9 +513,13 @@ export async function loader({
     r2Key: shareable.r2_key,
   })
   const [comments, latestCommentCreatedAt, revisitContext] = await Promise.all([
-    loadCommentThreads(db, commentAccess, user),
-    latestOtherCommentCreatedAt(db, shareable.id, user.id),
-    detectedRenderType
+    isHistoricalVersion
+      ? Promise.resolve([] as ReadonlyArray<CommentThreadView>)
+      : loadCommentThreads(db, commentAccess, user),
+    isHistoricalVersion
+      ? Promise.resolve(null)
+      : latestOtherCommentCreatedAt(db, shareable.id, user.id),
+    detectedRenderType && !isHistoricalVersion
       ? loadViewerRevisitContext(db, {
           shareableId: shareable.id,
           viewerUserId: user.id,
@@ -484,7 +545,7 @@ export async function loader({
     derivedTitle: shareable.derived_title,
     titleOverride: shareable.title_override,
     description: shareable.description,
-    entrypointPath: shareable.entrypoint_path,
+    entrypointPath: displayedVersion.entrypoint_path,
     ownerId: shareable.owner_user_id,
     ownerEmail: ownerEmail ?? shareable.owner_email,
     ownerName: shareable.owner_name,
@@ -524,15 +585,15 @@ export async function loader({
     const bundlePaths = await db
       .selectFrom('version_files')
       .select('path')
-      .where('version_id', '=', shareable.current_version_id!)
+      .where('version_id', '=', displayedVersion.id)
       .execute()
     const token = await signSandboxToken(
       {
         uid: user.id,
         wid: shareable.workspace_id,
         aid: shareable.id,
-        vid: shareable.current_version_id!,
-        fid: storageKey,
+        vid: displayedVersion.id,
+        fid: displayedVersion.r2_key,
         mt: modifiedTime,
         t: 'static_site',
         jti: nanoid(),
@@ -570,6 +631,9 @@ export async function loader({
         canChangeVisibility: isOwner,
         availableVisibilities,
         currentVersionId: shareable.current_version_id,
+        displayedVersionId: displayedVersion.id,
+        displayedVersionOrdinal,
+        isHistoricalVersion,
         versions,
         grants,
         comments,
@@ -578,13 +642,13 @@ export async function loader({
       sandboxUrl: buildArtifactSandboxUrl(
         env,
         shareable.id,
-        shareable.current_version_id!,
+        displayedVersion.id,
         token,
-        shareable.entrypoint_path ?? undefined,
+        displayedVersion.entrypoint_path ?? undefined,
       ),
       bundlePaths: bundlePaths.map((file) => file.path),
-      fallbackToIndex: Number(shareable.fallback_to_index) === 1,
-      canonicalUrl,
+      fallbackToIndex: Number(displayedVersion.fallback_to_index) === 1,
+      canonicalUrl: canonicalUrlString,
     }
   }
 
@@ -601,6 +665,9 @@ export async function loader({
         canViewHistory,
         canChangeVisibility: isOwner,
         currentVersionId: shareable.current_version_id,
+        displayedVersionId: displayedVersion.id,
+        displayedVersionOrdinal,
+        isHistoricalVersion,
         versions,
         grants,
         comments,
@@ -615,8 +682,8 @@ export async function loader({
       uid: user.id,
       wid: shareable.workspace_id,
       aid: shareable.id,
-      vid: shareable.current_version_id!,
-      fid: storageKey,
+      vid: displayedVersion.id,
+      fid: displayedVersion.r2_key,
       mt: modifiedTime,
       t: renderType,
       jti: nanoid(),
@@ -647,9 +714,9 @@ export async function loader({
   const sandboxUrl = buildArtifactSandboxUrl(
     env,
     shareable.id,
-    shareable.current_version_id!,
+    displayedVersion.id,
     token,
-    shareable.entrypoint_path ?? undefined,
+    displayedVersion.entrypoint_path ?? undefined,
   )
 
   return {
@@ -663,6 +730,9 @@ export async function loader({
       canChangeVisibility: isOwner,
       availableVisibilities,
       currentVersionId: shareable.current_version_id,
+      displayedVersionId: displayedVersion.id,
+      displayedVersionOrdinal,
+      isHistoricalVersion,
       versions,
       grants,
       comments,
@@ -670,7 +740,7 @@ export async function loader({
     },
     renderType,
     sandboxUrl,
-    canonicalUrl,
+    canonicalUrl: canonicalUrlString,
   }
 }
 
@@ -790,6 +860,9 @@ async function buildLinkAnonymousResponse(
     canChangeVisibility: false,
     availableVisibilities: [] as ReadonlyArray<EditableVisibility>,
     currentVersionId: shareable.current_version_id,
+    displayedVersionId: shareable.current_version_id!,
+    displayedVersionOrdinal: 1,
+    isHistoricalVersion: false,
     versions: [] as ReadonlyArray<VersionRow>,
     grants: [] as ReadonlyArray<GrantEntry>,
     comments: [] as ReadonlyArray<CommentThreadView>,
@@ -995,12 +1068,15 @@ async function loadHistoryVersions(
   db: ReturnType<typeof createDb>,
   shareableId: string,
   currentVersionId: string | null,
+  displayedVersionId: string,
 ): Promise<ReadonlyArray<VersionRow>> {
   const [countRow, rows] = await Promise.all([
     db
       .selectFrom('versions')
       .select((eb) => eb.fn.count<number>('id').as('count'))
       .where('shareable_id', '=', shareableId)
+      .where('status', '=', 'published')
+      .where('published_at', 'is not', null)
       .executeTakeFirst(),
     db
       .selectFrom('versions')
@@ -1013,6 +1089,8 @@ async function loadHistoryVersions(
         'users.name as createdByName',
       ])
       .where('versions.shareable_id', '=', shareableId)
+      .where('versions.status', '=', 'published')
+      .where('versions.published_at', 'is not', null)
       .orderBy('versions.created_at', 'desc')
       .orderBy('versions.id', 'desc')
       .limit(50)
@@ -1020,7 +1098,7 @@ async function loadHistoryVersions(
   ])
   const total = Number(countRow?.count ?? 0)
 
-  return rows.map((row, index) => ({
+  const versions = rows.map((row, index) => ({
     id: row.id,
     ordinal: total - index,
     createdAt: row.createdAt,
@@ -1028,6 +1106,50 @@ async function loadHistoryVersions(
     isCurrent: row.id === currentVersionId,
     createdByLabel: row.createdByName ?? row.createdByEmail,
   }))
+  if (versions.some((version) => version.id === displayedVersionId)) {
+    return versions
+  }
+
+  const displayedRow = await db
+    .selectFrom('versions')
+    .leftJoin('users', 'users.id', 'versions.created_by_id')
+    .select((eb) => [
+      'versions.id',
+      'versions.created_at as createdAt',
+      'versions.size_bytes as sizeBytes',
+      'users.email as createdByEmail',
+      'users.name as createdByName',
+      eb
+        .selectFrom('versions as older')
+        .select((sub) => sub.fn.count<number>('older.id').as('count'))
+        .whereRef('older.shareable_id', '=', 'versions.shareable_id')
+        .where('older.status', '=', 'published')
+        .where('older.published_at', 'is not', null)
+        .where(
+          sql<boolean>`(
+            older.created_at < versions.created_at
+            OR (older.created_at = versions.created_at AND older.id <= versions.id)
+          )`,
+        )
+        .as('ordinal'),
+    ])
+    .where('versions.shareable_id', '=', shareableId)
+    .where('versions.id', '=', displayedVersionId)
+    .where('versions.status', '=', 'published')
+    .where('versions.published_at', 'is not', null)
+    .executeTakeFirstOrThrow()
+
+  return [
+    ...versions,
+    {
+      id: displayedRow.id,
+      ordinal: Number(displayedRow.ordinal),
+      createdAt: displayedRow.createdAt,
+      sizeBytes: displayedRow.sizeBytes,
+      isCurrent: displayedRow.id === currentVersionId,
+      createdByLabel: displayedRow.createdByName ?? displayedRow.createdByEmail,
+    },
+  ]
 }
 
 export function meta({ loaderData }: Route.MetaArgs) {
@@ -1189,7 +1311,8 @@ function PreauthFallback({ canonicalUrl }: { canonicalUrl: string }) {
   const { t } = useT()
   const cliCommand = buildPreauthCliOpenCommand(canonicalUrl)
   const [agentHelpOpen, setAgentHelpOpen] = useState(false)
-  const returnPath = new URL(canonicalUrl).pathname
+  const returnUrl = new URL(canonicalUrl)
+  const returnPath = `${returnUrl.pathname}${returnUrl.search}`
   const signInHref = `/sign-in?method=email&next=${encodeURIComponent(returnPath)}`
   return (
     <Stack gap="0" align="center" justify="center" asChild>

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -320,7 +320,11 @@ export async function loader({
   }
 
   if (!user) {
-    if (shareable.visibility === 'link' && !requestedVersionId) {
+    if (
+      shareable.visibility === 'link' &&
+      (!requestedVersionId ||
+        requestedVersionId === shareable.current_version_id)
+    ) {
       return await buildLinkAnonymousResponse(
         db,
         { ...shareable, r2_key: shareable.r2_key! },
@@ -1137,7 +1141,10 @@ async function loadHistoryVersions(
     .where('versions.id', '=', displayedVersionId)
     .where('versions.status', '=', 'published')
     .where('versions.published_at', 'is not', null)
-    .executeTakeFirstOrThrow()
+    .executeTakeFirst()
+  if (!displayedRow) {
+    throw new Response('Not found', { status: 404 })
+  }
 
   return [
     ...versions,

--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.test.ts
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.test.ts
@@ -156,6 +156,47 @@ describe('/api/shareables/:id/sandbox-token', () => {
     expect(body.sandboxUrl).not.toContain('as_next=')
   })
 
+  test('refreshes the selected published historical version', async () => {
+    let queryCount = 0
+    dbMock.selectFrom.mockImplementation(() => {
+      queryCount += 1
+      return shareableQuery(
+        queryCount === 1
+          ? {
+              id: 'html123abc',
+              workspace_id: 'ws1',
+              owner_user_id: 'owner1',
+              name: 'demo.html',
+              visibility: 'private',
+              container_id: null,
+              current_version_id: 'v2',
+              r2_key: 'ws1/html123abc/v2/demo.html',
+              entrypoint_path: '/demo.html',
+              artifact_kind: 'html_page',
+              version_artifact_kind: 'html_page',
+            }
+          : {
+              id: 'v1',
+              r2_key: 'ws1/html123abc/v1/demo.html',
+              entrypoint_path: '/demo.html',
+              artifact_kind: 'html_page',
+            },
+      )
+    })
+
+    const response = await loader(loaderArgs('html123abc', 'v1'))
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { sandboxUrl: string }
+    expect(body.sandboxUrl).toContain(
+      'html123abc--v-7631.sandbox.artifactshare.com',
+    )
+    const token = new URL(body.sandboxUrl).searchParams.get('t')
+    await expect(
+      verifySandboxToken(token!, 'test-secret-with-enough-entropy-for-hmac'),
+    ).resolves.toMatchObject({ vid: 'v1', fid: 'ws1/html123abc/v1/demo.html' })
+  })
+
   test('does not return a token when access is denied', async () => {
     dbMock.selectFrom.mockReturnValue(
       shareableQuery({
@@ -182,7 +223,7 @@ describe('/api/shareables/:id/sandbox-token', () => {
   })
 })
 
-function loaderArgs(id = 'abc123def4') {
+function loaderArgs(id = 'abc123def4', versionId?: string) {
   const ctx = new Map()
   const user = requireUserMock()
   if (user) ctx.set(userContextSymbol, user)
@@ -190,7 +231,9 @@ function loaderArgs(id = 'abc123def4') {
     context: ctx,
     params: { id },
     request: new Request(
-      `https://artifactshare.test/api/shareables/${id}/sandbox-token`,
+      `https://artifactshare.test/api/shareables/${id}/sandbox-token${
+        versionId ? `?version=${versionId}` : ''
+      }`,
     ),
   } as never
 }

--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
@@ -11,7 +11,7 @@ import {
 import { createDb } from '~/services/db.server'
 import type { Route } from './+types/api.shareables.$id.sandbox-token'
 
-export async function loader({ context, params }: Route.LoaderArgs) {
+export async function loader({ context, params, request }: Route.LoaderArgs) {
   const user = context.get(userContext)
   const db = createDb()
   const shareable = await db
@@ -84,15 +84,51 @@ export async function loader({ context, params }: Route.LoaderArgs) {
     return Response.json({ error: 'not-found' }, { status: 404 })
   }
 
+  const requestedVersionId = new URL(request.url).searchParams
+    .get('version')
+    ?.trim()
+  if (
+    !user &&
+    requestedVersionId &&
+    requestedVersionId !== shareable.current_version_id
+  ) {
+    return Response.json({ error: 'not-found' }, { status: 404 })
+  }
+  const version = requestedVersionId
+    ? await db
+        .selectFrom('versions')
+        .select(['id', 'r2_key', 'entrypoint_path', 'artifact_kind'])
+        .where('shareable_id', '=', shareable.id)
+        .where('id', '=', requestedVersionId)
+        .where('status', '=', 'published')
+        .where('published_at', 'is not', null)
+        .executeTakeFirst()
+    : {
+        id: shareable.current_version_id,
+        r2_key: shareable.r2_key,
+        entrypoint_path: shareable.entrypoint_path,
+        artifact_kind: shareable.version_artifact_kind,
+      }
+  const versionRenderType =
+    version?.artifact_kind === 'static_site'
+      ? 'static_site'
+      : version?.artifact_kind === 'html_page' ||
+          version?.artifact_kind === 'markdown_page'
+        ? renderTypeFromKind(version.artifact_kind)
+        : null
+  if (!version || !versionRenderType) {
+    return Response.json({ error: 'not-found' }, { status: 404 })
+  }
+
   const token = await signSandboxToken(
     {
       uid: user?.id ?? null,
       wid: shareable.workspace_id,
       aid: shareable.id,
-      vid: shareable.current_version_id,
-      fid: shareable.r2_key,
+      vid: version.id,
+      fid: version.r2_key,
       mt: check.meta.modifiedTime,
-      t: renderType,
+      t: versionRenderType,
       jti: nanoid(),
     },
     env.BETTER_AUTH_SECRET,
@@ -101,11 +137,11 @@ export async function loader({ context, params }: Route.LoaderArgs) {
   const sandboxUrl = artifactSandboxUrl(
     env,
     shareable.id,
-    shareable.current_version_id,
+    version.id,
     token,
-    renderType === 'static_site'
-      ? (shareable.entrypoint_path ?? undefined)
+    versionRenderType === 'static_site'
+      ? (version.entrypoint_path ?? undefined)
       : undefined,
   )
-  return Response.json({ sandboxUrl, renderType })
+  return Response.json({ sandboxUrl, renderType: versionRenderType })
 }

--- a/apps/web/app/routes/dev.scenarios.$scenario/+components/viewer-fixture.tsx
+++ b/apps/web/app/routes/dev.scenarios.$scenario/+components/viewer-fixture.tsx
@@ -46,6 +46,7 @@ export function ViewerFixture({
         user={tooltipOpen ? VIEWER_USER : null}
         renderType="md"
         collapsible={tooltipOpen}
+        onCommentsOpen={() => undefined}
       />
       <ViewerBodySurface data-regression-region="main">
         <iframe


### PR DESCRIPTION
## Summary

- let authenticated viewers open any published artifact version from version history
- keep the selected version in the Viewer URL and provide a clear return to the current version
- suspend comments, live updates, replacement, export, and view/read tracking while viewing history
- refresh sandbox tokens for the exact selected published version

## Validation

- `pnpm validate:static`
- `pnpm --filter @artifactshare/web test:behavior-browser`
- `pnpm --filter @artifactshare/web build`
- `pnpm integration:test:run`
- `pnpm build:sandbox`
- desktop and 390px mobile historical-version UI critique

## Review

- Codex implementation review: no unresolved findings on `78632a7`
- Claude implementation review: no blockers on `78632a7`; query preservation and hard-reload navigation were classified as non-blocking because historical mode intentionally has no comment context and version changes require a clean viewer state
