### PR TITLE
Show update notice for source availability

### DIFF
--- a/apps/web/app/updates/entries/2026-08-18-source-available.en.md
+++ b/apps/web/app/updates/entries/2026-08-18-source-available.en.md
@@ -3,6 +3,7 @@ title: Artifact Share source code is now available
 date: 2026-08-18
 products: [web, cli]
 kind: new
+notice: true
 ---
 
 The source code for Artifact Share is now available on [GitHub](https://github.com/artifactshare/artifactshare). You may study and modify the code and self-host it for your organization.

--- a/apps/web/app/updates/entries/2026-08-18-source-available.ja.md
+++ b/apps/web/app/updates/entries/2026-08-18-source-available.ja.md
@@ -3,6 +3,7 @@ title: Artifact Share のソースコードを公開しました
 date: 2026-08-18
 products: [web, cli]
 kind: new
+notice: true
 ---
 
 Artifact Share のソースコードを [GitHub](https://github.com/artifactshare/artifactshare) で公開しました。コードを閲覧・改変し、社内でセルフホストできます。


### PR DESCRIPTION
## Summary

- mark the source-availability update as a user notice in both locales
- restore the unread update indicator on the avatar menu

## Validation

- `pnpm exec vitest --config vitest.config.ts --run app/services/updates-content.server.test.ts app/services/updates-visibility.server.test.ts`
- `pnpm validate:static`
- `pnpm public:scan .`
- Codex implementation review: no findings
- Claude implementation review: no findings
