### PR TITLE
fix: clean up viewer list follow-ups

### DIFF
--- a/apps/web/app/routes/a.$id/+components/viewer-shell-state.ts
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell-state.ts
@@ -12,7 +12,6 @@ interface ViewerShellState {
   chromeCollapsed: boolean
   historyOpen: boolean
   viewerListOpen: boolean
-  viewerListOpenedFrom: ViewerListOpenedFrom | null
   viewerListCloseReason: ViewerListCloseReason | null
   artifactId: string
   dropActive: boolean
@@ -26,7 +25,6 @@ type ViewerShellAction =
   | {
       type: 'viewer-list-open-changed'
       open: boolean
-      from?: ViewerListOpenedFrom
       // close (open: false) の理由。省略時は 'user'。
       reason?: ViewerListCloseReason
     }
@@ -41,7 +39,6 @@ export function createViewerShellState(artifactId: string): ViewerShellState {
     chromeCollapsed: false,
     historyOpen: false,
     viewerListOpen: false,
-    viewerListOpenedFrom: null,
     viewerListCloseReason: null,
     artifactId,
     dropActive: false,
@@ -64,7 +61,6 @@ export function viewerShellReducer(
             ...state,
             historyOpen: true,
             viewerListOpen: false,
-            viewerListOpenedFrom: null,
             viewerListCloseReason: 'forced',
           }
         : { ...state, historyOpen: false }
@@ -73,14 +69,12 @@ export function viewerShellReducer(
         ? {
             ...state,
             viewerListOpen: true,
-            viewerListOpenedFrom: action.from ?? null,
             viewerListCloseReason: null,
             historyOpen: false,
           }
         : {
             ...state,
             viewerListOpen: false,
-            viewerListOpenedFrom: null,
             viewerListCloseReason: action.reason ?? 'user',
           }
     case 'artifact-changed':
@@ -90,7 +84,6 @@ export function viewerShellReducer(
         ...state,
         artifactId: action.artifactId,
         viewerListOpen: false,
-        viewerListOpenedFrom: null,
         viewerListCloseReason: 'forced',
       }
     case 'file-drag-entered':
@@ -98,7 +91,6 @@ export function viewerShellReducer(
         ...state,
         historyOpen: true,
         viewerListOpen: false,
-        viewerListOpenedFrom: null,
         viewerListCloseReason: 'forced',
         dropActive: true,
         dropCatcherVisible: true,

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.test.ts
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.test.ts
@@ -525,29 +525,27 @@ async function nextMicrotask() {
 describe('viewerShellReducer viewer list exclusivity', () => {
   const base = createViewerShellState('artifact-1')
 
-  test('opening the viewer list closes history and records the origin', () => {
+  test('opening the viewer list closes history', () => {
     const state = viewerShellReducer(
       { ...base, historyOpen: true },
-      { type: 'viewer-list-open-changed', open: true, from: 'meta' },
+      { type: 'viewer-list-open-changed', open: true },
     )
     expect(state.viewerListOpen).toBe(true)
-    expect(state.viewerListOpenedFrom).toBe('meta')
     expect(state.historyOpen).toBe(false)
   })
 
-  test('closing the viewer list clears the recorded origin', () => {
+  test('closing the viewer list records a user close reason', () => {
     const state = viewerShellReducer(
-      { ...base, viewerListOpen: true, viewerListOpenedFrom: 'menu' },
+      { ...base, viewerListOpen: true },
       { type: 'viewer-list-open-changed', open: false },
     )
     expect(state.viewerListOpen).toBe(false)
-    expect(state.viewerListOpenedFrom).toBe(null)
     expect(state.viewerListCloseReason).toBe('user')
   })
 
   test('records a forced close reason when passed explicitly', () => {
     const state = viewerShellReducer(
-      { ...base, viewerListOpen: true, viewerListOpenedFrom: 'meta' },
+      { ...base, viewerListOpen: true },
       { type: 'viewer-list-open-changed', open: false, reason: 'forced' },
     )
     expect(state.viewerListOpen).toBe(false)
@@ -557,7 +555,7 @@ describe('viewerShellReducer viewer list exclusivity', () => {
   test('reopening clears the recorded close reason', () => {
     const state = viewerShellReducer(
       { ...base, viewerListCloseReason: 'forced' },
-      { type: 'viewer-list-open-changed', open: true, from: 'meta' },
+      { type: 'viewer-list-open-changed', open: true },
     )
     expect(state.viewerListOpen).toBe(true)
     expect(state.viewerListCloseReason).toBe(null)
@@ -565,42 +563,38 @@ describe('viewerShellReducer viewer list exclusivity', () => {
 
   test('opening history closes the viewer list', () => {
     const state = viewerShellReducer(
-      { ...base, viewerListOpen: true, viewerListOpenedFrom: 'meta' },
+      { ...base, viewerListOpen: true },
       { type: 'history-open-changed', open: true },
     )
     expect(state.historyOpen).toBe(true)
     expect(state.viewerListOpen).toBe(false)
-    expect(state.viewerListOpenedFrom).toBe(null)
     expect(state.viewerListCloseReason).toBe('forced')
   })
 
   test('closing history leaves the viewer list untouched', () => {
     const state = viewerShellReducer(
-      { ...base, viewerListOpen: true, viewerListOpenedFrom: 'meta' },
+      { ...base, viewerListOpen: true },
       { type: 'history-open-changed', open: false },
     )
     expect(state.viewerListOpen).toBe(true)
-    expect(state.viewerListOpenedFrom).toBe('meta')
   })
 
   test('file drag opening history closes the viewer list', () => {
     const state = viewerShellReducer(
-      { ...base, viewerListOpen: true, viewerListOpenedFrom: 'menu' },
+      { ...base, viewerListOpen: true },
       { type: 'file-drag-entered' },
     )
     expect(state.historyOpen).toBe(true)
     expect(state.viewerListOpen).toBe(false)
-    expect(state.viewerListOpenedFrom).toBe(null)
   })
 
   test('artifact change closes the viewer list and tracks the new id', () => {
     const state = viewerShellReducer(
-      { ...base, viewerListOpen: true, viewerListOpenedFrom: 'meta' },
+      { ...base, viewerListOpen: true },
       { type: 'artifact-changed', artifactId: 'artifact-2' },
     )
     expect(state.artifactId).toBe('artifact-2')
     expect(state.viewerListOpen).toBe(false)
-    expect(state.viewerListOpenedFrom).toBe(null)
     expect(state.viewerListCloseReason).toBe('forced')
   })
 })

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -1544,7 +1544,7 @@ function useViewerShellController({
       viewerListReturnFocusRef.current = returnFocusTo ?? getActiveElement()
       comments.changePanelOpen(false)
       viewerList.openFetch()
-      dispatch({ type: 'viewer-list-open-changed', open: true, from })
+      dispatch({ type: 'viewer-list-open-changed', open: true })
     },
     [comments.changePanelOpen, viewerList.openFetch, viewerListOpen],
   )

--- a/apps/web/app/routes/api.shareables.$id.viewers.test.ts
+++ b/apps/web/app/routes/api.shareables.$id.viewers.test.ts
@@ -18,6 +18,7 @@ vi.mock('~/middleware/context', () => ({
 }))
 vi.mock('~/services/db.server', () => ({
   createDb: () => fixtureRef.db,
+  d1DatabaseFor: () => undefined,
 }))
 
 import type { Kysely } from 'kysely'

--- a/apps/web/app/routes/viewer-list.behavior.browser.test.tsx
+++ b/apps/web/app/routes/viewer-list.behavior.browser.test.tsx
@@ -124,7 +124,7 @@ function Harness() {
     }
     returnFocusRef.current = returnFocusTo
     viewerList.openFetch()
-    dispatch({ type: 'viewer-list-open-changed', open: true, from })
+    dispatch({ type: 'viewer-list-open-changed', open: true })
   }
   return (
     <TooltipProvider>

--- a/apps/web/app/services/db.server.ts
+++ b/apps/web/app/services/db.server.ts
@@ -3,10 +3,18 @@ import { Kysely } from 'kysely'
 import { D1Dialect } from 'kysely-d1'
 import type { DB } from '~/types/db'
 
-export function createDb(): Kysely<DB> {
-  return new Kysely<DB>({
-    dialect: new D1Dialect({ database: env.DB }),
+const d1Databases = new WeakMap<Kysely<DB>, D1Database>()
+
+export function createDb(database: D1Database = env.DB): Kysely<DB> {
+  const db = new Kysely<DB>({
+    dialect: new D1Dialect({ database }),
   })
+  d1Databases.set(db, database)
+  return db
+}
+
+export function d1DatabaseFor(db: Kysely<DB>): D1Database | undefined {
+  return d1Databases.get(db)
 }
 
 export type Db = ReturnType<typeof createDb>

--- a/apps/web/app/services/viewer-list.server.test.ts
+++ b/apps/web/app/services/viewer-list.server.test.ts
@@ -8,6 +8,7 @@ import type { Kysely } from 'kysely'
 import type { SessionUser } from '~/lib/user'
 import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
 import type { DB } from '~/types/db'
+import { createDb } from './db.server'
 import {
   countShareableViewers,
   listShareableViewers,
@@ -449,6 +450,50 @@ describe('viewer-list.server', () => {
   })
 
   describe('countShareableViewers', () => {
+    test('runs the compiled reads through the D1 binding associated with the passed db', async () => {
+      const prepared: Array<{ sql: string; parameters: unknown[] }> = []
+      let batchCalls = 0
+      const d1 = {
+        prepare(sql: string) {
+          return {
+            bind(...parameters: unknown[]) {
+              const statement = { sql, parameters }
+              prepared.push(statement)
+              return statement
+            },
+          }
+        },
+        async batch(statements: unknown[]) {
+          batchCalls += 1
+          expect(statements).toEqual(prepared)
+          return [
+            { results: [{ id: memberUser.id }] },
+            { results: [{ count: 4 }] },
+            { results: [{ count: 2 }] },
+          ]
+        },
+      } as unknown as D1Database
+      const d1Db = createDb(d1)
+
+      try {
+        await expect(
+          countShareableViewers(d1Db, {
+            shareableId: 's1',
+            artifactWorkspaceId: 'ws1',
+            requesterUserId: memberUser.id,
+          }),
+        ).resolves.toEqual({
+          requesterIsActiveHumanMember: true,
+          viewerCount: 4,
+          hasMultipleActiveHumanMembers: true,
+        })
+        expect(batchCalls).toBe(1)
+        expect(prepared).toHaveLength(3)
+      } finally {
+        await d1Db.destroy()
+      }
+    })
+
     test('member requester with viewers: eligible, counted, multi-member', async () => {
       await seedViewers(db)
       expect(

--- a/apps/web/app/services/viewer-list.server.ts
+++ b/apps/web/app/services/viewer-list.server.ts
@@ -1,7 +1,7 @@
-import { env } from 'cloudflare:workers'
 import type { ExpressionBuilder, Kysely } from 'kysely'
 import type { SessionUser } from '~/lib/user'
 import { loadShareableViewAccess } from '~/services/comments.server'
+import { d1DatabaseFor } from '~/services/db.server'
 import type { DB } from '~/types/db'
 
 // Who viewed (viewer list): shared disclosure rule and its two consumers.
@@ -86,18 +86,20 @@ function disclosedMembersQuery(db: Kysely<DB>, workspaceId: string) {
 // Service tests use an in-process Kysely database without a binding and fall
 // back to sequential execution.
 async function runReadBatch(
+  db: Kysely<DB>,
   queries: Array<{
     compile(): { sql: string; parameters: ReadonlyArray<unknown> }
     execute(): Promise<unknown[]>
   }>,
 ): Promise<unknown[][]> {
-  if (!env.DB) {
+  const database = d1DatabaseFor(db)
+  if (!database) {
     return await Promise.all(queries.map((query) => query.execute()))
   }
-  const results = await env.DB.batch(
+  const results = await database.batch(
     queries.map((query) => {
       const compiled = query.compile()
-      return env.DB.prepare(compiled.sql).bind(...compiled.parameters)
+      return database.prepare(compiled.sql).bind(...compiled.parameters)
     }),
   )
   return results.map((result) => (result.results ?? []) as unknown[])
@@ -138,6 +140,7 @@ export async function countShareableViewers(
     .select((eb) => eb.fn.countAll<number>().as('count'))
 
   const [requesterRows, viewerCountRows, memberCountRows] = (await runReadBatch(
+    db,
     [requesterQuery, viewerCountQuery, memberCountQuery],
   )) as [
     Array<{ id: string }>,
@@ -273,7 +276,7 @@ export async function listShareableViewers(
     access.workspaceId,
   ).select((eb) => eb.fn.countAll<number>().as('count'))
 
-  const [pageRows, totalRows] = (await runReadBatch([
+  const [pageRows, totalRows] = (await runReadBatch(db, [
     rowsQuery,
     totalQuery,
   ])) as [

--- a/scripts/check-screen-ledger.test.mjs
+++ b/scripts/check-screen-ledger.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import { checkScreenLedger, hasDefaultExport } from './check-screen-ledger.mjs'
 import {
@@ -27,6 +28,37 @@ const routeTree = [
   },
 ]
 const screens = [{ id: 'profile', route: { en: '/settings/profile' } }]
+
+function exportedFunctionBody(source, name) {
+  const declaration = source.indexOf(`export function ${name}(`)
+  assert.notEqual(declaration, -1, `missing export function ${name}`)
+  const openingBrace = source.indexOf('{', declaration)
+  let depth = 0
+  for (let index = openingBrace; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1
+    if (source[index] === '}') depth -= 1
+    if (depth === 0) return source.slice(openingBrace, index + 1)
+  }
+  assert.fail(`unterminated export function ${name}`)
+}
+
+test('screen capture devShareableId stays identical to the scenario seeder', () => {
+  const captureSource = readFileSync(
+    new URL('./screen-capture.mjs', import.meta.url),
+    'utf8',
+  )
+  const seederSource = readFileSync(
+    new URL(
+      '../apps/web/app/services/dev-screen-state.server.ts',
+      import.meta.url,
+    ),
+    'utf8',
+  )
+  assert.equal(
+    exportedFunctionBody(captureSource, 'devShareableId'),
+    exportedFunctionBody(seederSource, 'devShareableId'),
+  )
+})
 
 test('accepts both default export forms', () => {
   assert.equal(hasDefaultExport('export default function Profile() {}'), true)


### PR DESCRIPTION
## 現状

閲覧者リストの read batch が、渡された Kysely ハンドルではなくグローバルな D1 binding を使っていた。また、フォーカス復帰方式の変更後も未使用の入口状態が残り、画面キャプチャとシナリオシードに複製された shareable ID 生成処理の一致を検査できていなかった。

## 変更

- `createDb()` が Kysely ハンドルと D1 binding の対応を保持し、read batch が渡されたハンドルに対応する binding を使うように変更
- D1 batch 経路を実行し、3 クエリが 1 batch になることを確認するテストを追加
- 未使用の `viewerListOpenedFrom` 状態と関連 reducer テストを削除し、入口種別は UI イベント内だけで扱うように整理
- 画面キャプチャとシナリオシードの `devShareableId` 実装が一致することを保証する契約テストを追加

## 検証

- `pnpm validate:static`
  - web unit: 285 files / 3005 tests（3004 pass、1 skip）
  - React Doctor: 100
  - public scan: 0 findings
- viewer list の対象 unit: 43 tests pass
- viewer list browser behavior: 3 tests pass
- Codex / Claude implementation deep review: findings なし
