### PR TITLE
fix: bind D1 batches to their query database

### DIFF
--- a/apps/web/app/lib/d1-batch.server.test.ts
+++ b/apps/web/app/lib/d1-batch.server.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const globalBatch = vi.hoisted(() => vi.fn())
+
+vi.mock('cloudflare:workers', () => ({
+  env: {
+    DB: {
+      prepare: vi.fn(() => {
+        throw new Error('global D1 must not prepare injected queries')
+      }),
+      batch: globalBatch,
+    },
+  },
+}))
+
+import { createDb } from '~/services/db.server'
+import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
+import { runD1Batch } from './d1-batch.server'
+
+describe('runD1Batch', () => {
+  beforeEach(() => {
+    globalBatch.mockClear()
+  })
+
+  test('uses the D1 binding associated with the query db instead of global env.DB', async () => {
+    const prepared: Array<{ sql: string; parameters: unknown[] }> = []
+    const injectedBatch = vi.fn(async () => [])
+    const injectedD1 = {
+      prepare(sql: string) {
+        return {
+          bind(...parameters: unknown[]) {
+            const statement = { sql, parameters }
+            prepared.push(statement)
+            return statement
+          },
+        }
+      },
+      batch: injectedBatch,
+    } as unknown as D1Database
+    const db = createDb(injectedD1)
+
+    try {
+      await runD1Batch(
+        db,
+        db.insertInto('workspaces').values({
+          id: 'ws-injected',
+          hd: 'injected.example',
+          name: 'Injected',
+          created_at: '2026-08-19T00:00:00.000Z',
+        }),
+      )
+
+      expect(injectedBatch).toHaveBeenCalledOnce()
+      expect(injectedBatch).toHaveBeenCalledWith(prepared)
+      expect(prepared).toHaveLength(1)
+      expect(globalBatch).not.toHaveBeenCalled()
+    } finally {
+      await db.destroy()
+    }
+  })
+
+  test('executes queries sequentially when the db has no D1 binding', async () => {
+    const fixture = createMigratedInMemoryDb()
+
+    try {
+      await runD1Batch(
+        fixture.db,
+        fixture.db.insertInto('workspaces').values({
+          id: 'ws-fallback',
+          hd: 'fallback.example',
+          name: 'Fallback',
+          created_at: '2026-08-19T00:00:00.000Z',
+        }),
+        fixture.db
+          .updateTable('workspaces')
+          .set({ name: 'Fallback updated' })
+          .where('id', '=', 'ws-fallback'),
+      )
+
+      await expect(
+        fixture.db
+          .selectFrom('workspaces')
+          .select(['id', 'name'])
+          .where('id', '=', 'ws-fallback')
+          .executeTakeFirst(),
+      ).resolves.toEqual({ id: 'ws-fallback', name: 'Fallback updated' })
+      expect(globalBatch).not.toHaveBeenCalled()
+    } finally {
+      await fixture.db.destroy()
+    }
+  })
+})

--- a/apps/web/app/lib/d1-batch.server.ts
+++ b/apps/web/app/lib/d1-batch.server.ts
@@ -1,19 +1,22 @@
-import { env } from 'cloudflare:workers'
-import type { Compilable } from 'kysely'
+import type { Compilable, Kysely } from 'kysely'
+import { d1DatabaseFor } from '~/lib/d1-database-registry.server'
+import type { DB } from '~/types/db'
 
 export async function runD1Batch(
+  db: Kysely<DB>,
   ...queries: Compilable<unknown>[]
 ): Promise<void> {
   // Service tests use an in-process Kysely database without a Workers binding.
   // Production always takes the D1 batch path below.
-  if (!env.DB) {
+  const database = d1DatabaseFor(db)
+  if (!database) {
     for (const query of queries)
       await (query as unknown as { execute: () => Promise<unknown> }).execute()
     return
   }
   const stmts = queries.map((query) => {
     const compiled = query.compile()
-    return env.DB.prepare(compiled.sql).bind(...compiled.parameters)
+    return database.prepare(compiled.sql).bind(...compiled.parameters)
   })
-  await env.DB.batch(stmts)
+  await database.batch(stmts)
 }

--- a/apps/web/app/lib/d1-database-registry.server.ts
+++ b/apps/web/app/lib/d1-database-registry.server.ts
@@ -1,0 +1,15 @@
+import type { Kysely } from 'kysely'
+import type { DB } from '~/types/db'
+
+const d1Databases = new WeakMap<Kysely<DB>, D1Database>()
+
+export function associateD1Database(
+  db: Kysely<DB>,
+  database: D1Database,
+): void {
+  d1Databases.set(db, database)
+}
+
+export function d1DatabaseFor(db: Kysely<DB>): D1Database | undefined {
+  return d1Databases.get(db)
+}

--- a/apps/web/app/services/auth.server.oauth-workspace-integration.test.ts
+++ b/apps/web/app/services/auth.server.oauth-workspace-integration.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { DatabaseSync } from 'node:sqlite'
 import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
-import { createD1BatchDbMock } from '~/test/d1-batch-mock'
+import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
 
 const sqliteRef = vi.hoisted(() => ({
   current: null as DatabaseSync | null,
@@ -191,7 +191,7 @@ describe('Better Auth OAuth workspace integration', () => {
   })
 
   test('Google hd joins an existing claim through profile mapping and hooks', async () => {
-    fixture = createMigratedInMemoryDb()
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqliteRef.current = fixture.sqlite
     const { db } = fixture
     await seedClaim(db, 'ws-existing-hd')
@@ -219,7 +219,7 @@ describe('Better Auth OAuth workspace integration', () => {
   })
 
   test('Google without hd matches an existing claim through the account hook', async () => {
-    fixture = createMigratedInMemoryDb()
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqliteRef.current = fixture.sqlite
     const { db } = fixture
     await seedClaim(db, 'ws-existing-no-hd')
@@ -238,7 +238,7 @@ describe('Better Auth OAuth workspace integration', () => {
   })
 
   test('Google new hd creates a claim workspace and moves the user in the account hook', async () => {
-    fixture = createMigratedInMemoryDb()
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqliteRef.current = fixture.sqlite
     const { db } = fixture
 
@@ -269,7 +269,7 @@ describe('Better Auth OAuth workspace integration', () => {
   })
 
   test('Google hd takes precedence over a different claimed email domain', async () => {
-    fixture = createMigratedInMemoryDb()
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqliteRef.current = fixture.sqlite
     const { db } = fixture
     await seedClaim(db, 'ws-email-domain', 'alias.example')
@@ -290,7 +290,7 @@ describe('Better Auth OAuth workspace integration', () => {
   })
 
   test('email code first login stays in a viewer workspace without claim membership', async () => {
-    fixture = createMigratedInMemoryDb()
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqliteRef.current = fixture.sqlite
     const { db } = fixture
     await seedClaim(db, 'ws-claimed')

--- a/apps/web/app/services/auth.server.ts
+++ b/apps/web/app/services/auth.server.ts
@@ -35,6 +35,7 @@ import { nowIso } from '~/lib/datetime'
 import { normalizeLocaleTag } from '~/lib/i18n.server'
 import { PLAN_STORAGE_QUOTA_BYTES } from '~/lib/billing-plan.server'
 import { LINK_SHARING_PLAN_DEFAULTS } from '~/lib/link-sharing-policy'
+import { associateD1Database } from '~/lib/d1-database-registry.server'
 import type { SessionUser } from '~/lib/user'
 import { isReservedBotEmailDomain } from '~/lib/bot-account'
 import {
@@ -140,6 +141,7 @@ function buildAuth() {
   // Reuse the dialect across our Kysely instance + better-auth's, so we don't
   // pay for two D1Dialect constructions per request.
   const db = new Kysely<DB>({ dialect })
+  associateD1Database(db, env.DB)
 
   return betterAuth({
     baseURL: env.BETTER_AUTH_URL,
@@ -967,9 +969,11 @@ function normalizeBearerSessionToken(token: string): string {
 }
 
 function createSessionDb() {
-  return new Kysely<DB>({
+  const db = new Kysely<DB>({
     dialect: new D1Dialect({ database: env.DB }),
   })
+  associateD1Database(db, env.DB)
+  return db
 }
 
 async function resolveSessionUser(

--- a/apps/web/app/services/billing-sync.server.test.ts
+++ b/apps/web/app/services/billing-sync.server.test.ts
@@ -3,8 +3,7 @@ import type { Kysely } from 'kysely'
 import type Stripe from 'stripe'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { PLAN_STORAGE_QUOTA_BYTES } from '~/lib/billing-plan.server'
-import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
-import { createD1BatchDbMock } from '~/test/d1-batch-mock'
+import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
 import type { DB } from '~/types/db'
 import {
   derivePlanFromSubscription,
@@ -48,7 +47,7 @@ describe('billing sync service', () => {
   let db: Kysely<DB>
 
   beforeEach(() => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqlite = fixture.sqlite
     db = fixture.db
     sqliteRef.current = sqlite

--- a/apps/web/app/services/billing-sync.server.ts
+++ b/apps/web/app/services/billing-sync.server.ts
@@ -258,7 +258,7 @@ export async function syncWorkspaceSubscription(
       .where('stripe_event_id', '=', options.stripeEventId)
       .where('processed_at', 'is', null),
   )
-  await runD1Batch(...batch)
+  await runD1Batch(db, ...batch)
 
   return { kind: 'ok' }
 }

--- a/apps/web/app/services/bot-members.server.ts
+++ b/apps/web/app/services/bot-members.server.ts
@@ -508,6 +508,7 @@ export async function createWorkspaceBot(
 
   try {
     await runD1Batch(
+      db,
       userInsert,
       memberInsert,
       profileInsert,
@@ -697,6 +698,7 @@ export async function cancelWorkspaceBot(
     .where(eligible)
 
   await runD1Batch(
+    db,
     audit,
     deleteGrants,
     deleteShareableGrants,
@@ -860,6 +862,7 @@ export async function stopWorkspaceBot(
     )
 
   await runD1Batch(
+    db,
     cas,
     revokeAudits,
     revokeCredentials,
@@ -1082,6 +1085,7 @@ export async function reissueWorkspaceBotCredential(
 
   try {
     await runD1Batch(
+      db,
       supersede,
       revokeOldCredentials,
       deleteOldSessions,

--- a/apps/web/app/services/cli-refresh-credentials.server.test.ts
+++ b/apps/web/app/services/cli-refresh-credentials.server.test.ts
@@ -1,9 +1,8 @@
 import type { DatabaseSync } from 'node:sqlite'
 import type { Kysely } from 'kysely'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { createD1BatchDbMock } from '~/test/d1-batch-mock'
+import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
 import { seedUser, seedWorkspace } from '~/test/db-seed-fixture'
-import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
 import type { DB } from '~/types/db'
 
 const sqliteRef = vi.hoisted(() => ({
@@ -31,7 +30,7 @@ describe('cli-refresh-credentials service', () => {
   let db: Kysely<DB>
 
   beforeEach(() => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqlite = fixture.sqlite
     sqliteRef.current = sqlite
     db = fixture.db
@@ -1290,7 +1289,7 @@ describe('bot refresh guards', () => {
   let db: Kysely<DB>
 
   beforeEach(() => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqlite = fixture.sqlite
     sqliteRef.current = sqlite
     db = fixture.db

--- a/apps/web/app/services/cli-refresh-credentials.server.ts
+++ b/apps/web/app/services/cli-refresh-credentials.server.ts
@@ -423,6 +423,7 @@ export async function issueCliRefreshCredential(
         )
     : null
   await runD1Batch(
+    db,
     ...(supersedeAudit ? [supersedeAudit] : []),
     ...(deletePriorDeviceSessions ? [deletePriorDeviceSessions] : []),
     ...(supersedePriorCredentials ? [supersedePriorCredentials] : []),
@@ -693,6 +694,7 @@ export async function refreshCliSession(
   })
 
   await runD1Batch(
+    db,
     rotate,
     replacement,
     session,
@@ -842,7 +844,7 @@ async function refreshLegacyCliSession(
           eb.val(now).as('created_at'),
         ]),
     )
-  await runD1Batch(audit, session, sessionLink, sessionAuthority, used)
+  await runD1Batch(db, audit, session, sessionLink, sessionAuthority, used)
   const committed = await db
     .selectFrom('sessions')
     .select('id')
@@ -1055,6 +1057,7 @@ async function revokeAllCliRefreshCredentialFamiliesAtomic(
       )}`
     : undefined
   await runD1Batch(
+    db,
     ...buildCliRefreshCredentialRevocationStatements(db, {
       actorUserId: input.actorUserId,
       targetUserId: input.targetUserId,
@@ -1252,7 +1255,7 @@ async function revokeCliRefreshCredentialFamilyAtomic(
     linkedSessions,
     credentials,
   ]
-  await runD1Batch(...statements)
+  await runD1Batch(db, ...statements)
   return 'ok'
 }
 

--- a/apps/web/app/services/comments.server.test.ts
+++ b/apps/web/app/services/comments.server.test.ts
@@ -1,8 +1,7 @@
 import type { DatabaseSync } from 'node:sqlite'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { Kysely } from 'kysely'
-import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
-import { createD1BatchDbMock } from '~/test/d1-batch-mock'
+import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
 import type { SessionUser } from '~/lib/user'
 import type { DB } from '~/types/db'
 import {
@@ -71,12 +70,12 @@ vi.mock('cloudflare:workers', () => ({
 }))
 
 describe('comments server', () => {
-  let fixture: ReturnType<typeof createMigratedInMemoryDb>
+  let fixture: ReturnType<typeof createD1BatchFixture>
 
   beforeEach(async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-29T00:00:00.000Z'))
-    fixture = createMigratedInMemoryDb()
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
     sqliteRef.bucketText = '<p>Updated body keeps the selected words here.</p>'

--- a/apps/web/app/services/comments.server.ts
+++ b/apps/web/app/services/comments.server.ts
@@ -575,7 +575,7 @@ export async function createCommentThread(
     )
   }
   try {
-    await runD1Batch(...queries)
+    await runD1Batch(db, ...queries)
   } catch {
     return { kind: 'commit-failed' }
   }
@@ -608,6 +608,7 @@ export async function replyToCommentThread(
   const messageId = nanoid()
   try {
     await runD1Batch(
+      db,
       db.insertInto('comment_messages').values({
         id: messageId,
         thread_id: threadId,
@@ -753,6 +754,7 @@ async function mutateLoadedCommentMessage(
   const now = nowIso()
   try {
     await runD1Batch(
+      db,
       db
         .updateTable('comment_messages')
         .set({ body, updated_at: now })
@@ -796,6 +798,7 @@ async function mutateLoadedCommentMessageDelete(
   const now = nowIso()
   try {
     await runD1Batch(
+      db,
       db.deleteFrom('comment_messages').where('id', '=', message.id),
       db
         .deleteFrom('comment_anchors')
@@ -858,6 +861,7 @@ export async function deleteCommentThread(
 
   try {
     await runD1Batch(
+      db,
       db.deleteFrom('comment_anchors').where('thread_id', '=', threadId),
       db.deleteFrom('comment_messages').where('thread_id', '=', threadId),
       db

--- a/apps/web/app/services/db.server.ts
+++ b/apps/web/app/services/db.server.ts
@@ -1,20 +1,17 @@
 import { env } from 'cloudflare:workers'
 import { Kysely } from 'kysely'
 import { D1Dialect } from 'kysely-d1'
+import { associateD1Database } from '~/lib/d1-database-registry.server'
 import type { DB } from '~/types/db'
 
-const d1Databases = new WeakMap<Kysely<DB>, D1Database>()
+export { d1DatabaseFor } from '~/lib/d1-database-registry.server'
 
 export function createDb(database: D1Database = env.DB): Kysely<DB> {
   const db = new Kysely<DB>({
     dialect: new D1Dialect({ database }),
   })
-  d1Databases.set(db, database)
+  associateD1Database(db, database)
   return db
-}
-
-export function d1DatabaseFor(db: Kysely<DB>): D1Database | undefined {
-  return d1Databases.get(db)
 }
 
 export type Db = ReturnType<typeof createDb>

--- a/apps/web/app/services/link-sharing.server.test.ts
+++ b/apps/web/app/services/link-sharing.server.test.ts
@@ -1,8 +1,7 @@
 import type { DatabaseSync } from 'node:sqlite'
 import type { Kysely } from 'kysely'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
-import { createD1BatchDbMock } from '~/test/d1-batch-mock'
+import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
 import type { DB } from '~/types/db'
 
 const sqliteRef = vi.hoisted(() => ({
@@ -27,7 +26,7 @@ describe('workspace link-sharing service', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     await db

--- a/apps/web/app/services/link-sharing.server.ts
+++ b/apps/web/app/services/link-sharing.server.ts
@@ -213,7 +213,7 @@ export async function reopenExpiredLink(
     created_at: at,
   })
   const { runD1Batch } = await import('~/lib/d1-batch.server')
-  await runD1Batch(update, audit)
+  await runD1Batch(db, update, audit)
   return { kind: 'ok', linkExpiresAt: resolved.linkExpiresAt }
 }
 
@@ -372,7 +372,7 @@ export async function updateWorkspaceExternalAccessPolicy(
     }),
   )
   const { runD1Batch } = await import('~/lib/d1-batch.server')
-  await runD1Batch(...queries)
+  await runD1Batch(db, ...queries)
   return { kind: 'ok', policy: next, shortenedLinkCount }
 }
 

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -1,7 +1,7 @@
 import type { DatabaseSync } from 'node:sqlite'
 import type { Kysely } from 'kysely'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
+import { createD1BatchFixture } from '~/test/d1-batch-mock'
 import type { DB } from '~/types/db'
 
 const storageMock = vi.hoisted(() => ({
@@ -549,7 +549,7 @@ describe('headless publish wiring', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     storageMock.putArtifact.mockReset().mockResolvedValue(undefined)

--- a/apps/web/app/services/oauth-workspace-integration.server.test.ts
+++ b/apps/web/app/services/oauth-workspace-integration.server.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { DatabaseSync } from 'node:sqlite'
 import type { Kysely } from 'kysely'
 import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
-import { createD1BatchDbMock } from '~/test/d1-batch-mock'
+import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
 import type { DB } from '~/types/db'
 import {
   applyOAuthWorkspaceIntegration,
@@ -29,7 +29,7 @@ describe('OAuth workspace integration', () => {
   })
 
   function setup() {
-    fixture = createMigratedInMemoryDb()
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqliteRef.current = fixture.sqlite
     return fixture.db
   }

--- a/apps/web/app/services/projects.server.ts
+++ b/apps/web/app/services/projects.server.ts
@@ -1021,7 +1021,7 @@ export async function saveProjectShareDefaults(
     }
   }
 
-  if (statements.length > 0) await runD1Batch(...statements)
+  if (statements.length > 0) await runD1Batch(db, ...statements)
 
   // Detect bot-directed writes that committed 0 rows (stop won the race):
   // never report success for a grant that did not land. Existence alone is not

--- a/apps/web/app/services/shareables.server.test.ts
+++ b/apps/web/app/services/shareables.server.test.ts
@@ -1,8 +1,7 @@
 import type { DatabaseSync } from 'node:sqlite'
 import type { Kysely } from 'kysely'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
-import { createD1BatchDbMock } from '~/test/d1-batch-mock'
+import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
 import {
   loadStaticSiteFixture,
   loadStaticSiteFixtureFiles,
@@ -566,7 +565,7 @@ describe('uploadShareable', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
@@ -2082,7 +2081,7 @@ describe('commitDialogChanges', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
@@ -2444,7 +2443,7 @@ describe('StaticSiteBundleUploadSession', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
@@ -3405,7 +3404,7 @@ describe('generateUniqueShareableId', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
@@ -3500,7 +3499,7 @@ describe('StaticSiteBundleVersionUploadSession', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
@@ -3811,7 +3810,7 @@ describe('createVersion', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
@@ -4147,7 +4146,7 @@ describe('cross-workspace owner operations', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
@@ -4473,7 +4472,7 @@ describe('deleteShareable', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
@@ -4961,7 +4960,7 @@ describe('stable keys (publish --key)', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
@@ -5353,7 +5352,7 @@ describe('member removal credential blocking', () => {
   let db: Kysely<DB>
 
   beforeEach(async () => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -605,7 +605,7 @@ export async function commitDialogChanges(
 
   if (queries.length > 0) {
     try {
-      await runD1Batch(...queries)
+      await runD1Batch(db, ...queries)
     } catch (err) {
       if (addEmails.length > 0 && isSqliteConstraintError(err)) {
         return { kind: 'too-many-grants', limit: MAX_GRANT_EMAILS }
@@ -627,6 +627,7 @@ export async function commitDialogChanges(
       ) {
         try {
           await runD1Batch(
+            db,
             db
               .updateTable('shareables')
               .set({
@@ -1122,7 +1123,7 @@ export async function createVersion(
         }),
       )
     }
-    await runD1Batch(...versionQueries)
+    await runD1Batch(db, ...versionQueries)
   } catch {
     await deleteArtifact(env.BUCKET, prepared.r2Key).catch((err) => {
       console.error('r2_compensation_failed', {
@@ -1385,7 +1386,7 @@ export async function deleteShareable(
   }
   batch.push(db.deleteFrom('shareables').where('id', '=', shareableId))
   try {
-    await runD1Batch(...batch)
+    await runD1Batch(db, ...batch)
   } catch {
     return { kind: 'delete-failed' }
   }
@@ -1564,6 +1565,7 @@ export async function moveShareableContainer(
       )
     }
     await runD1Batch(
+      db,
       update,
       db
         .deleteFrom('project_pins')
@@ -1914,7 +1916,7 @@ async function createNewShareableFromFile(
           }),
         )
       }
-      await runD1Batch(...queries)
+      await runD1Batch(db, ...queries)
     } catch (err) {
       await Promise.all([
         deleteArtifact(env.BUCKET, prepared.r2Key).catch((deleteErr) => {
@@ -2320,7 +2322,7 @@ export class StaticSiteBundleUploadSession {
     if (slackNotification.query) queries.push(slackNotification.query)
 
     try {
-      await runD1Batch(...queries)
+      await runD1Batch(this.db, ...queries)
     } catch (err) {
       const keyConflict = await didArtifactKeyConflict(this.db, err, {
         ownerUserId: this.user.id,
@@ -2470,7 +2472,7 @@ export class StaticSiteBundleUploadSession {
       versionPublishedEventQuery(this.db, { versionId: this.versionId }),
     )
     try {
-      await runD1Batch(...versionQueries)
+      await runD1Batch(this.db, ...versionQueries)
     } catch (err) {
       console.error('static_site_version_d1_commit_failed', {
         shareable_id: this.shareableId,

--- a/apps/web/app/services/team-management.server.test.ts
+++ b/apps/web/app/services/team-management.server.test.ts
@@ -1,8 +1,7 @@
 import type { DatabaseSync } from 'node:sqlite'
 import type { Kysely } from 'kysely'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
-import { createD1BatchDbMock } from '~/test/d1-batch-mock'
+import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
 import type { DB } from '~/types/db'
 import { viewerDisplayCheck } from './access.server'
 import { issueCliRefreshCredential } from './cli-refresh-credentials.server'
@@ -55,7 +54,11 @@ describe('team-management service', () => {
   let db: Kysely<DB>
 
   beforeEach(() => {
-    const fixture = createMigratedInMemoryDb()
+    const fixture = createD1BatchFixture({
+      sqlite: sqliteRef,
+      beforeBatch: batchHookRef,
+      batchCount: batchCountRef,
+    })
     sqlite = fixture.sqlite
     db = fixture.db
     sqliteRef.current = sqlite

--- a/apps/web/app/services/team-management.server.ts
+++ b/apps/web/app/services/team-management.server.ts
@@ -686,6 +686,7 @@ export async function transferRemovedMemberAssets(
     removedMemberGuard(db, actor.workspaceId, targetUserId, actor.id)
 
   await runD1Batch(
+    db,
     db
       .insertInto('audit_events')
       .columns([
@@ -886,6 +887,7 @@ export async function restoreWorkspaceMember(
     workspaceMemberRestoreGuard(db, actor, targetUserId, sourceWorkspaceId)
   const detail = JSON.stringify({ email: target.email, name: target.name })
   await runD1Batch(
+    db,
     db
       .insertInto('audit_events')
       .columns([
@@ -1108,7 +1110,7 @@ export async function transferWorkspaceOwner(
       ),
     )
 
-  await runD1Batch(auditInsert, demoteActor, promoteTarget)
+  await runD1Batch(db, auditInsert, demoteActor, promoteTarget)
 
   const [promoted, audited] = await Promise.all([
     db
@@ -1201,6 +1203,7 @@ export async function removeWorkspaceMember(
     const newWorkspaceId = nanoid()
     const workspaceName = `${target.email}'s workspace`
     await runD1Batch(
+      db,
       db
         .insertInto('workspaces')
         .columns([
@@ -1392,7 +1395,7 @@ export async function removeWorkspaceMember(
         exists(workspaceAdminQuery(db, actor.id, oldWorkspaceId)),
       ),
   )
-  await runD1Batch(...removalBatch)
+  await runD1Batch(db, ...removalBatch)
 
   const removed = await db
     .selectFrom('workspace_members')
@@ -1730,7 +1733,7 @@ async function runRoleMutationBatch(
         db.selectFrom('audit_events').select('id').where('id', '=', auditId),
       ),
     )
-  await runD1Batch(audit, update)
+  await runD1Batch(db, audit, update)
   const changed = await db
     .selectFrom('workspace_members')
     .select('role')

--- a/apps/web/app/services/workspace-domain-claims.server.test.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { DatabaseSync } from 'node:sqlite'
 import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
-import { createD1BatchDbMock } from '~/test/d1-batch-mock'
+import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
 import type { DB } from '~/types/db'
 import type { Kysely } from 'kysely'
 import {
@@ -33,7 +33,7 @@ describe('workspace domain claims', () => {
   })
 
   function setup() {
-    fixture = createMigratedInMemoryDb()
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqliteRef.current = fixture.sqlite
     return fixture.db
   }

--- a/apps/web/app/services/workspace-domain-claims.server.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.ts
@@ -346,21 +346,14 @@ async function moveUserToWorkspaceIfSafe(
         ),
       ]),
     )
-  if ((env as { DB?: unknown }).DB) {
-    await runD1Batch(
-      userUpdate,
-      membershipUpsert,
-      targetMembershipGuardQuery,
-      sourceMembershipDelete,
-      emptySourceWorkspaceDelete,
-    )
-  } else {
-    await userUpdate.execute()
-    await membershipUpsert.execute()
-    await targetMembershipGuardQuery.execute()
-    await sourceMembershipDelete.execute()
-    await emptySourceWorkspaceDelete.execute()
-  }
+  await runD1Batch(
+    db,
+    userUpdate,
+    membershipUpsert,
+    targetMembershipGuardQuery,
+    sourceMembershipDelete,
+    emptySourceWorkspaceDelete,
+  )
   return input.targetWorkspaceId
 }
 

--- a/apps/web/app/services/workspace-domain-claims.server.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.ts
@@ -1,6 +1,5 @@
 import { sql, type Kysely } from 'kysely'
 import { nanoid } from 'nanoid'
-import { env } from 'cloudflare:workers'
 import { runD1Batch } from '~/lib/d1-batch.server'
 import { nowIso } from '~/lib/datetime'
 import {

--- a/apps/web/app/test/d1-batch-mock.ts
+++ b/apps/web/app/test/d1-batch-mock.ts
@@ -1,4 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite'
+import { associateD1Database } from '~/lib/d1-database-registry.server'
+import { createMigratedInMemoryDb } from './sqlite-fixture'
 
 export type D1BatchStmt = { sql: string; params: unknown[] }
 
@@ -53,4 +55,13 @@ export function createD1BatchDbMock(options: D1BatchMockOptions) {
       }
     },
   }
+}
+
+export function createD1BatchFixture(options: D1BatchMockOptions) {
+  const fixture = createMigratedInMemoryDb()
+  associateD1Database(
+    fixture.db,
+    createD1BatchDbMock(options) as unknown as D1Database,
+  )
+  return fixture
 }

--- a/apps/web/integration/bot-members.test.ts
+++ b/apps/web/integration/bot-members.test.ts
@@ -14,8 +14,7 @@ import {
 } from 'vitest'
 import { mkdirSync } from 'node:fs'
 import { readFile, readdir, writeFile } from 'node:fs/promises'
-import { Kysely } from 'kysely'
-import { D1Dialect } from 'kysely-d1'
+import type { Kysely } from 'kysely'
 import type { DB } from '../app/types/db'
 import {
   partitionMigrationNames,
@@ -147,6 +146,7 @@ const {
 } = await import('../app/services/bot-members.server')
 const { refreshCliSession } =
   await import('../app/services/cli-refresh-credentials.server')
+const { createDb } = await import('../app/services/db.server')
 
 async function applyProductionD1Schema() {
   const env = await worker.getEnv<{ DB: D1Database }>()
@@ -271,7 +271,8 @@ beforeEach(async () => {
   rawDb = env.DB
   envRef.db = env.DB
   envRef.beforeNextBatch = null
-  db = new Kysely<DB>({ dialect: new D1Dialect({ database: env.DB }) })
+  const { env: serviceEnv } = await import('cloudflare:workers')
+  db = createDb(serviceEnv.DB)
   await seedWorkspaceFixture()
 })
 


### PR DESCRIPTION
## Summary

- bind every D1 batch to the same database handle that created its Kysely queries
- migrate batch-writing services to pass their database handle explicitly
- preserve the sequential SQLite fallback used by service tests
- add regression coverage for injected D1 bindings and unassociated test databases

## Root cause

`runD1Batch` compiled queries from an injected Kysely instance but always executed them through the global Workers binding. Reads and authorization checks could therefore use one database while the resulting writes were sent to another.

## Impact

Injected, alternate, and future tenant-specific database bindings now remain consistent across reads, authorization, and atomic batch writes.

## Validation

- `pnpm validate:static`
- 3,006 web unit tests passed (1 skipped)
- React Doctor score: 100
- public repository scan: 0 findings
- Codex implementation review: no findings
- Claude implementation review: no findings
