### PR TITLE
fix: ignore metadata before static site limits

### DIFF
--- a/apps/web/app/services/shareables.server.test.ts
+++ b/apps/web/app/services/shareables.server.test.ts
@@ -2910,6 +2910,33 @@ describe('StaticSiteBundleUploadSession', () => {
     expect(storageMock.putArtifact).toHaveBeenCalledTimes(1)
   })
 
+  test('ignores trailing OS metadata after reaching the static site file limit', async () => {
+    const begun = await beginStaticSiteBundleUploadSession(db, OWNER)
+
+    expect(begun.kind).toBe('ok')
+    if (begun.kind !== 'ok') throw new Error('expected ok')
+
+    for (let index = 0; index < 50; index += 1) {
+      await expect(
+        begun.session.addFile(
+          siteFile(`/pages/${index}.html`, 16, 'text/html'),
+        ),
+      ).resolves.toEqual({ kind: 'ok' })
+    }
+
+    await expect(
+      begun.session.addFile(siteFile('/.DS_Store', 12, '')),
+    ).resolves.toEqual({ kind: 'ok' })
+    await expect(
+      begun.session.addFile(
+        siteFile('/__MACOSX/pages/extra.html', 12, 'text/html'),
+      ),
+    ).resolves.toEqual({ kind: 'ok' })
+
+    expect(begun.session.fileCount).toBe(50)
+    expect(storageMock.putArtifact).toHaveBeenCalledTimes(50)
+  })
+
   test('uses an HTML entrypoint title as the static site display title', async () => {
     const begun = await beginStaticSiteBundleUploadSession(db, OWNER)
 

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -2053,12 +2053,13 @@ export class StaticSiteBundleUploadSession {
 
   async addFile(file: File): Promise<StaticSiteAddFileResult> {
     if (this.#closed) return { kind: 'storage-failed' }
-    if (this.files.length >= MAX_STATIC_SITE_FILES) {
-      return { kind: 'too-many-files', limit: MAX_STATIC_SITE_FILES }
-    }
 
     const rawPath = file.name
     if (isIgnoredStaticSiteUploadPath(rawPath)) return { kind: 'ok' }
+
+    if (this.files.length >= MAX_STATIC_SITE_FILES) {
+      return { kind: 'too-many-files', limit: MAX_STATIC_SITE_FILES }
+    }
 
     const pathValidation = validateBundlePath(rawPath)
     if (pathValidation.kind === 'blocked') {


### PR DESCRIPTION
## Summary

- ignore static-site OS metadata paths before enforcing the accepted-file count limit
- add a boundary regression test with 50 accepted files followed by ignored metadata

## Root cause

The upload session checked the accepted-file count before applying the ignored-path predicate. A trailing `.DS_Store` or `__MACOSX` entry was therefore rejected after 50 real files even though ignored files are not stored or counted.

## Impact

Static-site bundle results are now independent of whether ignored OS metadata appears before or after the accepted files.

## Validation

- `pnpm validate:static`
- shareables service: 149 tests passed
- 3,007 web unit tests passed (1 skipped)
- React Doctor score: 100
- public repository scan: 0 findings
- Codex implementation review: no findings
- Claude implementation review: no findings
