### PR TITLE
release: CLI 0.11.3

### DIFF
--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "package_version": "0.11.2",
+  "package_version": "0.11.3",
   "commands": [
     {
       "path": "",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ For user-facing announcements, see https://artifactshare.com/updates?product=cli
 
 ## Unreleased
 
+## 0.11.3 - 2026-08-20
+
 - Support Windows Credential Manager for saved profiles, resolve Windows config homes without `HOME`, and expose token-store diagnostics from `doctor --json`. The explicit plaintext fallback is now limited to POSIX systems with mode `0600` instead of implying Windows protection from ignored mode bits.
 - `profiles import-token` detects workspace-issued bot tokens (`asb_` prefix), imports them as rotating refresh credentials (the first refresh consumes the displayed token; the rotated credential is stored before success is reported), persists `kind: "bot"` in the profile, and adds `--force` to replace an existing profile credential (no-op for API tokens). Rejected bot tokens report `bot_token_invalid`; runtime 401s on bot profiles now point to an admin reissue instead of login/preset/API-token recovery. `profiles list` and `doctor` surface bot profiles.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artifactshare/cli",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Upload and share HTML, Markdown, folders, and static sites from terminals, AI agents, automation, and CI.",
   "homepage": "https://artifactshare.com/connect",
   "repository": {


### PR DESCRIPTION
## Summary

- prepare `@artifactshare/cli` 0.11.3
- publish the accumulated Windows credential storage and bot-token import release notes
- synchronize the generated public CLI reference version

## Validation

- `pnpm validate:cli` — 462 passed, 1 Windows-only test skipped locally
- `pnpm validate:static` — 3013 web tests passed, React Doctor 100, public scan 0 findings
- `pnpm check:cli-release`
- `pnpm check:cli-changelog`
- `pnpm check:cli-reference`
- exact-commit Codex and Claude implementation reviews — no findings
- trusted-main pull-request boundary guard — passed
