### PR TITLE
Fix GA artifact view initialization order

### DIFF
--- a/apps/web/app/components/app/analytics-gtag.test.tsx
+++ b/apps/web/app/components/app/analytics-gtag.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment happy-dom
-import React from 'react'
+import React, { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRoot, type Root } from 'react-dom/client'
+import { trackEvent } from '~/lib/analytics/track.client'
 
 import { AnalyticsGtag } from './analytics-gtag'
 
@@ -72,7 +73,7 @@ describe('AnalyticsGtag', () => {
     expect(gtag).toHaveBeenCalledWith('set', { user_id: 'u-hash' })
   })
 
-  it('sets user_id before config so login-time hits carry it', async () => {
+  it('queues consent, js, config, and user_id in order', async () => {
     const gtag = vi.fn()
     ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
     await React.act(async () => {
@@ -84,16 +85,84 @@ describe('AnalyticsGtag', () => {
         />,
       )
     })
-    const setIndex = gtag.mock.calls.findIndex(
-      ([command, params]) =>
-        command === 'set' &&
-        (params as { user_id?: string })?.user_id === 'u-hash',
+    expect(gtag.mock.calls.map(([command]) => command)).toEqual([
+      'consent',
+      'js',
+      'config',
+      'set',
+    ])
+  })
+
+  it('initializes before a preceding sibling passive event', async () => {
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    function DirectLandingEvent() {
+      useEffect(() => {
+        trackEvent('artifact_view', { artifact_id: 'direct' })
+      }, [])
+      return null
+    }
+    await React.act(async () => {
+      root.render(
+        <>
+          <DirectLandingEvent />
+          <AnalyticsGtag
+            shouldLoadAnalytics
+            measurementId="G-TEST"
+            userId={null}
+          />
+        </>,
+      )
+    })
+    expect(gtag.mock.calls.map(([command]) => command)).toEqual([
+      'consent',
+      'js',
+      'config',
+      'set',
+      'event',
+    ])
+    expect(gtag).toHaveBeenLastCalledWith('event', 'artifact_view', {
+      artifact_id: 'direct',
+    })
+  })
+
+  it('sends a pending passive event once consent becomes available', async () => {
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    function ConsentAwareEvent({ shouldLoad }: { shouldLoad: boolean }) {
+      useEffect(() => {
+        trackEvent('artifact_view', { artifact_id: 'after-consent' })
+      }, [shouldLoad])
+      return null
+    }
+    const render = (shouldLoad: boolean) => (
+      <>
+        <ConsentAwareEvent shouldLoad={shouldLoad} />
+        <AnalyticsGtag
+          shouldLoadAnalytics={shouldLoad}
+          measurementId="G-TEST"
+          userId={null}
+        />
+      </>
     )
-    const configIndex = gtag.mock.calls.findIndex(
-      ([command]) => command === 'config',
+    await React.act(async () => root.render(render(false)))
+    expect(gtag).not.toHaveBeenCalledWith(
+      'event',
+      'artifact_view',
+      expect.anything(),
     )
-    expect(setIndex).toBeGreaterThanOrEqual(0)
-    expect(configIndex).toBeGreaterThan(setIndex)
+
+    await React.act(async () => root.render(render(true)))
+    expect(gtag.mock.calls.map(([command]) => command)).toEqual([
+      'consent',
+      'js',
+      'config',
+      'set',
+      'event',
+    ])
+    expect(gtag).toHaveBeenLastCalledWith('event', 'artifact_view', {
+      artifact_id: 'after-consent',
+    })
   })
 
   it('denies consent in the loaded runtime and cleans cookies on withdrawal', async () => {

--- a/apps/web/app/components/app/analytics-gtag.tsx
+++ b/apps/web/app/components/app/analytics-gtag.tsx
@@ -1,9 +1,12 @@
-import { useEffect } from 'react'
+import { useEffect, useLayoutEffect } from 'react'
 
 import { setAnalyticsRuntimeState } from '~/lib/analytics/track.client'
 import { clearFirstTouch } from '~/lib/analytics/first-touch.client'
 
 let warnedMissingMeasurementId = false
+
+const useClientLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect
 
 function removeAnalyticsCookies(measurementId: string | null): void {
   const cookieNames = ['_ga']
@@ -32,7 +35,6 @@ function loadGtag(measurementId: string): void {
   script.id = 'as-gtag-js'
   script.async = true
   script.src = 'https://www.googletagmanager.com/gtag/js?id=' + measurementId
-  document.head.appendChild(script)
 
   const w = window as unknown as { gtag?: (...args: unknown[]) => void }
   // Basic consent mode: gtag only loads once consent allows, so analytics is
@@ -49,6 +51,9 @@ function loadGtag(measurementId: string): void {
     send_page_view: false,
     cookie_domain: 'none',
   })
+  // Queue the complete Google tag snippet before loading gtag.js. Custom
+  // events are only eligible to send after this initialization sequence.
+  document.head.appendChild(script)
 }
 
 // Reconciles the GA4 gtag runtime with the consent state resolved by the root
@@ -59,9 +64,8 @@ function syncGtagWithConsent(
   measurementId: string | null,
   userId: string | null,
 ): void {
-  setAnalyticsRuntimeState({ shouldLoadAnalytics, measurementId })
-
   if (!shouldLoadAnalytics) {
+    setAnalyticsRuntimeState({ shouldLoadAnalytics: false, measurementId })
     // Consent not granted (withdrawn or pre-consent in the EU). If gtag.js is
     // already loaded, tell it consent is denied so GA stops using analytics
     // storage (Enhanced Measurement etc.) — not just our own wrapper — then
@@ -81,18 +85,19 @@ function syncGtagWithConsent(
   }
 
   if (measurementId) {
-    // Establish user_id before gtag's config/first hit so login-time funnel
-    // events carry it, independent of send_page_view. null clears a prior user
-    // (logout). On re-grant after withdrawal loadGtag only flips consent back,
-    // so this set is also what re-applies user_id then.
+    loadGtag(measurementId)
+    // Apply user_id after config and before enabling the event sender. Since
+    // send_page_view is false, the first hit is still the later custom event.
+    // null clears a prior user (logout); re-grant also reapplies the current id.
     const w = window as unknown as { gtag?: (...args: unknown[]) => void }
     w.gtag?.('set', { user_id: userId })
-    loadGtag(measurementId)
+    setAnalyticsRuntimeState({ shouldLoadAnalytics: true, measurementId })
     return
   }
 
   // Consent granted but no Measurement ID configured: nothing to load; warn in
   // dev so a missing GA4_MEASUREMENT_ID is diagnosable.
+  setAnalyticsRuntimeState({ shouldLoadAnalytics: true, measurementId: null })
   removeAnalyticsCookies(measurementId)
   if (import.meta.env.DEV && !warnedMissingMeasurementId) {
     warnedMissingMeasurementId = true
@@ -109,7 +114,9 @@ export function AnalyticsGtag({
   measurementId: string | null
   userId: string | null
 }): null {
-  useEffect(() => {
+  // All passive event effects run after this layout effect, including a direct
+  // landing's ArtifactViewTracker even though it appears earlier in the tree.
+  useClientLayoutEffect(() => {
     syncGtagWithConsent(shouldLoadAnalytics, measurementId, userId)
   }, [shouldLoadAnalytics, measurementId, userId])
 

--- a/apps/web/app/routes/a.$id/+components/artifact-view-tracker.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/artifact-view-tracker.test.tsx
@@ -12,9 +12,6 @@ describe('ArtifactViewTracker', () => {
   let gtag: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    // Intentionally leave the sender runtime uninitialized (default: no consent,
-    // no id): the tracker must initialize it from the root loader itself before
-    // sending — the AnalyticsGtag sibling effect runs too late on a direct land.
     gtag = vi.fn()
     ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
     container = document.createElement('div')
@@ -38,6 +35,12 @@ describe('ArtifactViewTracker', () => {
       measurementId: 'G-TEST',
     },
   ) {
+    // AnalyticsGtag owns the sender runtime and initializes it before passive
+    // tracker effects. This unit test supplies that already-resolved state.
+    setAnalyticsRuntimeState({
+      shouldLoadAnalytics: consent.shouldLoad,
+      measurementId: consent.measurementId,
+    })
     // `a/:id` must nest under the `root` route so its loader runs and
     // useRouteLoaderData('root') resolves for the tracker (siblings would not
     // match the same URL).
@@ -91,7 +94,7 @@ describe('ArtifactViewTracker', () => {
     )
   })
 
-  it('sends an html artifact view once, initializing its own runtime', async () => {
+  it('sends an html artifact view once after runtime initialization', async () => {
     await renderTracker({ artifactId: 'tracked-artifact', canTrackView: true })
     expect(gtag).toHaveBeenCalledTimes(1)
     expect(gtag).toHaveBeenCalledWith(

--- a/apps/web/app/routes/a.$id/+components/artifact-view-tracker.tsx
+++ b/apps/web/app/routes/a.$id/+components/artifact-view-tracker.tsx
@@ -5,10 +5,7 @@ import {
   ANALYTICS_PARAMS,
   type AnalyticsRenderType,
 } from '~/lib/analytics/events'
-import {
-  setAnalyticsRuntimeState,
-  trackEvent,
-} from '~/lib/analytics/track.client'
+import { trackEvent } from '~/lib/analytics/track.client'
 import { captureFirstTouch } from '~/lib/analytics/first-touch.client'
 import {
   referrerDomainFromReferrer,
@@ -28,14 +25,6 @@ function recordArtifactView(input: {
 }): void {
   if (!input.canTrackView) return
   if (seenArtifactViews.has(input.key)) return
-  // On a direct landing the AnalyticsGtag sibling effect runs after this one, so
-  // initialize the sender's runtime here before sending — otherwise the first
-  // artifact_view is dropped (default consent=false) and never retried. The head
-  // dataLayer queue then holds the event until gtag.js loads.
-  setAnalyticsRuntimeState({
-    shouldLoadAnalytics: input.shouldLoad,
-    measurementId: input.measurementId,
-  })
   captureFirstTouch({
     shouldLoadAnalytics: input.shouldLoad,
     artifactId: input.artifactId,


### PR DESCRIPTION
## Summary

- initialize the Google tag during the client layout phase before passive analytics events run
- queue consent, tag configuration, and user identity before enabling custom event sends
- keep pre-consent artifact views retryable and cover direct landings and later consent with regression tests

## Validation

- `pnpm validate:static`
- focused analytics tests: 16 passed
- `pnpm public:scan .` (0 findings)
- public PR boundary guard
- Codex and Claude implementation reviews (no blockers)
