### PR TITLE
Fix GA authentication funnel measurement

### DIFF
--- a/apps/web/app/components/app/analytics-auth-tracker.test.tsx
+++ b/apps/web/app/components/app/analytics-auth-tracker.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  captureAuthAttempt,
+  clearAuthAttempt,
+  readAuthAttempt,
+} from '~/lib/analytics/auth-attempt.client'
+import { setAnalyticsRuntimeState } from '~/lib/analytics/track.client'
+import { AnalyticsAuthTracker } from './analytics-auth-tracker'
+
+describe('AnalyticsAuthTracker', () => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const gtag = vi.fn()
+
+  beforeEach(() => {
+    gtag.mockClear()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    setAnalyticsRuntimeState({
+      shouldLoadAnalytics: true,
+      measurementId: 'G-TEST',
+    })
+    clearAuthAttempt()
+    history.replaceState(null, '', '/a/example')
+  })
+
+  afterEach(() => {
+    setAnalyticsRuntimeState({
+      shouldLoadAnalytics: false,
+      measurementId: null,
+    })
+  })
+
+  test('sends existing sign-in completion and same-artifact return once', async () => {
+    captureAuthAttempt({
+      method: 'google',
+      callbackURL: '/a/example',
+      shouldLoadAnalytics: true,
+    })
+    await React.act(async () => {
+      root.render(<AnalyticsAuthTracker authenticated signup={null} />)
+    })
+    expect(gtag).toHaveBeenCalledWith('event', 'auth_completed', {
+      method: 'google',
+      account_state: 'existing',
+    })
+    expect(gtag).toHaveBeenCalledWith('event', 'artifact_returned_after_auth', {
+      method: 'google',
+      account_state: 'existing',
+    })
+    expect(readAuthAttempt()).toBeNull()
+
+    await React.act(async () => {
+      root.render(<AnalyticsAuthTracker authenticated signup={null} />)
+    })
+    expect(gtag).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/app/components/app/analytics-auth-tracker.test.tsx
+++ b/apps/web/app/components/app/analytics-auth-tracker.test.tsx
@@ -40,7 +40,13 @@ describe('AnalyticsAuthTracker', () => {
       shouldLoadAnalytics: true,
     })
     await React.act(async () => {
-      root.render(<AnalyticsAuthTracker authenticated signup={null} />)
+      root.render(
+        <AnalyticsAuthTracker
+          authenticated
+          signup={null}
+          shouldLoadAnalytics
+        />,
+      )
     })
     expect(gtag).toHaveBeenCalledWith('event', 'auth_completed', {
       method: 'google',
@@ -53,8 +59,54 @@ describe('AnalyticsAuthTracker', () => {
     expect(readAuthAttempt()).toBeNull()
 
     await React.act(async () => {
-      root.render(<AnalyticsAuthTracker authenticated signup={null} />)
+      root.render(
+        <AnalyticsAuthTracker
+          authenticated
+          signup={null}
+          shouldLoadAnalytics
+        />,
+      )
     })
     expect(gtag).toHaveBeenCalledTimes(2)
+  })
+
+  test('retries completion when analytics consent is granted later', async () => {
+    captureAuthAttempt({
+      method: 'email',
+      callbackURL: '/a/example',
+      shouldLoadAnalytics: true,
+    })
+    setAnalyticsRuntimeState({
+      shouldLoadAnalytics: false,
+      measurementId: 'G-TEST',
+    })
+    await React.act(async () => {
+      root.render(
+        <AnalyticsAuthTracker
+          authenticated
+          signup={null}
+          shouldLoadAnalytics={false}
+        />,
+      )
+    })
+    expect(gtag).not.toHaveBeenCalled()
+
+    setAnalyticsRuntimeState({
+      shouldLoadAnalytics: true,
+      measurementId: 'G-TEST',
+    })
+    await React.act(async () => {
+      root.render(
+        <AnalyticsAuthTracker
+          authenticated
+          signup={null}
+          shouldLoadAnalytics
+        />,
+      )
+    })
+    expect(gtag).toHaveBeenCalledWith('event', 'auth_completed', {
+      method: 'email',
+      account_state: 'existing',
+    })
   })
 })

--- a/apps/web/app/components/app/analytics-auth-tracker.tsx
+++ b/apps/web/app/components/app/analytics-auth-tracker.tsx
@@ -19,7 +19,14 @@ export function AnalyticsAuthTracker({
   // than a component-owned event handler, so an effect is the event boundary.
   useEffect(() => {
     if (!authenticated) return
-    const attempt = readAuthAttempt()
+    let currentArtifactId: string | undefined
+    try {
+      const match = /^\/a\/([^/]+)$/u.exec(location.pathname)
+      currentArtifactId = match?.[1] ? decodeURIComponent(match[1]) : undefined
+    } catch {
+      currentArtifactId = undefined
+    }
+    const attempt = readAuthAttempt(currentArtifactId)
     if (!attempt || attempt.authCompletedSent) return
     // react-doctor-disable-next-line react-doctor/no-event-handler
     const accountState = signup ? 'new' : 'existing'
@@ -29,10 +36,6 @@ export function AnalyticsAuthTracker({
     })
     if (sent) markAuthCompleted(accountState)
     if (sent && attempt.artifactId) {
-      const match = /^\/a\/([^/]+)$/u.exec(location.pathname)
-      const currentArtifactId = match?.[1]
-        ? decodeURIComponent(match[1])
-        : undefined
       if (currentArtifactId === attempt.artifactId) {
         const returned = trackEvent(
           ANALYTICS_EVENTS.artifactReturnedAfterAuth,

--- a/apps/web/app/components/app/analytics-auth-tracker.tsx
+++ b/apps/web/app/components/app/analytics-auth-tracker.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from 'react'
+import { ANALYTICS_EVENTS, ANALYTICS_PARAMS } from '~/lib/analytics/events'
+import {
+  clearAuthAttempt,
+  markAuthCompleted,
+  readAuthAttempt,
+} from '~/lib/analytics/auth-attempt.client'
+import { trackEvent } from '~/lib/analytics/track.client'
+import type { AnalyticsSignupPayload } from '~/lib/analytics/signup-payload'
+
+export function AnalyticsAuthTracker({
+  authenticated,
+  signup,
+}: {
+  authenticated: boolean
+  signup: AnalyticsSignupPayload | null
+}): null {
+  // OAuth and OTP completion arrive through navigation/session state rather
+  // than a component-owned event handler, so an effect is the event boundary.
+  useEffect(() => {
+    if (!authenticated) return
+    const attempt = readAuthAttempt()
+    if (!attempt || attempt.authCompletedSent) return
+    // react-doctor-disable-next-line react-doctor/no-event-handler
+    const accountState = signup ? 'new' : 'existing'
+    const sent = trackEvent(ANALYTICS_EVENTS.authCompleted, {
+      [ANALYTICS_PARAMS.method]: attempt.method,
+      [ANALYTICS_PARAMS.accountState]: accountState,
+    })
+    if (sent) markAuthCompleted(accountState)
+    if (sent && attempt.artifactId) {
+      const match = /^\/a\/([^/]+)$/u.exec(location.pathname)
+      const currentArtifactId = match?.[1]
+        ? decodeURIComponent(match[1])
+        : undefined
+      if (currentArtifactId === attempt.artifactId) {
+        const returned = trackEvent(
+          ANALYTICS_EVENTS.artifactReturnedAfterAuth,
+          {
+            [ANALYTICS_PARAMS.method]: attempt.method,
+            [ANALYTICS_PARAMS.accountState]: accountState,
+          },
+        )
+        if (returned) clearAuthAttempt()
+      }
+    }
+  }, [authenticated, signup])
+  return null
+}

--- a/apps/web/app/components/app/analytics-auth-tracker.tsx
+++ b/apps/web/app/components/app/analytics-auth-tracker.tsx
@@ -11,9 +11,11 @@ import type { AnalyticsSignupPayload } from '~/lib/analytics/signup-payload'
 export function AnalyticsAuthTracker({
   authenticated,
   signup,
+  shouldLoadAnalytics,
 }: {
   authenticated: boolean
   signup: AnalyticsSignupPayload | null
+  shouldLoadAnalytics: boolean
 }): null {
   // OAuth and OTP completion arrive through navigation/session state rather
   // than a component-owned event handler, so an effect is the event boundary.
@@ -47,6 +49,6 @@ export function AnalyticsAuthTracker({
         if (returned) clearAuthAttempt()
       }
     }
-  }, [authenticated, signup])
+  }, [authenticated, shouldLoadAnalytics, signup])
   return null
 }

--- a/apps/web/app/components/app/analytics-gtag.tsx
+++ b/apps/web/app/components/app/analytics-gtag.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect } from 'react'
 
 import { setAnalyticsRuntimeState } from '~/lib/analytics/track.client'
 import { clearFirstTouch } from '~/lib/analytics/first-touch.client'
+import { clearAuthAttempt } from '~/lib/analytics/auth-attempt.client'
 
 let warnedMissingMeasurementId = false
 
@@ -80,6 +81,7 @@ function syncGtagWithConsent(
       })
     }
     clearFirstTouch()
+    clearAuthAttempt()
     removeAnalyticsCookies(measurementId)
     return
   }

--- a/apps/web/app/components/app/analytics-gtag.tsx
+++ b/apps/web/app/components/app/analytics-gtag.tsx
@@ -2,7 +2,7 @@ import { useEffect, useLayoutEffect } from 'react'
 
 import { setAnalyticsRuntimeState } from '~/lib/analytics/track.client'
 import { clearFirstTouch } from '~/lib/analytics/first-touch.client'
-import { clearAuthAttempt } from '~/lib/analytics/auth-attempt.client'
+import { clearAllAuthAttempts } from '~/lib/analytics/auth-attempt.client'
 
 let warnedMissingMeasurementId = false
 
@@ -81,7 +81,7 @@ function syncGtagWithConsent(
       })
     }
     clearFirstTouch()
-    clearAuthAttempt()
+    clearAllAuthAttempts()
     removeAnalyticsCookies(measurementId)
     return
   }

--- a/apps/web/app/components/app/sign-in-options.tsx
+++ b/apps/web/app/components/app/sign-in-options.tsx
@@ -4,10 +4,12 @@ import { GoogleMark } from './google-mark'
 import { MicrosoftMark } from './microsoft-mark'
 import { LastUsedBadge } from './last-used-badge'
 import { Button } from '~/components/ui/button'
+import { useRouteLoaderData } from 'react-router'
 import { useT } from '~/hooks/use-t'
 import { signIn } from '~/lib/auth-client'
 import { ANALYTICS_EVENTS, ANALYTICS_PARAMS } from '~/lib/analytics/events'
 import { trackEvent } from '~/lib/analytics/track.client'
+import { captureAuthAttempt } from '~/lib/analytics/auth-attempt.client'
 
 /**
  * Provider sign-in buttons (Google / Microsoft), full-width and stacked.
@@ -29,6 +31,9 @@ export function SignInOptions({
   errorCallbackURL?: string
 }) {
   const { t } = useT()
+  const root = useRouteLoaderData<{
+    analyticsConsent?: { shouldLoadAnalytics: boolean }
+  }>('root')
 
   const resolveCallback = () =>
     callbackURL ??
@@ -40,6 +45,11 @@ export function SignInOptions({
     const callback = resolveCallback()
     trackEvent(ANALYTICS_EVENTS.signUpStart, {
       [ANALYTICS_PARAMS.method]: provider,
+    })
+    captureAuthAttempt({
+      method: provider,
+      callbackURL: callback,
+      shouldLoadAnalytics: root?.analyticsConsent?.shouldLoadAnalytics ?? false,
     })
     signIn.social({
       provider,

--- a/apps/web/app/lib/analytics/auth-attempt.client.test.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.test.ts
@@ -94,6 +94,28 @@ describe('auth attempt analytics cookie', () => {
     expect(readAuthAttempt()).toBeNull()
   })
 
+  test('fails closed when tab storage is unavailable', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'sessionStorage')
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get: () => {
+        throw new DOMException('blocked', 'SecurityError')
+      },
+    })
+    try {
+      expect(() =>
+        captureAuthAttempt({
+          method: 'google',
+          callbackURL: '/a/example',
+          shouldLoadAnalytics: true,
+        }),
+      ).not.toThrow()
+      expect(readAuthAttempt()).toBeNull()
+    } finally {
+      Object.defineProperty(window, 'sessionStorage', descriptor!)
+    }
+  })
+
   test('keeps concurrent browser-tab attempts independent', () => {
     captureAuthAttempt({
       method: 'google',

--- a/apps/web/app/lib/analytics/auth-attempt.client.test.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.test.ts
@@ -2,13 +2,14 @@
 import { beforeEach, describe, expect, test } from 'vitest'
 import {
   captureAuthAttempt,
+  clearAllAuthAttempts,
   clearAuthAttempt,
   markAuthCompleted,
   readAuthAttempt,
 } from './auth-attempt.client'
 
 describe('auth attempt analytics cookie', () => {
-  beforeEach(() => clearAuthAttempt())
+  beforeEach(() => clearAllAuthAttempts())
 
   test('does not create state before analytics consent', () => {
     captureAuthAttempt({
@@ -54,13 +55,37 @@ describe('auth attempt analytics cookie', () => {
     })
   })
 
-  test('does not consume an attempt from another browser tab', () => {
+  test('recovers a sole attempt after mobile tab storage is discarded', () => {
     captureAuthAttempt({
       method: 'google',
       callbackURL: '/a/example',
       shouldLoadAnalytics: true,
     })
     sessionStorage.clear()
-    expect(readAuthAttempt()).toBeNull()
+    expect(readAuthAttempt()).toEqual(
+      expect.objectContaining({ method: 'google', artifactId: 'example' }),
+    )
+  })
+
+  test('keeps concurrent browser-tab attempts independent', () => {
+    captureAuthAttempt({
+      method: 'google',
+      callbackURL: '/a/first',
+      shouldLoadAnalytics: true,
+    })
+    const first = readAuthAttempt()
+    expect(first).not.toBeNull()
+    captureAuthAttempt({
+      method: 'microsoft',
+      callbackURL: '/a/second',
+      shouldLoadAnalytics: true,
+    })
+    expect(readAuthAttempt()).toEqual(
+      expect.objectContaining({ method: 'microsoft', artifactId: 'second' }),
+    )
+    sessionStorage.setItem('__as_auth_attempt_nonce', first!.nonce)
+    expect(readAuthAttempt()).toEqual(
+      expect.objectContaining({ method: 'google', artifactId: 'first' }),
+    )
   })
 })

--- a/apps/web/app/lib/analytics/auth-attempt.client.test.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.test.ts
@@ -62,9 +62,36 @@ describe('auth attempt analytics cookie', () => {
       shouldLoadAnalytics: true,
     })
     sessionStorage.clear()
-    expect(readAuthAttempt()).toEqual(
+    expect(readAuthAttempt('example')).toEqual(
       expect.objectContaining({ method: 'google', artifactId: 'example' }),
     )
+  })
+
+  test('does not recover another tab attempt on an unrelated page', () => {
+    captureAuthAttempt({
+      method: 'google',
+      callbackURL: '/a/example',
+      shouldLoadAnalytics: true,
+    })
+    sessionStorage.clear()
+    expect(readAuthAttempt()).toBeNull()
+    expect(readAuthAttempt('different')).toBeNull()
+  })
+
+  test('replaces the same tab attempt when authentication is retried', () => {
+    captureAuthAttempt({
+      method: 'email',
+      callbackURL: '/a/example',
+      shouldLoadAnalytics: true,
+    })
+    const firstNonce = readAuthAttempt()!.nonce
+    captureAuthAttempt({
+      method: 'google',
+      callbackURL: '/a/example',
+      shouldLoadAnalytics: true,
+    })
+    sessionStorage.setItem('__as_auth_attempt_nonce', firstNonce)
+    expect(readAuthAttempt()).toBeNull()
   })
 
   test('keeps concurrent browser-tab attempts independent', () => {
@@ -75,6 +102,7 @@ describe('auth attempt analytics cookie', () => {
     })
     const first = readAuthAttempt()
     expect(first).not.toBeNull()
+    sessionStorage.clear()
     captureAuthAttempt({
       method: 'microsoft',
       callbackURL: '/a/second',

--- a/apps/web/app/lib/analytics/auth-attempt.client.test.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.test.ts
@@ -29,6 +29,7 @@ describe('auth attempt analytics cookie', () => {
       method: 'microsoft',
       artifactId: 'example',
       authCompletedSent: false,
+      nonce: expect.any(String),
     })
     markAuthCompleted('existing')
     expect(readAuthAttempt()).toEqual({
@@ -36,6 +37,7 @@ describe('auth attempt analytics cookie', () => {
       artifactId: 'example',
       authCompletedSent: true,
       accountState: 'existing',
+      nonce: expect.any(String),
     })
   })
 
@@ -48,6 +50,17 @@ describe('auth attempt analytics cookie', () => {
     expect(readAuthAttempt()).toEqual({
       method: 'email',
       authCompletedSent: false,
+      nonce: expect.any(String),
     })
+  })
+
+  test('does not consume an attempt from another browser tab', () => {
+    captureAuthAttempt({
+      method: 'google',
+      callbackURL: '/a/example',
+      shouldLoadAnalytics: true,
+    })
+    sessionStorage.clear()
+    expect(readAuthAttempt()).toBeNull()
   })
 })

--- a/apps/web/app/lib/analytics/auth-attempt.client.test.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, test } from 'vitest'
+import {
+  captureAuthAttempt,
+  clearAuthAttempt,
+  markAuthCompleted,
+  readAuthAttempt,
+} from './auth-attempt.client'
+
+describe('auth attempt analytics cookie', () => {
+  beforeEach(() => clearAuthAttempt())
+
+  test('does not create state before analytics consent', () => {
+    captureAuthAttempt({
+      method: 'google',
+      callbackURL: '/a/example',
+      shouldLoadAnalytics: false,
+    })
+    expect(readAuthAttempt()).toBeNull()
+  })
+
+  test('preserves only the shared artifact target and completion state', () => {
+    captureAuthAttempt({
+      method: 'microsoft',
+      callbackURL: '/a/example?from=sign-in',
+      shouldLoadAnalytics: true,
+    })
+    expect(readAuthAttempt()).toEqual({
+      method: 'microsoft',
+      artifactId: 'example',
+      authCompletedSent: false,
+    })
+    markAuthCompleted('existing')
+    expect(readAuthAttempt()).toEqual({
+      method: 'microsoft',
+      artifactId: 'example',
+      authCompletedSent: true,
+      accountState: 'existing',
+    })
+  })
+
+  test('does not retain non-artifact callback paths', () => {
+    captureAuthAttempt({
+      method: 'email',
+      callbackURL: '/settings',
+      shouldLoadAnalytics: true,
+    })
+    expect(readAuthAttempt()).toEqual({
+      method: 'email',
+      authCompletedSent: false,
+    })
+  })
+})

--- a/apps/web/app/lib/analytics/auth-attempt.client.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.ts
@@ -1,6 +1,7 @@
 import type { SignupMethod } from '~/services/signup-analytics.server'
 
 export const AUTH_ATTEMPT_COOKIE = '__as_auth_attempt'
+const AUTH_ATTEMPT_TAB_KEY = '__as_auth_attempt_nonce'
 const AUTH_ATTEMPT_MAX_AGE_SECONDS = 1800
 
 export interface AuthAttempt {
@@ -8,6 +9,7 @@ export interface AuthAttempt {
   artifactId?: string
   authCompletedSent: boolean
   accountState?: 'new' | 'existing'
+  nonce: string
 }
 
 function readCookie(): string | null {
@@ -40,6 +42,9 @@ export function readAuthAttempt(): AuthAttempt | null {
       !['new', 'existing'].includes(value.accountState)
     )
       return null
+    if (!value.nonce || typeof value.nonce !== 'string') return null
+    if (sessionStorage.getItem(AUTH_ATTEMPT_TAB_KEY) !== value.nonce)
+      return null
     return value as AuthAttempt
   } catch {
     return null
@@ -70,10 +75,13 @@ export function captureAuthAttempt(input: {
   shouldLoadAnalytics: boolean
 }): void {
   if (!input.shouldLoadAnalytics || typeof document === 'undefined') return
+  const nonce = crypto.randomUUID()
+  sessionStorage.setItem(AUTH_ATTEMPT_TAB_KEY, nonce)
   writeAuthAttempt({
     method: input.method,
     artifactId: artifactIdFromCallback(input.callbackURL),
     authCompletedSent: false,
+    nonce,
   })
 }
 
@@ -88,6 +96,7 @@ export function markAuthCompleted(accountState: 'new' | 'existing'): void {
 }
 
 export function clearAuthAttempt(): void {
+  sessionStorage.removeItem(AUTH_ATTEMPT_TAB_KEY)
   // Clears the same non-authentication analytics state described above.
   // react-doctor-disable-next-line react-doctor/insecure-session-cookie
   document.cookie = `${AUTH_ATTEMPT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`

--- a/apps/web/app/lib/analytics/auth-attempt.client.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.ts
@@ -56,14 +56,20 @@ function readAuthAttempts(): AuthAttempt[] {
   }
 }
 
-export function readAuthAttempt(): AuthAttempt | null {
+export function readAuthAttempt(
+  recoveryArtifactId?: string,
+): AuthAttempt | null {
   const attempts = readAuthAttempts()
   const tabNonce = sessionStorage.getItem(AUTH_ATTEMPT_TAB_KEY)
   if (tabNonce) return attempts.find(({ nonce }) => nonce === tabNonce) ?? null
   // Mobile browsers may discard sessionStorage while an OAuth tab is
   // backgrounded. A sole pending attempt is still unambiguous; multiple
   // candidates fail closed rather than attributing the wrong method/artifact.
-  if (attempts.length === 1) {
+  if (
+    attempts.length === 1 &&
+    recoveryArtifactId !== undefined &&
+    attempts[0].artifactId === recoveryArtifactId
+  ) {
     sessionStorage.setItem(AUTH_ATTEMPT_TAB_KEY, attempts[0].nonce)
     return attempts[0]
   }
@@ -94,10 +100,13 @@ export function captureAuthAttempt(input: {
   shouldLoadAnalytics: boolean
 }): void {
   if (!input.shouldLoadAnalytics || typeof document === 'undefined') return
+  const previousTabNonce = sessionStorage.getItem(AUTH_ATTEMPT_TAB_KEY)
   const nonce = crypto.randomUUID()
   sessionStorage.setItem(AUTH_ATTEMPT_TAB_KEY, nonce)
   writeAuthAttempts([
-    ...readAuthAttempts().filter((attempt) => attempt.nonce !== nonce),
+    ...readAuthAttempts().filter(
+      (attempt) => attempt.nonce !== previousTabNonce,
+    ),
     {
       method: input.method,
       artifactId: artifactIdFromCallback(input.callbackURL),

--- a/apps/web/app/lib/analytics/auth-attempt.client.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.ts
@@ -15,13 +15,13 @@ export interface AuthAttempt {
 
 function readCookie(): string | null {
   if (typeof document === 'undefined') return null
-  const prefix = `${AUTH_ATTEMPT_COOKIE}=`
-  const raw = document.cookie
-    .split(';')
-    .map((part) => part.trim())
-    .find((part) => part.startsWith(prefix))
-  if (!raw) return null
   try {
+    const prefix = `${AUTH_ATTEMPT_COOKIE}=`
+    const raw = document.cookie
+      .split(';')
+      .map((part) => part.trim())
+      .find((part) => part.startsWith(prefix))
+    if (!raw) return null
     return decodeURIComponent(raw.slice(prefix.length))
   } catch {
     return null
@@ -100,12 +100,26 @@ export function readAuthAttempt(
   return null
 }
 
-function writeAuthAttempts(values: AuthAttempt[]): void {
-  const secure = location.protocol === 'https:' ? '; Secure' : ''
-  // Analytics-only state: no credential, identity, email, or authorization
-  // data. The viewer and root trackers intentionally consume it in JS.
-  // react-doctor-disable-next-line react-doctor/insecure-session-cookie
-  document.cookie = `${AUTH_ATTEMPT_COOKIE}=${encodeURIComponent(JSON.stringify(values.slice(-MAX_AUTH_ATTEMPTS)))}; Path=/; Max-Age=${AUTH_ATTEMPT_MAX_AGE_SECONDS}; SameSite=Lax${secure}`
+function writeAuthAttempts(values: AuthAttempt[]): boolean {
+  try {
+    const secure = location.protocol === 'https:' ? '; Secure' : ''
+    // Analytics-only state: no credential, identity, email, or authorization
+    // data. The viewer and root trackers intentionally consume it in JS.
+    // react-doctor-disable-next-line react-doctor/insecure-session-cookie
+    document.cookie = `${AUTH_ATTEMPT_COOKIE}=${encodeURIComponent(JSON.stringify(values.slice(-MAX_AUTH_ATTEMPTS)))}; Path=/; Max-Age=${AUTH_ATTEMPT_MAX_AGE_SECONDS}; SameSite=Lax${secure}`
+    return true
+  } catch {
+    return false
+  }
+}
+
+function expireAuthAttemptCookie(): void {
+  try {
+    // react-doctor-disable-next-line react-doctor/insecure-session-cookie
+    document.cookie = `${AUTH_ATTEMPT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`
+  } catch {
+    // Analytics state must never interrupt authentication or rendering.
+  }
 }
 
 function artifactIdFromCallback(callbackURL: string): string | undefined {
@@ -132,7 +146,7 @@ export function captureAuthAttempt(input: {
     return
   }
   if (!writeTabNonce(nonce)) return
-  writeAuthAttempts([
+  const stored = writeAuthAttempts([
     ...readAuthAttempts().filter(
       (attempt) => attempt.nonce !== previousTabNonce,
     ),
@@ -143,6 +157,7 @@ export function captureAuthAttempt(input: {
       nonce,
     },
   ])
+  if (!stored) removeTabNonce()
 }
 
 export function markAuthCompleted(accountState: 'new' | 'existing'): void {
@@ -167,13 +182,10 @@ export function clearAuthAttempt(): void {
     writeAuthAttempts(remaining)
     return
   }
-  // Clears the same non-authentication analytics state described above.
-  // react-doctor-disable-next-line react-doctor/insecure-session-cookie
-  document.cookie = `${AUTH_ATTEMPT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`
+  expireAuthAttemptCookie()
 }
 
 export function clearAllAuthAttempts(): void {
   removeTabNonce()
-  // react-doctor-disable-next-line react-doctor/insecure-session-cookie
-  document.cookie = `${AUTH_ATTEMPT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`
+  expireAuthAttemptCookie()
 }

--- a/apps/web/app/lib/analytics/auth-attempt.client.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.ts
@@ -1,11 +1,12 @@
-import type { SignupMethod } from '~/services/signup-analytics.server'
+import type { AnalyticsAuthMethod } from './events'
 
 export const AUTH_ATTEMPT_COOKIE = '__as_auth_attempt'
 const AUTH_ATTEMPT_TAB_KEY = '__as_auth_attempt_nonce'
 const AUTH_ATTEMPT_MAX_AGE_SECONDS = 1800
+const MAX_AUTH_ATTEMPTS = 4
 
 export interface AuthAttempt {
-  method: SignupMethod
+  method: AnalyticsAuthMethod
   artifactId?: string
   authCompletedSent: boolean
   accountState?: 'new' | 'existing'
@@ -27,36 +28,54 @@ function readCookie(): string | null {
   }
 }
 
-export function readAuthAttempt(): AuthAttempt | null {
+function validAttempt(value: Partial<AuthAttempt>): value is AuthAttempt {
+  if (!['google', 'microsoft', 'email'].includes(value.method ?? ''))
+    return false
+  if (value.artifactId !== undefined && typeof value.artifactId !== 'string')
+    return false
+  if (typeof value.authCompletedSent !== 'boolean') return false
+  if (
+    value.accountState !== undefined &&
+    !['new', 'existing'].includes(value.accountState)
+  )
+    return false
+  return Boolean(value.nonce && typeof value.nonce === 'string')
+}
+
+function readAuthAttempts(): AuthAttempt[] {
   const raw = readCookie()
-  if (!raw) return null
+  if (!raw) return []
   try {
-    const value = JSON.parse(raw) as Partial<AuthAttempt>
-    if (!['google', 'microsoft', 'email'].includes(value.method ?? ''))
-      return null
-    if (value.artifactId !== undefined && typeof value.artifactId !== 'string')
-      return null
-    if (typeof value.authCompletedSent !== 'boolean') return null
-    if (
-      value.accountState !== undefined &&
-      !['new', 'existing'].includes(value.accountState)
+    const value: unknown = JSON.parse(raw)
+    if (!Array.isArray(value)) return []
+    return value.filter((attempt): attempt is AuthAttempt =>
+      validAttempt(attempt as Partial<AuthAttempt>),
     )
-      return null
-    if (!value.nonce || typeof value.nonce !== 'string') return null
-    if (sessionStorage.getItem(AUTH_ATTEMPT_TAB_KEY) !== value.nonce)
-      return null
-    return value as AuthAttempt
   } catch {
-    return null
+    return []
   }
 }
 
-function writeAuthAttempt(value: AuthAttempt): void {
+export function readAuthAttempt(): AuthAttempt | null {
+  const attempts = readAuthAttempts()
+  const tabNonce = sessionStorage.getItem(AUTH_ATTEMPT_TAB_KEY)
+  if (tabNonce) return attempts.find(({ nonce }) => nonce === tabNonce) ?? null
+  // Mobile browsers may discard sessionStorage while an OAuth tab is
+  // backgrounded. A sole pending attempt is still unambiguous; multiple
+  // candidates fail closed rather than attributing the wrong method/artifact.
+  if (attempts.length === 1) {
+    sessionStorage.setItem(AUTH_ATTEMPT_TAB_KEY, attempts[0].nonce)
+    return attempts[0]
+  }
+  return null
+}
+
+function writeAuthAttempts(values: AuthAttempt[]): void {
   const secure = location.protocol === 'https:' ? '; Secure' : ''
   // Analytics-only state: no credential, identity, email, or authorization
   // data. The viewer and root trackers intentionally consume it in JS.
   // react-doctor-disable-next-line react-doctor/insecure-session-cookie
-  document.cookie = `${AUTH_ATTEMPT_COOKIE}=${encodeURIComponent(JSON.stringify(value))}; Path=/; Max-Age=${AUTH_ATTEMPT_MAX_AGE_SECONDS}; SameSite=Lax${secure}`
+  document.cookie = `${AUTH_ATTEMPT_COOKIE}=${encodeURIComponent(JSON.stringify(values.slice(-MAX_AUTH_ATTEMPTS)))}; Path=/; Max-Age=${AUTH_ATTEMPT_MAX_AGE_SECONDS}; SameSite=Lax${secure}`
 }
 
 function artifactIdFromCallback(callbackURL: string): string | undefined {
@@ -70,34 +89,53 @@ function artifactIdFromCallback(callbackURL: string): string | undefined {
 }
 
 export function captureAuthAttempt(input: {
-  method: SignupMethod
+  method: AnalyticsAuthMethod
   callbackURL: string
   shouldLoadAnalytics: boolean
 }): void {
   if (!input.shouldLoadAnalytics || typeof document === 'undefined') return
   const nonce = crypto.randomUUID()
   sessionStorage.setItem(AUTH_ATTEMPT_TAB_KEY, nonce)
-  writeAuthAttempt({
-    method: input.method,
-    artifactId: artifactIdFromCallback(input.callbackURL),
-    authCompletedSent: false,
-    nonce,
-  })
+  writeAuthAttempts([
+    ...readAuthAttempts().filter((attempt) => attempt.nonce !== nonce),
+    {
+      method: input.method,
+      artifactId: artifactIdFromCallback(input.callbackURL),
+      authCompletedSent: false,
+      nonce,
+    },
+  ])
 }
 
 export function markAuthCompleted(accountState: 'new' | 'existing'): void {
   const attempt = readAuthAttempt()
   if (!attempt) return
-  writeAuthAttempt({
-    ...attempt,
-    authCompletedSent: true,
-    accountState,
-  })
+  writeAuthAttempts(
+    readAuthAttempts().map((candidate) =>
+      candidate.nonce === attempt.nonce
+        ? { ...candidate, authCompletedSent: true, accountState }
+        : candidate,
+    ),
+  )
 }
 
 export function clearAuthAttempt(): void {
+  const attempt = readAuthAttempt()
   sessionStorage.removeItem(AUTH_ATTEMPT_TAB_KEY)
+  const remaining = attempt
+    ? readAuthAttempts().filter(({ nonce }) => nonce !== attempt.nonce)
+    : []
+  if (remaining.length) {
+    writeAuthAttempts(remaining)
+    return
+  }
   // Clears the same non-authentication analytics state described above.
+  // react-doctor-disable-next-line react-doctor/insecure-session-cookie
+  document.cookie = `${AUTH_ATTEMPT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`
+}
+
+export function clearAllAuthAttempts(): void {
+  sessionStorage.removeItem(AUTH_ATTEMPT_TAB_KEY)
   // react-doctor-disable-next-line react-doctor/insecure-session-cookie
   document.cookie = `${AUTH_ATTEMPT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`
 }

--- a/apps/web/app/lib/analytics/auth-attempt.client.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.ts
@@ -1,0 +1,94 @@
+import type { SignupMethod } from '~/services/signup-analytics.server'
+
+export const AUTH_ATTEMPT_COOKIE = '__as_auth_attempt'
+const AUTH_ATTEMPT_MAX_AGE_SECONDS = 1800
+
+export interface AuthAttempt {
+  method: SignupMethod
+  artifactId?: string
+  authCompletedSent: boolean
+  accountState?: 'new' | 'existing'
+}
+
+function readCookie(): string | null {
+  if (typeof document === 'undefined') return null
+  const prefix = `${AUTH_ATTEMPT_COOKIE}=`
+  const raw = document.cookie
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix))
+  if (!raw) return null
+  try {
+    return decodeURIComponent(raw.slice(prefix.length))
+  } catch {
+    return null
+  }
+}
+
+export function readAuthAttempt(): AuthAttempt | null {
+  const raw = readCookie()
+  if (!raw) return null
+  try {
+    const value = JSON.parse(raw) as Partial<AuthAttempt>
+    if (!['google', 'microsoft', 'email'].includes(value.method ?? ''))
+      return null
+    if (value.artifactId !== undefined && typeof value.artifactId !== 'string')
+      return null
+    if (typeof value.authCompletedSent !== 'boolean') return null
+    if (
+      value.accountState !== undefined &&
+      !['new', 'existing'].includes(value.accountState)
+    )
+      return null
+    return value as AuthAttempt
+  } catch {
+    return null
+  }
+}
+
+function writeAuthAttempt(value: AuthAttempt): void {
+  const secure = location.protocol === 'https:' ? '; Secure' : ''
+  // Analytics-only state: no credential, identity, email, or authorization
+  // data. The viewer and root trackers intentionally consume it in JS.
+  // react-doctor-disable-next-line react-doctor/insecure-session-cookie
+  document.cookie = `${AUTH_ATTEMPT_COOKIE}=${encodeURIComponent(JSON.stringify(value))}; Path=/; Max-Age=${AUTH_ATTEMPT_MAX_AGE_SECONDS}; SameSite=Lax${secure}`
+}
+
+function artifactIdFromCallback(callbackURL: string): string | undefined {
+  try {
+    const pathname = new URL(callbackURL, location.origin).pathname
+    const match = /^\/a\/([^/]+)$/u.exec(pathname)
+    return match?.[1] ? decodeURIComponent(match[1]) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function captureAuthAttempt(input: {
+  method: SignupMethod
+  callbackURL: string
+  shouldLoadAnalytics: boolean
+}): void {
+  if (!input.shouldLoadAnalytics || typeof document === 'undefined') return
+  writeAuthAttempt({
+    method: input.method,
+    artifactId: artifactIdFromCallback(input.callbackURL),
+    authCompletedSent: false,
+  })
+}
+
+export function markAuthCompleted(accountState: 'new' | 'existing'): void {
+  const attempt = readAuthAttempt()
+  if (!attempt) return
+  writeAuthAttempt({
+    ...attempt,
+    authCompletedSent: true,
+    accountState,
+  })
+}
+
+export function clearAuthAttempt(): void {
+  // Clears the same non-authentication analytics state described above.
+  // react-doctor-disable-next-line react-doctor/insecure-session-cookie
+  document.cookie = `${AUTH_ATTEMPT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`
+}

--- a/apps/web/app/lib/analytics/auth-attempt.client.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.ts
@@ -56,11 +56,36 @@ function readAuthAttempts(): AuthAttempt[] {
   }
 }
 
+function readTabNonce(): string | null {
+  try {
+    return sessionStorage.getItem(AUTH_ATTEMPT_TAB_KEY)
+  } catch {
+    return null
+  }
+}
+
+function writeTabNonce(nonce: string): boolean {
+  try {
+    sessionStorage.setItem(AUTH_ATTEMPT_TAB_KEY, nonce)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function removeTabNonce(): void {
+  try {
+    sessionStorage.removeItem(AUTH_ATTEMPT_TAB_KEY)
+  } catch {
+    // Analytics state must never interrupt authentication or rendering.
+  }
+}
+
 export function readAuthAttempt(
   recoveryArtifactId?: string,
 ): AuthAttempt | null {
   const attempts = readAuthAttempts()
-  const tabNonce = sessionStorage.getItem(AUTH_ATTEMPT_TAB_KEY)
+  const tabNonce = readTabNonce()
   if (tabNonce) return attempts.find(({ nonce }) => nonce === tabNonce) ?? null
   // Mobile browsers may discard sessionStorage while an OAuth tab is
   // backgrounded. A sole pending attempt is still unambiguous; multiple
@@ -70,8 +95,7 @@ export function readAuthAttempt(
     recoveryArtifactId !== undefined &&
     attempts[0].artifactId === recoveryArtifactId
   ) {
-    sessionStorage.setItem(AUTH_ATTEMPT_TAB_KEY, attempts[0].nonce)
-    return attempts[0]
+    return writeTabNonce(attempts[0].nonce) ? attempts[0] : null
   }
   return null
 }
@@ -100,9 +124,14 @@ export function captureAuthAttempt(input: {
   shouldLoadAnalytics: boolean
 }): void {
   if (!input.shouldLoadAnalytics || typeof document === 'undefined') return
-  const previousTabNonce = sessionStorage.getItem(AUTH_ATTEMPT_TAB_KEY)
-  const nonce = crypto.randomUUID()
-  sessionStorage.setItem(AUTH_ATTEMPT_TAB_KEY, nonce)
+  const previousTabNonce = readTabNonce()
+  let nonce: string
+  try {
+    nonce = crypto.randomUUID()
+  } catch {
+    return
+  }
+  if (!writeTabNonce(nonce)) return
   writeAuthAttempts([
     ...readAuthAttempts().filter(
       (attempt) => attempt.nonce !== previousTabNonce,
@@ -130,7 +159,7 @@ export function markAuthCompleted(accountState: 'new' | 'existing'): void {
 
 export function clearAuthAttempt(): void {
   const attempt = readAuthAttempt()
-  sessionStorage.removeItem(AUTH_ATTEMPT_TAB_KEY)
+  removeTabNonce()
   const remaining = attempt
     ? readAuthAttempts().filter(({ nonce }) => nonce !== attempt.nonce)
     : []
@@ -144,7 +173,7 @@ export function clearAuthAttempt(): void {
 }
 
 export function clearAllAuthAttempts(): void {
-  sessionStorage.removeItem(AUTH_ATTEMPT_TAB_KEY)
+  removeTabNonce()
   // react-doctor-disable-next-line react-doctor/insecure-session-cookie
   document.cookie = `${AUTH_ATTEMPT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`
 }

--- a/apps/web/app/lib/analytics/events.test.ts
+++ b/apps/web/app/lib/analytics/events.test.ts
@@ -10,6 +10,8 @@ describe('analytics definitions', () => {
     expect(Object.values(ANALYTICS_EVENTS)).toEqual([
       'artifact_view',
       'sign_up_start',
+      'auth_completed',
+      'artifact_returned_after_auth',
       'sign_up',
       'workspace_created',
       'first_artifact_posted',

--- a/apps/web/app/lib/analytics/events.ts
+++ b/apps/web/app/lib/analytics/events.ts
@@ -3,6 +3,8 @@
 export const ANALYTICS_EVENTS = {
   artifactView: 'artifact_view',
   signUpStart: 'sign_up_start',
+  authCompleted: 'auth_completed',
+  artifactReturnedAfterAuth: 'artifact_returned_after_auth',
   signUp: 'sign_up',
   workspaceCreated: 'workspace_created',
   firstArtifactPosted: 'first_artifact_posted',
@@ -20,6 +22,9 @@ export const ANALYTICS_PARAMS = {
   utmTerm: 'utm_term',
   utmContent: 'utm_content',
   channel: 'channel',
+  visibility: 'visibility',
+  viewerState: 'viewer_state',
+  accountState: 'account_state',
 } as const
 export type AnalyticsParamKey =
   (typeof ANALYTICS_PARAMS)[keyof typeof ANALYTICS_PARAMS]
@@ -68,6 +73,12 @@ export const ANALYTICS_CUSTOM_DIMENSIONS: ReadonlyArray<{
   { parameterName: ANALYTICS_PARAMS.utmTerm, displayName: 'UTM Term' },
   { parameterName: ANALYTICS_PARAMS.utmContent, displayName: 'UTM Content' },
   { parameterName: ANALYTICS_PARAMS.channel, displayName: 'Channel' },
+  { parameterName: ANALYTICS_PARAMS.visibility, displayName: 'Visibility' },
+  { parameterName: ANALYTICS_PARAMS.viewerState, displayName: 'Viewer State' },
+  {
+    parameterName: ANALYTICS_PARAMS.accountState,
+    displayName: 'Account State',
+  },
 ]
 // Node の .mjs consumer は React source graph に現れないため抑制する。
 // react-doctor-disable-next-line deslop/unused-export

--- a/apps/web/app/lib/analytics/events.ts
+++ b/apps/web/app/lib/analytics/events.ts
@@ -11,6 +11,7 @@ export const ANALYTICS_EVENTS = {
 } as const
 export type AnalyticsEventName =
   (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS]
+export type AnalyticsAuthMethod = 'google' | 'microsoft' | 'email'
 export const ANALYTICS_PARAMS = {
   artifactId: 'artifact_id',
   renderType: 'render_type',

--- a/apps/web/app/lib/analytics/signup-payload.ts
+++ b/apps/web/app/lib/analytics/signup-payload.ts
@@ -1,8 +1,8 @@
 import type { FirstTouch } from './first-touch'
-import type { SignupMethod } from '~/services/signup-analytics.server'
+import type { AnalyticsAuthMethod } from './events'
 
 export interface AnalyticsSignupPayload {
-  method: SignupMethod
+  method: AnalyticsAuthMethod
   workspaceCreated: boolean
   firstTouch: FirstTouch | null
 }

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -29,6 +29,7 @@ import { AnalyticsConsentBanner } from '~/components/app/analytics-consent-banne
 import { AnalyticsConsentProvider } from '~/components/app/analytics-consent-provider'
 import { AnalyticsGtag } from '~/components/app/analytics-gtag'
 import { AnalyticsSignupTracker } from '~/components/app/analytics-signup-tracker'
+import { AnalyticsAuthTracker } from '~/components/app/analytics-auth-tracker'
 import { ViewerTimezone } from '~/components/app/viewer-timezone'
 import { createDb } from '~/services/db.server'
 import { claimPendingSignup } from '~/services/signup-analytics.server'
@@ -159,6 +160,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
           userId={data?.analyticsUserId ?? null}
         />
         <AnalyticsSignupTracker signup={data?.analyticsSignup ?? null} />
+        <AnalyticsAuthTracker
+          authenticated={Boolean(data?.user)}
+          signup={data?.analyticsSignup ?? null}
+        />
         <ViewerTimezone />
         <ScrollRestoration />
         <Scripts />

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -163,6 +163,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <AnalyticsAuthTracker
           authenticated={Boolean(data?.user)}
           signup={data?.analyticsSignup ?? null}
+          shouldLoadAnalytics={
+            data?.analyticsConsent?.shouldLoadAnalytics ?? false
+          }
         />
         <ViewerTimezone />
         <ScrollRestoration />

--- a/apps/web/app/routes/a.$id/+components/artifact-view-tracker.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/artifact-view-tracker.test.tsx
@@ -57,7 +57,12 @@ describe('ArtifactViewTracker', () => {
           {
             path: 'a/:id',
             Component: () => (
-              <ArtifactViewTracker {...props} renderType="html" />
+              <ArtifactViewTracker
+                {...props}
+                renderType="html"
+                visibility="link"
+                viewerState="anonymous"
+              />
             ),
           },
         ],
@@ -103,6 +108,8 @@ describe('ArtifactViewTracker', () => {
       expect.objectContaining({
         artifact_id: 'tracked-artifact',
         render_type: 'html',
+        visibility: 'link',
+        viewer_state: 'anonymous',
         utm_source: 'test',
       }),
     )

--- a/apps/web/app/routes/a.$id/+components/artifact-view-tracker.tsx
+++ b/apps/web/app/routes/a.$id/+components/artifact-view-tracker.tsx
@@ -11,6 +11,11 @@ import {
   referrerDomainFromReferrer,
   utmFromSearch,
 } from '~/lib/analytics/first-touch'
+import type { Visibility } from '~/lib/shareable-types'
+import {
+  clearAuthAttempt,
+  readAuthAttempt,
+} from '~/lib/analytics/auth-attempt.client'
 
 const seenArtifactViews = new Set<string>()
 
@@ -20,6 +25,8 @@ function recordArtifactView(input: {
   renderType: AnalyticsRenderType
   shouldLoad: boolean
   measurementId: string | null
+  visibility: Visibility
+  viewerState: 'anonymous' | 'authenticated'
   key: string
   search: string
 }): void {
@@ -33,6 +40,8 @@ function recordArtifactView(input: {
   const sent = trackEvent(ANALYTICS_EVENTS.artifactView, {
     [ANALYTICS_PARAMS.artifactId]: input.artifactId,
     [ANALYTICS_PARAMS.renderType]: input.renderType,
+    [ANALYTICS_PARAMS.visibility]: input.visibility,
+    [ANALYTICS_PARAMS.viewerState]: input.viewerState,
     [ANALYTICS_PARAMS.referrerDomain]: referrerDomainFromReferrer(
       document.referrer,
     ),
@@ -45,16 +54,34 @@ function recordArtifactView(input: {
   // Mark seen only once actually sent, so a pre-consent view can still fire if
   // consent is granted later (which re-runs the effect via shouldLoad).
   if (sent) seenArtifactViews.add(input.key)
+  if (input.viewerState === 'authenticated') {
+    const attempt = readAuthAttempt()
+    if (
+      attempt?.authCompletedSent &&
+      attempt.artifactId === input.artifactId &&
+      attempt.accountState
+    ) {
+      const returned = trackEvent(ANALYTICS_EVENTS.artifactReturnedAfterAuth, {
+        [ANALYTICS_PARAMS.method]: attempt.method,
+        [ANALYTICS_PARAMS.accountState]: attempt.accountState,
+      })
+      if (returned) clearAuthAttempt()
+    }
+  }
 }
 
 export function ArtifactViewTracker({
   artifactId,
   renderType,
   canTrackView,
+  visibility,
+  viewerState,
 }: {
   artifactId: string
   renderType: AnalyticsRenderType
   canTrackView: boolean
+  visibility: Visibility
+  viewerState: 'anonymous' | 'authenticated'
 }): null {
   const location = useLocation()
   const root = useRouteLoaderData<{
@@ -70,6 +97,8 @@ export function ArtifactViewTracker({
       renderType,
       shouldLoad,
       measurementId,
+      visibility,
+      viewerState,
       key: `${artifactId}::${location.key}`,
       search: location.search,
     })
@@ -81,6 +110,8 @@ export function ArtifactViewTracker({
     location.search,
     shouldLoad,
     measurementId,
+    visibility,
+    viewerState,
   ])
   return null
 }

--- a/apps/web/app/routes/a.$id/+components/artifact-view-tracker.tsx
+++ b/apps/web/app/routes/a.$id/+components/artifact-view-tracker.tsx
@@ -55,7 +55,7 @@ function recordArtifactView(input: {
   // consent is granted later (which re-runs the effect via shouldLoad).
   if (sent) seenArtifactViews.add(input.key)
   if (input.viewerState === 'authenticated') {
-    const attempt = readAuthAttempt()
+    const attempt = readAuthAttempt(input.artifactId)
     if (
       attempt?.authCompletedSent &&
       attempt.artifactId === input.artifactId &&

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -1317,6 +1317,8 @@ export default function ViewerRoute({ loaderData }: Route.ComponentProps) {
             artifactId={loaderData.artifact.id}
             renderType={loaderData.renderType}
             canTrackView={loaderData.canTrackView}
+            visibility={loaderData.artifact.visibility}
+            viewerState={loaderData.user ? 'authenticated' : 'anonymous'}
           />
         </>
       )
@@ -1335,6 +1337,8 @@ export default function ViewerRoute({ loaderData }: Route.ComponentProps) {
             artifactId={loaderData.artifact.id}
             renderType="static_site"
             canTrackView={loaderData.canTrackView}
+            visibility={loaderData.artifact.visibility}
+            viewerState={loaderData.user ? 'authenticated' : 'anonymous'}
           />
         </>
       )

--- a/apps/web/app/routes/sign-in.tsx
+++ b/apps/web/app/routes/sign-in.tsx
@@ -139,17 +139,17 @@ export default function SignIn() {
   const handleSendCode = async (e: FormEvent) => {
     e.preventDefault()
     dispatch({ type: 'submitStart' })
-    captureAuthAttempt({
-      method: 'email',
-      callbackURL,
-      shouldLoadAnalytics:
-        rootData?.analyticsConsent?.shouldLoadAnalytics ?? false,
-    })
     try {
       const result = await sendSignInOtp(email)
       if (result.error) {
         dispatch({ type: 'submitFailed', error: t('signin.error.generic') })
       } else {
+        captureAuthAttempt({
+          method: 'email',
+          callbackURL,
+          shouldLoadAnalytics:
+            rootData?.analyticsConsent?.shouldLoadAnalytics ?? false,
+        })
         dispatch({ type: 'codeSent' })
       }
     } catch {

--- a/apps/web/app/routes/sign-in.tsx
+++ b/apps/web/app/routes/sign-in.tsx
@@ -28,6 +28,7 @@ import {
 import { PublicFooter } from '~/components/app/public-footer'
 import { ANALYTICS_EVENTS, ANALYTICS_PARAMS } from '~/lib/analytics/events'
 import { trackEvent } from '~/lib/analytics/track.client'
+import { captureAuthAttempt } from '~/lib/analytics/auth-attempt.client'
 
 type Step = 'email' | 'code'
 
@@ -85,7 +86,10 @@ export default function SignIn() {
   const { t, locale } = useT()
   const [params] = useSearchParams()
   const rootData = useRouteLoaderData('root') as
-    | { maintenance?: boolean }
+    | {
+        maintenance?: boolean
+        analyticsConsent?: { shouldLoadAnalytics: boolean }
+      }
     | undefined
   const maintenance = rootData?.maintenance === true
 
@@ -135,6 +139,12 @@ export default function SignIn() {
   const handleSendCode = async (e: FormEvent) => {
     e.preventDefault()
     dispatch({ type: 'submitStart' })
+    captureAuthAttempt({
+      method: 'email',
+      callbackURL,
+      shouldLoadAnalytics:
+        rootData?.analyticsConsent?.shouldLoadAnalytics ?? false,
+    })
     try {
       const result = await sendSignInOtp(email)
       if (result.error) {

--- a/apps/web/app/services/signup-analytics.server.ts
+++ b/apps/web/app/services/signup-analytics.server.ts
@@ -1,7 +1,8 @@
 import type { Kysely } from 'kysely'
 import type { DB } from '~/types/db'
+import type { AnalyticsAuthMethod } from '~/lib/analytics/events'
 
-export type SignupMethod = 'google' | 'microsoft' | 'email'
+export type SignupMethod = AnalyticsAuthMethod
 // Default claim lease. Module-private: claimPendingSignup applies it internally
 // and callers rely on the default, so it is not part of the module's API.
 const PENDING_SIGNUP_LEASE_MS = 5 * 60 * 1000


### PR DESCRIPTION
## Implementation

- add visibility and viewer authentication state to artifact view analytics
- distinguish completed sign-ins from new registrations
- record return to the originating shared artifact after authentication
- bind short-lived analytics attempts to each browser tab and clear them with consent withdrawal

## Visible effect

Shared-link authentication funnels can distinguish anonymous entry, existing sign-in, new registration, and successful return without changing the sign-in or viewer UI.

## Validation

- `pnpm validate:static`
- focused analytics tests
- Codex and Claude deep implementation review with no unresolved blockers
- trusted-main public boundary guard
