### PR TITLE
Declare read-only MCP tools non-destructive

### DIFF
--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -666,8 +666,18 @@ describe('headless publish wiring', () => {
         openWorldHint: false,
       })
     }
-    for (const name of ['whoami', 'list_artifacts', 'get_artifact']) {
-      expect(byName.get(name)?.readOnlyHint).toBe(true)
+    for (const name of [
+      'whoami',
+      'list_artifacts',
+      'get_artifact',
+      'preview_artifact',
+      'list_comments',
+      'list_projects',
+    ]) {
+      expect(byName.get(name)).toMatchObject({
+        destructiveHint: false,
+        readOnlyHint: true,
+      })
     }
   })
 

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -362,6 +362,7 @@ const WHOAMI_OUTPUT_SCHEMA = {
 // All non-delete writes retain history, so they aren't destructive.
 const READ_ONLY_ANNOTATIONS = {
   readOnlyHint: true,
+  destructiveHint: false,
   openWorldHint: false,
 } as const
 


### PR DESCRIPTION
## Summary

- explicitly mark the shared read-only MCP annotations as non-destructive
- extend the MCP tool contract test to cover both read-only and non-destructive hints

## Validation

- `pnpm --dir apps/web exec vitest --config vitest.config.ts --run app/services/mcp/tools.server.test.ts` (129 tests passed)
- `pnpm validate:static`
- public pull-request boundary guard against `origin/main`
- Codex implementation review: no findings
- Claude implementation review: no findings
