### PR TITLE
Support MP4 playback in static sites

### DIFF
--- a/apps/web/app/lib/upload-artifact-validation.ts
+++ b/apps/web/app/lib/upload-artifact-validation.ts
@@ -29,6 +29,7 @@ const STATIC_SITE_ALLOWED_EXTENSIONS = [
   '.gif',
   '.webp',
   '.avif',
+  '.mp4',
   '.ico',
   '.woff',
   '.woff2',

--- a/apps/web/app/routes/_home/+components/upload-artifact-dialog.test.ts
+++ b/apps/web/app/routes/_home/+components/upload-artifact-dialog.test.ts
@@ -86,6 +86,7 @@ describe('UploadArtifactDialog upload validation', () => {
           new File(['{}'], 'data.json', { type: 'application/json' }),
           new File(['{}'], 'blog.data', { type: 'application/json' }),
           new File(['ico'], 'favicon.ico', { type: 'image/x-icon' }),
+          new File(['video'], 'demo.mp4', { type: 'video/mp4' }),
           new File(['{}'], 'app.js.map', { type: 'application/json' }),
         ],
         t,

--- a/apps/web/app/routes/api.shareables.$id.export-asset.test.ts
+++ b/apps/web/app/routes/api.shareables.$id.export-asset.test.ts
@@ -63,6 +63,25 @@ describe('/api/shareables/:id/export-asset/*', () => {
     await expect(response.text()).resolves.toBe('body { color: red; }')
   })
 
+  test('serves MP4 video with its declared content type', async () => {
+    getExportAssetMock.mockResolvedValue({
+      kind: 'ok',
+      object: {
+        body: new Blob(['video']).stream(),
+        size: 5,
+      },
+      path: '/demo.mp4',
+      contentType: 'video/mp4',
+    })
+
+    const response = await loader(loaderArgs('site123abc', 'demo.mp4'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('video/mp4')
+    expect(response.headers.get('content-length')).toBe('5')
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+  })
+
   test('rewrites linked CSS root-relative asset URLs', async () => {
     getExportAssetMock.mockResolvedValue({
       kind: 'ok',

--- a/apps/web/app/services/shareables.server.test.ts
+++ b/apps/web/app/services/shareables.server.test.ts
@@ -3012,7 +3012,7 @@ describe('StaticSiteBundleUploadSession', () => {
     expect(version.fallback_to_index).toBe(0)
   })
 
-  test('accepts framework sidecar files in static site bundles', async () => {
+  test('accepts framework sidecars and MP4 video in static site bundles', async () => {
     const begun = await beginStaticSiteBundleUploadSession(db, OWNER)
 
     expect(begun.kind).toBe('ok')
@@ -3028,6 +3028,9 @@ describe('StaticSiteBundleUploadSession', () => {
     ).resolves.toEqual({ kind: 'ok' })
     await expect(
       begun.session.addFile(siteFile('/about.meta', 12, '')),
+    ).resolves.toEqual({ kind: 'ok' })
+    await expect(
+      begun.session.addFile(siteFile('/demo.mp4', 12, 'video/mp4')),
     ).resolves.toEqual({ kind: 'ok' })
 
     const result = await begun.session.commit('private')
@@ -3066,6 +3069,16 @@ describe('StaticSiteBundleUploadSession', () => {
         mime_type: 'text/x-component; charset=utf-8',
       },
     ])
+    const videoFile = await db
+      .selectFrom('version_files')
+      .select(['path', 'mime_type'])
+      .where('version_id', '=', begun.session.versionId)
+      .where('path', '=', '/demo.mp4')
+      .executeTakeFirstOrThrow()
+    expect(videoFile).toEqual({
+      path: '/demo.mp4',
+      mime_type: 'video/mp4',
+    })
   })
 
   test.each([

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -2666,6 +2666,8 @@ function staticSiteMimeType(path: string): string | null {
       return 'image/webp'
     case '.avif':
       return 'image/avif'
+    case '.mp4':
+      return 'video/mp4'
     case '.ico':
       return 'image/x-icon'
     case '.woff':

--- a/apps/web/app/services/storage.server.ts
+++ b/apps/web/app/services/storage.server.ts
@@ -2,6 +2,7 @@ export interface StoredArtifact {
   body: ReadableStream<Uint8Array> | null
   text(): Promise<string>
   httpMetadata?: R2HTTPMetadata
+  range?: R2Range
   size: number
   uploaded: Date
 }
@@ -39,13 +40,15 @@ export async function putArtifact(
 export async function getArtifact(
   bucket: R2Bucket,
   key: string,
+  options?: { range?: Headers },
 ): Promise<StoredArtifact | null> {
-  const object = await bucket.get(key)
+  const object = await bucket.get(key, options)
   if (!object) return null
   return {
     body: object.body,
     text: () => object.text(),
     httpMetadata: object.httpMetadata,
+    range: object.range,
     size: object.size,
     uploaded: object.uploaded,
   }

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -945,6 +945,34 @@ describe('handleArtifactSandboxRequest', () => {
     expect(storageMock.getArtifact).toHaveBeenCalledTimes(1)
   })
 
+  test('ignores unsupported static-site byte range formats', async () => {
+    storageMock.getArtifact
+      .mockResolvedValueOnce(
+        storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
+      )
+      .mockResolvedValueOnce(
+        storedBinaryArtifact(new Uint8Array(10), 'video/mp4'),
+      )
+    const token = await entrypointToken()
+    const entrypoint = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
+    )
+    const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/demo.mp4`, {
+        headers: { Cookie: cookie ?? '', Range: 'bytes=0-1,4-5' },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Length')).toBe('10')
+    expect(storageMock.getArtifact).toHaveBeenLastCalledWith(
+      {},
+      'ws-a/abc123def4/v-bundle/demo.mp4',
+    )
+  })
+
   test.each(['private'] as const)(
     'rejects an anonymous %s entrypoint token',
     async (visibility) => {

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -552,6 +552,17 @@ async function seedStaticSite(db: Kysely<DB>) {
         created_at: '2026-05-22T00:00:00.000Z',
       },
       {
+        id: 'vf-video',
+        version_id: 'v-bundle',
+        path: '/demo.mp4',
+        r2_key: 'ws-a/abc123def4/v-bundle/demo.mp4',
+        mime_type: 'video/mp4',
+        size_bytes: 10,
+        sha256: 'sha-video',
+        scan_flags: null,
+        created_at: '2026-05-22T00:00:00.000Z',
+      },
+      {
         id: 'vf-other-md',
         version_id: 'v-bundle',
         path: '/other.md',
@@ -858,6 +869,38 @@ describe('handleArtifactSandboxRequest', () => {
       {},
       'ws-a/abc123def4/v-bundle/index.html',
     )
+  })
+
+  test('serves byte ranges for static-site video assets', async () => {
+    storageMock.getArtifact
+      .mockResolvedValueOnce(
+        storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
+      )
+      .mockResolvedValueOnce({
+        ...storedBinaryArtifact(new Uint8Array([2, 3, 4, 5]), 'video/mp4'),
+        range: { offset: 2, length: 4 },
+        size: 10,
+      })
+    const token = await entrypointToken()
+    const entrypoint = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
+    )
+    const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/demo.mp4`, {
+        headers: { Cookie: cookie ?? '', Range: 'bytes=2-5' },
+      }),
+    )
+
+    expect(response.status).toBe(206)
+    expect(response.headers.get('Accept-Ranges')).toBe('bytes')
+    expect(response.headers.get('Content-Length')).toBe('4')
+    expect(response.headers.get('Content-Range')).toBe('bytes 2-5/10')
+    expect(response.headers.get('Content-Type')).toBe('video/mp4')
+    const rangeHeaders = storageMock.getArtifact.mock.calls.at(-1)?.[2]
+      ?.range as Headers
+    expect(rangeHeaders.get('Range')).toBe('bytes=2-5')
   })
 
   test.each(['private'] as const)(

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -923,6 +923,28 @@ describe('handleArtifactSandboxRequest', () => {
     )
   })
 
+  test('rejects unsatisfiable static-site byte ranges', async () => {
+    storageMock.getArtifact.mockResolvedValueOnce(
+      storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
+    )
+    const token = await entrypointToken()
+    const entrypoint = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
+    )
+    const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/demo.mp4`, {
+        headers: { Cookie: cookie ?? '', Range: 'bytes=10-20' },
+      }),
+    )
+
+    expect(response.status).toBe(416)
+    expect(response.headers.get('Content-Length')).toBe('0')
+    expect(response.headers.get('Content-Range')).toBe('bytes */10')
+    expect(storageMock.getArtifact).toHaveBeenCalledTimes(1)
+  })
+
   test.each(['private'] as const)(
     'rejects an anonymous %s entrypoint token',
     async (visibility) => {

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -889,7 +889,10 @@ describe('handleArtifactSandboxRequest', () => {
 
     const response = await handleArtifactSandboxRequest(
       new Request(`${sandboxOrigin()}/demo.mp4`, {
-        headers: { Cookie: cookie ?? '', Range: 'bytes=2-5' },
+        headers: {
+          Cookie: cookie ?? '',
+          Range: 'bytes=2-18446744073709551615',
+        },
       }),
     )
 
@@ -900,7 +903,7 @@ describe('handleArtifactSandboxRequest', () => {
     expect(response.headers.get('Content-Type')).toBe('video/mp4')
     const rangeHeaders = storageMock.getArtifact.mock.calls.at(-1)?.[2]
       ?.range as Headers
-    expect(rangeHeaders.get('Range')).toBe('bytes=2-5')
+    expect(rangeHeaders.get('Range')).toBe('bytes=2-18446744073709551615')
   })
 
   test('ignores byte ranges for transformed static-site documents', async () => {

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -851,6 +851,9 @@ describe('handleArtifactSandboxRequest', () => {
     expect(response.headers.get('Content-Security-Policy')).toContain(
       "font-src 'self' data: https://fonts.gstatic.com",
     )
+    expect(response.headers.get('Content-Security-Policy')).toContain(
+      "media-src 'self'",
+    )
     expect(storageMock.getArtifact).toHaveBeenCalledWith(
       {},
       'ws-a/abc123def4/v-bundle/index.html',

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -903,6 +903,26 @@ describe('handleArtifactSandboxRequest', () => {
     expect(rangeHeaders.get('Range')).toBe('bytes=2-5')
   })
 
+  test('ignores byte ranges for transformed static-site documents', async () => {
+    storageMock.getArtifact.mockResolvedValue(
+      storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
+    )
+    const token = await entrypointToken()
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`, {
+        headers: { Range: 'bytes=2-5' },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toContain('Hello')
+    expect(storageMock.getArtifact).toHaveBeenCalledWith(
+      {},
+      'ws-a/abc123def4/v-bundle/index.html',
+    )
+  })
+
   test.each(['private'] as const)(
     'rejects an anonymous %s entrypoint token',
     async (visibility) => {

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -497,7 +497,14 @@ async function serveBundleFile(
   },
   request: Request,
 ): Promise<Response> {
-  const range = request.headers.has('Range') ? request.headers : undefined
+  const transformsDocument =
+    file.mime_type === null ||
+    isHtmlContent(file.mime_type) ||
+    isMarkdownContent(file.mime_type)
+  const range =
+    !transformsDocument && request.headers.has('Range')
+      ? request.headers
+      : undefined
   const object = range
     ? await getArtifact(env.BUCKET, file.r2_key, { range })
     : await getArtifact(env.BUCKET, file.r2_key)

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -556,14 +556,12 @@ function rangeSatisfiabilityFor(
   if (size === 0) return false
   const [, startValue, endValue] = match
   if (startValue === '') {
-    const suffix = Number(endValue)
-    return Number.isSafeInteger(suffix) && suffix > 0
+    return BigInt(endValue) > 0n
   }
-  const start = Number(startValue)
-  if (!Number.isSafeInteger(start) || start >= size) return false
+  const start = BigInt(startValue)
+  if (start >= BigInt(size)) return false
   if (endValue === '') return true
-  const end = Number(endValue)
-  return Number.isSafeInteger(end) && end >= start
+  return BigInt(endValue) >= start
 }
 
 function rangeNotSatisfiableResponse(size: number): Response {

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -503,13 +503,17 @@ async function serveBundleFile(
     file.mime_type === null ||
     isHtmlContent(file.mime_type) ||
     isMarkdownContent(file.mime_type)
-  const range =
+  const requestedRange =
     !transformsDocument && request.headers.has('Range')
       ? request.headers
       : undefined
-  if (range && !isSatisfiableRange(range.get('Range'), file.size_bytes)) {
+  const rangeSatisfiability = requestedRange
+    ? rangeSatisfiabilityFor(requestedRange.get('Range'), file.size_bytes)
+    : null
+  if (rangeSatisfiability === false) {
     return rangeNotSatisfiableResponse(file.size_bytes)
   }
+  const range = rangeSatisfiability === true ? requestedRange : undefined
   const object = range
     ? await getArtifact(env.BUCKET, file.r2_key, { range })
     : await getArtifact(env.BUCKET, file.r2_key)
@@ -543,9 +547,13 @@ async function serveBundleFile(
   })
 }
 
-function isSatisfiableRange(value: string | null, size: number): boolean {
+function rangeSatisfiabilityFor(
+  value: string | null,
+  size: number,
+): boolean | null {
   const match = value?.match(/^bytes=(\d*)-(\d*)$/)
-  if (!match || size === 0) return false
+  if (!match) return null
+  if (size === 0) return false
   const [, startValue, endValue] = match
   if (startValue === '') {
     const suffix = Number(endValue)

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -404,6 +404,7 @@ async function serveBundleAsset(
       'version_files.path',
       'version_files.r2_key',
       'version_files.mime_type',
+      'version_files.size_bytes',
     ])
     .where('shareables.id', '=', bundle.aid)
     .where('shareables.workspace_id', '=', bundle.wid)
@@ -494,6 +495,7 @@ async function serveBundleFile(
   file: {
     r2_key: string
     mime_type: string | null
+    size_bytes: number
   },
   request: Request,
 ): Promise<Response> {
@@ -505,6 +507,9 @@ async function serveBundleFile(
     !transformsDocument && request.headers.has('Range')
       ? request.headers
       : undefined
+  if (range && !isSatisfiableRange(range.get('Range'), file.size_bytes)) {
+    return rangeNotSatisfiableResponse(file.size_bytes)
+  }
   const object = range
     ? await getArtifact(env.BUCKET, file.r2_key, { range })
     : await getArtifact(env.BUCKET, file.r2_key)
@@ -535,6 +540,32 @@ async function serveBundleFile(
   return contentResponse(object.body, contentType, null, {
     status: object.range ? 206 : 200,
     headers: rangeResponseHeaders(object),
+  })
+}
+
+function isSatisfiableRange(value: string | null, size: number): boolean {
+  const match = value?.match(/^bytes=(\d*)-(\d*)$/)
+  if (!match || size === 0) return false
+  const [, startValue, endValue] = match
+  if (startValue === '') {
+    const suffix = Number(endValue)
+    return Number.isSafeInteger(suffix) && suffix > 0
+  }
+  const start = Number(startValue)
+  if (!Number.isSafeInteger(start) || start >= size) return false
+  if (endValue === '') return true
+  const end = Number(endValue)
+  return Number.isSafeInteger(end) && end >= start
+}
+
+function rangeNotSatisfiableResponse(size: number): Response {
+  return contentResponse(null, 'text/plain; charset=utf-8', null, {
+    status: 416,
+    headers: new Headers({
+      'Accept-Ranges': 'bytes',
+      'Content-Length': '0',
+      'Content-Range': `bytes */${size}`,
+    }),
   })
 }
 

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -580,6 +580,7 @@ function artifactCsp(renderType: ArtifactType, embed = false): string {
             "style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com",
             "img-src 'self' data: blob:",
             "font-src 'self' data: https://fonts.gstatic.com",
+            "media-src 'self'",
             `connect-src 'self' ${EXTERNAL_SCRIPT_CSP_SOURCES}`,
             `frame-src ${YOUTUBE_FRAME_CSP_SOURCES}`,
           ]

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -87,7 +87,7 @@ export async function handleArtifactSandboxRequest(
   )
   if (!cookie) {
     if (identity !== null) {
-      return await serveAnonymousLinkBundleAsset(identity, path)
+      return await serveAnonymousLinkBundleAsset(identity, path, request)
     }
     return deniedResponse('no_bundle_cookie', 'Invalid token', 401, { path })
   }
@@ -102,7 +102,7 @@ export async function handleArtifactSandboxRequest(
       path,
     })
   }
-  return await serveBundleAsset(cookie, path)
+  return await serveBundleAsset(cookie, path, request)
 }
 
 function sandboxProbeResponse(request: Request): Response {
@@ -391,6 +391,7 @@ async function serveEntrypoint(
 async function serveBundleAsset(
   bundle: { wid: string; aid: string; vid: string },
   path: string,
+  request: Request,
 ): Promise<Response> {
   const db = createDb()
   const candidatePaths = hasFileExtension(path) ? [path] : [path, '/index.html']
@@ -412,7 +413,7 @@ async function serveBundleAsset(
     .where('version_files.path', 'in', candidatePaths)
     .execute()
   const requested = files.find((file) => file.path === path)
-  if (requested) return await serveBundleFile(requested)
+  if (requested) return await serveBundleFile(requested, request)
 
   const fallback = files.find(
     (file) =>
@@ -426,12 +427,13 @@ async function serveBundleAsset(
       { aid: bundle.aid, vid: bundle.vid, path },
     )
   }
-  return await serveBundleFile(fallback)
+  return await serveBundleFile(fallback, request)
 }
 
 async function serveAnonymousLinkBundleAsset(
   identity: { shareableId: string; versionId: string },
   path: string,
+  request: Request,
 ): Promise<Response> {
   const db = createDb()
   const bundle = await db
@@ -485,14 +487,20 @@ async function serveAnonymousLinkBundleAsset(
       path,
     })
   }
-  return await serveBundleAsset(bundle, path)
+  return await serveBundleAsset(bundle, path, request)
 }
 
-async function serveBundleFile(file: {
-  r2_key: string
-  mime_type: string | null
-}): Promise<Response> {
-  const object = await getArtifact(env.BUCKET, file.r2_key)
+async function serveBundleFile(
+  file: {
+    r2_key: string
+    mime_type: string | null
+  },
+  request: Request,
+): Promise<Response> {
+  const range = request.headers.has('Range') ? request.headers : undefined
+  const object = range
+    ? await getArtifact(env.BUCKET, file.r2_key, { range })
+    : await getArtifact(env.BUCKET, file.r2_key)
   if (!object) {
     return deniedResponse('r2_missing', 'This artifact is unavailable.', 404, {
       r2Key: file.r2_key,
@@ -517,7 +525,44 @@ async function serveBundleFile(file: {
       artifactCsp('static_site'),
     )
   }
-  return contentResponse(object.body, contentType, null)
+  return contentResponse(object.body, contentType, null, {
+    status: object.range ? 206 : 200,
+    headers: rangeResponseHeaders(object),
+  })
+}
+
+function rangeResponseHeaders(object: {
+  range?: R2Range
+  size: number
+}): Headers {
+  const headers = new Headers({ 'Accept-Ranges': 'bytes' })
+  if (!object.range) {
+    headers.set('Content-Length', String(object.size))
+    return headers
+  }
+
+  const resolved = resolveR2Range(object.range, object.size)
+  headers.set('Content-Length', String(resolved.length))
+  headers.set(
+    'Content-Range',
+    `bytes ${resolved.start}-${resolved.start + resolved.length - 1}/${object.size}`,
+  )
+  return headers
+}
+
+function resolveR2Range(
+  range: R2Range,
+  size: number,
+): { start: number; length: number } {
+  if ('suffix' in range) {
+    const length = Math.min(range.suffix, size)
+    return { start: size - length, length }
+  }
+  const start = Math.min(range.offset ?? 0, size)
+  return {
+    start,
+    length: Math.min(range.length ?? size - start, size - start),
+  }
 }
 
 function hasFileExtension(path: string): boolean {
@@ -670,18 +715,22 @@ function contentResponse(
   body: string | ReadableStream<Uint8Array> | null,
   contentType: string,
   csp: string | null,
+  init?: { status?: number; headers?: Headers },
 ): Response {
+  const headers = new Headers({
+    'Content-Type': contentType,
+    'Cache-Control': 'private, no-store, no-transform',
+    'Cross-Origin-Resource-Policy': 'same-site',
+    'Cross-Origin-Opener-Policy': 'same-origin',
+    'Permissions-Policy': PERMISSIONS_POLICY,
+    'Referrer-Policy': REFERRER_POLICY,
+    [ROBOTS_HEADER]: ROBOTS_VALUE,
+    'X-Content-Type-Options': 'nosniff',
+  })
+  for (const [name, value] of init?.headers ?? []) headers.set(name, value)
   const response = new Response(body, {
-    headers: {
-      'Content-Type': contentType,
-      'Cache-Control': 'private, no-store, no-transform',
-      'Cross-Origin-Resource-Policy': 'same-site',
-      'Cross-Origin-Opener-Policy': 'same-origin',
-      'Permissions-Policy': PERMISSIONS_POLICY,
-      'Referrer-Policy': REFERRER_POLICY,
-      [ROBOTS_HEADER]: ROBOTS_VALUE,
-      'X-Content-Type-Options': 'nosniff',
-    },
+    status: init?.status,
+    headers,
   })
   if (csp) response.headers.set(CSP_HEADER, csp)
   return response


### PR DESCRIPTION
## Summary

- allow MP4 files in static-site bundles and serve them as `video/mp4`
- permit same-origin media in the static-site sandbox CSP
- support satisfiable single byte ranges for reliable video playback and seeking
- preserve full HTML/Markdown transformations and return correct 416 responses for unsatisfiable ranges

## Validation

- `pnpm validate:static`
- focused sandbox and storage tests (74 passed)
- web typecheck
- trusted `origin/main` pull-request boundary guard
- Codex and Claude implementation reviews
