### PR TITLE
Handle the R2 runtime range shape

### DIFF
--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -878,7 +878,11 @@ describe('handleArtifactSandboxRequest', () => {
       )
       .mockResolvedValueOnce({
         ...storedBinaryArtifact(new Uint8Array([2, 3, 4, 5]), 'video/mp4'),
-        range: { offset: 2, length: 4 },
+        range: {
+          offset: 2,
+          length: 4,
+          suffix: undefined,
+        } as unknown as R2Range,
         size: 10,
       })
     const token = await entrypointToken()

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -598,14 +598,15 @@ function resolveR2Range(
   range: R2Range,
   size: number,
 ): { start: number; length: number } {
-  if ('suffix' in range) {
+  if ('suffix' in range && typeof range.suffix === 'number') {
     const length = Math.min(range.suffix, size)
     return { start: size - length, length }
   }
-  const start = Math.min(range.offset ?? 0, size)
+  const offsetRange = range as { offset?: number; length?: number }
+  const start = Math.min(offsetRange.offset ?? 0, size)
   return {
     start,
-    length: Math.min(range.length ?? size - start, size - start),
+    length: Math.min(offsetRange.length ?? size - start, size - start),
   }
 }
 


### PR DESCRIPTION
## Summary

- handle the Cloudflare R2 runtime range shape when `suffix` is present but undefined
- preserve offset/length byte-range response headers
- add a regression test for the production-observed shape

## Validation

- `pnpm validate:static`
- focused bundle sandbox tests (61 passed)
- trusted `origin/main` pull-request boundary guard
- Codex and Claude implementation reviews
