### PR TITLE
Derive range headers from validated requests

### DIFF
--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -877,10 +877,13 @@ describe('handleArtifactSandboxRequest', () => {
         storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
       )
       .mockResolvedValueOnce({
-        ...storedBinaryArtifact(new Uint8Array([2, 3, 4, 5]), 'video/mp4'),
+        ...storedBinaryArtifact(
+          new Uint8Array([2, 3, 4, 5, 6, 7, 8, 9]),
+          'video/mp4',
+        ),
         range: {
           offset: 2,
-          length: 4,
+          length: 8,
           suffix: undefined,
         } as unknown as R2Range,
         size: 10,
@@ -902,8 +905,8 @@ describe('handleArtifactSandboxRequest', () => {
 
     expect(response.status).toBe(206)
     expect(response.headers.get('Accept-Ranges')).toBe('bytes')
-    expect(response.headers.get('Content-Length')).toBe('4')
-    expect(response.headers.get('Content-Range')).toBe('bytes 2-5/10')
+    expect(response.headers.get('Content-Length')).toBe('8')
+    expect(response.headers.get('Content-Range')).toBe('bytes 2-9/10')
     expect(response.headers.get('Content-Type')).toBe('video/mp4')
     const rangeHeaders = storageMock.getArtifact.mock.calls.at(-1)?.[2]
       ?.range as Headers

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -541,9 +541,10 @@ async function serveBundleFile(
       artifactCsp('static_site'),
     )
   }
+  const rangeHeader = range?.get('Range') ?? null
   return contentResponse(object.body, contentType, null, {
-    status: object.range ? 206 : 200,
-    headers: rangeResponseHeaders(object),
+    status: rangeHeader ? 206 : 200,
+    headers: rangeResponseHeaders(object.size, rangeHeader),
   })
 }
 
@@ -575,39 +576,41 @@ function rangeNotSatisfiableResponse(size: number): Response {
   })
 }
 
-function rangeResponseHeaders(object: {
-  range?: R2Range
-  size: number
-}): Headers {
+function rangeResponseHeaders(size: number, value: string | null): Headers {
   const headers = new Headers({ 'Accept-Ranges': 'bytes' })
-  if (!object.range) {
-    headers.set('Content-Length', String(object.size))
+  if (!value) {
+    headers.set('Content-Length', String(size))
     return headers
   }
 
-  const resolved = resolveR2Range(object.range, object.size)
+  const resolved = resolveRequestedRange(value, size)
   headers.set('Content-Length', String(resolved.length))
   headers.set(
     'Content-Range',
-    `bytes ${resolved.start}-${resolved.start + resolved.length - 1}/${object.size}`,
+    `bytes ${resolved.start}-${resolved.start + resolved.length - 1}/${size}`,
   )
   return headers
 }
 
-function resolveR2Range(
-  range: R2Range,
+function resolveRequestedRange(
+  value: string,
   size: number,
 ): { start: number; length: number } {
-  if ('suffix' in range && typeof range.suffix === 'number') {
-    const length = Math.min(range.suffix, size)
+  const match = value.match(/^bytes=(\d*)-(\d*)$/)
+  if (!match) throw new Error('Validated byte range did not parse')
+  const [, startValue, endValue] = match
+  if (startValue === '') {
+    const length = Number(
+      BigInt(endValue) > BigInt(size) ? BigInt(size) : BigInt(endValue),
+    )
     return { start: size - length, length }
   }
-  const offsetRange = range as { offset?: number; length?: number }
-  const start = Math.min(offsetRange.offset ?? 0, size)
-  return {
-    start,
-    length: Math.min(offsetRange.length ?? size - start, size - start),
-  }
+  const start = Number(BigInt(startValue))
+  const end =
+    endValue === '' || BigInt(endValue) >= BigInt(size)
+      ? size - 1
+      : Number(BigInt(endValue))
+  return { start, length: end - start + 1 }
 }
 
 function hasFileExtension(path: string): boolean {


### PR DESCRIPTION
## Summary

- derive static-site byte-range response headers from the validated request
- avoid relying on undocumented R2 runtime range metadata shapes
- cover large end bounds and production-observed metadata in regression tests

## Validation

- `pnpm validate:static`
- focused bundle sandbox tests (61 passed)
- trusted `origin/main` pull-request boundary guard
- Codex and Claude implementation reviews
