### PR TITLE
Replace MCP iframe preview with a native card

### DIFF
--- a/apps/web/app/lib/agent-surface.ts
+++ b/apps/web/app/lib/agent-surface.ts
@@ -444,7 +444,7 @@ export const capabilitiesMd = [
   '| append_artifact | Append content exactly as provided. Markdown uses the source end; HTML uses the position before an ASCII case-insensitive </body>, falling back to the source end. Creates a new version at the same URL. |',
   '| list_artifacts | List artifacts the user has posted. |',
   "| get_artifact | Read an artifact's content and metadata (supports offset for large files). |",
-  '| preview_artifact | Get a browser-preview URL for an artifact. |',
+  '| preview_artifact | Show an artifact card with a link to the full viewer. |',
   '| list_comments | List comment threads on an artifact. |',
   '| post_comment | Post a comment or reply on an artifact. |',
   '| update_comment | Edit a comment the user posted. |',

--- a/apps/web/app/lib/cli-capability-matrix.json
+++ b/apps/web/app/lib/cli-capability-matrix.json
@@ -2679,10 +2679,16 @@
           "contract_identifiers": {
             "mcp_name": ["'preview_artifact'"],
             "mcp_description": [
-              "Show a visual preview of an artifact you can view — your own, or one shared with you in your workspa"
+              "Show a compact card for an artifact you can view — your own, or one shared with you in your workspac"
             ],
             "mcp_input": ["id"],
-            "mcp_output": ["id", "share_url", "preview_url", "title", "locale"],
+            "mcp_output": [
+              "id",
+              "share_url",
+              "title",
+              "artifact_kind",
+              "locale"
+            ],
             "mcp_recovery": [
               "If you do not know the id, call list_artifacts first"
             ]

--- a/apps/web/app/services/mcp/preview-widget.server.test.ts
+++ b/apps/web/app/services/mcp/preview-widget.server.test.ts
@@ -14,7 +14,7 @@ describe('computeClaudeWidgetDomain', () => {
 })
 
 describe('artifactPreviewResourceContents', () => {
-  test('carries Claude and ChatGPT widget domains together', async () => {
+  test('carries host widget domains without permitting nested frames', async () => {
     const result = await artifactPreviewResourceContents(
       'https://artifactshare.com',
       mcpResourceUrl('https://artifactshare.com'),
@@ -25,9 +25,24 @@ describe('artifactPreviewResourceContents', () => {
     expect(meta.ui.domain).toBe(
       '9c4c6fc24ec537cb113fc299b3b58165.claudemcpcontent.com',
     )
-    expect(meta.ui.csp.frameDomains).toEqual([
+    expect(meta.ui.csp).not.toHaveProperty('frameDomains')
+    expect(meta.ui.csp.resourceDomains).toEqual(['https://esm.sh'])
+  })
+
+  test('renders a portable card with standard and compatibility bridges', async () => {
+    const result = await artifactPreviewResourceContents(
       'https://artifactshare.com',
-      'https://*.sandbox.artifactshare.com',
-    ])
+      mcpResourceUrl('https://artifactshare.com'),
+    )
+    const html = result.contents[0].text
+
+    expect(html).toContain('id="as-card"')
+    expect(html).toContain('@modelcontextprotocol/ext-apps@1.7.5')
+    expect(html).toContain('new mod.PostMessageTransport()')
+    expect(html).toContain('window.openai.openExternal')
+    expect(html).toContain("url.protocol === 'https:'")
+    expect(html).not.toContain('<iframe')
+    expect(html).not.toContain('preview_url')
+    expect(html).not.toContain('requestDisplayMode')
   })
 })

--- a/apps/web/app/services/mcp/preview-widget.server.ts
+++ b/apps/web/app/services/mcp/preview-widget.server.ts
@@ -1,17 +1,10 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { SANDBOX_HOST } from '~/lib/hosts'
 import { computeTextSha256Hex } from '~/lib/sha256'
 
 /*
- * MCP Apps UI resource: a preview widget that renders an artifact inside the
- * chat host (ChatGPT / Cursor / Claude) with a fullscreen option. A tool whose
- * `_meta.ui.resourceUri` points at ARTIFACT_PREVIEW_TEMPLATE_URI makes the host
- * fetch this HTML via `resources/read` and render it after the tool runs.
- *
- * The widget reads the tool's structuredContent through whichever host bridge is
- * present — `window.openai` on ChatGPT, the `@modelcontextprotocol/ext-apps`
- * client on standard hosts — and frames `preview_url` (a cookie-free embed of
- * the artifact's sandboxed content; falls back to the share page).
+ * MCP Apps UI resource: a compact artifact card shared by ChatGPT, Claude,
+ * Cursor, and other conforming hosts. The full artifact opens in Artifact
+ * Share; the widget never frames or fetches artifact content itself.
  */
 
 export const ARTIFACT_PREVIEW_TEMPLATE_URI = 'ui://artifact-preview.html'
@@ -23,185 +16,165 @@ const RESOURCE_MIME_TYPE = 'text/html;profile=mcp-app'
 const WIDGET_HTML = `
 <style>
   :root { color-scheme: light dark; }
-  #as-preview * { box-sizing: border-box; }
-  #as-preview {
+  #as-card, #as-card * { box-sizing: border-box; }
+  #as-card {
+    --as-text: #25231f;
+    --as-muted: #706d66;
+    --as-border: rgba(55, 53, 47, 0.14);
+    --as-surface: #ffffff;
+    --as-accent: #e85d3f;
     font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-    display: flex; flex-direction: column; height: 100%; min-height: 360px; margin: 0;
-  }
-  /* Standard hosts (Cursor) can give the widget the full pane height, which lets
-     the framed artifact's 100vh hero balloon. Pin a card height inline, and only
-     fill the viewport in fullscreen. ChatGPT (window.openai) keeps height: 100%. */
-  #as-preview.as-managed { height: 460px; }
-  #as-preview.as-managed.as-full { height: 100vh; }
-  #as-bar {
-    display: flex; align-items: center; gap: 10px;
-    padding: 10px 12px; border-bottom: 1px solid rgba(55,53,47,0.12);
+    color: var(--as-text); background: var(--as-surface);
+    display: grid; grid-template-columns: 48px minmax(0, 1fr); gap: 14px;
+    align-items: center; width: 100%; min-height: 128px; margin: 0;
+    padding: 18px; border: 1px solid var(--as-border); border-radius: 16px;
   }
   #as-mark {
-    width: 22px; height: 22px; border-radius: 6px; flex: none;
-    background: linear-gradient(135deg, #ff8a65, #ff6f61);
+    display: grid; place-items: center; width: 48px; height: 48px;
+    border-radius: 13px; color: #fff; background: var(--as-accent);
+    font-size: 14px; font-weight: 750; letter-spacing: -0.02em;
+  }
+  #as-body { min-width: 0; }
+  #as-eyebrow {
+    color: var(--as-muted); font-size: 12px; font-weight: 650;
+    letter-spacing: 0.04em; text-transform: uppercase;
   }
   #as-title {
-    flex: 1; min-width: 0; font-weight: 600; font-size: 14px; color: #37352f;
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    margin: 4px 0 12px; overflow: hidden; color: var(--as-text);
+    font-size: 17px; font-weight: 700; line-height: 1.3;
+    text-overflow: ellipsis; white-space: nowrap;
   }
-  .as-btn {
-    font: inherit; font-size: 13px; padding: 6px 12px; border-radius: 8px;
-    border: 1px solid rgba(55,53,47,0.16); background: #fff; color: #37352f;
-    cursor: pointer; text-decoration: none; white-space: nowrap;
+  #as-actions { display: flex; align-items: center; gap: 10px; }
+  #as-open {
+    display: inline-flex; align-items: center; justify-content: center;
+    min-height: 36px; padding: 8px 13px; border: 1px solid var(--as-text);
+    border-radius: 9px; color: var(--as-surface); background: var(--as-text);
+    font-size: 13px; font-weight: 650; line-height: 1; text-decoration: none;
+    white-space: nowrap;
   }
-  .as-btn:hover { background: #fbfaf8; }
-  #as-frame-wrap { position: relative; flex: 1; background: #fbfaf8; }
-  #as-frame { border: 0; width: 100%; height: 100%; display: block; }
-  #as-empty { padding: 24px; color: rgba(55,53,47,0.65); font-size: 14px; }
+  #as-open:hover { opacity: 0.88; }
+  #as-open[hidden] { display: none; }
+  @media (prefers-color-scheme: dark) {
+    #as-card {
+      --as-text: #f3f1ec;
+      --as-muted: #aaa69e;
+      --as-border: rgba(255, 255, 255, 0.14);
+      --as-surface: #24231f;
+      --as-accent: #f06c4f;
+    }
+  }
 </style>
-<div id="as-preview">
-  <div id="as-bar">
-    <div id="as-mark"></div>
-    <div id="as-title">Artifact Share</div>
-    <button id="as-full" class="as-btn" type="button">Fullscreen</button>
-    <a id="as-open" class="as-btn" target="_blank" rel="noopener">Open</a>
+<div id="as-card">
+  <div id="as-mark" aria-hidden="true">AS</div>
+  <div id="as-body">
+    <div id="as-eyebrow">Artifact Share</div>
+    <div id="as-title">Artifact</div>
+    <div id="as-actions">
+      <a id="as-open" target="_blank" rel="noopener noreferrer">Open in Artifact Share ↗</a>
+    </div>
   </div>
-  <div id="as-frame-wrap"><div id="as-empty"></div></div>
 </div>
 <script>
 (function () {
   var titleEl = document.getElementById('as-title');
-  var fullBtn = document.getElementById('as-full');
+  var eyebrowEl = document.getElementById('as-eyebrow');
   var openLink = document.getElementById('as-open');
-  var wrap = document.getElementById('as-frame-wrap');
-  var preview = document.getElementById('as-preview');
-  // Set by whichever host bridge connects (ChatGPT or the MCP Apps standard).
-  var requestFullscreen = null;
-  // Opens an external URL through the host. The widget iframe is sandboxed
-  // without allow-popups, so a raw target=_blank link is blocked — the host has
-  // to open it for us.
-  var openExternal = null;
   var shareLink = '';
+  var openExternal = null;
 
-  // Only honour https URLs — defence in depth against a non-https scheme ever
-  // reaching the tool output (the server only ever mints https).
-  function https(u) {
-    return typeof u === 'string' && u.indexOf('https://') === 0 ? u : '';
-  }
+  var kindLabels = {
+    markdown_page: { en: 'Markdown', ja: 'Markdown' },
+    html_page: { en: 'HTML page', ja: 'HTMLページ' },
+    static_site: { en: 'Static site', ja: '静的サイト' },
+    spa: { en: 'Web app', ja: 'Webアプリ' },
+    workspace_app: { en: 'Workspace app', ja: 'ワークスペースアプリ' },
+  };
 
-  // Render from the tool's structuredContent: { share_url, preview_url, title,
-  // locale }. preview_url frames a cookie-free embed of the content; the "open"
-  // link goes to the share page so the user gets the full viewer in a browser.
-  function render(d) {
-    d = d || {};
-    var ja = d.locale === 'ja';
-    titleEl.textContent = d.title || (ja ? 'アーティファクト' : 'Artifact');
-    fullBtn.textContent = ja ? '全画面' : 'Fullscreen';
-    openLink.textContent = ja ? '新しいタブで開く ↗' : 'Open in new tab ↗';
-    shareLink = https(d.share_url);
-    var frameUrl = https(d.preview_url) || shareLink;
-    openLink.style.display = shareLink ? '' : 'none';
-    if (shareLink) openLink.href = shareLink; // for hover / copy-link
-    if (frameUrl && !document.getElementById('as-frame')) {
-      var f = document.createElement('iframe');
-      f.id = 'as-frame';
-      f.src = frameUrl;
-      f.setAttribute('referrerpolicy', 'no-referrer');
-      wrap.innerHTML = '';
-      wrap.appendChild(f);
+  // The server mints share_url. Still require an absolute HTTPS URL before it
+  // reaches either the anchor or a host link-opening API.
+  function validatedHttpsUrl(value) {
+    if (typeof value !== 'string') return '';
+    try {
+      var url = new URL(value);
+      return url.protocol === 'https:' ? url.href : '';
+    } catch (_) {
+      return '';
     }
   }
 
-  fullBtn.addEventListener('click', function () {
-    if (requestFullscreen) requestFullscreen();
-  });
+  function render(data) {
+    data = data || {};
+    var locale = data.locale === 'ja' ? 'ja' : 'en';
+    var labels = kindLabels[data.artifact_kind] || {
+      en: 'Artifact',
+      ja: 'アーティファクト',
+    };
+    titleEl.textContent = data.title || labels[locale];
+    eyebrowEl.textContent = 'Artifact Share · ' + labels[locale];
+    openLink.textContent =
+      locale === 'ja'
+        ? 'Artifact Shareで開く ↗'
+        : 'Open in Artifact Share ↗';
+    shareLink = validatedHttpsUrl(data.share_url);
+    if (shareLink) {
+      openLink.href = shareLink;
+      openLink.hidden = false;
+    } else {
+      openLink.removeAttribute('href');
+      openLink.hidden = true;
+    }
+  }
 
-  openLink.addEventListener('click', function (e) {
-    // Route through the host's link opener; the sandboxed iframe can't open a
-    // new window itself. Fall back to the default anchor if no bridge connected.
+  openLink.addEventListener('click', function (event) {
     if (openExternal && shareLink) {
-      e.preventDefault();
+      event.preventDefault();
       openExternal(shareLink);
     }
   });
 
-  // ChatGPT exposes window.openai; the tool result is window.openai.toolOutput.
+  // Keep ChatGPT's compatibility bridge ready as a fallback. A connected
+  // standard MCP Apps client below replaces its link opener.
   if (window.openai) {
-    requestFullscreen = function () {
-      if (window.openai.requestDisplayMode) {
-        window.openai.requestDisplayMode({ mode: 'fullscreen' });
-      }
-    };
     openExternal = function (url) {
-      if (window.openai.openExternal) window.openai.openExternal({ href: url });
+      if (window.openai.openExternal) {
+        window.openai.openExternal({ href: url });
+      }
     };
     render(window.openai.toolOutput);
     window.addEventListener(
       'openai:set_globals',
-      function () {
-        render(window.openai.toolOutput);
-      },
+      function () { render(window.openai.toolOutput); },
       { passive: true },
     );
-    return;
+  } else {
+    render(null);
   }
 
-  // MCP Apps standard host (Cursor / Claude): read structuredContent over
-  // postMessage via the ext-apps client. Loaded only on this branch, so ChatGPT
-  // never fetches it.
-  // Pin a card height here — standard hosts may give the widget the full pane
-  // height, ballooning the framed artifact's 100vh hero.
-  preview.classList.add('as-managed');
-  function applyDisplayMode(ctx) {
-    preview.classList.toggle('as-full', !!(ctx && ctx.displayMode === 'fullscreen'));
-  }
-  render(null); // show the chrome while the bridge connects
-  import('https://esm.sh/@modelcontextprotocol/ext-apps@1.7.4/app-with-deps')
+  // Prefer the standard MCP Apps bridge on every host. If the client cannot
+  // load or connect, the ChatGPT bridge or the plain HTTPS anchor remains.
+  import('https://esm.sh/@modelcontextprotocol/ext-apps@1.7.5/app-with-deps')
     .then(function (mod) {
       var app = new mod.App({
-        name: 'Artifact Share preview',
+        name: 'Artifact Share card',
         version: '1.0.0',
       });
-      app.ontoolresult = function (p) {
-        render(p && p.structuredContent);
-      };
-      app.ontoolinput = function (p) {
-        if (p && p.structuredContent) render(p.structuredContent);
-      };
-      app.onhostcontextchanged = applyDisplayMode;
-      openExternal = function (url) {
-        Promise.resolve(app.openLink({ url: url })).catch(function () {});
+      app.ontoolresult = function (result) {
+        render(result && result.structuredContent);
       };
       return app.connect(new mod.PostMessageTransport()).then(function () {
-        var ctx = app.getHostContext && app.getHostContext();
-        applyDisplayMode(ctx);
-        // Only offer fullscreen when the host advertises it; some hosts (Cursor)
-        // reject or mis-respond to the request otherwise, throwing in the client.
-        var canFull =
-          !!ctx &&
-          !!ctx.availableDisplayModes &&
-          ctx.availableDisplayModes.indexOf('fullscreen') >= 0;
-        if (canFull) {
-          requestFullscreen = function () {
-            Promise.resolve(
-              app.requestDisplayMode({ mode: 'fullscreen' }),
-            ).catch(function () {});
-          };
-        } else {
-          fullBtn.style.display = 'none';
-        }
+        openExternal = function (url) {
+          Promise.resolve(app.openLink({ url: url })).catch(function () {});
+        };
       });
     })
     .catch(function () {
-      // Leave the static chrome up if the client can't load.
+      // The compatibility bridge or anchor already provides the fallback.
     });
 })();
 </script>
 `.trim()
 
-/**
- * Register the preview widget as a UI resource. `appOrigin` is the app origin
- * (from the request base URL): the widget frames `/a/:id` from there, and it is
- * ChatGPT's widget domain — supplied through the `openai/widgetDomain`
- * compatibility alias. Claude reads the standard `_meta.ui.domain`, which must
- * be derived from the MCP server URL rather than the app origin.
- */
+/** Register the portable artifact card as an MCP Apps UI resource. */
 export function registerArtifactPreviewResource(
   server: McpServer,
   appOrigin: string,
@@ -211,9 +184,9 @@ export function registerArtifactPreviewResource(
     'artifact-preview',
     ARTIFACT_PREVIEW_TEMPLATE_URI,
     {
-      title: 'Artifact preview',
+      title: 'Artifact card',
       description:
-        'Renders a shared artifact inside the chat, with a fullscreen view.',
+        'Shows artifact details and opens the full artifact in Artifact Share.',
     },
     () => artifactPreviewResourceContents(appOrigin, mcpServerUrl),
   )
@@ -239,25 +212,17 @@ export async function artifactPreviewResourceContents(
         mimeType: RESOURCE_MIME_TYPE,
         text: WIDGET_HTML,
         _meta: {
-          // ChatGPT's widget domain via the compatibility alias (renders the
-          // widget under `<domain>.web-sandbox.oaiusercontent.com` and enables
-          // fullscreen). Claude ignores this alias.
+          // Compatibility alias for ChatGPT's dedicated widget origin.
           'openai/widgetDomain': appOrigin,
           ui: {
-            prefersBorder: true,
+            // The card draws its own boundary so hosts should not wrap it in a
+            // second border.
+            prefersBorder: false,
             domain: claudeWidgetDomain,
-            // Permit the widget to frame the preview target: the sandbox
-            // subdomain (embed token) for single-file artifacts, and the app
-            // origin (share page) for the multi-file fallback.
+            // The card loads only the standard MCP Apps client. It never frames
+            // or fetches artifact content, so frameDomains is intentionally absent.
             csp: {
-              frameDomains: [appOrigin, `https://*.${SANDBOX_HOST}`],
-              // Lets the widget load the MCP Apps standard client (used by
-              // Cursor / Claude). ChatGPT uses window.openai and never fetches
-              // it. Ignored by hosts that hardcode their widget CSP.
               resourceDomains: ['https://esm.sh'],
-              // The client's source map is fetched over connect-src; allow it
-              // so it doesn't error in the console (the module itself loads via
-              // resourceDomains).
               connectDomains: ['https://esm.sh'],
             },
           },

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -53,7 +53,7 @@ vi.mock('cloudflare:workers', () => ({
 
 vi.mock('~/services/storage.server', () => storageMock)
 
-import { defaultVisibilityFor } from '~/lib/shareable-types'
+import { defaultVisibilityFor, type ArtifactKind } from '~/lib/shareable-types'
 import { isOrgWorkspace } from '~/lib/user'
 import {
   createVersion,
@@ -2004,6 +2004,39 @@ describe('headless publish wiring', () => {
     )
     expect(result.structuredContent?.artifact_kind).toBe('static_site')
     expect(result.structuredContent).not.toHaveProperty('preview_url')
+  })
+
+  test('preview_artifact preserves an unknown artifact kind for card fallback', async () => {
+    const user = await loadMcpUser(db, 'owner-1')
+    if (!user) throw new Error('seed failed')
+    const published = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile('# x', 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    expect(published.kind).toBe('ok')
+    if (published.kind !== 'ok') return
+    await db
+      .updateTable('shareables')
+      .set({ artifact_kind: 'legacy_kind' as ArtifactKind })
+      .where('id', '=', published.id)
+      .execute()
+    await db
+      .updateTable('versions')
+      .set({ artifact_kind: 'legacy_kind' as ArtifactKind })
+      .where('shareable_id', '=', published.id)
+      .execute()
+
+    const body = await callTool(db, 'preview_artifact', { id: published.id })
+    const result = body.result as {
+      isError?: boolean
+      structuredContent?: { artifact_kind?: string }
+    }
+    expect(result.isError).toBeFalsy()
+    expect(result.structuredContent?.artifact_kind).toBe('legacy_kind')
   })
 
   test('preview_artifact returns not-found for an id you cannot view', async () => {

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -28,7 +28,6 @@ vi.mock('cloudflare:workers', () => ({
     BUCKET: {},
     // Non-production + no FLAGS binding → checkUploadPermission allows uploads.
     APP_ENV: 'development',
-    // Used to sign the preview_artifact embed sandbox token.
     BETTER_AUTH_SECRET: 'test-secret',
     DB: {
       prepare: (sql: string) => ({
@@ -1930,7 +1929,7 @@ describe('headless publish wiring', () => {
     expect(errorPayload(body).code).toBe('not-found')
   })
 
-  test('preview_artifact returns the share url and locale for a viewable artifact', async () => {
+  test('preview_artifact returns portable card metadata for a viewable artifact', async () => {
     const user = await loadMcpUser(db, 'owner-1')
     if (!user) throw new Error('seed failed')
     const published = await uploadShareable(
@@ -1952,8 +1951,8 @@ describe('headless publish wiring', () => {
       structuredContent?: {
         id?: string
         share_url?: string
-        preview_url?: string
         title?: string | null
+        artifact_kind?: string
         locale?: string
       }
     }
@@ -1962,19 +1961,15 @@ describe('headless publish wiring', () => {
     expect(result.structuredContent?.share_url).toBe(
       `https://artifactshare.com/a/${published.id}`,
     )
-    // A single-file artifact gets a cookie-free sandbox embed URL with a token.
-    const previewUrl = result.structuredContent?.preview_url ?? ''
-    expect(previewUrl).toContain(`${published.id}--v-`)
-    expect(previewUrl).toContain('.sandbox.')
-    expect(previewUrl).toContain('t=')
+    expect(result.structuredContent?.artifact_kind).toBe('markdown_page')
+    expect(result.structuredContent).not.toHaveProperty('preview_url')
     expect(typeof result.structuredContent?.locale).toBe('string')
-    // The reusable embed token must not leak into the model-facing text channel.
     const text = result.content?.[0]?.text ?? ''
     expect(text).not.toContain('.sandbox.')
     expect(text).not.toContain('t=')
   })
 
-  test('preview_artifact previews a multi-file bundle that get_artifact refuses', async () => {
+  test('preview_artifact returns card metadata for a multi-file bundle', async () => {
     const user = await loadMcpUser(db, 'owner-1')
     if (!user) throw new Error('seed failed')
     const published = await uploadShareable(
@@ -2001,17 +1996,14 @@ describe('headless publish wiring', () => {
     const body = await callTool(db, 'preview_artifact', { id: published.id })
     const result = body.result as {
       isError?: boolean
-      structuredContent?: { share_url?: string; preview_url?: string }
+      structuredContent?: { share_url?: string; artifact_kind?: string }
     }
     expect(result.isError).toBeFalsy()
     expect(result.structuredContent?.share_url).toBe(
       `https://artifactshare.com/a/${published.id}`,
     )
-    // A multi-file bundle has no single-file embed, so the preview falls back
-    // to the share page.
-    expect(result.structuredContent?.preview_url).toBe(
-      `https://artifactshare.com/a/${published.id}`,
-    )
+    expect(result.structuredContent?.artifact_kind).toBe('static_site')
+    expect(result.structuredContent).not.toHaveProperty('preview_url')
   })
 
   test('preview_artifact returns not-found for an id you cannot view', async () => {

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -1,14 +1,8 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { env } from 'cloudflare:workers'
-import { nanoid } from 'nanoid'
 import { z } from 'zod'
 import { CONNECT_AI_AGENTS_ANCHOR } from '~/lib/connect-link'
-import {
-  APEX_HOST,
-  artifactSandboxUrl,
-  SANDBOX_EMBED_TTL_SECONDS,
-} from '~/lib/hosts'
-import { signSandboxToken } from '~/lib/sandbox-token'
+import { APEX_HOST } from '~/lib/hosts'
 import {
   logUploadPermissionFailure,
   type UploadPermissionResult,
@@ -23,7 +17,6 @@ import {
   type Visibility,
 } from '~/lib/shareable-types'
 import { isOrgWorkspace } from '~/lib/user'
-import { renderTypeFromKind } from '~/lib/artifact-type'
 import { t, type Locale } from '~/lib/i18n'
 import { DEFAULT_LOCALE, isSupportedLocale } from '~/i18n/messages'
 import { shortVisibilityLabelKey } from '~/lib/visibility-labels'
@@ -241,11 +234,14 @@ const GET_ARTIFACT_OUTPUT_SCHEMA = {
 const PREVIEW_OUTPUT_SCHEMA = {
   id: z.string(),
   share_url: z.string(),
-  // The URL the preview widget frames. For single-file artifacts it is a
-  // cookie-free embed of the sandboxed content (so it renders inside the host
-  // without a sign-in); for multi-file sites it falls back to the share page.
-  preview_url: z.string(),
   title: z.string().nullable(),
+  artifact_kind: z.enum([
+    'markdown_page',
+    'html_page',
+    'static_site',
+    'spa',
+    'workspace_app',
+  ]),
   // The viewer's locale, so the preview widget can localize its own chrome.
   locale: z.string(),
 }
@@ -998,7 +994,7 @@ export function registerArtifactTools(
     {
       title: 'Preview artifact',
       description: toolDescription(
-        'Show a visual preview of an artifact you can view — your own, or one shared with you in your workspace — rendered inside the chat with a fullscreen option. Use it when the user wants to look at a shared artifact without leaving the conversation. If you do not know the id, call list_artifacts first.',
+        'Show a compact card for an artifact you can view — your own, or one shared with you in your workspace — with an action to open the full artifact in Artifact Share. Use it when the user wants to inspect or open a shared artifact. If you do not know the id, call list_artifacts first.',
       ),
       outputSchema: PREVIEW_OUTPUT_SCHEMA,
       annotations: READ_ONLY_ANNOTATIONS,
@@ -1024,16 +1020,16 @@ export function registerArtifactTools(
       const user = await getUser()
       if (!user) return unresolvedUserError()
 
-      // Viewer-scoped (same check as get_artifact / commenting): you can preview
+      // Viewer-scoped (same check as get_artifact / commenting): you can open
       // anything you can view, not just what you own. A non-viewable (or absent)
-      // id refuses without leaking which it was. Unlike get_artifact, the preview
-      // frames the rendered share page, so multi-file bundles are fine too.
+      // id refuses without leaking which it was. The card carries metadata only,
+      // so every artifact kind follows the same path.
       const sessionUser = mcpUserAsSessionUser(user)
       const access = await loadCommentAccess(ctx.db, sessionUser, args.id)
       if (!access) return artifactNotViewableError()
 
-      // The title is a nicety for the chat; read it best-effort for your own
-      // artifacts (the widget itself shows the title from the framed page).
+      // The title is a nicety for the card; read it best-effort for your own
+      // artifacts. Shared artifacts use the localized kind label instead.
       let title: string | null = null
       if (access.ownerUserId === user.id) {
         try {
@@ -1047,52 +1043,10 @@ export function registerArtifactTools(
         }
       }
 
-      // What the widget frames. Single-file artifacts (html / md) get a
-      // cookie-free embed token so the sandboxed content renders inside the host
-      // without a sign-in; multi-file sites fall back to the share page (their
-      // embed needs the bundle cookie path, handled separately).
       const shareLink = shareUrl(ctx.baseUrl, args.id)
-      const renderType = renderTypeFromKind(access.artifactKind as ArtifactKind)
-      let previewUrl = shareLink
-      if (
-        (renderType === 'html' || renderType === 'md') &&
-        access.currentVersionId &&
-        access.r2Key
-      ) {
-        const token = await signSandboxToken(
-          {
-            uid: user.id,
-            // The artifact's workspace, not the caller's: an artifact shared
-            // across workspaces (external grant) lives in its owner's, and the
-            // sandbox checks the token's wid against the artifact's row.
-            wid: access.workspaceId,
-            aid: args.id,
-            vid: access.currentVersionId,
-            fid: access.r2Key,
-            mt: null,
-            t: renderType,
-            jti: nanoid(),
-            emb: true,
-          },
-          env.BETTER_AUTH_SECRET,
-          SANDBOX_EMBED_TTL_SECONDS,
-        )
-        previewUrl = artifactSandboxUrl(
-          env,
-          args.id,
-          access.currentVersionId,
-          token,
-          access.entrypointPath ?? undefined,
-        )
-      }
-
       const locale = isSupportedLocale(user.locale)
         ? user.locale
         : DEFAULT_LOCALE
-      // Keep the reusable embed token out of the model-facing text channel (it
-      // would be echoed into the transcript): preview_url lives only in
-      // structuredContent, which the widget reads. The text carries the
-      // tokenless share link.
       return {
         content: textContent({
           id: args.id,
@@ -1103,8 +1057,8 @@ export function registerArtifactTools(
         structuredContent: {
           id: args.id,
           share_url: shareLink,
-          preview_url: previewUrl,
           title,
+          artifact_kind: access.artifactKind as ArtifactKind,
           locale,
         },
       }

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -1,5 +1,4 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { env } from 'cloudflare:workers'
 import { z } from 'zod'
 import { CONNECT_AI_AGENTS_ANCHOR } from '~/lib/connect-link'
 import { APEX_HOST } from '~/lib/hosts'
@@ -11,7 +10,6 @@ import { checkUploadAccess } from '~/services/upload-access.server'
 import {
   defaultVisibilityFor,
   isVisibility,
-  type ArtifactKind,
   type ContainerKind,
   type ProjectBaseVisibility,
   type Visibility,
@@ -235,13 +233,9 @@ const PREVIEW_OUTPUT_SCHEMA = {
   id: z.string(),
   share_url: z.string(),
   title: z.string().nullable(),
-  artifact_kind: z.enum([
-    'markdown_page',
-    'html_page',
-    'static_site',
-    'spa',
-    'workspace_app',
-  ]),
+  // Keep legacy or future kinds renderable; the card falls back to the generic
+  // "Artifact" label when it does not recognize this value.
+  artifact_kind: z.string(),
   // The viewer's locale, so the preview widget can localize its own chrome.
   locale: z.string(),
 }
@@ -1058,7 +1052,7 @@ export function registerArtifactTools(
           id: args.id,
           share_url: shareLink,
           title,
-          artifact_kind: access.artifactKind as ArtifactKind,
+          artifact_kind: access.artifactKind,
           locale,
         },
       }


### PR DESCRIPTION
## Summary

- replace the nested-iframe MCP artifact preview with a compact native card
- open the full artifact through the standard MCP Apps external-link bridge, with the ChatGPT compatibility bridge and HTTPS anchor as fallbacks
- remove signed sandbox preview URLs and `frameDomains` from the tool result and UI resource CSP

## Visible effect

ChatGPT, Claude, Cursor, and other MCP Apps hosts now show the same localized Artifact Share card with the artifact title, artifact type, and an action that opens the full viewer. The card supports light and dark color schemes and no longer requests fullscreen or embeds the Artifact Share viewer.

## Validation

- `pnpm validate:static`
- focused MCP and agent-surface tests: 144 passed
- visual Compose suite: 98 passed
- React Doctor: 100
- public repository scan: 0 findings
- Codex implementation review: no findings
- Claude implementation review: no findings
