### PR TITLE
chore: LP の公開サンプルリンクを scan allowlist に追加

### DIFF
--- a/config/public-repository-scan.json
+++ b/config/public-repository-scan.json
@@ -200,6 +200,12 @@
       "path": "^pnpm-lock\\.yaml$",
       "pattern": "i@izs\\.me",
       "reason": "upstream package deprecation metadata"
+    },
+    {
+      "category": "private-reference",
+      "path": "^apps/web/app/routes/_home/\\+components/landing(?:-page)?\\.(?:test\\.)?tsx$",
+      "pattern": "artifactshare\\.com/a/(?:3kfkaseiki|eio7kdav1k|z0pxvsducu|owcpuixuqq|k2md9883g0|cro460ml2k|k1llhb081t|95f5bg4q29|9x2k)\\b",
+      "reason": "link-shared public sample pages linked from the landing page, plus the fictional 9x2k… URL in its mock chats"
     }
   ]
 }


### PR DESCRIPTION
## 現状

トップページ LP のリニューアル(別 PR で進行中)は、ユースケースカードから 8 本のリンク共有サンプルページ(JA/EN 各 4)へリンクし、モックのチャット内に架空の `artifactshare.com/a/9x2k…` 表記を使う。public-repository-scan の private-reference パターンは `artifactshare.com/a/*` を既定で拒否し、PR ガードはこの設定を trusted main から読むため、リニューアル側ブランチ内に置いた allowlist は効かず pull-request-guard が落ちる。

## 変更

`config/public-repository-scan.json` の allowlist に、landing ファイル群(`landing-page.tsx` / `landing.test.tsx`)限定で、公開参照用に意図してリンク共有(無期限)にした 8 サンプルの id と架空 URL の `9x2k` のみを許可するエントリを追加する。パターンは id を列挙した完全一致で、任意の artifact URL は引き続き拒否される。

## 検証

- `pnpm public:scan .` → 0 findings
- PR 境界ガード(`public-development-guard.mjs --ci-pr`)を clean origin/main の trusted worktree から実行し green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
