### PR TITLE
デザインハーネスの正本をランディング刷新へ同期する

### DIFF
--- a/docs/reference/design-system.md
+++ b/docs/reference/design-system.md
@@ -149,7 +149,8 @@ shadcn/ui の new-york style を**ベースに採用**しつつ、color/spacing/
 
 | 表示面 | 所有範囲と方針 |
 |---|---|
-| 製品 UI | `app.css` が Geist Variable、日本語 system fallback、locale 固有の文字組みを所有する。追加の日本語 Web フォントは配信しない |
+| 製品 UI | `app.css` が Geist Variable、日本語 system fallback、locale 固有の文字組みを所有する。追加の日本語 Web フォントは配信しない (例外は下記のランディング見出しのみ) |
+| ランディング見出し | LP の hero / section 見出しだけ Zen Old Mincho 700 (`@fontsource`、自己ホスト) を使う。本文は製品 UI の stack を継承し、この serif を製品 UI 部品へ持ち込まない。製品ページは mount 後に stylesheet を動的 import し、dev-scenario fixture は撮影の `document.fonts.ready` 待ちが効くよう静的 import する |
 | ユーザー文書 | Markdown renderer またはアップロードされた文書自身が font stack と文字組みを所有し、製品 UI の指定を文書内へ注入しない |
 | PDF 書き出し | 書き出し処理が再現可能な日本語 font の埋め込みを所有する |
 | OG 画像 | preview image generator が利用可能な埋め込み font を所有する。製品 UI の OS fallback には依存しない |
@@ -157,7 +158,7 @@ shadcn/ui の new-york style を**ベースに採用**しつつ、color/spacing/
 
 ### 4.2 Type scale
 
-正本は Tailwind 既定スケール。自前のサイズトークンは持たない。
+正本は Tailwind 既定スケール。自前のサイズトークンは持たない。例外はランディングで、display 表現の clamp を伴う `--lp-text-*` スケールを `landing.css` に持つ (製品 UI からは参照しない)。
 
 | Utility | 用途 |
 |---|---|

--- a/docs/reference/design-system.md
+++ b/docs/reference/design-system.md
@@ -150,7 +150,7 @@ shadcn/ui の new-york style を**ベースに採用**しつつ、color/spacing/
 | 表示面 | 所有範囲と方針 |
 |---|---|
 | 製品 UI | `app.css` が Geist Variable、日本語 system fallback、locale 固有の文字組みを所有する。追加の日本語 Web フォントは配信しない (例外は下記のランディング見出しのみ) |
-| ランディング見出し | LP の hero / section 見出しだけ Zen Old Mincho 700 (`@fontsource`、自己ホスト) を使う。本文は製品 UI の stack を継承し、この serif を製品 UI 部品へ持ち込まない。製品ページは mount 後に stylesheet を動的 import し、dev-scenario fixture は撮影の `document.fonts.ready` 待ちが効くよう静的 import する |
+| ランディングの display 表現 | LP の hero / section 見出し、ステップ番号、証言の引用だけ Zen Old Mincho 700 (`@fontsource`、自己ホスト) を使う。本文は製品 UI の stack を継承し、この serif を製品 UI 部品へ持ち込まない。製品ページは mount 後に stylesheet を動的 import し、dev-scenario fixture は撮影の `document.fonts.ready` 待ちが効くよう静的 import する |
 | ユーザー文書 | Markdown renderer またはアップロードされた文書自身が font stack と文字組みを所有し、製品 UI の指定を文書内へ注入しない |
 | PDF 書き出し | 書き出し処理が再現可能な日本語 font の埋め込みを所有する |
 | OG 画像 | preview image generator が利用可能な埋め込み font を所有する。製品 UI の OS fallback には依存しない |
@@ -158,7 +158,7 @@ shadcn/ui の new-york style を**ベースに採用**しつつ、color/spacing/
 
 ### 4.2 Type scale
 
-正本は Tailwind 既定スケール。自前のサイズトークンは持たない。例外はランディングで、display 表現の clamp を伴う `--lp-text-*` スケールを `landing.css` に持つ (製品 UI からは参照しない)。
+正本は Tailwind 既定スケール。自前のサイズトークンは持たない。例外はランディングで、LP 全体の文字サイズを display の clamp から本文・キャプション・極小メタまで `--lp-text-*` スケールとして `landing.css` に持つ (製品 UI からは参照しない)。
 
 | Utility | 用途 |
 |---|---|
@@ -169,8 +169,8 @@ shadcn/ui の new-york style を**ベースに採用**しつつ、color/spacing/
 | `text-xl` | page title / empty state |
 | `text-2xl` | larger heading |
 | `text-3xl` | hero h1 |
-| `text-4xl` | landing h1 |
-| `text-5xl` | landing display |
+| `text-4xl` | pricing / guide h1 |
+| `text-5xl` | サインイン表示のブランド名 |
 
 10px 以下の極小表示 (バッジ等) は Tailwind に対応ステップが無いため、生 CSS の `font-size` で例外的に残す。
 

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -17,7 +17,29 @@ export const screens = [
     metric: '製品理解を高め、利用開始につなげる',
     role: 'サービスの価値と入口を伝える',
     primaryAction: 'サービスを始める',
-    states: [defaultState('通常のランディング')],
+    states: [
+      defaultState('通常のマーケティング LP (MCP タブ・リビール完了後)'),
+      {
+        id: 'cli-tab',
+        description: 'ヒーローの接続手段を CLI タブへ切り替えた状態',
+        setup: {
+          interactions: [
+            { action: 'click', selector: '[role="tab"]:has-text("CLI")' },
+          ],
+        },
+      },
+      {
+        id: 'focused-sign-in',
+        description:
+          '行き先つきリダイレクト (?next=) が出す集中サインイン表示',
+        setup: { query: '?next=/home' },
+      },
+      {
+        id: 'invite',
+        description: '招待リンク (?next=/a/…) が出す招待向けサインイン表示',
+        setup: { query: '?next=/a/example' },
+      },
+    ],
   },
   {
     id: 'about',

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -31,7 +31,7 @@ export const screens = [
       {
         id: 'focused-sign-in',
         description: '行き先つきリダイレクト (?next=) が出す集中サインイン表示',
-        setup: { query: '?next=/home' },
+        setup: { query: '?next=/projects/example' },
       },
       {
         id: 'invite',

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -30,8 +30,7 @@ export const screens = [
       },
       {
         id: 'focused-sign-in',
-        description:
-          '行き先つきリダイレクト (?next=) が出す集中サインイン表示',
+        description: '行き先つきリダイレクト (?next=) が出す集中サインイン表示',
         setup: { query: '?next=/home' },
       },
       {


### PR DESCRIPTION
## 現状

ランディング刷新でヒーローの明朝見出し (自己ホストの Zen Old Mincho 700) と LP 専用の `--lp-text-*` サイズスケール、複数の新しい利用者可視状態が入ったが、デザインハーネスの正本が旧ページのままだった。`docs/reference/design-system.md` §4.1 は「追加の日本語 Web フォントは配信しない」と現行実装を否定し、§4.2 の型スケール表は存在しない `landing h1` / `landing display` を載せ、画面台帳の landing エントリは `default` 1 状態のみで、状態マトリクス撮影とエージェント批評が新 LP の主要状態を検証できない。

## 変更

- `docs/reference/design-system.md` §4.1 の表示面テーブルへ「ランディングの display 表現」行を追加し、serif の適用範囲 (hero / section 見出し・ステップ番号・証言の引用) と、製品ページの動的 import / dev-scenario fixture の静的 import の違いを明記。製品 UI 行に例外参照を追記。
- §4.2 に LP 専用 `--lp-text-*` スケールの例外を明記し、`text-4xl` / `text-5xl` の用途行を現在の実消費者 (pricing / guide h1、サインイン表示のブランド名) へ更新。
- `scripts/screen-ledger.mjs` の landing states を 4 状態へ拡充: `default` (リビール完了後の説明へ更新)、`cli-tab` (CLI タブ切替)、`focused-sign-in` (`?next=/projects/example`)、`invite` (`?next=/a/example`)。

## 検証

- `pnpm screens:capture -- --screen landing`: 32/32 成功。cli-tab がヒーローの CLI プロンプト表示、focused-sign-in / invite がそれぞれのサインイン表示を撮影することを画像で確認。
- `pnpm validate:static` 全通過 (check:screen-ledger 40 screens / 139 routes、check:design-tokens、check:copy-glossary 含む)。
- `node --test scripts/check-screen-ledger.test.mjs`: 25/25 pass。
- 信頼済み `origin/main` からの boundary guard 再現: exit 0。`pnpm public:scan .`: 0 findings。
- Codex / Claude の implementation deep review を並列 2 巡実施。第 1 巡の指摘 (serif 適用範囲・スケール記述の過小・旧用途行・非実在 `next` パス) を反映し、最終コミットで両者 blocker ゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
