### PR TITLE
Update Stripe SDK to 22.5.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -70,7 +70,7 @@
     "satori": "0.28.0",
     "slack-cloudflare-workers": "1.3.10",
     "sonner": "2.0.8",
-    "stripe": "22.3.1",
+    "stripe": "22.5.0",
     "tailwind-merge": "3.6.0",
     "turndown": "^7.2.4",
     "tw-animate-css": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,8 +125,8 @@ importers:
         specifier: 2.0.8
         version: 2.0.8(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       stripe:
-        specifier: 22.3.1
-        version: 22.3.1(@types/node@24.13.3)
+        specifier: 22.5.0
+        version: 22.5.0(@types/node@24.13.3)
       tailwind-merge:
         specifier: 3.6.0
         version: 3.6.0
@@ -6105,8 +6105,8 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
-  stripe@22.3.1:
-    resolution: {integrity: sha512-6XSLN0KK0IdfXqDHqMg6CDoO3eO62ye9dhzw0fZp55AUOzHR1YRJOqYHTsuCi4QJ4Ni/usEmXtq69c9ghKDmYw==}
+  stripe@22.5.0:
+    resolution: {integrity: sha512-QVwMwriC0bbySx6R4dpsvJ0W//GojC1kwWVS6rPSoVqDUIZX4Hy3TaUrd2AZeXEAaKbfWIjQjvo3vKAReHZ0vQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -12142,7 +12142,7 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
-  stripe@22.3.1(@types/node@24.13.3):
+  stripe@22.5.0(@types/node@24.13.3):
     optionalDependencies:
       '@types/node': 24.13.3
 


### PR DESCRIPTION
## Summary

- update the Stripe Node SDK from 22.3.1 to 22.5.0
- move the SDK's default Stripe API version from `2026-06-24.dahlia` to `2026-07-29.dahlia`
- keep the existing billing integration unchanged because the affected Checkout, Billing Portal, subscription, and webhook APIs remain compatible

## Validation

- `pnpm install --frozen-lockfile`
- targeted billing and webhook tests: 4 files, 79 tests passed
- `node --test scripts/billing-regression.test.mjs`: 8 tests passed using local mocks; no external Stripe resources were created
- `pnpm check:dev-setup` with an isolated local D1 state: all recovery phases passed
- `pnpm validate:build`: application and CLI builds, dry runs, 30 integration tests, and runtime smoke passed
- `pnpm validate:static`: 3,039 tests passed, React Doctor score 100, public scan 0 findings
- Codex implementation review: no findings
- Claude implementation review: no findings
- trusted-main public development guard passed
