### PR TITLE
Update React Doctor to 0.9.12

### DIFF
--- a/apps/web/app/components/app/project-candidate-picker.test.tsx
+++ b/apps/web/app/components/app/project-candidate-picker.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { ProjectCandidatePicker } from './project-candidate-picker'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+vi.mock('~/hooks/use-t', () => ({
+  useT: () => ({
+    locale: 'en',
+    t: (key: string, values?: { count?: number }) =>
+      values?.count === undefined ? key : `${key}:${values.count}`,
+  }),
+}))
+
+describe('ProjectCandidatePicker', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    React.act(() => root.unmount())
+    container.remove()
+  })
+
+  test('loads candidates through the route loader and appends the next page', async () => {
+    const requests: string[] = []
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          element: (
+            <ProjectCandidatePicker
+              id="project"
+              purpose="bot-destination"
+              value={null}
+              onChange={vi.fn()}
+            />
+          ),
+        },
+        {
+          path: '/api/project-candidates',
+          loader: ({ request }) => {
+            const url = new URL(request.url)
+            requests.push(url.search)
+            if (url.searchParams.has('cursor')) {
+              return {
+                projects: [
+                  {
+                    id: 'project-2',
+                    name: 'Second project',
+                    baseVisibility: 'private' as const,
+                    updatedAt: '2026-08-22T00:00:00.000Z',
+                  },
+                ],
+                nextCursor: null,
+              }
+            }
+            return {
+              projects: [
+                {
+                  id: 'project-1',
+                  name: 'First project',
+                  baseVisibility: 'workspace' as const,
+                  updatedAt: '2026-08-22T00:00:00.000Z',
+                },
+              ],
+              nextCursor: 'next-page',
+            }
+          },
+        },
+      ],
+      { initialEntries: ['/'] },
+    )
+
+    await React.act(async () => {
+      root.render(<RouterProvider router={router} />)
+    })
+    await React.act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    await React.act(async () => {
+      container.querySelector('input')?.focus()
+    })
+
+    expect(requests).toEqual(['?purpose=bot-destination&q='])
+    expect(container.textContent).toContain('First project')
+
+    const more = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'projectPicker.more',
+    )
+    expect(more).toBeDefined()
+    await React.act(async () => {
+      more?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(requests).toEqual([
+      '?purpose=bot-destination&q=',
+      '?purpose=bot-destination&q=&cursor=next-page',
+    ])
+    expect(container.textContent).toContain('First project')
+    expect(container.textContent).toContain('Second project')
+  })
+})

--- a/apps/web/app/components/app/project-candidate-picker.test.tsx
+++ b/apps/web/app/components/app/project-candidate-picker.test.tsx
@@ -26,6 +26,7 @@ describe('ProjectCandidatePicker', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     React.act(() => root.unmount())
     container.remove()
   })
@@ -107,5 +108,79 @@ describe('ProjectCandidatePicker', () => {
     ])
     expect(container.textContent).toContain('First project')
     expect(container.textContent).toContain('Second project')
+  })
+
+  test('ignores an old response while a changed query is debouncing', async () => {
+    vi.useFakeTimers()
+    const responses = new Map<string, (value: unknown) => void>()
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          element: (
+            <ProjectCandidatePicker
+              id="project"
+              purpose="bot-destination"
+              value={null}
+              onChange={vi.fn()}
+            />
+          ),
+        },
+        {
+          path: '/api/project-candidates',
+          loader: ({ request }) =>
+            new Promise((resolve) => {
+              responses.set(
+                new URL(request.url).searchParams.get('q') ?? '',
+                resolve,
+              )
+            }),
+        },
+      ],
+      { initialEntries: ['/'] },
+    )
+
+    await React.act(async () => {
+      root.render(<RouterProvider router={router} />)
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    const input = container.querySelector('input')
+    expect(input).not.toBeNull()
+    await React.act(async () => {
+      if (!input) return
+      input.focus()
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'new')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await React.act(async () => {
+      responses.get('')?.({
+        projects: [
+          {
+            id: 'stale-project',
+            name: 'Stale project',
+            baseVisibility: 'workspace',
+            updatedAt: '2026-08-22T00:00:00.000Z',
+          },
+        ],
+        nextCursor: null,
+      })
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).not.toContain('Stale project')
+    expect(container.textContent).toContain('projectPicker.loading')
+
+    await React.act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    expect(responses.has('new')).toBe(true)
+    await React.act(async () => {
+      responses.get('new')?.({ projects: [], nextCursor: null })
+      await Promise.resolve()
+    })
+    expect(container.textContent).toContain('projectPicker.empty')
   })
 })

--- a/apps/web/app/components/app/project-candidate-picker.test.tsx
+++ b/apps/web/app/components/app/project-candidate-picker.test.tsx
@@ -27,12 +27,44 @@ describe('ProjectCandidatePicker', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllGlobals()
     React.act(() => root.unmount())
     container.remove()
   })
 
-  test('loads candidates through the route loader and appends the next page', async () => {
+  test('loads candidates and appends the next page', async () => {
     const requests: string[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(String(input), 'https://artifactshare.test')
+        requests.push(url.search)
+        const page = url.searchParams.has('cursor')
+          ? {
+              projects: [
+                {
+                  id: 'project-2',
+                  name: 'Second project',
+                  baseVisibility: 'private' as const,
+                  updatedAt: '2026-08-22T00:00:00.000Z',
+                },
+              ],
+              nextCursor: null,
+            }
+          : {
+              projects: [
+                {
+                  id: 'project-1',
+                  name: 'First project',
+                  baseVisibility: 'workspace' as const,
+                  updatedAt: '2026-08-22T00:00:00.000Z',
+                },
+              ],
+              nextCursor: 'next-page',
+            }
+        return Response.json(page)
+      }),
+    )
     const router = createMemoryRouter(
       [
         {
@@ -45,37 +77,6 @@ describe('ProjectCandidatePicker', () => {
               onChange={vi.fn()}
             />
           ),
-        },
-        {
-          path: '/api/project-candidates',
-          loader: ({ request }) => {
-            const url = new URL(request.url)
-            requests.push(url.search)
-            if (url.searchParams.has('cursor')) {
-              return {
-                projects: [
-                  {
-                    id: 'project-2',
-                    name: 'Second project',
-                    baseVisibility: 'private' as const,
-                    updatedAt: '2026-08-22T00:00:00.000Z',
-                  },
-                ],
-                nextCursor: null,
-              }
-            }
-            return {
-              projects: [
-                {
-                  id: 'project-1',
-                  name: 'First project',
-                  baseVisibility: 'workspace' as const,
-                  updatedAt: '2026-08-22T00:00:00.000Z',
-                },
-              ],
-              nextCursor: 'next-page',
-            }
-          },
         },
       ],
       { initialEntries: ['/'] },
@@ -112,7 +113,17 @@ describe('ProjectCandidatePicker', () => {
 
   test('ignores an old response while a changed query is debouncing', async () => {
     vi.useFakeTimers()
-    const responses = new Map<string, (value: unknown) => void>()
+    const responses = new Map<string, (value: Response) => void>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (input: RequestInfo | URL) =>
+          new Promise<Response>((resolve) => {
+            const url = new URL(String(input), 'https://artifactshare.test')
+            responses.set(url.searchParams.get('q') ?? '', resolve)
+          }),
+      ),
+    )
     const router = createMemoryRouter(
       [
         {
@@ -125,16 +136,6 @@ describe('ProjectCandidatePicker', () => {
               onChange={vi.fn()}
             />
           ),
-        },
-        {
-          path: '/api/project-candidates',
-          loader: ({ request }) =>
-            new Promise((resolve) => {
-              responses.set(
-                new URL(request.url).searchParams.get('q') ?? '',
-                resolve,
-              )
-            }),
         },
       ],
       { initialEntries: ['/'] },
@@ -156,17 +157,19 @@ describe('ProjectCandidatePicker', () => {
       input.dispatchEvent(new Event('input', { bubbles: true }))
     })
     await React.act(async () => {
-      responses.get('')?.({
-        projects: [
-          {
-            id: 'stale-project',
-            name: 'Stale project',
-            baseVisibility: 'workspace',
-            updatedAt: '2026-08-22T00:00:00.000Z',
-          },
-        ],
-        nextCursor: null,
-      })
+      responses.get('')?.(
+        Response.json({
+          projects: [
+            {
+              id: 'stale-project',
+              name: 'Stale project',
+              baseVisibility: 'workspace',
+              updatedAt: '2026-08-22T00:00:00.000Z',
+            },
+          ],
+          nextCursor: null,
+        }),
+      )
       await Promise.resolve()
     })
 
@@ -178,9 +181,40 @@ describe('ProjectCandidatePicker', () => {
     })
     expect(responses.has('new')).toBe(true)
     await React.act(async () => {
-      responses.get('new')?.({ projects: [], nextCursor: null })
+      responses.get('new')?.(Response.json({ projects: [], nextCursor: null }))
       await Promise.resolve()
     })
     expect(container.textContent).toContain('projectPicker.empty')
+  })
+
+  test('keeps a transport failure in the picker error state', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('offline')))
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          element: (
+            <ProjectCandidatePicker
+              id="project"
+              purpose="bot-destination"
+              value={null}
+              onChange={vi.fn()}
+            />
+          ),
+        },
+      ],
+      { initialEntries: ['/'] },
+    )
+
+    await React.act(async () => {
+      root.render(<RouterProvider router={router} />)
+    })
+    await React.act(async () => {
+      container.querySelector('input')?.focus()
+      await vi.runAllTimersAsync()
+    })
+
+    expect(container.textContent).toContain('projectPicker.error')
   })
 })

--- a/apps/web/app/components/app/project-candidate-picker.tsx
+++ b/apps/web/app/components/app/project-candidate-picker.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
-import { useFetcher } from 'react-router'
 import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
 import { useT } from '~/hooks/use-t'
@@ -13,7 +12,6 @@ export type ProjectCandidateOption = {
 }
 
 type Page = { projects: ProjectCandidateOption[]; nextCursor: string | null }
-type CandidateResponse = Page | { error: { code?: string } }
 type SearchState = Page & {
   status: 'loading' | 'ready' | 'error'
   loadingMore: boolean
@@ -45,12 +43,7 @@ export function ProjectCandidatePicker({
 }) {
   const { t, locale } = useT()
   const listId = useId()
-  const fetcher = useFetcher<CandidateResponse>()
-  const loadCandidates = fetcher.load
-  const candidateData = fetcher.data
-  const fetcherState = fetcher.state
-  const requestModeRef = useRef<'initial' | 'more'>('initial')
-  const acceptResponseRef = useRef(false)
+  const generation = useRef(0)
   const [query, setQuery] = useState('')
   const [search, setSearch] = useState(initialSearchState)
   const [open, setOpen] = useState(false)
@@ -62,69 +55,72 @@ export function ProjectCandidatePicker({
     setSearch((state) => ({ ...state, loadMoreError: false }))
   }
 
+  // useFetcher forwards thrown loader/transport errors to the route
+  // ErrorBoundary, while this picker must keep them in its inline error state.
+  // react-doctor-disable-next-line no-fetch-in-effect
   useEffect(() => {
-    setSearch(initialSearchState)
-    requestModeRef.current = 'initial'
-    acceptResponseRef.current = false
+    const current = ++generation.current
+    const controller = new AbortController()
     const timer = window.setTimeout(
       () => {
-        acceptResponseRef.current = true
-        void loadCandidates(projectCandidateUrl({ purpose, userCode, query }))
+        void fetchPage({ purpose, userCode, query, signal: controller.signal })
+          .then((page) => {
+            if (generation.current !== current) return
+            setSearch({
+              ...page,
+              status: 'ready',
+              loadingMore: false,
+              loadMoreError: false,
+              active: page.projects.length ? 0 : -1,
+            })
+          })
+          .catch(() => {
+            if (controller.signal.aborted || generation.current !== current)
+              return
+            setSearch((state) => ({ ...state, status: 'error' }))
+          })
       },
       query ? 200 : 0,
     )
-    return () => window.clearTimeout(timer)
-  }, [loadCandidates, purpose, query, userCode])
-
-  useEffect(() => {
-    if (fetcherState !== 'idle' || !candidateData || !acceptResponseRef.current)
-      return
-    if (!('projects' in candidateData)) {
-      setSearch((state) =>
-        requestModeRef.current === 'initial'
-          ? { ...state, status: 'error' }
-          : { ...state, loadingMore: false, loadMoreError: true },
-      )
-      return
+    return () => {
+      window.clearTimeout(timer)
+      controller.abort()
     }
-    const page = candidateData
-    if (requestModeRef.current === 'initial') {
-      setSearch({
-        ...page,
-        status: 'ready',
-        loadingMore: false,
-        loadMoreError: false,
-        active: page.projects.length ? 0 : -1,
-      })
-      return
-    }
-    setSearch((state) => {
-      const ids = new Set(state.projects.map((project) => project.id))
-      return {
-        ...state,
-        projects: [
-          ...state.projects,
-          ...page.projects.filter((project) => !ids.has(project.id)),
-        ],
-        nextCursor: page.nextCursor,
-        loadingMore: false,
-        loadMoreError: false,
-      }
-    })
-  }, [candidateData, fetcherState])
+  }, [purpose, query, userCode])
 
   const loadMore = () => {
     if (!nextCursor || loadingMore) return
-    requestModeRef.current = 'more'
-    acceptResponseRef.current = true
+    const current = generation.current
     setSearch((state) => ({
       ...state,
       loadingMore: true,
       loadMoreError: false,
     }))
-    void loadCandidates(
-      projectCandidateUrl({ purpose, userCode, query, cursor: nextCursor }),
-    )
+    void fetchPage({ purpose, userCode, query, cursor: nextCursor })
+      .then((page) => {
+        if (generation.current !== current) return
+        setSearch((state) => {
+          const ids = new Set(state.projects.map((project) => project.id))
+          return {
+            ...state,
+            projects: [
+              ...state.projects,
+              ...page.projects.filter((project) => !ids.has(project.id)),
+            ],
+            nextCursor: page.nextCursor,
+          }
+        })
+      })
+      .catch(() => {
+        if (generation.current === current) {
+          setSearch((state) => ({ ...state, loadMoreError: true }))
+        }
+      })
+      .finally(() => {
+        if (generation.current === current) {
+          setSearch((state) => ({ ...state, loadingMore: false }))
+        }
+      })
   }
 
   const choose = (project: ProjectCandidateOption) => {
@@ -154,7 +150,7 @@ export function ProjectCandidatePicker({
         value={query}
         onFocus={() => setOpen(true)}
         onChange={(event) => {
-          acceptResponseRef.current = false
+          generation.current += 1
           setQuery(event.target.value)
           setSearch(initialSearchState)
           setOpen(true)
@@ -298,14 +294,20 @@ function ProjectLabel({
   )
 }
 
-function projectCandidateUrl(input: {
+async function fetchPage(input: {
   purpose: 'bot-destination' | 'agent-approval'
   userCode?: string
   query: string
   cursor?: string
-}): string {
+  signal?: AbortSignal
+}): Promise<Page> {
   const params = new URLSearchParams({ purpose: input.purpose, q: input.query })
   if (input.userCode) params.set('user_code', input.userCode)
   if (input.cursor) params.set('cursor', input.cursor)
-  return `/api/project-candidates?${params}`
+  const response = await fetch(`/api/project-candidates?${params}`, {
+    headers: { accept: 'application/json' },
+    signal: input.signal,
+  })
+  if (!response.ok) throw new Error(`project candidates: ${response.status}`)
+  return (await response.json()) as Page
 }

--- a/apps/web/app/components/app/project-candidate-picker.tsx
+++ b/apps/web/app/components/app/project-candidate-picker.tsx
@@ -50,6 +50,7 @@ export function ProjectCandidatePicker({
   const candidateData = fetcher.data
   const fetcherState = fetcher.state
   const requestModeRef = useRef<'initial' | 'more'>('initial')
+  const acceptResponseRef = useRef(false)
   const [query, setQuery] = useState('')
   const [search, setSearch] = useState(initialSearchState)
   const [open, setOpen] = useState(false)
@@ -64,8 +65,10 @@ export function ProjectCandidatePicker({
   useEffect(() => {
     setSearch(initialSearchState)
     requestModeRef.current = 'initial'
+    acceptResponseRef.current = false
     const timer = window.setTimeout(
       () => {
+        acceptResponseRef.current = true
         void loadCandidates(projectCandidateUrl({ purpose, userCode, query }))
       },
       query ? 200 : 0,
@@ -74,7 +77,8 @@ export function ProjectCandidatePicker({
   }, [loadCandidates, purpose, query, userCode])
 
   useEffect(() => {
-    if (fetcherState !== 'idle' || !candidateData) return
+    if (fetcherState !== 'idle' || !candidateData || !acceptResponseRef.current)
+      return
     if (!('projects' in candidateData)) {
       setSearch((state) =>
         requestModeRef.current === 'initial'
@@ -112,6 +116,7 @@ export function ProjectCandidatePicker({
   const loadMore = () => {
     if (!nextCursor || loadingMore) return
     requestModeRef.current = 'more'
+    acceptResponseRef.current = true
     setSearch((state) => ({
       ...state,
       loadingMore: true,
@@ -149,6 +154,7 @@ export function ProjectCandidatePicker({
         value={query}
         onFocus={() => setOpen(true)}
         onChange={(event) => {
+          acceptResponseRef.current = false
           setQuery(event.target.value)
           setSearch(initialSearchState)
           setOpen(true)

--- a/apps/web/app/components/app/project-candidate-picker.tsx
+++ b/apps/web/app/components/app/project-candidate-picker.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useFetcher } from 'react-router'
 import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
 import { useT } from '~/hooks/use-t'
@@ -12,6 +13,7 @@ export type ProjectCandidateOption = {
 }
 
 type Page = { projects: ProjectCandidateOption[]; nextCursor: string | null }
+type CandidateResponse = Page | { error: { code?: string } }
 type SearchState = Page & {
   status: 'loading' | 'ready' | 'error'
   loadingMore: boolean
@@ -43,7 +45,11 @@ export function ProjectCandidatePicker({
 }) {
   const { t, locale } = useT()
   const listId = useId()
-  const generation = useRef(0)
+  const fetcher = useFetcher<CandidateResponse>()
+  const loadCandidates = fetcher.load
+  const candidateData = fetcher.data
+  const fetcherState = fetcher.state
+  const requestModeRef = useRef<'initial' | 'more'>('initial')
   const [query, setQuery] = useState('')
   const [search, setSearch] = useState(initialSearchState)
   const [open, setOpen] = useState(false)
@@ -56,78 +62,64 @@ export function ProjectCandidatePicker({
   }
 
   useEffect(() => {
-    const current = ++generation.current
-    const controller = new AbortController()
+    setSearch(initialSearchState)
+    requestModeRef.current = 'initial'
     const timer = window.setTimeout(
       () => {
-        void fetchPage({
-          purpose,
-          userCode,
-          query,
-          signal: controller.signal,
-        })
-          .then((page) => {
-            if (generation.current !== current) return
-            setSearch({
-              ...page,
-              status: 'ready',
-              loadingMore: false,
-              loadMoreError: false,
-              active: page.projects.length ? 0 : -1,
-            })
-          })
-          .catch(() => {
-            if (controller.signal.aborted || generation.current !== current)
-              return
-            setSearch((state) => ({ ...state, status: 'error' }))
-          })
+        void loadCandidates(projectCandidateUrl({ purpose, userCode, query }))
       },
       query ? 200 : 0,
     )
-    return () => {
-      window.clearTimeout(timer)
-      controller.abort()
+    return () => window.clearTimeout(timer)
+  }, [loadCandidates, purpose, query, userCode])
+
+  useEffect(() => {
+    if (fetcherState !== 'idle' || !candidateData) return
+    if (!('projects' in candidateData)) {
+      setSearch((state) =>
+        requestModeRef.current === 'initial'
+          ? { ...state, status: 'error' }
+          : { ...state, loadingMore: false, loadMoreError: true },
+      )
+      return
     }
-  }, [purpose, query, userCode])
+    const page = candidateData
+    if (requestModeRef.current === 'initial') {
+      setSearch({
+        ...page,
+        status: 'ready',
+        loadingMore: false,
+        loadMoreError: false,
+        active: page.projects.length ? 0 : -1,
+      })
+      return
+    }
+    setSearch((state) => {
+      const ids = new Set(state.projects.map((project) => project.id))
+      return {
+        ...state,
+        projects: [
+          ...state.projects,
+          ...page.projects.filter((project) => !ids.has(project.id)),
+        ],
+        nextCursor: page.nextCursor,
+        loadingMore: false,
+        loadMoreError: false,
+      }
+    })
+  }, [candidateData, fetcherState])
 
   const loadMore = () => {
     if (!nextCursor || loadingMore) return
-    const current = generation.current
+    requestModeRef.current = 'more'
     setSearch((state) => ({
       ...state,
       loadingMore: true,
       loadMoreError: false,
     }))
-    void fetchPage({
-      purpose,
-      userCode,
-      query,
-      cursor: nextCursor,
-    })
-      .then((page) => {
-        if (generation.current !== current) return
-        setSearch((state) => {
-          const ids = new Set(state.projects.map((project) => project.id))
-          return {
-            ...state,
-            projects: [
-              ...state.projects,
-              ...page.projects.filter((project) => !ids.has(project.id)),
-            ],
-            nextCursor: page.nextCursor,
-          }
-        })
-      })
-      .catch(() => {
-        if (generation.current === current) {
-          setSearch((state) => ({ ...state, loadMoreError: true }))
-        }
-      })
-      .finally(() => {
-        if (generation.current === current) {
-          setSearch((state) => ({ ...state, loadingMore: false }))
-        }
-      })
+    void loadCandidates(
+      projectCandidateUrl({ purpose, userCode, query, cursor: nextCursor }),
+    )
   }
 
   const choose = (project: ProjectCandidateOption) => {
@@ -157,7 +149,6 @@ export function ProjectCandidatePicker({
         value={query}
         onFocus={() => setOpen(true)}
         onChange={(event) => {
-          generation.current += 1
           setQuery(event.target.value)
           setSearch(initialSearchState)
           setOpen(true)
@@ -301,20 +292,14 @@ function ProjectLabel({
   )
 }
 
-async function fetchPage(input: {
+function projectCandidateUrl(input: {
   purpose: 'bot-destination' | 'agent-approval'
   userCode?: string
   query: string
   cursor?: string
-  signal?: AbortSignal
-}): Promise<Page> {
+}): string {
   const params = new URLSearchParams({ purpose: input.purpose, q: input.query })
   if (input.userCode) params.set('user_code', input.userCode)
   if (input.cursor) params.set('cursor', input.cursor)
-  const response = await fetch(`/api/project-candidates?${params}`, {
-    headers: { accept: 'application/json' },
-    signal: input.signal,
-  })
-  if (!response.ok) throw new Error(`project candidates: ${response.status}`)
-  return (await response.json()) as Page
+  return `/api/project-candidates?${params}`
 }

--- a/apps/web/app/components/app/project-manage-dialogs.tsx
+++ b/apps/web/app/components/app/project-manage-dialogs.tsx
@@ -39,28 +39,30 @@ async function postProjectAction(
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action }),
     })
-    if (res.ok) return { ok: true }
-    const body = (await res.json().catch(() => null)) as {
-      error?: {
-        code?: string
-        message?: string
-        details?: {
-          holder_name?: string | null
-          upgrade_request?: UpgradeRequestView
+    if (!res.ok) {
+      const body = (await res.json().catch(() => null)) as {
+        error?: {
+          code?: string
+          message?: string
+          details?: {
+            holder_name?: string | null
+            upgrade_request?: UpgradeRequestView
+          }
         }
+      } | null
+      const code = body?.error?.code
+      const limitMatch = body?.error?.message?.match(/\((\d+) projects?\)/)
+      const holderName = body?.error?.details?.holder_name
+      return {
+        ok: false,
+        status: res.status,
+        code,
+        limit: limitMatch ? Number(limitMatch[1]) : undefined,
+        holderName: typeof holderName === 'string' ? holderName : undefined,
+        upgradeRequest: body?.error?.details?.upgrade_request,
       }
-    } | null
-    const code = body?.error?.code
-    const limitMatch = body?.error?.message?.match(/\((\d+) projects?\)/)
-    const holderName = body?.error?.details?.holder_name
-    return {
-      ok: false,
-      status: res.status,
-      code,
-      limit: limitMatch ? Number(limitMatch[1]) : undefined,
-      holderName: typeof holderName === 'string' ? holderName : undefined,
-      upgradeRequest: body?.error?.details?.upgrade_request,
     }
+    return { ok: true }
   } catch {
     return { ok: false, status: 0 }
   }

--- a/apps/web/app/components/ui/progress.tsx
+++ b/apps/web/app/components/ui/progress.tsx
@@ -21,7 +21,7 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary size-full flex-1 transition-all"
+        className="bg-primary size-full flex-1 transition-transform"
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/apps/web/app/hooks/use-latest-ref.ts
+++ b/apps/web/app/hooks/use-latest-ref.ts
@@ -1,0 +1,13 @@
+import { useEffect, useLayoutEffect, useRef } from 'react'
+
+const useIsomorphicLayoutEffect =
+  typeof document === 'undefined' ? useEffect : useLayoutEffect
+
+/** Keep the latest committed value available to asynchronous callbacks. */
+export function useLatestRef<T>(value: T) {
+  const ref = useRef(value)
+  useIsomorphicLayoutEffect(() => {
+    ref.current = value
+  }, [value])
+  return ref
+}

--- a/apps/web/app/routes/_home/+components/file-row.tsx
+++ b/apps/web/app/routes/_home/+components/file-row.tsx
@@ -504,17 +504,7 @@ const FileRowSurface = memo(function FileRowSurface({
               <span className={projectClassName} title={projectSublineTitle}>
                 {inlineOwner ? (
                   <>
-                    <AuthorAvatar
-                      id={data.ownerId}
-                      image={data.ownerImage}
-                      initial={data.ownerInitial}
-                      size="xs"
-                    />
-                    <span className="truncate">{owner}</span>
-                    {data.ownerIsBot ? <BotBadge /> : null}
-                    {data.ownerIsExternal ? (
-                      <ExtTag label={t('author.external')} />
-                    ) : null}
+                    <FileOwner data={data} owner={owner} />
                   </>
                 ) : null}
                 {motionSubline ? (
@@ -625,17 +615,11 @@ const FileRowSurface = memo(function FileRowSurface({
               ) : null}
               {!inlineOwner && !hideMobileOwner ? (
                 <span className={cn(mobileOwnerClassName, 'col-span-2')}>
-                  <AuthorAvatar
-                    id={data.ownerId}
-                    image={data.ownerImage}
-                    initial={data.ownerInitial}
-                    size="xs"
+                  <FileOwner
+                    data={data}
+                    owner={owner}
+                    ownerNameClassName="min-w-0 truncate"
                   />
-                  <span className="min-w-0 truncate">{owner}</span>
-                  {data.ownerIsBot ? <BotBadge /> : null}
-                  {data.ownerIsExternal ? (
-                    <ExtTag label={t('author.external')} />
-                  ) : null}
                 </span>
               ) : null}
               {!inlineOwner &&
@@ -700,22 +684,41 @@ const FileRowSurface = memo(function FileRowSurface({
           className={cn(authorClassName, compactOnly)}
           data-regression-responsive="desktop-only"
         >
-          <AuthorAvatar
-            id={data.ownerId}
-            image={data.ownerImage}
-            initial={data.ownerInitial}
-            size="xs"
+          <FileOwner
+            data={data}
+            owner={owner}
+            ownerNameClassName="min-w-0 truncate"
           />
-          <span className="min-w-0 truncate">{owner}</span>
-          {data.ownerIsBot ? <BotBadge /> : null}
-          {data.ownerIsExternal ? (
-            <ExtTag label={t('author.external')} />
-          ) : null}
         </span>
       ) : null}
     </>
   )
 })
+
+function FileOwner({
+  data,
+  owner,
+  ownerNameClassName = 'truncate',
+}: {
+  data: FileRowData
+  owner: string
+  ownerNameClassName?: string
+}) {
+  const { t } = useT()
+  return (
+    <>
+      <AuthorAvatar
+        id={data.ownerId}
+        image={data.ownerImage}
+        initial={data.ownerInitial}
+        size="xs"
+      />
+      <span className={ownerNameClassName}>{owner}</span>
+      {data.ownerIsBot ? <BotBadge /> : null}
+      {data.ownerIsExternal ? <ExtTag label={t('author.external')} /> : null}
+    </>
+  )
+}
 
 function DateRailCell({
   presentation,

--- a/apps/web/app/routes/_home/+components/landing-page.tsx
+++ b/apps/web/app/routes/_home/+components/landing-page.tsx
@@ -114,24 +114,27 @@ function CopyButton({ value }: { value: string }) {
     if (timerRef.current) clearTimeout(timerRef.current)
     timerRef.current = setTimeout(() => setState('idle'), 1500)
   }
+  const copy = async () => {
+    const write = navigator.clipboard?.writeText(value)
+    if (!write) {
+      settle('failed')
+      return
+    }
+    try {
+      await write
+      settle('copied')
+    } catch {
+      settle('failed')
+    }
+  }
   return (
     <>
       <button
         type="button"
         className="border-border bg-card text-faint hover:border-border-strong hover:text-foreground inline-flex flex-none cursor-pointer items-center gap-1.5 rounded-sm border px-2.5 py-1 font-sans text-xs font-semibold transition-[color,border-color,transform] duration-150 active:scale-96"
-        onClick={() => {
-          // Confirm only after the write resolves; an unavailable or
-          // rejecting clipboard reports failure instead of staying silent.
-          const write = navigator.clipboard?.writeText(value)
-          if (!write) {
-            settle('failed')
-            return
-          }
-          write.then(
-            () => settle('copied'),
-            () => settle('failed'),
-          )
-        }}
+        // Confirm only after the write resolves; an unavailable or rejecting
+        // clipboard reports failure instead of staying silent.
+        onClick={() => void copy()}
       >
         {/* Only the icon changes, so the button width — and the codebox line
           wrapping around it — never shifts. The outcome text is announced to
@@ -298,11 +301,14 @@ function HeroVisual({ instant = false }: { instant?: boolean }) {
   // Only the typewriter needs JavaScript. The layout effect clears the
   // server-rendered prompt before the first post-hydration paint, so the
   // completed text never flashes and vanishes a frame later.
+  // Every scheduled tick is owned by `timer` and cleared by the returned
+  // cleanup. The scanner cannot follow the recursive assignment in `tick`.
+  // react-doctor-disable-next-line react-doctor/effect-needs-cleanup
   useIsomorphicLayoutEffect(() => {
     const promptEl = promptRef.current
-    if (!promptEl || instant || prefersReducedMotion()) return
+    if (!promptEl || instant || prefersReducedMotion()) return () => undefined
     let i = 0
-    let timer: ReturnType<typeof setTimeout>
+    let timer: ReturnType<typeof setTimeout> | undefined
     const tick = () => {
       i += 1
       promptEl.textContent = prompt.slice(0, i) + (i < prompt.length ? '▍' : '')
@@ -311,7 +317,7 @@ function HeroVisual({ instant = false }: { instant?: boolean }) {
     promptEl.textContent = ''
     timer = setTimeout(tick, TYPEWRITER_START_MS)
     return () => {
-      clearTimeout(timer)
+      if (timer !== undefined) clearTimeout(timer)
       promptEl.textContent = prompt
     }
   }, [instant, prompt])

--- a/apps/web/app/routes/_home/+components/upload-dropzone.tsx
+++ b/apps/web/app/routes/_home/+components/upload-dropzone.tsx
@@ -56,10 +56,10 @@ export function UploadDropzone({
         const dataTransfer = event.dataTransfer
         const fallbackFiles = Array.from(dataTransfer.files)
         void filesFromDrop(dataTransfer)
-          .then(onFiles)
-          .catch(() =>
+          .then(onFiles, () =>
             fallbackFiles.length > 0 ? onFiles(fallbackFiles) : onDropError(),
           )
+          .catch(onDropError)
       }}
     >
       <UploadIcon aria-hidden="true" />

--- a/apps/web/app/routes/_home/+components/upload-dropzone.tsx
+++ b/apps/web/app/routes/_home/+components/upload-dropzone.tsx
@@ -55,9 +55,11 @@ export function UploadDropzone({
         onDragOverChange(false)
         const dataTransfer = event.dataTransfer
         const fallbackFiles = Array.from(dataTransfer.files)
-        void filesFromDrop(dataTransfer).then(onFiles, () =>
-          fallbackFiles.length > 0 ? onFiles(fallbackFiles) : onDropError(),
-        )
+        void filesFromDrop(dataTransfer)
+          .then(onFiles)
+          .catch(() =>
+            fallbackFiles.length > 0 ? onFiles(fallbackFiles) : onDropError(),
+          )
       }}
     >
       <UploadIcon aria-hidden="true" />

--- a/apps/web/app/routes/_home/+hooks/use-bulk-actions.ts
+++ b/apps/web/app/routes/_home/+hooks/use-bulk-actions.ts
@@ -75,9 +75,8 @@ export function useBulkActions(visibleIds?: string[]) {
       setBusy(true)
       try {
         const result = await runBulkActions(ids, operation, options)
-        setSelected((current) =>
-          current.filter((id) => !result.succeeded.includes(id)),
-        )
+        const succeeded = new Set(result.succeeded)
+        setSelected((current) => current.filter((id) => !succeeded.has(id)))
         return result
       } finally {
         setBusy(false)

--- a/apps/web/app/routes/_home/_protected/files.tsx
+++ b/apps/web/app/routes/_home/_protected/files.tsx
@@ -138,6 +138,7 @@ export default function Files({ loaderData }: Route.ComponentProps) {
   const layout = useOutletContext<HomeLayoutContext>()
   const rowActions = useFileRowActions()
   const bulk = useBulkActions(loaderData.files.map((f) => f.id))
+  const selectedIds = useMemo(() => new Set(bulk.selected), [bulk.selected])
   const ref = useRef<HTMLDivElement>(null)
   const nav = useNavigation()
   const navigate = useNavigate()
@@ -218,7 +219,7 @@ export default function Files({ loaderData }: Route.ComponentProps) {
                   hideMobileVisibility
                   onAction={(action) => rowActions.open(action, f)}
                   selectable
-                  selected={bulk.selected.includes(f.id)}
+                  selected={selectedIds.has(f.id)}
                   onToggleSelect={() => bulk.toggle(f.id)}
                 />
               ))}

--- a/apps/web/app/routes/_protected/+components/project-redesign-body.tsx
+++ b/apps/web/app/routes/_protected/+components/project-redesign-body.tsx
@@ -215,7 +215,7 @@ export function ProjectRedesignBody({
             meta={t('project.createdOrder')}
           />
           {groups.map((group) => (
-            <div key={group.key || 'ssr'}>
+            <div key={group.key || `undated-${group.items[0]?.id}`}>
               {group.heading ? (
                 <AppSectionHeader
                   as="h3"

--- a/apps/web/app/routes/_protected/+components/project-redesign-body.tsx
+++ b/apps/web/app/routes/_protected/+components/project-redesign-body.tsx
@@ -78,6 +78,7 @@ export function ProjectRedesignBody({
   const fetcher = useFetcher()
   const rowActions = useFileRowActions()
   const bulk = useBulkActions(files.map((f) => f.id))
+  const selectedIds = useMemo(() => new Set(bulk.selected), [bulk.selected])
   const pin = (intent: 'pin' | 'unpin', shareableId: string) =>
     fetcher.submit({ intent, shareableId }, { method: 'post' })
   const pinnedIds = useMemo(
@@ -213,8 +214,8 @@ export function ProjectRedesignBody({
             title={t('project.recentFiles')}
             meta={t('project.createdOrder')}
           />
-          {groups.map((group, index) => (
-            <div key={`${group.key}-${index}`}>
+          {groups.map((group) => (
+            <div key={group.key || 'ssr'}>
               {group.heading ? (
                 <AppSectionHeader
                   as="h3"
@@ -244,7 +245,7 @@ export function ProjectRedesignBody({
                     }
                     pinned={pinnedIds.has(file.id)}
                     selectable
-                    selected={bulk.selected.includes(file.id)}
+                    selected={selectedIds.has(file.id)}
                     onToggleSelect={() => bulk.toggle(file.id)}
                   />
                 ))}

--- a/apps/web/app/routes/_protected/projects.$id.files.tsx
+++ b/apps/web/app/routes/_protected/projects.$id.files.tsx
@@ -172,6 +172,7 @@ export default function ProjectFiles({ loaderData }: Route.ComponentProps) {
     }
   }
   const bulk = useBulkActions(files.map((f) => f.id))
+  const selectedIds = new Set(bulk.selected)
   const lastPage = pages.at(-1)
   const nextCursor = (lastPage ?? loaderData).nextCursor
   const remaining = Math.max(0, loaderData.total - files.length)
@@ -261,8 +262,8 @@ export default function ProjectFiles({ loaderData }: Route.ComponentProps) {
             }
           />
         ) : (
-          groups.map((group, index) => (
-            <div key={`${group.key}-${index}`}>
+          groups.map((group) => (
+            <div key={group.key || 'ssr'}>
               {group.heading ? (
                 <AppSectionHeader title={group.heading} variant="group" />
               ) : null}
@@ -278,7 +279,7 @@ export default function ProjectFiles({ loaderData }: Route.ComponentProps) {
                     menuEnabled
                     onAction={(action) => rowActions.open(action, file)}
                     selectable
-                    selected={bulk.selected.includes(file.id)}
+                    selected={selectedIds.has(file.id)}
                     onToggleSelect={() => bulk.toggle(file.id)}
                   />
                 ))}

--- a/apps/web/app/routes/_protected/projects.$id.files.tsx
+++ b/apps/web/app/routes/_protected/projects.$id.files.tsx
@@ -263,7 +263,7 @@ export default function ProjectFiles({ loaderData }: Route.ComponentProps) {
           />
         ) : (
           groups.map((group) => (
-            <div key={group.key || 'ssr'}>
+            <div key={group.key || `undated-${group.items[0]?.id}`}>
               {group.heading ? (
                 <AppSectionHeader title={group.heading} variant="group" />
               ) : null}

--- a/apps/web/app/routes/_protected/settings/+components/bot-section.tsx
+++ b/apps/web/app/routes/_protected/settings/+components/bot-section.tsx
@@ -315,11 +315,13 @@ function CopyableEmail({ email }: { email: string }) {
       className="text-muted-foreground w-fit text-left text-xs hover:underline"
       title={t('team.bots.copyEmail')}
       onClick={() => {
-        void writeClipboardText(email).then((ok) => {
-          if (!ok) return
-          setCopied(true)
-          setTimeout(() => setCopied(false), 1500)
-        })
+        void writeClipboardText(email)
+          .then((ok) => {
+            if (!ok) return
+            setCopied(true)
+            setTimeout(() => setCopied(false), 1500)
+          })
+          .catch(() => undefined)
       }}
     >
       {copied ? t('team.bots.emailCopied') : email}

--- a/apps/web/app/routes/a.$id/+components/comment-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/comment-panel.tsx
@@ -532,6 +532,7 @@ function ThreadCard({
         const start = navigationPointerRef.current
         navigationPointerRef.current = null
         if (!start || start.pointerId !== event.pointerId) return
+        if (isThreadNavigationHandledByChild(event.target)) return
         if (
           Math.abs(event.clientX - start.x) > 5 ||
           Math.abs(event.clientY - start.y) > 5

--- a/apps/web/app/routes/a.$id/+components/comment-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/comment-panel.tsx
@@ -467,6 +467,11 @@ function ThreadCard({
   const pendingDelete = pendingKeys.has(`thread:${thread.id}`)
   const threadRef = useRef<HTMLElement | null>(null)
   const replyRef = useRef<HTMLTextAreaElement | null>(null)
+  const navigationPointerRef = useRef<{
+    pointerId: number
+    x: number
+    y: number
+  } | null>(null)
   const firstMessage = thread.messages[0]
   const replyMessages = thread.messages.slice(1)
 
@@ -511,12 +516,31 @@ function ThreadCard({
           'text-muted-foreground bg-[color-mix(in_srgb,var(--success)_7%,var(--background))]',
       )}
       // A full-size button below provides the keyboard target. Pointer capture
-      // complements it for non-interactive thread content without pretending
-      // the article containing other controls is itself a button.
-      onPointerUpCapture={(event) => {
-        if (!canNavigateToText) return
+      // complements it for taps on non-interactive content without turning the
+      // article containing other controls into a button.
+      onPointerDownCapture={(event) => {
+        navigationPointerRef.current = null
+        if (!canNavigateToText || !event.isPrimary || event.button !== 0) return
         if (isThreadNavigationHandledByChild(event.target)) return
+        navigationPointerRef.current = {
+          pointerId: event.pointerId,
+          x: event.clientX,
+          y: event.clientY,
+        }
+      }}
+      onPointerUpCapture={(event) => {
+        const start = navigationPointerRef.current
+        navigationPointerRef.current = null
+        if (!start || start.pointerId !== event.pointerId) return
+        if (
+          Math.abs(event.clientX - start.x) > 5 ||
+          Math.abs(event.clientY - start.y) > 5
+        )
+          return
         onNavigate()
+      }}
+      onPointerCancel={() => {
+        navigationPointerRef.current = null
       }}
     >
       {canNavigateToText ? (

--- a/apps/web/app/routes/a.$id/+components/comment-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/comment-panel.tsx
@@ -106,7 +106,7 @@ export function CommentPanel({
     scope: string
     value: number
   } | null>(null)
-  const autoFilterTargetRef = useRef<{
+  const [autoFilterTarget, setAutoFilterTarget] = useState<{
     key: string
     filter: CommentFilter
   } | null>(null)
@@ -136,27 +136,27 @@ export function CommentPanel({
     ? `${targetThread.id}:${targetThread.status}`
     : null
 
-  if (!targetThreadId) {
-    autoFilterTargetRef.current = null
+  if (!targetThreadId && autoFilterTarget !== null) {
+    setAutoFilterTarget(null)
   }
   if (
     open &&
     targetThread &&
     filter !== 'all' &&
     filter !== targetThread.status &&
-    autoFilterTargetRef.current?.key !== targetThreadFilterKey
+    autoFilterTarget?.key !== targetThreadFilterKey
   ) {
-    autoFilterTargetRef.current = {
+    setAutoFilterTarget({
       key: targetThreadFilterKey ?? targetThread.id,
       filter: targetThread.status,
-    }
+    })
   }
   const visibleFilter = activeRequestedFilter
     ? activeRequestedFilter
     : open &&
         targetThreadFilterKey &&
-        autoFilterTargetRef.current?.key === targetThreadFilterKey
-      ? autoFilterTargetRef.current.filter
+        autoFilterTarget?.key === targetThreadFilterKey
+      ? autoFilterTarget.filter
       : filter
 
   const visibleThreads = useMemo(() => {
@@ -314,20 +314,7 @@ export function CommentPanel({
         className="max-sheet:inset-x-2.5 max-sheet:top-auto max-sheet:bottom-0 max-sheet:h-[var(--height-comment-panel-sheet)] max-sheet:w-auto max-sheet:max-w-none max-sheet:rounded-t-[var(--r-lg)] max-sheet:border-t-divider max-sheet:border-r-divider max-sheet:border-l-divider gap-0"
         aria-describedby={undefined}
       >
-        <SheetHeader>
-          <SheetTitle>
-            <IconMessage size={16} aria-hidden="true" />
-            <span>{t('comments.title')}</span>
-          </SheetTitle>
-          <SheetClose asChild>
-            <IconButton
-              type="button"
-              icon={IconX}
-              size="md"
-              aria-label={t('common.close')}
-            />
-          </SheetClose>
-        </SheetHeader>
+        <CommentPanelHeader />
 
         <Tabs
           className="flex min-h-0 flex-1 flex-col"
@@ -335,9 +322,11 @@ export function CommentPanel({
           onValueChange={(value) => {
             const item = value as CommentFilter
             setActiveRequestedFilter(undefined)
-            autoFilterTargetRef.current = targetThreadFilterKey
-              ? { key: targetThreadFilterKey, filter: item }
-              : null
+            setAutoFilterTarget(
+              targetThreadFilterKey
+                ? { key: targetThreadFilterKey, filter: item }
+                : null,
+            )
             setFilter(item)
           }}
         >
@@ -368,6 +357,26 @@ export function CommentPanel({
         ) : null}
       </SheetContent>
     </Sheet>
+  )
+}
+
+function CommentPanelHeader() {
+  const { t } = useT()
+  return (
+    <SheetHeader>
+      <SheetTitle>
+        <IconMessage size={16} aria-hidden="true" />
+        <span>{t('comments.title')}</span>
+      </SheetTitle>
+      <SheetClose asChild>
+        <IconButton
+          type="button"
+          icon={IconX}
+          size="md"
+          aria-label={t('common.close')}
+        />
+      </SheetClose>
+    </SheetHeader>
   )
 }
 
@@ -501,7 +510,10 @@ function ThreadCard({
         thread.status === 'resolved' &&
           'text-muted-foreground bg-[color-mix(in_srgb,var(--success)_7%,var(--background))]',
       )}
-      onClickCapture={(event) => {
+      // A full-size button below provides the keyboard target. Pointer capture
+      // complements it for non-interactive thread content without pretending
+      // the article containing other controls is itself a button.
+      onPointerUpCapture={(event) => {
         if (!canNavigateToText) return
         if (isThreadNavigationHandledByChild(event.target)) return
         onNavigate()

--- a/apps/web/app/routes/a.$id/+components/replace-version-dropzone.tsx
+++ b/apps/web/app/routes/a.$id/+components/replace-version-dropzone.tsx
@@ -157,12 +157,12 @@ function DropzoneButton({
         if (replaceMode === 'static_site') {
           const fallbackFiles = Array.from(event.dataTransfer.files)
           void filesFromDrop(event.dataTransfer)
-            .then(submitFiles)
-            .catch(() =>
+            .then(submitFiles, () =>
               fallbackFiles.length > 0
                 ? submitFiles(fallbackFiles)
                 : toast.error(t('upload.error.dropReadFailed')),
             )
+            .catch(() => toast.error(t('upload.error.dropReadFailed')))
         } else {
           submitFiles(event.dataTransfer.files)
         }

--- a/apps/web/app/routes/a.$id/+components/replace-version-dropzone.tsx
+++ b/apps/web/app/routes/a.$id/+components/replace-version-dropzone.tsx
@@ -156,11 +156,13 @@ function DropzoneButton({
         setLocalDropActive(false)
         if (replaceMode === 'static_site') {
           const fallbackFiles = Array.from(event.dataTransfer.files)
-          void filesFromDrop(event.dataTransfer).then(submitFiles, () =>
-            fallbackFiles.length > 0
-              ? submitFiles(fallbackFiles)
-              : toast.error(t('upload.error.dropReadFailed')),
-          )
+          void filesFromDrop(event.dataTransfer)
+            .then(submitFiles)
+            .catch(() =>
+              fallbackFiles.length > 0
+                ? submitFiles(fallbackFiles)
+                : toast.error(t('upload.error.dropReadFailed')),
+            )
         } else {
           submitFiles(event.dataTransfer.files)
         }

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -307,7 +307,7 @@ function useSandboxFrameController({
   const frameRef = useRef<HTMLIFrameElement | null>(null)
   const wasTransitioningRef = useRef(false)
   const readyFallbackTimeoutRef = useRef<number | null>(null)
-  const staticSiteAuthRef = useRef<number | null>(null)
+  const [staticSiteAuthRef] = useState(() => ({ current: Date.now() }))
   const frameNavigationIdRef = useRef(0)
   const reportedGenerationRef = useRef<number | null>(null)
   const reportTimerRef = useRef<number | null>(null)
@@ -316,9 +316,6 @@ function useSandboxFrameController({
   const securityChallengeRef = useRef<string | null>(null)
   const securityTokenRef = useRef<string | null>(null)
   const mermaidRenderChallengeRef = useRef<string | null>(null)
-  if (staticSiteAuthRef.current === null) {
-    staticSiteAuthRef.current = Date.now()
-  }
   const trustedMessageOrigin = new URL(url).origin
   const commentLabels = useMemo(
     () => ({
@@ -413,7 +410,7 @@ function useSandboxFrameController({
           signal: controller.signal,
         })
         const marker = response.headers.get('X-ArtifactShare-Sandbox-Probe')
-        const body = await response.text()
+        const body = response.ok ? await response.text() : ''
         if (
           !shouldAcceptNavigationResult(
             generation,

--- a/apps/web/app/routes/a.$id/+components/viewer-list-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-list-panel.tsx
@@ -11,6 +11,7 @@ import { Button } from '~/components/ui/button'
 import { IconButton } from '~/components/app/icon-button'
 import { AuthorAvatar } from '~/components/app/author-avatar'
 import { useT } from '~/hooks/use-t'
+import { useLatestRef } from '~/hooks/use-latest-ref'
 import { formatRelative, isUtcZTimestamp } from '~/lib/datetime'
 import type {
   ViewerListRowView,
@@ -62,10 +63,8 @@ export function ViewerListPanel({
   const translator = useT()
   const { t, tPlural, locale } = translator
   const wasOpenRef = useRef(open)
-  const skipReturnFocusRef = useRef(skipReturnFocus)
-  skipReturnFocusRef.current = skipReturnFocus
-  const closeReasonRef = useRef(closeReason)
-  closeReasonRef.current = closeReason
+  const skipReturnFocusRef = useLatestRef(skipReturnFocus)
+  const closeReasonRef = useLatestRef(closeReason)
 
   useEffect(() => {
     if (wasOpenRef.current && !open) {
@@ -84,7 +83,7 @@ export function ViewerListPanel({
       }
     }
     wasOpenRef.current = open
-  }, [open, returnFocusRef])
+  }, [closeReasonRef, open, returnFocusRef, skipReturnFocusRef])
 
   return (
     <Sheet modal={false} open={open} onOpenChange={onOpenChange}>

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -54,6 +54,7 @@ import {
   type ReplaceVersionInput,
 } from '../+hooks/use-replace-version'
 import { useT } from '~/hooks/use-t'
+import { useLatestRef } from '~/hooks/use-latest-ref'
 import { displayTitle } from '~/lib/display-title'
 import {
   artifactSupportsComments,
@@ -521,25 +522,15 @@ function useViewerComments({
 }) {
   const returnFocusRef = useRef<HTMLElement | null>(null)
   const requestedFilterRef = useRef<'all' | undefined>(undefined)
-  const artifactIdRef = useRef(artifactId)
-  artifactIdRef.current = artifactId
-  const onViewCountChangedRef = useRef(onViewCountChanged)
-  onViewCountChangedRef.current = onViewCountChanged
-  const onVersionChangedRef = useRef(onVersionChanged)
-  onVersionChangedRef.current = onVersionChanged
-  const onVersionReconcileRef = useRef(onVersionReconcile)
-  onVersionReconcileRef.current = onVersionReconcile
-  const onLiveConnectionChangedRef = useRef(onLiveConnectionChanged)
-  onLiveConnectionChangedRef.current = onLiveConnectionChanged
-  const onPanelOpenedRef = useRef(onPanelOpened)
-  onPanelOpenedRef.current = onPanelOpened
-  const threadsRef = useRef(initialThreads)
-  const appliedCommentMutationEchoesRef =
-    useRef<AppliedCommentMutationEchoes | null>(null)
-  if (appliedCommentMutationEchoesRef.current === null) {
-    appliedCommentMutationEchoesRef.current = new Map()
-  }
-  const appliedCommentMutationEchoes = appliedCommentMutationEchoesRef.current
+  const artifactIdRef = useLatestRef(artifactId)
+  const onViewCountChangedRef = useLatestRef(onViewCountChanged)
+  const onVersionChangedRef = useLatestRef(onVersionChanged)
+  const onVersionReconcileRef = useLatestRef(onVersionReconcile)
+  const onLiveConnectionChangedRef = useLatestRef(onLiveConnectionChanged)
+  const onPanelOpenedRef = useLatestRef(onPanelOpened)
+  const [appliedCommentMutationEchoes] = useState<AppliedCommentMutationEchoes>(
+    () => new Map(),
+  )
   const deferredCommentRefreshDuringMutationRef = useRef(false)
   const fetchSeqRef = useRef(0)
   const fetchAbortRef = useRef<AbortController | null>(null)
@@ -552,7 +543,7 @@ function useViewerComments({
     ),
   )
   const totalCount = state.threads.length
-  threadsRef.current = state.threads
+  const threadsRef = useLatestRef(state.threads)
 
   if (state.artifactId !== artifactId) {
     dispatchComment({
@@ -575,7 +566,7 @@ function useViewerComments({
     returnFocusRef.current = null
     onPanelOpenedRef.current?.()
     dispatchComment({ type: 'thread-targeted', threadId: targetCommentId })
-  }, [targetCommentId])
+  }, [onPanelOpenedRef, targetCommentId])
 
   const openPanel = useCallback(
     (returnFocusTo?: HTMLElement | null, requestedFilter?: 'all') => {
@@ -584,7 +575,7 @@ function useViewerComments({
       onPanelOpenedRef.current?.()
       dispatchComment({ type: 'panel-open-changed', open: true })
     },
-    [],
+    [onPanelOpenedRef],
   )
 
   const replaceThreads = useCallback(
@@ -595,14 +586,17 @@ function useViewerComments({
   )
   const isCurrentArtifactId = useCallback(
     (requestArtifactId: string) => artifactIdRef.current === requestArtifactId,
-    [],
+    [artifactIdRef],
   )
 
-  const changePanelOpen = useCallback((open: boolean) => {
-    if (!open) requestedFilterRef.current = undefined
-    if (open) onPanelOpenedRef.current?.()
-    dispatchComment({ type: 'panel-open-changed', open })
-  }, [])
+  const changePanelOpen = useCallback(
+    (open: boolean) => {
+      if (!open) requestedFilterRef.current = undefined
+      if (open) onPanelOpenedRef.current?.()
+      dispatchComment({ type: 'panel-open-changed', open })
+    },
+    [onPanelOpenedRef],
+  )
 
   const targetThread = useCallback(
     (
@@ -616,7 +610,7 @@ function useViewerComments({
         scroll: options?.scroll,
       })
     },
-    [],
+    [onPanelOpenedRef],
   )
 
   const startTextSelection = useCallback((anchor: PendingTextAnchor) => {
@@ -648,12 +642,12 @@ function useViewerComments({
       if (JSON.stringify(threadsRef.current) === JSON.stringify(threads)) return
       dispatchComment({ type: 'threads-replaced', threads })
     },
-    [],
+    [threadsRef],
   )
 
   const abortLatestThreadFetch = useEffectEvent(() => {
     fetchSeqRef.current += 1
-    fetchSchedulerRef.current?.cancelPending()
+    fetchScheduler.cancelPending()
     fetchAbortRef.current?.abort()
     fetchAbortRef.current = null
   })
@@ -766,21 +760,19 @@ function useViewerComments({
     [artifactId, isCurrentArtifactId, replaceThreadsIfChanged],
   )
 
-  const fetchLatestThreadsOnceRef = useRef(fetchLatestThreadsOnce)
-  fetchLatestThreadsOnceRef.current = fetchLatestThreadsOnce
-  const fetchSchedulerRef = useRef<CommentRefreshScheduler | null>(null)
-  if (!fetchSchedulerRef.current) {
-    fetchSchedulerRef.current = createCommentRefreshScheduler((options) =>
+  const fetchLatestThreadsOnceRef = useLatestRef(fetchLatestThreadsOnce)
+  const [fetchScheduler] = useState(() =>
+    createCommentRefreshScheduler((options) =>
       fetchLatestThreadsOnceRef.current(options),
-    )
-  }
+    ),
+  )
 
-  const fetchLatestThreads = useCallback((options?: CommentRefreshOptions) => {
-    return (
-      fetchSchedulerRef.current?.request(options) ??
-      Promise.resolve('keep-connection')
-    )
-  }, [])
+  const fetchLatestThreads = useCallback(
+    (options?: CommentRefreshOptions) => {
+      return fetchScheduler.request(options)
+    },
+    [fetchScheduler],
+  )
 
   useEffect(() => {
     return () => {
@@ -788,10 +780,13 @@ function useViewerComments({
     }
   }, [artifactId])
 
+  // `closeSocket` closes the active socket and clears every reconnect and
+  // heartbeat timer in the cleanup returned at the end of this effect.
+  // react-doctor-disable-next-line react-doctor/effect-needs-cleanup
   useEffect(() => {
     if (!liveEnabled) {
       onLiveConnectionChangedRef.current?.(false)
-      return
+      return () => undefined
     }
 
     let disposed = false
@@ -1089,6 +1084,10 @@ function useViewerComments({
     currentUserId,
     fetchLatestThreads,
     liveEnabled,
+    onLiveConnectionChangedRef,
+    onVersionChangedRef,
+    onVersionReconcileRef,
+    onViewCountChangedRef,
   ])
 
   return {
@@ -1210,8 +1209,8 @@ function useLatestVersionNotice({
   currentVersionId: string | null
   liveAvailable: boolean
 }) {
-  const currentVersionIdRef = useRef(currentVersionId)
-  const liveAvailableRef = useRef(liveAvailable)
+  const currentVersionIdRef = useLatestRef(currentVersionId)
+  const liveAvailableRef = useLatestRef(liveAvailable)
   const latestCheckSeqRef = useRef(0)
   const latestCheckAbortRef = useRef<AbortController | null>(null)
   const latestCheckKindRef = useRef<LatestVersionCheckKind | null>(null)
@@ -1223,8 +1222,6 @@ function useLatestVersionNotice({
     hasNewerVersion: false,
   }))
 
-  currentVersionIdRef.current = currentVersionId
-  liveAvailableRef.current = liveAvailable
   if (notice.currentVersionId !== currentVersionId) {
     setNotice({ currentVersionId, hasNewerVersion: false })
   }
@@ -1247,18 +1244,21 @@ function useLatestVersionNotice({
     [],
   )
 
-  const markVersionChanged = useCallback((nextVersionId: string) => {
-    const current = currentVersionIdRef.current
-    if (!current) return
-    if (nextVersionId !== current) {
-      latestCheckSeqRef.current += 1
-    }
-    setNotice((previous) =>
-      previous.currentVersionId === current
-        ? { ...previous, hasNewerVersion: nextVersionId !== current }
-        : previous,
-    )
-  }, [])
+  const markVersionChanged = useCallback(
+    (nextVersionId: string) => {
+      const current = currentVersionIdRef.current
+      if (!current) return
+      if (nextVersionId !== current) {
+        latestCheckSeqRef.current += 1
+      }
+      setNotice((previous) =>
+        previous.currentVersionId === current
+          ? { ...previous, hasNewerVersion: nextVersionId !== current }
+          : previous,
+      )
+    },
+    [currentVersionIdRef],
+  )
 
   const checkLatestVersion = useCallback(
     async function checkLatestVersion(
@@ -1338,7 +1338,13 @@ function useLatestVersionNotice({
       if (seq !== latestCheckSeqRef.current) return
       markVersionChanged(body.currentVersionId)
     },
-    [artifactId, clearLatestVersionRetry, markVersionChanged],
+    [
+      artifactId,
+      clearLatestVersionRetry,
+      currentVersionIdRef,
+      liveAvailableRef,
+      markVersionChanged,
+    ],
   )
 
   useEffect(() => {

--- a/apps/web/app/routes/a.$id/+hooks/use-replace-version.ts
+++ b/apps/web/app/routes/a.$id/+hooks/use-replace-version.ts
@@ -7,6 +7,7 @@ import {
   REPLACE_VERSION_ERROR_I18N,
 } from '~/lib/api-errors'
 import { useT } from '~/hooks/use-t'
+import { useLatestRef } from '~/hooks/use-latest-ref'
 import {
   appendUploadFiles,
   filterUploadFiles,
@@ -39,8 +40,7 @@ export function useReplaceVersion(
   const revalidator = useRevalidator()
   const pending = useRef(false)
   // options を ref で保持して、callback identity を毎 render で変えない
-  const optionsRef = useRef(options)
-  optionsRef.current = options
+  const optionsRef = useLatestRef(options)
 
   return useCallback(
     async (input: ReplaceVersionInput) => {
@@ -69,7 +69,7 @@ export function useReplaceVersion(
         pending.current = false
       }
     },
-    [revalidator, shareableId, translator],
+    [optionsRef, revalidator, shareableId, translator],
   )
 }
 

--- a/apps/web/app/routes/a.$id/+hooks/use-viewer-list.ts
+++ b/apps/web/app/routes/a.$id/+hooks/use-viewer-list.ts
@@ -1,10 +1,17 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 import {
   cfRayFrom,
   fetchJsonWithViewerTimeout,
   logViewerNetworkEvent,
   viewerFetchFailureReason,
 } from '~/lib/viewer-network'
+import { useLatestRef } from '~/hooks/use-latest-ref'
 
 export interface ViewerListRowView {
   userId: string
@@ -79,108 +86,112 @@ export function useViewerList({
   const [state, setState] = useState<ViewerListFetchState>(emptyViewerListState)
   const seqRef = useRef(0)
   const generationRef = useRef(0)
-  const openRef = useRef(open)
-  openRef.current = open
-  const artifactIdRef = useRef(artifactId)
-  artifactIdRef.current = artifactId
+  const openRef = useLatestRef(open)
+  const artifactIdRef = useLatestRef(artifactId)
   const abortRef = useRef<AbortController | null>(null)
   const loadMoreInFlightRef = useRef(false)
-  const nextCursorRef = useRef<string | null>(null)
-  nextCursorRef.current = state.nextCursor
+  const nextCursorRef = useLatestRef(state.nextCursor)
 
   // artifact 切替はコメント reducer と同じ render-phase 比較で検知し、取得済み
   // リストを破棄する (stale 応答は generation/seq 照合でも二重に弾かれる)。
   const [trackedArtifactId, setTrackedArtifactId] = useState(artifactId)
   if (trackedArtifactId !== artifactId) {
     setTrackedArtifactId(artifactId)
+    setState(emptyViewerListState())
+  }
+  useLayoutEffect(() => {
     generationRef.current += 1
     seqRef.current += 1
     loadMoreInFlightRef.current = false
-    setState(emptyViewerListState())
-  }
-
-  const runFetch = useCallback((mode: 'initial' | 'more') => {
-    const requestArtifactId = artifactIdRef.current
-    const generation = generationRef.current
-    const cursor = mode === 'more' ? nextCursorRef.current : null
-    const seq = seqRef.current + 1
-    seqRef.current = seq
     abortRef.current?.abort()
-    const controller = new AbortController()
-    abortRef.current = controller
-    if (mode === 'more') loadMoreInFlightRef.current = true
-    setState((current) =>
-      mode === 'initial'
-        ? { ...emptyViewerListState(), status: 'loading' }
-        : { ...current, loadingMore: true },
-    )
-    const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''
-    void fetchJsonWithViewerTimeout<{
-      viewers?: unknown
-      nextCursor?: unknown
-      totalViewers?: unknown
-    }>(
-      `/api/shareables/${encodeURIComponent(requestArtifactId)}/viewers${query}`,
-      {
-        headers: { accept: 'application/json' },
-        cache: 'no-store',
-        signal: controller.signal,
-      },
-    )
-      .catch((error: unknown) => {
-        logViewerNetworkEvent({
-          channel: 'fetch',
-          purpose: 'viewer-list',
-          state: 'failed',
-          reason: viewerFetchFailureReason(error),
-        })
-        return null
-      })
-      .then((result) => {
-        if (abortRef.current === controller) abortRef.current = null
-        if (mode === 'more' && seq === seqRef.current) {
-          loadMoreInFlightRef.current = false
-        }
-        // Only the last-started operation's response applies; stale responses
-        // (artifact switched, panel closed/reopened) are discarded.
-        if (seq !== seqRef.current) return
-        if (generation !== generationRef.current) return
-        if (artifactIdRef.current !== requestArtifactId) return
-        if (!openRef.current) return
-        const response = result?.response
-        if (response && !response.ok) {
+    abortRef.current = null
+  }, [artifactId])
+
+  const runFetch = useCallback(
+    (mode: 'initial' | 'more') => {
+      const requestArtifactId = artifactIdRef.current
+      const generation = generationRef.current
+      const cursor = mode === 'more' ? nextCursorRef.current : null
+      const seq = seqRef.current + 1
+      seqRef.current = seq
+      abortRef.current?.abort()
+      const controller = new AbortController()
+      abortRef.current = controller
+      if (mode === 'more') loadMoreInFlightRef.current = true
+      setState((current) =>
+        mode === 'initial'
+          ? { ...emptyViewerListState(), status: 'loading' }
+          : { ...current, loadingMore: true },
+      )
+      const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''
+      void fetchJsonWithViewerTimeout<{
+        viewers?: unknown
+        nextCursor?: unknown
+        totalViewers?: unknown
+      }>(
+        `/api/shareables/${encodeURIComponent(requestArtifactId)}/viewers${query}`,
+        {
+          headers: { accept: 'application/json' },
+          cache: 'no-store',
+          signal: controller.signal,
+        },
+      )
+        .catch((error: unknown) => {
           logViewerNetworkEvent({
             channel: 'fetch',
             purpose: 'viewer-list',
-            state: 'response-error',
-            status: response.status,
-            cfRay: cfRayFrom(response),
+            state: 'failed',
+            reason: viewerFetchFailureReason(error),
           })
-        }
-        const body = result?.body ?? null
-        const rows = body ? parseViewerListRows(body.viewers) : null
-        if (!response?.ok || !rows) {
-          setState((current) =>
-            mode === 'initial'
-              ? { ...current, status: 'error' }
-              : // 「さらに表示」失敗はボタンを再クリック可能なまま維持する。
-                { ...current, loadingMore: false },
-          )
-          return
-        }
-        setState((current) => ({
-          rows: mode === 'initial' ? rows : [...current.rows, ...rows],
-          totalViewers:
-            typeof body?.totalViewers === 'number'
-              ? body.totalViewers
-              : current.totalViewers,
-          nextCursor:
-            typeof body?.nextCursor === 'string' ? body.nextCursor : null,
-          status: 'loaded',
-          loadingMore: false,
-        }))
-      })
-  }, [])
+          return null
+        })
+        .then((result) => {
+          if (abortRef.current === controller) abortRef.current = null
+          if (mode === 'more' && seq === seqRef.current) {
+            loadMoreInFlightRef.current = false
+          }
+          // Only the last-started operation's response applies; stale responses
+          // (artifact switched, panel closed/reopened) are discarded.
+          if (seq !== seqRef.current) return
+          if (generation !== generationRef.current) return
+          if (artifactIdRef.current !== requestArtifactId) return
+          if (!openRef.current) return
+          const response = result?.response
+          if (response && !response.ok) {
+            logViewerNetworkEvent({
+              channel: 'fetch',
+              purpose: 'viewer-list',
+              state: 'response-error',
+              status: response.status,
+              cfRay: cfRayFrom(response),
+            })
+          }
+          const body = result?.body ?? null
+          const rows = body ? parseViewerListRows(body.viewers) : null
+          if (!response?.ok || !rows) {
+            setState((current) =>
+              mode === 'initial'
+                ? { ...current, status: 'error' }
+                : // 「さらに表示」失敗はボタンを再クリック可能なまま維持する。
+                  { ...current, loadingMore: false },
+            )
+            return
+          }
+          setState((current) => ({
+            rows: mode === 'initial' ? rows : [...current.rows, ...rows],
+            totalViewers:
+              typeof body?.totalViewers === 'number'
+                ? body.totalViewers
+                : current.totalViewers,
+            nextCursor:
+              typeof body?.nextCursor === 'string' ? body.nextCursor : null,
+            status: 'loaded',
+            loadingMore: false,
+          }))
+        })
+    },
+    [artifactIdRef, nextCursorRef, openRef],
+  )
 
   // パネルを開くイベントで呼ぶ。開くたびに取得し (前回リストは即破棄)、
   // open generation を進めて閉→開をまたぐ stale 応答を無効化する。
@@ -197,12 +208,12 @@ export function useViewerList({
     if (loadMoreInFlightRef.current) return
     if (!nextCursorRef.current) return
     runFetch('more')
-  }, [runFetch])
+  }, [nextCursorRef, openRef, runFetch])
 
   const retry = useCallback(() => {
     if (!openRef.current) return
     runFetch('initial')
-  }, [runFetch])
+  }, [openRef, runFetch])
 
   useEffect(
     () => () => {

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -504,9 +504,13 @@ export async function loader({
     ...version,
     isDisplayed: version.id === displayedVersion.id,
   }))
-  const displayedVersionOrdinal = versions.find(
+  const displayedHistoryVersion = versions.find(
     (version) => version.id === displayedVersion.id,
-  )!.ordinal
+  )
+  if (!displayedHistoryVersion) {
+    throw new Response('Not found', { status: 404 })
+  }
+  const displayedVersionOrdinal = displayedHistoryVersion.ordinal
   // creator なら visibility に関わらず grants を pre-load する。
   // private / workspace の切り替え時に、既存の個別許可を最初から見せる。
   const grants = isOwner

--- a/apps/web/app/routes/dev.scenarios.$scenario/+components/focused-device-fixture.tsx
+++ b/apps/web/app/routes/dev.scenarios.$scenario/+components/focused-device-fixture.tsx
@@ -37,6 +37,7 @@ export function FocusedDeviceFixture() {
           </FieldLabel>
           <select
             id="fixture-agent-project"
+            aria-label="Project this agent can work in"
             defaultValue="design"
             className="border-input bg-background h-10 rounded-md border px-3"
           >

--- a/apps/web/app/services/slack.server.test.ts
+++ b/apps/web/app/services/slack.server.test.ts
@@ -547,6 +547,33 @@ describe('deleteWorkspaceSlackConnection', () => {
     expect(remaining).toEqual([{ id: 'sw1' }])
   })
 
+  test.each(['invalid_auth', 'account_inactive'])(
+    'deletes the connection when Slack returns non-2xx %s',
+    async (error) => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: false, error }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      await seedAdmin(db, 'u1', 'ws1')
+      await seedSlackWorkspaceRow(db, 'sw1', 'ws1')
+
+      const result = await deleteWorkspaceSlackConnection(
+        db,
+        actor('u1', 'ws1'),
+        'sw1',
+      )
+
+      expect(result).toEqual({ kind: 'ok' })
+      const remaining = await db
+        .selectFrom('slack_workspaces')
+        .select('id')
+        .execute()
+      expect(remaining).toEqual([])
+    },
+  )
+
   test('non-admin cannot delete a connection', async () => {
     await seedAdmin(db, 'u1', 'ws1')
     await seedSlackWorkspaceRow(db, 'sw1', 'ws1')

--- a/apps/web/app/services/slack.server.ts
+++ b/apps/web/app/services/slack.server.ts
@@ -512,7 +512,12 @@ async function revokeSlackBotToken(botToken: string): Promise<boolean> {
       },
       body: JSON.stringify({}),
     })
-    if (!response.ok) return false
+    if (!response.ok) {
+      const result = (await response.json()) as { error?: string }
+      return (
+        result.error === 'invalid_auth' || result.error === 'account_inactive'
+      )
+    }
     const result = (await response.json()) as {
       ok?: boolean
       error?: string

--- a/apps/web/app/services/slack.server.ts
+++ b/apps/web/app/services/slack.server.ts
@@ -512,12 +512,13 @@ async function revokeSlackBotToken(botToken: string): Promise<boolean> {
       },
       body: JSON.stringify({}),
     })
+    if (!response.ok) return false
     const result = (await response.json()) as {
       ok?: boolean
       error?: string
       revoked?: boolean
     }
-    if (response.ok && result.ok !== false) return result.revoked === true
+    if (result.ok !== false) return result.revoked === true
     return (
       result.error === 'invalid_auth' || result.error === 'account_inactive'
     )

--- a/apps/web/workers/d1-backup-workflow.ts
+++ b/apps/web/workers/d1-backup-workflow.ts
@@ -191,10 +191,22 @@ function d1ExportHeaders(env: Cloudflare.Env): Headers {
 
 async function fetchD1Export<T>(url: string, init: RequestInit): Promise<T> {
   const response = await fetch(url, init)
+  if (!response.ok) {
+    const body = (await response
+      .json()
+      .catch(() => null)) as D1ExportApiResponse<T> | null
+    const message =
+      body?.errors
+        ?.flatMap((error) => (error.message ? [error.message] : []))
+        .join('; ') ||
+      body?.error ||
+      `HTTP ${response.status}`
+    throw new Error(`D1 export API failed: ${message}`)
+  }
   const body = (await response
     .json()
     .catch(() => null)) as D1ExportApiResponse<T> | null
-  if (!response.ok || !body?.success) {
+  if (!body?.success) {
     const message =
       body?.errors
         ?.flatMap((error) => (error.message ? [error.message] : []))

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@tanstack/markdown": "0.0.13",
-    "react-doctor": "0.7.0",
+    "react-doctor": "0.9.12",
     "vite-plus": "0.2.9",
     "wrangler": "4.111.0",
     "yaml": "2.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: 0.0.13
         version: 0.0.13(react@19.2.8)
       react-doctor:
-        specifier: 0.7.0
-        version: 0.7.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@7.0.2001)(supports-color@10.2.2)
+        specifier: 0.9.12
+        version: 0.9.12(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@7.0.2001)(supports-color@10.2.2)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
       vite-plus:
         specifier: 0.2.9
         version: 0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
@@ -278,6 +278,9 @@ packages:
 
   '@apm-js-collab/tracing-hooks@0.13.0':
     resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
+
+  '@astrojs/compiler@4.0.0':
+    resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -579,23 +582,14 @@ packages:
   '@dotenvx/primitives@0.8.0':
     resolution: {integrity: sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg==}
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
-
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
-
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/runtime@1.11.3':
     resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
-
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -1380,256 +1374,124 @@ packages:
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
-  '@oxc-parser/binding-android-arm-eabi@0.132.0':
-    resolution: {integrity: sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==}
+  '@oxc-parser/binding-android-arm-eabi@0.143.0':
+    resolution: {integrity: sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxc-parser/binding-android-arm-eabi@0.135.0':
-    resolution: {integrity: sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxc-parser/binding-android-arm64@0.132.0':
-    resolution: {integrity: sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==}
+  '@oxc-parser/binding-android-arm64@0.143.0':
+    resolution: {integrity: sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-parser/binding-android-arm64@0.135.0':
-    resolution: {integrity: sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-parser/binding-darwin-arm64@0.132.0':
-    resolution: {integrity: sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==}
+  '@oxc-parser/binding-darwin-arm64@0.143.0':
+    resolution: {integrity: sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-arm64@0.135.0':
-    resolution: {integrity: sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-x64@0.132.0':
-    resolution: {integrity: sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==}
+  '@oxc-parser/binding-darwin-x64@0.143.0':
+    resolution: {integrity: sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.135.0':
-    resolution: {integrity: sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-parser/binding-freebsd-x64@0.132.0':
-    resolution: {integrity: sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==}
+  '@oxc-parser/binding-freebsd-x64@0.143.0':
+    resolution: {integrity: sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-freebsd-x64@0.135.0':
-    resolution: {integrity: sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
-    resolution: {integrity: sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==}
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.143.0':
+    resolution: {integrity: sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.135.0':
-    resolution: {integrity: sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==}
+  '@oxc-parser/binding-linux-arm-musleabihf@0.143.0':
+    resolution: {integrity: sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
-    resolution: {integrity: sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.135.0':
-    resolution: {integrity: sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
-    resolution: {integrity: sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==}
+  '@oxc-parser/binding-linux-arm64-gnu@0.143.0':
+    resolution: {integrity: sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.135.0':
-    resolution: {integrity: sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
-    resolution: {integrity: sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==}
+  '@oxc-parser/binding-linux-arm64-musl@0.143.0':
+    resolution: {integrity: sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.135.0':
-    resolution: {integrity: sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
-    resolution: {integrity: sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==}
+  '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
+    resolution: {integrity: sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.135.0':
-    resolution: {integrity: sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
-    resolution: {integrity: sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==}
+  '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
+    resolution: {integrity: sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.135.0':
-    resolution: {integrity: sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
-    resolution: {integrity: sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==}
+  '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
+    resolution: {integrity: sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.135.0':
-    resolution: {integrity: sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
-    resolution: {integrity: sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==}
+  '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
+    resolution: {integrity: sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.135.0':
-    resolution: {integrity: sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
-    resolution: {integrity: sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==}
+  '@oxc-parser/binding-linux-x64-gnu@0.143.0':
+    resolution: {integrity: sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.135.0':
-    resolution: {integrity: sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-x64-musl@0.132.0':
-    resolution: {integrity: sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==}
+  '@oxc-parser/binding-linux-x64-musl@0.143.0':
+    resolution: {integrity: sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-x64-musl@0.135.0':
-    resolution: {integrity: sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-openharmony-arm64@0.132.0':
-    resolution: {integrity: sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==}
+  '@oxc-parser/binding-openharmony-arm64@0.143.0':
+    resolution: {integrity: sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-parser/binding-openharmony-arm64@0.135.0':
-    resolution: {integrity: sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-parser/binding-wasm32-wasi@0.132.0':
-    resolution: {integrity: sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@oxc-parser/binding-wasm32-wasi@0.135.0':
-    resolution: {integrity: sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
-    resolution: {integrity: sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==}
+  '@oxc-parser/binding-win32-arm64-msvc@0.143.0':
+    resolution: {integrity: sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.135.0':
-    resolution: {integrity: sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
-    resolution: {integrity: sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==}
+  '@oxc-parser/binding-win32-ia32-msvc@0.143.0':
+    resolution: {integrity: sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.135.0':
-    resolution: {integrity: sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
-    resolution: {integrity: sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-x64-msvc@0.135.0':
-    resolution: {integrity: sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==}
+  '@oxc-parser/binding-win32-x64-msvc@0.143.0':
+    resolution: {integrity: sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1637,12 +1499,6 @@ packages:
   '@oxc-project/runtime@0.143.0':
     resolution: {integrity: sha512-zIuXUf+YGIgsPk0xlQmzTY8NCSc8jE/pSfDodlQ9H3EGZABmr+AtIjXRrnpQAXuXzhDSNqZz9cuhud8hDDLvpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@oxc-project/types@0.132.0':
-    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
-
-  '@oxc-project/types@0.135.0':
-    resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
 
   '@oxc-project/types@0.143.0':
     resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
@@ -1905,22 +1761,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.66.0':
-    resolution: {integrity: sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
   '@oxlint/binding-android-arm-eabi@1.77.0':
     resolution: {integrity: sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
-    os: [android]
-
-  '@oxlint/binding-android-arm64@1.66.0':
-    resolution: {integrity: sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
     os: [android]
 
   '@oxlint/binding-android-arm64@1.77.0':
@@ -1929,22 +1773,10 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.66.0':
-    resolution: {integrity: sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@oxlint/binding-darwin-arm64@1.77.0':
     resolution: {integrity: sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@oxlint/binding-darwin-x64@1.66.0':
-    resolution: {integrity: sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
 
   '@oxlint/binding-darwin-x64@1.77.0':
@@ -1953,32 +1785,14 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.66.0':
-    resolution: {integrity: sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@oxlint/binding-freebsd-x64@1.77.0':
     resolution: {integrity: sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
-    resolution: {integrity: sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@oxlint/binding-linux-arm-gnueabihf@1.77.0':
     resolution: {integrity: sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
-    resolution: {integrity: sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1989,26 +1803,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.66.0':
-    resolution: {integrity: sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxlint/binding-linux-arm64-gnu@1.77.0':
     resolution: {integrity: sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@oxlint/binding-linux-arm64-musl@1.66.0':
-    resolution: {integrity: sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-arm64-musl@1.77.0':
     resolution: {integrity: sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==}
@@ -2017,24 +1817,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
-    resolution: {integrity: sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxlint/binding-linux-ppc64-gnu@1.77.0':
     resolution: {integrity: sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
-    resolution: {integrity: sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -2045,13 +1831,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.66.0':
-    resolution: {integrity: sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
   '@oxlint/binding-linux-riscv64-musl@1.77.0':
     resolution: {integrity: sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2059,24 +1838,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.66.0':
-    resolution: {integrity: sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@oxlint/binding-linux-s390x-gnu@1.77.0':
     resolution: {integrity: sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-x64-gnu@1.66.0':
-    resolution: {integrity: sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -2087,13 +1852,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.66.0':
-    resolution: {integrity: sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@oxlint/binding-linux-x64-musl@1.77.0':
     resolution: {integrity: sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2101,23 +1859,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.66.0':
-    resolution: {integrity: sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@oxlint/binding-openharmony-arm64@1.77.0':
     resolution: {integrity: sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
-
-  '@oxlint/binding-win32-arm64-msvc@1.66.0':
-    resolution: {integrity: sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
 
   '@oxlint/binding-win32-arm64-msvc@1.77.0':
     resolution: {integrity: sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==}
@@ -2125,22 +1871,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.66.0':
-    resolution: {integrity: sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@oxlint/binding-win32-ia32-msvc@1.77.0':
     resolution: {integrity: sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
-    os: [win32]
-
-  '@oxlint/binding-win32-x64-msvc@1.66.0':
-    resolution: {integrity: sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [win32]
 
   '@oxlint/binding-win32-x64-msvc@1.77.0':
@@ -3054,6 +2788,10 @@ packages:
   '@sentry/server-utils@10.69.0':
     resolution: {integrity: sha512-0MwHrA8+nNvMIsqf8m3cXwCBlUjr6AS7N6CZvHJtY1DkqEvQqEbD5VIrhzEyHN/KMZIgQ8XeDCQRhjnXFQGRhg==}
     engines: {node: '>=18'}
+
+  '@shaderfrog/glsl-parser@7.0.1':
+    resolution: {integrity: sha512-8mpfsoPeRhesY3pOrzNZBL8uG6N5GVX1EHLBYbd4gzKs+c7vaEIqpTNK5VrffU33qQN4cwpP2v3u4aPPBU32sw==}
+    engines: {node: '>=16'}
 
   '@shuding/opentype.js@1.4.0-beta.0':
     resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
@@ -4447,8 +4185,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.7.0:
-    resolution: {integrity: sha512-Vqu24fmew+Pq9wNNO92EVHpk3pax0tb4t47fWKhW0lvWtvyFXUeglwFFLneT4x2CaZfBkw41HqGaSmW4+ro4tg==}
+  deslop-js@0.9.12:
+    resolution: {integrity: sha512-Ku6Zngzmu4EISb58WUkRKZytfgWjJ18Cic7lb4wl+/BF0tHWRvpBOLlA0FP35r82mV45Y72AK3RPC1Nw0GLbIw==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -5511,12 +5249,8 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
-  oxc-parser@0.132.0:
-    resolution: {integrity: sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  oxc-parser@0.135.0:
-    resolution: {integrity: sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==}
+  oxc-parser@0.143.0:
+    resolution: {integrity: sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-resolver@11.24.2:
@@ -5535,23 +5269,13 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-plugin-react-doctor@0.7.0:
-    resolution: {integrity: sha512-PryBJ2NSnu8aZsDB4uBcpM6y0bRTYCOHqLFDGhDg0ZFw8w5ntjkHhxiIwrd1qT5RzhtAXi7BxI2DmeacY/06tg==}
+  oxlint-plugin-react-doctor@0.9.12:
+    resolution: {integrity: sha512-BplcCUU/tGByFGgY1YIax6evUmjk0K8zOGGrdPs3A3dqamrzjUvVuJdYpM1Ftyt/B5fFx6+VwRrWi3YZbIz4VQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tsgolint@7.0.2001:
     resolution: {integrity: sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==}
     hasBin: true
-
-  oxlint@1.66.0:
-    resolution: {integrity: sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      oxlint-tsgolint: '>=0.22.1'
-    peerDependenciesMeta:
-      oxlint-tsgolint:
-        optional: true
 
   oxlint@1.77.0:
     resolution: {integrity: sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==}
@@ -5767,8 +5491,8 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-doctor@0.7.0:
-    resolution: {integrity: sha512-Cmim+jiw9w7Hob+nEBdg+He75r4hA5NqHjet2KcnAYxjIK5qQ8gemr5QJLnFokCyU7w+ArihDvpyrRLb7hM0NQ==}
+  react-doctor@0.9.12:
+    resolution: {integrity: sha512-H7RNg13RYKwpQvi3+O3IkSj8pAD1pGTxSetxu7aOwXX3wmF+BydCLDiWxkPT9Pq7bIMHjuJ0taSZLsxEjlNjcA==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -6684,6 +6408,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@astrojs/compiler@4.0.0': {}
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -7009,20 +6735,9 @@ snapshots:
 
   '@dotenvx/primitives@0.8.0': {}
 
-  '@emnapi/core@1.10.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/core@1.11.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.10.0':
-    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -7032,11 +6747,6 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.11.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7561,13 +7271,6 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@emnapi/core': 1.11.2
@@ -7671,139 +7374,64 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
-  '@oxc-parser/binding-android-arm-eabi@0.132.0':
+  '@oxc-parser/binding-android-arm-eabi@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm-eabi@0.135.0':
+  '@oxc-parser/binding-android-arm64@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.132.0':
+  '@oxc-parser/binding-darwin-arm64@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.135.0':
+  '@oxc-parser/binding-darwin-x64@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.132.0':
+  '@oxc-parser/binding-freebsd-x64@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.135.0':
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.132.0':
+  '@oxc-parser/binding-linux-arm-musleabihf@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.135.0':
+  '@oxc-parser/binding-linux-arm64-gnu@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.132.0':
+  '@oxc-parser/binding-linux-arm64-musl@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.135.0':
+  '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
+  '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.135.0':
+  '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
+  '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.135.0':
+  '@oxc-parser/binding-linux-x64-gnu@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
+  '@oxc-parser/binding-linux-x64-musl@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.135.0':
+  '@oxc-parser/binding-openharmony-arm64@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
+  '@oxc-parser/binding-win32-arm64-msvc@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.135.0':
+  '@oxc-parser/binding-win32-ia32-msvc@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-wasm32-wasi@0.132.0':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optional: true
-
-  '@oxc-parser/binding-wasm32-wasi@0.135.0':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optional: true
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.135.0':
+  '@oxc-parser/binding-win32-x64-msvc@0.143.0':
     optional: true
 
   '@oxc-project/runtime@0.143.0': {}
-
-  '@oxc-project/types@0.132.0': {}
-
-  '@oxc-project/types@0.135.0': {}
 
   '@oxc-project/types@0.143.0': {}
 
@@ -7945,115 +7573,58 @@ snapshots:
   '@oxlint-tsgolint/win32-x64@7.0.2001':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.66.0':
-    optional: true
-
   '@oxlint/binding-android-arm-eabi@1.77.0':
-    optional: true
-
-  '@oxlint/binding-android-arm64@1.66.0':
     optional: true
 
   '@oxlint/binding-android-arm64@1.77.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.66.0':
-    optional: true
-
   '@oxlint/binding-darwin-arm64@1.77.0':
-    optional: true
-
-  '@oxlint/binding-darwin-x64@1.66.0':
     optional: true
 
   '@oxlint/binding-darwin-x64@1.77.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.66.0':
-    optional: true
-
   '@oxlint/binding-freebsd-x64@1.77.0':
-    optional: true
-
-  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-arm-gnueabihf@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
-    optional: true
-
   '@oxlint/binding-linux-arm-musleabihf@1.77.0':
-    optional: true
-
-  '@oxlint/binding-linux-arm64-gnu@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-gnu@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.66.0':
-    optional: true
-
   '@oxlint/binding-linux-arm64-musl@1.77.0':
-    optional: true
-
-  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-ppc64-gnu@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
-    optional: true
-
   '@oxlint/binding-linux-riscv64-gnu@1.77.0':
-    optional: true
-
-  '@oxlint/binding-linux-riscv64-musl@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-riscv64-musl@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.66.0':
-    optional: true
-
   '@oxlint/binding-linux-s390x-gnu@1.77.0':
-    optional: true
-
-  '@oxlint/binding-linux-x64-gnu@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-x64-gnu@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.66.0':
-    optional: true
-
   '@oxlint/binding-linux-x64-musl@1.77.0':
-    optional: true
-
-  '@oxlint/binding-openharmony-arm64@1.66.0':
     optional: true
 
   '@oxlint/binding-openharmony-arm64@1.77.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.66.0':
-    optional: true
-
   '@oxlint/binding-win32-arm64-msvc@1.77.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.66.0':
-    optional: true
-
   '@oxlint/binding-win32-ia32-msvc@1.77.0':
-    optional: true
-
-  '@oxlint/binding-win32-x64-msvc@1.66.0':
     optional: true
 
   '@oxlint/binding-win32-x64-msvc@1.77.0':
@@ -8984,6 +8555,8 @@ snapshots:
       meriyah: 6.1.4
     transitivePeerDependencies:
       - supports-color
+
+  '@shaderfrog/glsl-parser@7.0.1': {}
 
   '@shuding/opentype.js@1.4.0-beta.0':
     dependencies:
@@ -10215,12 +9788,12 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.7.0:
+  deslop-js@0.9.12:
     dependencies:
-      '@oxc-project/types': 0.132.0
+      '@oxc-project/types': 0.143.0
       fast-glob: 3.3.3
       minimatch: 10.2.6
-      oxc-parser: 0.132.0
+      oxc-parser: 0.143.0
       oxc-resolver: 11.24.2
       typescript: 5.9.3
 
@@ -11255,55 +10828,29 @@ snapshots:
 
   outvariant@1.4.3: {}
 
-  oxc-parser@0.132.0:
+  oxc-parser@0.143.0:
     dependencies:
-      '@oxc-project/types': 0.132.0
+      '@oxc-project/types': 0.143.0
     optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.132.0
-      '@oxc-parser/binding-android-arm64': 0.132.0
-      '@oxc-parser/binding-darwin-arm64': 0.132.0
-      '@oxc-parser/binding-darwin-x64': 0.132.0
-      '@oxc-parser/binding-freebsd-x64': 0.132.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.132.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.132.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.132.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.132.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.132.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-x64-musl': 0.132.0
-      '@oxc-parser/binding-openharmony-arm64': 0.132.0
-      '@oxc-parser/binding-wasm32-wasi': 0.132.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.132.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.132.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.132.0
-
-  oxc-parser@0.135.0:
-    dependencies:
-      '@oxc-project/types': 0.135.0
-    optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.135.0
-      '@oxc-parser/binding-android-arm64': 0.135.0
-      '@oxc-parser/binding-darwin-arm64': 0.135.0
-      '@oxc-parser/binding-darwin-x64': 0.135.0
-      '@oxc-parser/binding-freebsd-x64': 0.135.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.135.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.135.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.135.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.135.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.135.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.135.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.135.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.135.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.135.0
-      '@oxc-parser/binding-linux-x64-musl': 0.135.0
-      '@oxc-parser/binding-openharmony-arm64': 0.135.0
-      '@oxc-parser/binding-wasm32-wasi': 0.135.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.135.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.135.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.135.0
+      '@oxc-parser/binding-android-arm-eabi': 0.143.0
+      '@oxc-parser/binding-android-arm64': 0.143.0
+      '@oxc-parser/binding-darwin-arm64': 0.143.0
+      '@oxc-parser/binding-darwin-x64': 0.143.0
+      '@oxc-parser/binding-freebsd-x64': 0.143.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.143.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.143.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.143.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.143.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.143.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.143.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.143.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.143.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.143.0
+      '@oxc-parser/binding-linux-x64-musl': 0.143.0
+      '@oxc-parser/binding-openharmony-arm64': 0.143.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.143.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.143.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.143.0
 
   oxc-resolver@11.24.2:
     optionalDependencies:
@@ -11377,12 +10924,14 @@ snapshots:
       '@oxfmt/binding-win32-x64-msvc': 0.62.0
       vite-plus: 0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
-  oxlint-plugin-react-doctor@0.7.0:
+  oxlint-plugin-react-doctor@0.9.12:
     dependencies:
+      '@shaderfrog/glsl-parser': 7.0.1
       '@typescript-eslint/types': 8.66.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
-      oxc-parser: 0.135.0
+      lightningcss: 1.33.0
+      oxc-parser: 0.143.0
 
   oxlint-tsgolint@7.0.2001:
     optionalDependencies:
@@ -11392,29 +10941,6 @@ snapshots:
       '@oxlint-tsgolint/linux-x64': 7.0.2001
       '@oxlint-tsgolint/win32-arm64': 7.0.2001
       '@oxlint-tsgolint/win32-x64': 7.0.2001
-
-  oxlint@1.66.0(oxlint-tsgolint@7.0.2001):
-    optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.66.0
-      '@oxlint/binding-android-arm64': 1.66.0
-      '@oxlint/binding-darwin-arm64': 1.66.0
-      '@oxlint/binding-darwin-x64': 1.66.0
-      '@oxlint/binding-freebsd-x64': 1.66.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.66.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.66.0
-      '@oxlint/binding-linux-arm64-gnu': 1.66.0
-      '@oxlint/binding-linux-arm64-musl': 1.66.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.66.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.66.0
-      '@oxlint/binding-linux-riscv64-musl': 1.66.0
-      '@oxlint/binding-linux-s390x-gnu': 1.66.0
-      '@oxlint/binding-linux-x64-gnu': 1.66.0
-      '@oxlint/binding-linux-x64-musl': 1.66.0
-      '@oxlint/binding-openharmony-arm64': 1.66.0
-      '@oxlint/binding-win32-arm64-msvc': 1.66.0
-      '@oxlint/binding-win32-ia32-msvc': 1.66.0
-      '@oxlint/binding-win32-x64-msvc': 1.66.0
-      oxlint-tsgolint: 7.0.2001
 
   oxlint@1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
@@ -11685,31 +11211,34 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
-  react-doctor@0.7.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@7.0.2001)(supports-color@10.2.2):
+  react-doctor@0.9.12(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@7.0.2001)(supports-color@10.2.2)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
-      '@babel/code-frame': 7.29.7
+      '@astrojs/compiler': 4.0.0
       '@sentry/node': 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(supports-color@10.2.2)
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.7.0
+      deslop-js: 0.9.12
       eslint-plugin-react-hooks: 7.1.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
       jiti: 2.7.0
       magicast: 0.5.4
-      oxlint: 1.66.0(oxlint-tsgolint@7.0.2001)
-      oxlint-plugin-react-doctor: 0.7.0
+      oxc-resolver: 11.24.2
+      oxlint: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint-plugin-react-doctor: 0.9.12
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
       yaml: 2.9.0
+      yoga-layout: 3.2.1
     transitivePeerDependencies:
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
       - eslint
       - oxlint-tsgolint
       - supports-color
+      - vite-plus
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## Summary

- update React Doctor from 0.7.0 to 0.9.12
- disposition all diagnostics introduced by 0.9 with commit-phase refs, explicit async/error handling, stable list identities, accessibility fixes, and focused component extraction
- preserve local picker errors, Slack revoke semantics, drop handling, and pointer interactions with regression coverage

Of the original 44 diagnostics, 41 are resolved in code. Three are documented, line-local exceptions: two cleanup scanner limitations where the effects already return complete timer/socket cleanup, and one intentional manual fetch that keeps candidate transport failures in the picker's inline error state because React Router fetcher loader failures propagate to a route error boundary.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm validate:static` (3015 passed, 1 skipped; React Doctor 100; public scan 0)
- `pnpm validate:build`
- `pnpm test:behavior-browser` (55 passed)
- `pnpm check:scenario-routes`
- `pnpm visual:compose` (94 passed; no baseline differences)
- focused candidate, Slack, viewer, comment, file-list, and drop behavior tests
- Codex implementation review: no findings on `4105020`
- Claude implementation review: no findings on `4105020`
- trusted-main public development guard

## UI review

- exact Compose visual baselines pass without updates
- component extraction preserves the existing DOM and styling
- pointer navigation now requires a primary, low-movement gesture that begins and ends outside nested controls
