### PR TITLE
Prevent cross-tab auth analytics duplication

### DIFF
--- a/apps/web/app/components/app/analytics-auth-tracker.test.tsx
+++ b/apps/web/app/components/app/analytics-auth-tracker.test.tsx
@@ -109,4 +109,59 @@ describe('AnalyticsAuthTracker', () => {
       account_state: 'existing',
     })
   })
+
+  test('does not let another tab claim the same artifact attempt', async () => {
+    captureAuthAttempt({
+      method: 'google',
+      callbackURL: '/a/example',
+      shouldLoadAnalytics: true,
+    })
+    const initiatingNonce = readAuthAttempt()!.nonce
+
+    // The cookie is shared across tabs, but sessionStorage is not.
+    sessionStorage.clear()
+    await React.act(async () => {
+      root.render(
+        <AnalyticsAuthTracker
+          authenticated={false}
+          signup={null}
+          shouldLoadAnalytics
+        />,
+      )
+    })
+    await React.act(async () => {
+      root.render(
+        <AnalyticsAuthTracker
+          authenticated
+          signup={null}
+          shouldLoadAnalytics
+        />,
+      )
+    })
+    expect(gtag).not.toHaveBeenCalled()
+
+    sessionStorage.setItem('__as_auth_attempt_nonce', initiatingNonce)
+    await React.act(async () => {
+      root.render(
+        <AnalyticsAuthTracker
+          authenticated={false}
+          signup={null}
+          shouldLoadAnalytics
+        />,
+      )
+    })
+    await React.act(async () => {
+      root.render(
+        <AnalyticsAuthTracker
+          authenticated
+          signup={null}
+          shouldLoadAnalytics
+        />,
+      )
+    })
+    expect(gtag).toHaveBeenCalledWith('event', 'auth_completed', {
+      method: 'google',
+      account_state: 'existing',
+    })
+  })
 })

--- a/apps/web/app/components/app/analytics-auth-tracker.tsx
+++ b/apps/web/app/components/app/analytics-auth-tracker.tsx
@@ -28,7 +28,7 @@ export function AnalyticsAuthTracker({
     } catch {
       currentArtifactId = undefined
     }
-    const attempt = readAuthAttempt(currentArtifactId)
+    const attempt = readAuthAttempt()
     if (!attempt || attempt.authCompletedSent) return
     // react-doctor-disable-next-line react-doctor/no-event-handler
     const accountState = signup ? 'new' : 'existing'

--- a/apps/web/app/lib/analytics/auth-attempt.client.test.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.test.ts
@@ -55,19 +55,7 @@ describe('auth attempt analytics cookie', () => {
     })
   })
 
-  test('recovers a sole attempt after mobile tab storage is discarded', () => {
-    captureAuthAttempt({
-      method: 'google',
-      callbackURL: '/a/example',
-      shouldLoadAnalytics: true,
-    })
-    sessionStorage.clear()
-    expect(readAuthAttempt('example')).toEqual(
-      expect.objectContaining({ method: 'google', artifactId: 'example' }),
-    )
-  })
-
-  test('does not recover another tab attempt on an unrelated page', () => {
+  test('does not recover an attempt after tab ownership is lost', () => {
     captureAuthAttempt({
       method: 'google',
       callbackURL: '/a/example',
@@ -75,7 +63,16 @@ describe('auth attempt analytics cookie', () => {
     })
     sessionStorage.clear()
     expect(readAuthAttempt()).toBeNull()
-    expect(readAuthAttempt('different')).toBeNull()
+  })
+
+  test('does not claim another tab attempt for the same artifact', () => {
+    captureAuthAttempt({
+      method: 'google',
+      callbackURL: '/a/example',
+      shouldLoadAnalytics: true,
+    })
+    sessionStorage.clear()
+    expect(readAuthAttempt()).toBeNull()
   })
 
   test('replaces the same tab attempt when authentication is retried', () => {

--- a/apps/web/app/lib/analytics/auth-attempt.client.ts
+++ b/apps/web/app/lib/analytics/auth-attempt.client.ts
@@ -81,22 +81,13 @@ function removeTabNonce(): void {
   }
 }
 
-export function readAuthAttempt(
-  recoveryArtifactId?: string,
-): AuthAttempt | null {
+export function readAuthAttempt(): AuthAttempt | null {
   const attempts = readAuthAttempts()
   const tabNonce = readTabNonce()
   if (tabNonce) return attempts.find(({ nonce }) => nonce === tabNonce) ?? null
-  // Mobile browsers may discard sessionStorage while an OAuth tab is
-  // backgrounded. A sole pending attempt is still unambiguous; multiple
-  // candidates fail closed rather than attributing the wrong method/artifact.
-  if (
-    attempts.length === 1 &&
-    recoveryArtifactId !== undefined &&
-    attempts[0].artifactId === recoveryArtifactId
-  ) {
-    return writeTabNonce(attempts[0].nonce) ? attempts[0] : null
-  }
+  // The shared cookie cannot distinguish a tab that lost sessionStorage from
+  // another open tab showing the same artifact. Recovering by artifact would
+  // let both tabs emit auth_completed, so analytics fails closed instead.
   return null
 }
 

--- a/apps/web/app/routes/a.$id/+components/artifact-view-tracker.tsx
+++ b/apps/web/app/routes/a.$id/+components/artifact-view-tracker.tsx
@@ -55,7 +55,7 @@ function recordArtifactView(input: {
   // consent is granted later (which re-runs the effect via shouldLoad).
   if (sent) seenArtifactViews.add(input.key)
   if (input.viewerState === 'authenticated') {
-    const attempt = readAuthAttempt(input.artifactId)
+    const attempt = readAuthAttempt()
     if (
       attempt?.authCompletedSent &&
       attempt.artifactId === input.artifactId &&


### PR DESCRIPTION
## Summary

- require the initiating tab’s session nonce before attributing authentication analytics
- fail closed when tab-local analytics ownership is lost
- cover the same-artifact, second-tab race without changing authentication or return navigation

## Validation

- `pnpm validate:static`
- Codex implementation review: no blockers
- Claude implementation review: no findings

## Tradeoff

If a browser discards the initiating tab’s `sessionStorage` during authentication, completion analytics may be omitted. Authentication and return navigation are unaffected; this avoids cross-tab duplication and misattribution.