### PR TITLE
Add a persona registry to the task ledger

### DIFF
--- a/docs/reference/screen-capture.md
+++ b/docs/reference/screen-capture.md
@@ -6,7 +6,9 @@ The screen capture harness creates review material from the real local applicati
 
 [`scripts/task-ledger.mjs`](../../scripts/task-ledger.mjs) is the source of truth for the main journeys in the publish → react → republish loop. The screen ledger owns individual screens and representative visual states; the task ledger owns user context and the sequence through start, action, pending, success, failure, recovery, and next action. Walkthroughs will reproduce those transitions and collect their evidence.
 
-The task data also owns its selection criteria and update procedure. Run `pnpm check:task-ledger` after changing either ledger; it validates the task contract and its screen references.
+The task ledger also owns the persona registry: each task references one persona, and each persona records who the user is, whether the flow is operated directly or delegated to an AI agent (`mediation`), and the development sign-in persona that reproduces its default context (`auth`). Update the persona definitions first when observed usage stops matching them.
+
+The task data also owns its selection criteria and update procedure. Run `pnpm check:task-ledger` after changing either ledger; it validates the task contract, the persona registry, and the screen references.
 
 ## Run
 

--- a/docs/reference/screen-capture.md
+++ b/docs/reference/screen-capture.md
@@ -6,7 +6,7 @@ The screen capture harness creates review material from the real local applicati
 
 [`scripts/task-ledger.mjs`](../../scripts/task-ledger.mjs) is the source of truth for the main journeys in the publish → react → republish loop. The screen ledger owns individual screens and representative visual states; the task ledger owns user context and the sequence through start, action, pending, success, failure, recovery, and next action. Walkthroughs will reproduce those transitions and collect their evidence.
 
-The task ledger also owns the persona registry: each task references one persona, and each persona records who the user is, whether the flow is operated directly or delegated to an AI agent (`mediation`), and the development sign-in persona that reproduces its default context (`auth`). Update the persona definitions first when observed usage stops matching them.
+The task ledger also owns the persona registry: each task references one persona, and each persona records who the user is, whether the flow is operated directly or delegated to an AI agent (`mediation`), and the sign-in context that reproduces its default state (`auth`) — a development sign-in persona, or `anonymous` for flows that begin signed out. Update the persona definitions first when observed usage stops matching them.
 
 The task data also owns its selection criteria and update procedure. Run `pnpm check:task-ledger` after changing either ledger; it validates the task contract, the persona registry, and the screen references.
 

--- a/scripts/check-task-ledger.mjs
+++ b/scripts/check-task-ledger.mjs
@@ -45,19 +45,21 @@ export function checkTaskLedger({
     failures.push('selection criteria required')
   if (!Array.isArray(procedure) || procedure.length === 0)
     failures.push('change procedure required')
-  if (!Array.isArray(ledgerPersonas) || ledgerPersonas.length === 0)
-    failures.push('personas required')
+  const registry = Array.isArray(ledgerPersonas) ? ledgerPersonas : []
+  if (registry.length === 0) failures.push('personas required')
   if (ledgerTasks.length < 8 || ledgerTasks.length > 12)
     failures.push(`expected 8-12 primary tasks, found ${ledgerTasks.length}`)
 
-  for (const persona of ledgerPersonas ?? []) {
+  for (const persona of registry) {
     const label = persona.id || '<missing-persona-id>'
     for (const field of ['id', 'name', 'summary'])
       if (typeof persona[field] !== 'string' || !persona[field].trim())
         failures.push(`${label}: persona ${field} required`)
-    if (personaIds.has(persona.id))
-      failures.push(`${label}: duplicate persona id`)
-    personaIds.add(persona.id)
+    if (typeof persona.id === 'string' && persona.id.trim()) {
+      if (personaIds.has(persona.id))
+        failures.push(`${label}: duplicate persona id`)
+      personaIds.add(persona.id)
+    }
     if (!personaMediations.has(persona.mediation))
       failures.push(`${label}: invalid persona mediation ${persona.mediation}`)
     if (!authPersonas.has(persona.auth))

--- a/scripts/check-task-ledger.mjs
+++ b/scripts/check-task-ledger.mjs
@@ -1,6 +1,8 @@
-import { screens } from './screen-ledger.mjs'
+import { authPersonas, screens } from './screen-ledger.mjs'
 import {
   changeProcedure,
+  personaMediations,
+  personas,
   selectionCriteria,
   taskFlowPhases,
   taskLoopStages,
@@ -30,19 +32,37 @@ function screenReferences(ledgerScreens) {
 export function checkTaskLedger({
   ledgerTasks = tasks,
   ledgerScreens = screens,
+  ledgerPersonas = personas,
   criteria = selectionCriteria,
   procedure = changeProcedure,
 } = {}) {
   const failures = []
   const ids = new Set()
+  const personaIds = new Set()
   const validReferences = screenReferences(ledgerScreens)
 
   if (!Array.isArray(criteria) || criteria.length === 0)
     failures.push('selection criteria required')
   if (!Array.isArray(procedure) || procedure.length === 0)
     failures.push('change procedure required')
+  if (!Array.isArray(ledgerPersonas) || ledgerPersonas.length === 0)
+    failures.push('personas required')
   if (ledgerTasks.length < 8 || ledgerTasks.length > 12)
     failures.push(`expected 8-12 primary tasks, found ${ledgerTasks.length}`)
+
+  for (const persona of ledgerPersonas ?? []) {
+    const label = persona.id || '<missing-persona-id>'
+    for (const field of ['id', 'name', 'summary'])
+      if (typeof persona[field] !== 'string' || !persona[field].trim())
+        failures.push(`${label}: persona ${field} required`)
+    if (personaIds.has(persona.id))
+      failures.push(`${label}: duplicate persona id`)
+    personaIds.add(persona.id)
+    if (!personaMediations.has(persona.mediation))
+      failures.push(`${label}: invalid persona mediation ${persona.mediation}`)
+    if (!authPersonas.has(persona.auth))
+      failures.push(`${label}: unknown persona auth ${persona.auth}`)
+  }
 
   for (const task of ledgerTasks) {
     const label = task.id || '<missing-id>'
@@ -52,6 +72,9 @@ export function checkTaskLedger({
 
     if (ids.has(task.id)) failures.push(`${label}: duplicate task id`)
     ids.add(task.id)
+
+    if (!personaIds.has(task.persona))
+      failures.push(`${label}: unknown persona ${task.persona}`)
 
     if (!taskLoopStages.has(task.loopStage))
       failures.push(`${label}: invalid loop stage ${task.loopStage}`)
@@ -94,6 +117,6 @@ if (import.meta.main) {
     process.exit(1)
   }
   console.log(
-    `task-ledger check ok: ${tasks.length} tasks, ${selectionCriteria.length} selection criteria, ${changeProcedure.length} change steps`,
+    `task-ledger check ok: ${tasks.length} tasks, ${personas.length} personas, ${selectionCriteria.length} selection criteria, ${changeProcedure.length} change steps`,
   )
 }

--- a/scripts/check-task-ledger.mjs
+++ b/scripts/check-task-ledger.mjs
@@ -51,6 +51,10 @@ export function checkTaskLedger({
     failures.push(`expected 8-12 primary tasks, found ${ledgerTasks.length}`)
 
   for (const persona of registry) {
+    if (!persona || typeof persona !== 'object') {
+      failures.push('<invalid-persona-entry>: persona object required')
+      continue
+    }
     const label = persona.id || '<missing-persona-id>'
     for (const field of ['id', 'name', 'summary'])
       if (typeof persona[field] !== 'string' || !persona[field].trim())

--- a/scripts/check-task-ledger.test.mjs
+++ b/scripts/check-task-ledger.test.mjs
@@ -123,6 +123,39 @@ test('requires a non-empty persona registry', () =>
     'personas required',
   ))
 
+test('reports a non-array persona registry without throwing', () =>
+  assert.equal(
+    checkTaskLedger({
+      ...options(
+        Array.from({ length: 8 }, (_, index) =>
+          fixtureTask({ id: `task-${index}` }),
+        ),
+      ),
+      ledgerPersonas: {},
+    })[0],
+    'personas required',
+  ))
+
+test('rejects a task without a persona even when a registry entry lacks an id', () => {
+  const failures = checkTaskLedger({
+    ...options(
+      Array.from({ length: 8 }, (_, index) =>
+        fixtureTask({ id: `task-${index}`, persona: undefined }),
+      ),
+    ),
+    ledgerPersonas: [
+      {
+        name: 'name',
+        summary: 'summary',
+        mediation: 'mixed',
+        auth: 'anonymous',
+      },
+    ],
+  })
+  assert.ok(failures.includes('<missing-persona-id>: persona id required'))
+  assert.ok(failures.includes('task-0: unknown persona undefined'))
+})
+
 test('ships a registry that covers every ledger task', () => {
   const ids = new Set(personas.map((persona) => persona.id))
   for (const task of tasks) assert.ok(ids.has(task.persona), task.id)

--- a/scripts/check-task-ledger.test.mjs
+++ b/scripts/check-task-ledger.test.mjs
@@ -123,6 +123,19 @@ test('requires a non-empty persona registry', () =>
     'personas required',
   ))
 
+test('reports a non-object persona entry without throwing', () =>
+  assert.equal(
+    checkTaskLedger({
+      ...options(
+        Array.from({ length: 8 }, (_, index) =>
+          fixtureTask({ id: `task-${index}` }),
+        ),
+      ),
+      ledgerPersonas: [null],
+    })[0],
+    '<invalid-persona-entry>: persona object required',
+  ))
+
 test('reports a non-array persona registry without throwing', () =>
   assert.equal(
     checkTaskLedger({

--- a/scripts/check-task-ledger.test.mjs
+++ b/scripts/check-task-ledger.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { checkTaskLedger } from './check-task-ledger.mjs'
-import { tasks } from './task-ledger.mjs'
+import { personas, tasks } from './task-ledger.mjs'
 
 const screen = {
   id: 'fixture',
@@ -70,6 +70,62 @@ test('requires every flow phase in order', () => {
     )[0],
     /flow phases must be start, action, pending, success, failure, recovery, next/,
   )
+})
+
+test('rejects a task referencing an unknown persona', () => {
+  const failures = checkTaskLedger(
+    options(
+      Array.from({ length: 8 }, (_, index) =>
+        fixtureTask({
+          id: `task-${index}`,
+          persona: index === 0 ? 'missing-persona' : tasks[0].persona,
+        }),
+      ),
+    ),
+  )
+  assert.deepEqual(failures, ['task-0: unknown persona missing-persona'])
+})
+
+test('rejects an incomplete persona registry', () => {
+  const failures = checkTaskLedger({
+    ...options(
+      Array.from({ length: 8 }, (_, index) =>
+        fixtureTask({ id: `task-${index}`, persona: 'fixture-persona' }),
+      ),
+    ),
+    ledgerPersonas: [
+      {
+        id: 'fixture-persona',
+        name: '',
+        summary: 'summary',
+        mediation: 'walk-in',
+        auth: 'nobody',
+      },
+    ],
+  })
+  assert.deepEqual(failures, [
+    'fixture-persona: persona name required',
+    'fixture-persona: invalid persona mediation walk-in',
+    'fixture-persona: unknown persona auth nobody',
+  ])
+})
+
+test('requires a non-empty persona registry', () =>
+  assert.equal(
+    checkTaskLedger({
+      ...options(
+        Array.from({ length: 8 }, (_, index) =>
+          fixtureTask({ id: `task-${index}` }),
+        ),
+      ),
+      ledgerPersonas: [],
+    })[0],
+    'personas required',
+  ))
+
+test('ships a registry that covers every ledger task', () => {
+  const ids = new Set(personas.map((persona) => persona.id))
+  for (const task of tasks) assert.ok(ids.has(task.persona), task.id)
 })
 
 test('requires selection and change guidance', () =>

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -767,14 +767,16 @@ export const screens = [
   },
 ]
 
+export const authPersonas = new Set([
+  'anonymous',
+  'free-owner',
+  'plus-owner',
+  'team-owner',
+  'team-member',
+])
+
 const values = {
-  auth: new Set([
-    'anonymous',
-    'free-owner',
-    'plus-owner',
-    'team-owner',
-    'team-member',
-  ]),
+  auth: authPersonas,
   loop: new Set([
     'create',
     'post',

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -401,7 +401,10 @@ export const screens = [
           scenario: 'home/empty',
           interactions: [
             { action: 'click', selector: 'button:has-text("Add a file")' },
-            { action: 'hover', selector: '[role="dialog"]' },
+            // Assert the dialog opened by hovering its inert title, not the
+            // dialog surface: the surface centre lands on the dropzone and
+            // captures its hover style.
+            { action: 'hover', selector: '[data-slot="dialog-title"]' },
           ],
         },
       },

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -400,7 +400,7 @@ export const screens = [
         setup: {
           scenario: 'home/empty',
           interactions: [
-            { action: 'click', selector: 'a[href="/?upload=1"]' },
+            { action: 'click', selector: 'button:has-text("Add a file")' },
             { action: 'hover', selector: '[role="dialog"]' },
           ],
         },

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -397,7 +397,13 @@ export const screens = [
       {
         id: 'upload-dialog',
         description: 'Web アップロードダイアログを開いた状態',
-        setup: { scenario: 'home/empty', query: '?upload=1' },
+        setup: {
+          scenario: 'home/empty',
+          interactions: [
+            { action: 'click', selector: 'a[href="/?upload=1"]' },
+            { action: 'hover', selector: '[role="dialog"]' },
+          ],
+        },
       },
       {
         id: 'updates-menu-open',

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -395,6 +395,11 @@ export const screens = [
         setup: { scenario: 'home/first-file' },
       },
       {
+        id: 'upload-dialog',
+        description: 'Web アップロードダイアログを開いた状態',
+        setup: { scenario: 'home/empty', query: '?upload=1' },
+      },
+      {
         id: 'updates-menu-open',
         description: '新着の更新情報をアバターメニューで確認した状態',
         setup: {

--- a/scripts/task-ledger.mjs
+++ b/scripts/task-ledger.mjs
@@ -16,6 +16,50 @@ export const taskLoopStages = new Set([
   'republish',
 ])
 
+export const personaMediations = new Set([
+  'human-direct',
+  'agent-mediated',
+  'mixed',
+])
+
+// 利用者像の正本。各タスクは persona を 1 つ参照する。
+// mediation は主要な操作の担い手 (本人が直接操作するか、AI エージェントに任せるか)。
+// auth は persona の既定の文脈を再現する dev sign-in persona。
+export const personas = [
+  {
+    id: 'ai-native-poster',
+    name: 'AI ネイティブ投稿者',
+    summary:
+      'AI エージェントで仕事の成果物を作り、チームへ共有して反応を受け取る投稿者。投稿と更新の操作はエージェントに任せ、本人は共有 URL と画面で結果を確認する。',
+    mediation: 'agent-mediated',
+    auth: 'team-owner',
+  },
+  {
+    id: 'first-time-explorer',
+    name: 'ひとりで試す初回投稿者',
+    summary:
+      '記事や紹介をきっかけに個人で登録し、手元のファイルを Web から直接アップロードして試す利用者。まだ共有相手が決まっておらず、価値の確認が目的。',
+    mediation: 'human-direct',
+    auth: 'free-owner',
+  },
+  {
+    id: 'link-receiver',
+    name: '共有リンクの受け手',
+    summary:
+      '同僚や関係者から共有 URL を受け取って閲覧する利用者。AI ツールの利用者とは限らず、閲覧から始まり、次の投稿者になり得る。',
+    mediation: 'human-direct',
+    auth: 'team-member',
+  },
+  {
+    id: 'team-collaborator',
+    name: 'チームの継続利用メンバー',
+    summary:
+      '所属ワークスペースの共有物を読み、コメントし、自分でも投稿するメンバー。プロジェクトの文脈でファイルを探し、仕事の流れの中で再訪する。',
+    mediation: 'mixed',
+    auth: 'team-member',
+  },
+]
+
 export const selectionCriteria = [
   '投稿、共有、閲覧、反応、再投稿の輪を前へ進める主要な利用者タスクである',
   '複数の画面または一つの画面内の複数状態をまたぎ、画面単体の検査だけでは断絶を見落とし得る',
@@ -23,6 +67,7 @@ export const selectionCriteria = [
 ]
 
 export const changeProcedure = [
+  '利用者は personas 正本から選んで参照し、観測した利用状況が persona 定義と食い違う場合は persona 側を先に更新する',
   '既存タスクと目的、利用者、開始状況が重複しないか確認する',
   '選定基準を満たすタスクだけを追加し、観測した利用状況が変わった場合は既存項目を更新する',
   '全 phase と参照画面を記入し、pnpm check:task-ledger で画面台帳との整合を確認する',
@@ -44,6 +89,7 @@ export const tasks = [
   {
     id: 'return-to-recent-file',
     title: '最近見たファイルへ戻る',
+    persona: 'team-collaborator',
     actor: '以前見たファイルをもう一度確認したい利用者',
     startingSituation:
       '複数のファイルを閲覧した後で、名前や保存先を正確には覚えていない',
@@ -88,8 +134,9 @@ export const tasks = [
   },
   {
     id: 'publish-first-file',
-    title: '最初のファイルを投稿して結果を確認する',
-    actor: 'Artifact Share を初めて使う投稿者',
+    title: '最初のファイルを Web から投稿して結果を確認する',
+    persona: 'first-time-explorer',
+    actor: '手元のファイルを初めて自分で投稿する利用者',
     startingSituation:
       '共有したいローカルファイルがあり、まだ投稿したことがない',
     prerequisite: '対応形式のファイルと、利用可能なアカウントを持っている',
@@ -100,28 +147,28 @@ export const tasks = [
     metric: '初回投稿を開始した利用者の投稿完了率',
     flow: flow({
       start: {
-        description: '投稿方法を確認して認証を始める',
-        screens: ['start/default', 'guides-cli/default'],
+        description: 'Home の空の状態からアップロードを始める',
+        screens: ['home/empty'],
       },
       action: {
-        description: 'デバイス認証を完了し、ファイルを投稿する',
-        screens: ['device/with-code'],
+        description: 'アップロードダイアログでファイルを選んで投稿する',
+        screens: ['home/empty'],
       },
       pending: {
-        description: '認証または投稿処理の完了を待つ',
-        screens: ['device/with-code'],
+        description: 'アップロード処理の完了を待つ',
+        screens: ['home/empty'],
       },
       success: {
         description: 'Home に最初のファイルが現れ、Viewer で内容を確認できる',
         screens: ['home/first-file', 'viewer/default'],
       },
       failure: {
-        description: '認証できない、または投稿結果を Home で確認できない',
-        screens: ['sign-in/account-not-linked', 'home/empty'],
+        description: '形式やサイズ、アップロード可否の制限で投稿を完了できない',
+        screens: ['home/empty'],
       },
       recovery: {
-        description: 'アカウントと投稿手順を確認して再実行する',
-        screens: ['sign-in/with-purpose', 'guides-cli/default'],
+        description: '利用開始の案内で対応形式と手順を確認して再実行する',
+        screens: ['start/default', 'home/empty'],
       },
       next: {
         description: '投稿したファイルを開いて共有へ進む',
@@ -130,8 +177,57 @@ export const tasks = [
     }),
   },
   {
+    id: 'confirm-agent-publish',
+    title: 'エージェントに任せた投稿の結果を確認する',
+    persona: 'ai-native-poster',
+    actor: '成果物の投稿を AI エージェントに任せた投稿者',
+    startingSituation:
+      'エージェントへ投稿を依頼し、完了報告と共有 URL を受け取った',
+    prerequisite:
+      'エージェントが自分のアカウントで接続済みで、投稿対象の成果物がある',
+    goal: '投稿が意図した内容と保存先で完了したことを自分で確認する',
+    completion:
+      '投稿されたファイルを Viewer で確認し、保存先と公開範囲を把握している',
+    confirmation: 'Viewer のタイトル、本文、保存先表示が依頼した内容と一致する',
+    loopStage: 'publish',
+    metric: 'エージェント経由の投稿を投稿者本人が確認する割合',
+    flow: flow({
+      start: {
+        description: 'エージェントから受け取った共有 URL を開く',
+        screens: ['viewer/default'],
+      },
+      action: {
+        description: '内容、保存先、公開範囲を確認する',
+        screens: ['viewer/default'],
+      },
+      pending: {
+        description: 'Viewer の読み込みを待つ',
+        screens: ['viewer/default'],
+      },
+      success: {
+        description: '依頼した内容が意図した保存先に投稿されている',
+        screens: ['viewer/default', 'home/default'],
+      },
+      failure: {
+        description:
+          '別アカウントや意図しない保存先へ投稿され、自分の Home から見つからない',
+        screens: ['sign-in/account-not-linked', 'files/content-rich'],
+      },
+      recovery: {
+        description:
+          'エージェントの接続アカウントを確認し、正しい対象へ再投稿を依頼する',
+        screens: ['settings-cli-sessions/active-cli', 'guides-cli/default'],
+      },
+      next: {
+        description: '共有リンクを相手へ渡す',
+        screens: ['viewer/default'],
+      },
+    }),
+  },
+  {
     id: 'share-file-link',
     title: 'ファイルの共有リンクを相手へ渡す',
+    persona: 'ai-native-poster',
     actor: '投稿済みファイルをレビューしてもらいたい所有者',
     startingSituation: 'Viewer で共有対象のファイルを確認している',
     prerequisite: '共有対象と、意図した公開範囲が決まっている',
@@ -174,6 +270,7 @@ export const tasks = [
   {
     id: 'open-received-file',
     title: '受け取った共有リンクからファイルを読む',
+    persona: 'link-receiver',
     actor: 'Artifact Share の共有リンクを受け取った閲覧者',
     startingSituation: '相手からファイルの共有リンクが届いている',
     prerequisite: 'リンクが有効で、必要な場合はアクセス権を持っている',
@@ -217,6 +314,7 @@ export const tasks = [
   {
     id: 'comment-on-file',
     title: '共有されたファイルへコメントする',
+    persona: 'team-collaborator',
     actor: 'ファイルの内容へ具体的な反応を返したい閲覧者',
     startingSituation: 'Viewer で対象ファイルを読んでいる',
     prerequisite: 'コメント可能な権限があり、伝える内容が決まっている',
@@ -257,8 +355,57 @@ export const tasks = [
     }),
   },
   {
+    id: 'start-own-use-after-viewing',
+    title: '受け取ったファイルの閲覧から自分の利用を始める',
+    persona: 'link-receiver',
+    actor: '共有されたファイルを見て自分でも使いたくなった閲覧者',
+    startingSituation:
+      '共有 URL で受け取ったファイルを閲覧し、製品を知ったばかり',
+    prerequisite:
+      '有効な共有リンクを閲覧でき、サインアップに使えるアカウントを持っている',
+    goal: '閲覧をきっかけに、自分のワークスペースで最初の投稿の準備まで進む',
+    completion:
+      '自分のワークスペースの Home が表示され、最初の投稿手順を把握している',
+    confirmation:
+      '自分のアカウントとワークスペースが画面に表示され、次の投稿手順が分かる',
+    loopStage: 'publish',
+    metric: '共有 URL の閲覧からサインアップへの転換率',
+    flow: flow({
+      start: {
+        description: '閲覧中のファイルから製品の説明と利用開始の入口を見つける',
+        screens: ['viewer/default', 'viewer/intro-open'],
+      },
+      action: {
+        description: 'サインアップして自分のワークスペースを開く',
+        screens: ['sign-in/with-purpose', 'start/default'],
+      },
+      pending: {
+        description: '認証とワークスペースの準備を待つ',
+        screens: ['sign-in/with-purpose'],
+      },
+      success: {
+        description: '自分の Home が開き、最初の投稿へ進める',
+        screens: ['home/empty'],
+      },
+      failure: {
+        description:
+          '利用開始の入口や自分での使い方が分からず、閲覧だけで離脱する',
+        screens: ['viewer/default', 'sign-in/default'],
+      },
+      recovery: {
+        description: '利用開始の案内から投稿手順を確認して進み直す',
+        screens: ['start/default', 'guides-cli/default'],
+      },
+      next: {
+        description: '最初のファイルを投稿する',
+        screens: ['home/empty', 'guides-cli/default'],
+      },
+    }),
+  },
+  {
     id: 'review-new-reactions',
     title: '投稿後に新しい反応を確認する',
+    persona: 'ai-native-poster',
     actor: '共有したファイルへの反応を確認したい投稿者',
     startingSituation: 'ファイルを共有した後で Home に戻ってきた',
     prerequisite: '共有済みファイルに新しいコメントまたは活動がある',
@@ -301,6 +448,7 @@ export const tasks = [
   {
     id: 'republish-updated-file',
     title: '同じ共有リンクで更新版を再投稿する',
+    persona: 'ai-native-poster',
     actor: '反応を反映した更新版を共有したい投稿者',
     startingSituation: '共有済みファイルをローカルで更新した',
     prerequisite:
@@ -344,6 +492,7 @@ export const tasks = [
   {
     id: 'organize-file-in-project',
     title: '投稿済みファイルをプロジェクトへ整理する',
+    persona: 'ai-native-poster',
     actor: '投稿済みファイルをチームの仕事単位へ整理したい所有者',
     startingSituation: '自分のファイル一覧に整理前のファイルがある',
     prerequisite: '移動先のプロジェクトと、その共有範囲を理解している',
@@ -386,6 +535,7 @@ export const tasks = [
   {
     id: 'find-project-file',
     title: 'プロジェクトから必要なファイルを見つける',
+    persona: 'team-collaborator',
     actor: 'チームのプロジェクトに参加している利用者',
     startingSituation: 'プロジェクト内のファイルを確認する必要がある',
     prerequisite: '対象プロジェクトの閲覧権限を持っている',
@@ -429,7 +579,8 @@ export const tasks = [
   {
     id: 'recover-interrupted-publish',
     title: '認証や投稿の失敗から復帰して投稿を完了する',
-    actor: 'CLI からの投稿を始めたが途中で完了できなかった利用者',
+    persona: 'ai-native-poster',
+    actor: 'エージェント経由の投稿を始めたが途中で完了できなかった利用者',
     startingSituation: '認証、ネットワーク、入力のいずれかで投稿が止まっている',
     prerequisite: '元のファイルを保持しており、投稿を再実行できる',
     goal: '失敗理由を理解し、入力や認証を直して投稿を完了する',

--- a/scripts/task-ledger.mjs
+++ b/scripts/task-ledger.mjs
@@ -394,11 +394,11 @@ export const tasks = [
       },
       recovery: {
         description: '利用開始の案内から投稿手順を確認して進み直す',
-        screens: ['start/default', 'guides-cli/default'],
+        screens: ['start/default'],
       },
       next: {
         description: '最初のファイルを投稿する',
-        screens: ['home/empty', 'guides-cli/default'],
+        screens: ['home/empty'],
       },
     }),
   },

--- a/scripts/task-ledger.mjs
+++ b/scripts/task-ledger.mjs
@@ -152,19 +152,20 @@ export const tasks = [
       },
       action: {
         description: 'アップロードダイアログでファイルを選んで投稿する',
-        screens: ['home/empty'],
+        screens: ['home/upload-dialog'],
       },
       pending: {
         description: 'アップロード処理の完了を待つ',
-        screens: ['home/empty'],
+        screens: ['home/upload-dialog'],
       },
       success: {
         description: 'Home に最初のファイルが現れ、Viewer で内容を確認できる',
         screens: ['home/first-file', 'viewer/default'],
       },
       failure: {
-        description: '形式やサイズ、アップロード可否の制限で投稿を完了できない',
-        screens: ['home/empty'],
+        description:
+          '形式やサイズ、アップロード可否の制限でダイアログから先へ進めない',
+        screens: ['home/upload-dialog'],
       },
       recovery: {
         description: '利用開始の案内で対応形式と手順を確認して再実行する',

--- a/scripts/task-ledger.mjs
+++ b/scripts/task-ledger.mjs
@@ -46,9 +46,9 @@ export const personas = [
     id: 'link-receiver',
     name: '共有リンクの受け手',
     summary:
-      '同僚や関係者から共有 URL を受け取って閲覧する利用者。AI ツールの利用者とは限らず、閲覧から始まり、次の投稿者になり得る。',
+      '同僚や関係者から共有 URL を受け取って閲覧する利用者。AI ツールの利用者とは限らず、閲覧から始まり、次の投稿者になり得る。既定の開始文脈は未認証で、必要になった時点でサインインする。',
     mediation: 'human-direct',
-    auth: 'team-member',
+    auth: 'anonymous',
   },
   {
     id: 'team-collaborator',


### PR DESCRIPTION
## Implementation

- Add a persona registry to `scripts/task-ledger.mjs` as the source of truth for who each primary task serves. Four personas cover the current loop: an AI-native poster who delegates publishing to an agent, a first-time explorer who uploads directly from the web UI, a link receiver who starts as an unauthenticated viewer, and a team collaborator inside a shared workspace. Each entry records `mediation` (human-direct / agent-mediated / mixed) and the dev sign-in persona (`auth`) that reproduces its default context.
- Reference one persona from every task and update the change procedure so persona definitions are corrected before tasks when observed usage diverges.
- Split publishing into two journeys: `publish-first-file` now describes the web-direct first upload from an empty Home, and the new `confirm-agent-publish` covers the owner verifying a publish they delegated to an agent (including the wrong-account / wrong-destination failure path).
- Add `start-own-use-after-viewing`: the viewer-to-poster conversion journey from reading a received share URL to reaching an own workspace ready for a first post.
- Extend `scripts/check-task-ledger.mjs` to validate the registry (required fields, unique ids, mediation enum, known auth persona) and every task's persona reference. A non-array registry is reported as a failure instead of throwing, and an id-less registry entry cannot mask a task that omits its persona. `scripts/screen-ledger.mjs` now exports `authPersonas` so both ledgers validate against the same sign-in vocabulary.
- Register `home/upload-dialog` in the screen ledger by clicking the Home header "Add a file" button and waiting for the dialog to be visible, so the first-upload journey's dialog and failure phases reference a state that can show them and the capture fails loudly if the dialog stops opening. Verified live: `pnpm screens:capture -- --screen home` produced all 20 home captures including the four upload-dialog variants showing the open dialog.
- Document the persona registry in `docs/reference/screen-capture.md`.

## Visible effect

The task ledger can now answer "whose flow is this" for every primary journey, and walkthrough or critique tooling can pick the reproducing sign-in persona and the mediation mode from the ledger instead of inferring them. Ledger edits that reference an unknown persona fail `pnpm check:task-ledger` (and the static validation lane).

## Validation

- `pnpm check:task-ledger` — ok: 12 tasks, 4 personas
- `pnpm check:screen-ledger` — ok
- `node --test scripts/check-task-ledger.test.mjs` — 11 pass
- `node --test scripts/check-screen-ledger.test.mjs` — pass
- `pnpm format`, `pnpm lint` — clean
- `pnpm public:scan .` — 0 findings
- `pnpm validate:static` — 288 test files / 3037 tests passed, react-doctor 100 (rerun after each commit)
- PR boundary guard reproduced from a trusted `origin/main` checkout — status 0

## Review gate

Codex and Claude implementation reviews ran in parallel on each candidate commit. Round 1 (both reviewers): the link-receiver persona started authenticated despite owning the signup journey (fixed: `auth: 'anonymous'`), and the validator threw on a malformed registry and let an id-less entry mask missing task references (fixed, with tests). Round 2: Codex clean; Claude flagged the reference doc describing `auth` strictly as a dev sign-in persona while `anonymous` is a legal value (fixed: doc wording). Round 3: Claude found the non-object registry entry still throwing (fixed, with a test) and the conversion journey handing off to the CLI guide after its target task became web-direct (fixed: hands off to Home). Round 4: Codex clean; Claude showed the upload dialog is capturable via the existing `?upload=1` entry, so the repeated `home/empty` observation was resolved by registering `home/upload-dialog` instead of deferring it. Round 5: Codex clean; Claude noted the query-only setup would silently capture a plain empty Home if the dialog stopped opening (fixed: interaction-driven setup). Round 6 (both reviewers): the chosen CTA selector does not exist on the Home route — fixed by clicking the header "Add a file" button, then verified with a real capture run (`pnpm screens:capture -- --screen home`, 20/20 succeeded, dialog visible in the upload-dialog captures). Round 7: Codex clean; Claude caught the dialog-surface hover landing on the dropzone at the mobile viewport and capturing its hover style — fixed by hovering the inert dialog title, re-verified with another live capture run (20/20, dropzone resting in all variants). Round 8 (final commit): Codex clean; Claude confirmed the validator and capture changes sound and reported three ledger-data observations, classified as follow-ups / non-actionable: persona `auth` values are not cross-checked against the auth of statically captured screens (walkthroughs sign in per task, so this is a latent gap the walkthrough work owns), the first-upload journey's pending/failure phases share the idle dialog state (progress/error variants also belong to the walkthrough work), and `confirm-agent-publish` concentrates its happy path on the viewer (the task still crosses six screens across its flow, meeting the selection criterion). No unresolved blocker on the final commit.

## Follow-ups

- Add an anonymous `viewer` state so the viewer-to-poster conversion journey can be captured signed out, matching the link-receiver persona's default context. The walkthrough harness work also owns cross-checking persona `auth` against the `auth` of referenced screens when it reproduces task contexts, and richer upload progress/error states for the first-upload journey.
