### PR TITLE
Allow one public design decision link

### DIFF
--- a/config/public-repository-scan.json
+++ b/config/public-repository-scan.json
@@ -89,6 +89,24 @@
       "reason": "scanner pattern declaration"
     },
     {
+      "category": "private-reference",
+      "path": "^docs/reference/design-system\\.md$",
+      "pattern": "^\\.\\./decisions/discovery-and-list-limit-roles\\.md$",
+      "reason": "public design decision referenced by the design-system critique criteria"
+    },
+    {
+      "category": "private-reference",
+      "path": "^docs/reference/design-system\\.md$",
+      "pattern": "^\\.\\./decisions/$",
+      "reason": "bounded prefix match for the exact public design decision allowlist"
+    },
+    {
+      "category": "private-reference",
+      "path": "^config/repository-boundary\\.json$",
+      "pattern": "^docs/decisions/discovery-and-list-limit-roles\\.md$",
+      "reason": "exact public design decision in the repository boundary manifest"
+    },
+    {
       "category": "public-ci-reachability",
       "path": "^\\.github/workflows/deploy-production\\.yml$",
       "pattern": "^secrets\\.$",


### PR DESCRIPTION
## Summary

- allow one exact public design-decision link from the design-system reference
- allow the same exact decision path in the repository-boundary manifest
- keep the exception bounded by category, source file, and matched value

This is a prerequisite policy change. A follow-up PR will add the decision document and classify that document in `config/repository-boundary.json`; this PR intentionally does not add the document itself.

## Validation

- `pnpm validate:static`
- `pnpm public:scan .`
- trusted-main public development guard against `origin/main`
- Codex implementation review: no findings
- Claude implementation review: the future document also needs boundary classification; retained for the follow-up PR by design
