### PR TITLE
Measure copy link outcomes

### DIFF
--- a/apps/web/app/lib/analytics/events.test.ts
+++ b/apps/web/app/lib/analytics/events.test.ts
@@ -6,9 +6,11 @@ import {
   ANALYTICS_PARAMS,
 } from './events'
 describe('analytics definitions', () => {
-  test('defines unique funnel events', () => {
+  test('defines the analytics events', () => {
     expect(Object.values(ANALYTICS_EVENTS)).toEqual([
       'artifact_view',
+      'copy_link_succeeded',
+      'copy_link_failed',
       'sign_up_start',
       'auth_completed',
       'artifact_returned_after_auth',

--- a/apps/web/app/lib/analytics/events.ts
+++ b/apps/web/app/lib/analytics/events.ts
@@ -2,6 +2,8 @@
 
 export const ANALYTICS_EVENTS = {
   artifactView: 'artifact_view',
+  copyLinkSucceeded: 'copy_link_succeeded',
+  copyLinkFailed: 'copy_link_failed',
   signUpStart: 'sign_up_start',
   authCompleted: 'auth_completed',
   artifactReturnedAfterAuth: 'artifact_returned_after_auth',

--- a/apps/web/app/lib/clipboard.test.ts
+++ b/apps/web/app/lib/clipboard.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { bindI18n } from '~/lib/i18n'
+import { setAnalyticsRuntimeState } from './analytics/track.client'
+import { copyShareUrl } from './clipboard'
+
+const toastMock = vi.hoisted(() => vi.fn())
+
+vi.mock('sonner', () => ({ toast: toastMock }))
+
+const translator = bindI18n('en')
+const shareUrl = 'https://example.com/shared/file'
+
+describe('copyShareUrl analytics', () => {
+  const writeText = vi.fn()
+  const execCommand = vi.fn()
+  const gtag = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    })
+    Object.defineProperty(window, 'gtag', {
+      configurable: true,
+      value: gtag,
+    })
+    setAnalyticsRuntimeState({
+      shouldLoadAnalytics: true,
+      measurementId: 'G-TEST',
+    })
+  })
+
+  afterEach(() => {
+    setAnalyticsRuntimeState({
+      shouldLoadAnalytics: false,
+      measurementId: null,
+    })
+  })
+
+  test('records success when the Clipboard API writes the URL', async () => {
+    writeText.mockResolvedValue(undefined)
+
+    await copyShareUrl(shareUrl, translator)
+
+    expect(execCommand).not.toHaveBeenCalled()
+    expect(gtag).toHaveBeenCalledOnce()
+    expect(gtag).toHaveBeenCalledWith('event', 'copy_link_succeeded', {})
+    expect(toastMock).toHaveBeenCalledWith('Copied · paste anywhere')
+  })
+
+  test('records success when the legacy fallback copies the URL', async () => {
+    writeText.mockRejectedValue(new Error('clipboard denied'))
+    execCommand.mockReturnValue(true)
+
+    await copyShareUrl(shareUrl, translator)
+
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(gtag).toHaveBeenCalledOnce()
+    expect(gtag).toHaveBeenCalledWith('event', 'copy_link_succeeded', {})
+  })
+
+  test('records failure only when both copy methods fail', async () => {
+    writeText.mockRejectedValue(new Error('clipboard denied'))
+    execCommand.mockReturnValue(false)
+
+    await copyShareUrl(shareUrl, translator)
+
+    expect(gtag).toHaveBeenCalledOnce()
+    expect(gtag).toHaveBeenCalledWith('event', 'copy_link_failed', {})
+    expect(toastMock).toHaveBeenCalledWith(`Copied · ${shareUrl}`)
+  })
+
+  test('records failure without changing a thrown fallback error', async () => {
+    writeText.mockRejectedValue(new Error('clipboard denied'))
+    execCommand.mockImplementation(() => {
+      throw new Error('copy command unavailable')
+    })
+
+    await expect(copyShareUrl(shareUrl, translator)).rejects.toThrow(
+      'copy command unavailable',
+    )
+
+    expect(gtag).toHaveBeenCalledOnce()
+    expect(gtag).toHaveBeenCalledWith('event', 'copy_link_failed', {})
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+
+  test('does not record a result without analytics consent', async () => {
+    setAnalyticsRuntimeState({
+      shouldLoadAnalytics: false,
+      measurementId: 'G-TEST',
+    })
+    writeText.mockResolvedValue(undefined)
+
+    await copyShareUrl(shareUrl, translator)
+
+    expect(gtag).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/app/lib/clipboard.ts
+++ b/apps/web/app/lib/clipboard.ts
@@ -1,4 +1,6 @@
 import { toast } from 'sonner'
+import { ANALYTICS_EVENTS } from '~/lib/analytics/events'
+import { trackEvent } from '~/lib/analytics/track.client'
 import type { Translator } from '~/lib/i18n'
 
 /**
@@ -10,10 +12,18 @@ export async function copyShareUrl(
   url: string,
   translator: Translator,
 ): Promise<void> {
-  const copied = await writeClipboardText(url)
+  let copied: boolean
+  try {
+    copied = await writeClipboardText(url)
+  } catch (error) {
+    trackEvent(ANALYTICS_EVENTS.copyLinkFailed)
+    throw error
+  }
   if (copied) {
+    trackEvent(ANALYTICS_EVENTS.copyLinkSucceeded)
     toast(translator.t('toast.copiedPasteAnywhere'))
   } else {
+    trackEvent(ANALYTICS_EVENTS.copyLinkFailed)
     toast(translator.t('toast.copied', { url }))
   }
 }


### PR DESCRIPTION
## What changed

- Record separate consent-gated analytics events for successful and failed share-link copies.
- Treat a successful legacy clipboard fallback as success and a failed or throwing fallback as failure.
- Keep the existing copy behavior and toast text unchanged.
- Send no URL, artifact identifier, or user-provided value with either event.

## Validation

- `pnpm validate:static`
- Codex implementation review: no findings
- Claude implementation review: no findings
