### PR TITLE
Preflight CLI token storage before device login

### DIFF
--- a/packages/cli/src/command-runners/login.ts
+++ b/packages/cli/src/command-runners/login.ts
@@ -37,6 +37,7 @@ import {
   nonEmpty,
   readGlobalConfig,
   readProfileToken,
+  probeTokenStoreWritable,
   saveProfileApiTokenCredential,
   saveProfileSessionCredential,
   writeGlobalConfig,
@@ -119,6 +120,12 @@ export async function performDeviceLogin(
 ): Promise<DeviceLoginResult> {
   const preset = await resolveAuthorizationPreset(profile, options)
   if ('error' in preset) return { ok: false, error: preset.error }
+  if (!(await probeTokenStoreWritable(profile, options))) {
+    return {
+      ok: false,
+      error: tokenStoreUnavailableError(profile, 'native_store_unavailable'),
+    }
+  }
   const request = await requestConfig(options)
   if (request.error) return { ok: false, error: request.error }
 

--- a/packages/cli/src/login.test.ts
+++ b/packages/cli/src/login.test.ts
@@ -41,7 +41,12 @@ test('login --json rejects an unavailable token store before device authorizatio
         assert.equal(payload.error.details.profile, 'client-a')
         assert.equal(payload.error.details.cause, 'native_store_unavailable')
         assert.equal(payload.error.recovery.kind, 'ask_human')
-        assert.match(payload.error.hint, /--allow-plaintext-token-store/)
+        assert.match(
+          payload.error.hint,
+          process.platform === 'win32'
+            ? /Credential Manager/
+            : /--allow-plaintext-token-store/,
+        )
         assert.equal(requests, 0)
       },
     )

--- a/packages/cli/src/login.test.ts
+++ b/packages/cli/src/login.test.ts
@@ -19,6 +19,37 @@ const loginEnv = {
   ARTIFACTSHARE_TEST_BROWSER_OPENER: 'success',
 }
 
+test('login --json rejects an unavailable token store before device authorization', async () => {
+  const configHome = await mkdtemp(join(tmpdir(), 'artifactshare-login-'))
+  let requests = 0
+  try {
+    await withServer(
+      (_request, response) => {
+        requests += 1
+        response.statusCode = 500
+        response.end()
+      },
+      async (baseUrl) => {
+        const result = await runAsync(
+          ['login', '--profile', 'client-a', '--base-url', baseUrl, '--json'],
+          { ...loginEnv, ARTIFACTSHARE_CONFIG_HOME: configHome },
+        )
+        const payload = expectFailure(result, {
+          command: 'login',
+          code: 'token_store_unavailable',
+        })
+        assert.equal(payload.error.details.profile, 'client-a')
+        assert.equal(payload.error.details.cause, 'native_store_unavailable')
+        assert.equal(payload.error.recovery.kind, 'ask_human')
+        assert.match(payload.error.hint, /--allow-plaintext-token-store/)
+        assert.equal(requests, 0)
+      },
+    )
+  } finally {
+    await rm(configHome, { recursive: true, force: true })
+  }
+})
+
 test('login --json completes device flow and saves a profile token', async () => {
   const configHome = await mkdtemp(join(tmpdir(), 'artifactshare-login-'))
   let tokenPolls = 0


### PR DESCRIPTION
## Current behavior

Device login can complete browser approval before discovering that the CLI has nowhere safe to persist the resulting credential.

## Change

- Probe the configured token store before requesting a device code.
- Return the existing `token_store_unavailable` JSON contract immediately when no native store or explicitly approved plaintext store is available.
- Preserve the current native-store and explicit 0600 plaintext-store paths.

## Validation

- `pnpm public:scan .`
- `pnpm validate:static`
- `pnpm validate:cli`
- Codex and Claude implementation reviews on commit `00842cc96a30`; no unresolved findings
- Pull-request boundary guard against `origin/main`
