### PR TITLE
Allow longer spec review findings

### DIFF
--- a/scripts/spec-review-input.mjs
+++ b/scripts/spec-review-input.mjs
@@ -1,5 +1,6 @@
 const cliPackage = '@artifactshare/cli@0.10.2'
 const reviewStateMarker = '<!-- artifactshare-spec-review-state:v1 -->'
+const maxReviewResultChars = 1500
 
 const requiredScopeFields = [
   ['owner_decisions', 'Owner decisions'],
@@ -242,7 +243,7 @@ function specReviewPrompt({
     ],
   }
   const prompt = [
-    'Review this specification. Return only one JSON object of at most 700 characters with at most 5 findings matching the contract below; no markdown or exploration log.',
+    `Review this specification. Return only one JSON object of at most ${maxReviewResultChars} characters with at most 5 findings matching the contract below; no markdown or exploration log.`,
     'A blocker is valid only when it identifies a broken current acceptance criterion or new correctness/safety evidence and a minimal fix.',
     'A repeated owner decision without new evidence is non_actionable.',
     `Output contract: ${JSON.stringify(contract)}`,
@@ -315,7 +316,7 @@ function normalizeReviewResult(raw) {
   const verdict = findings.some(({ severity }) => severity === 'blocker')
     ? 'FINDINGS'
     : 'GO'
-  if (JSON.stringify({ verdict, findings }).length > 700)
+  if (JSON.stringify({ verdict, findings }).length > maxReviewResultChars)
     throw new Error('Reviewer result exceeds the concise output limit.')
   return { verdict, findings }
 }

--- a/scripts/spec-review-input.test.mjs
+++ b/scripts/spec-review-input.test.mjs
@@ -260,7 +260,24 @@ test('accepts findings that contain only non-blockers', () => {
   assert.equal(result.verdict, 'GO')
 })
 
-test('rejects reviewer output that cannot fit bounded state', () => {
+test('accepts detailed reviewer output above the former per-reviewer limit', () => {
+  const result = normalizeReviewResult(
+    JSON.stringify({
+      verdict: 'FINDINGS',
+      findings: [
+        {
+          id: 'large',
+          severity: 'follow_up',
+          summary: 'x'.repeat(1300),
+        },
+      ],
+    }),
+  )
+  assert.equal(result.verdict, 'GO')
+  assert.equal(result.findings[0].summary.length, 1300)
+})
+
+test('rejects reviewer output above the expanded durable-state budget', () => {
   assert.throws(
     () =>
       normalizeReviewResult(
@@ -268,9 +285,9 @@ test('rejects reviewer output that cannot fit bounded state', () => {
           verdict: 'FINDINGS',
           findings: [
             {
-              id: 'large',
+              id: 'too-large',
               severity: 'follow_up',
-              summary: 'x'.repeat(1300),
+              summary: 'x'.repeat(1600),
             },
           ],
         }),


### PR DESCRIPTION
## Summary

- expand the per-reviewer specification finding budget from 700 to 1500 characters
- keep the reviewer prompt and enforced limit synchronized through one constant
- retain the five-finding cap and reject output beyond the expanded durable-state budget

## Validation

- `pnpm test:scripts`
- `pnpm public:scan .`
- `pnpm validate:static`
- trusted-main public development boundary guard
- Codex and Claude implementation reviews
