### PR TITLE
fix(web): wrap long Japanese OG titles

### DIFF
--- a/apps/web/app/services/og-title-layout.test.ts
+++ b/apps/web/app/services/og-title-layout.test.ts
@@ -57,6 +57,19 @@ describe('layoutOgTitle', () => {
     expect(result.lines.join('')).toBe(result.text)
   })
 
+  test('wraps a mixed Japanese title instead of replacing it with an ellipsis', () => {
+    const title = 'ソフトウェアファクトリー 2026'
+    const result = layoutOgTitle(title)
+
+    expect(result.lines.join('')).toBe(title)
+    expect(result.lines).not.toEqual(['…'])
+    expect(
+      result.lines
+        .slice(1)
+        .every((line) => !/^[ァィゥェォッャュョー]/u.test(line)),
+    ).toBe(true)
+  })
+
   test('preserves word boundaries around incidental Japanese text', () => {
     const title = 'Deploy the v2.3 API 手順書 for the internal team release'
     const result = layoutOgTitle(title)
@@ -84,6 +97,14 @@ describe('layoutOgTitle', () => {
     const url = `https://example.com/${'a'.repeat(120)}`
     const result = layoutOgTitle(url)
     expect(result.text).toBe('…')
+    expect(result.lines).toEqual(['…'])
+    expect(result.lines.join('')).not.toContain('https://')
+  })
+
+  test('does not split an oversized URL containing Japanese text', () => {
+    const url = `https://example.com/${'a'.repeat(80)}/日本語`
+    const result = layoutOgTitle(url)
+
     expect(result.lines).toEqual(['…'])
     expect(result.lines.join('')).not.toContain('https://')
   })

--- a/apps/web/app/services/og-title-layout.ts
+++ b/apps/web/app/services/og-title-layout.ts
@@ -6,6 +6,11 @@ const JAPANESE_CHARACTER =
   '[\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}]'
 const JAPANESE_PARTICLE = '[のにをはがへとで]'
 const CLOSING_PUNCTUATION = /^[、。，．）」』】〉》〕］｝！？!?]/u
+const FORBIDDEN_JAPANESE_LINE_START =
+  /^[、。，．）」』】〉》〕］｝！？!?ぁぃぅぇぉっゃゅょゎァィゥェォッャュョヮヵヶー]/u
+const FORBIDDEN_JAPANESE_LINE_END = /[（「『【〈《〔［｛]$/u
+const NON_JAPANESE_TOKEN =
+  /(?:https?:\/\/|www\.)\S+|[\p{Script=Latin}\p{Number}][\p{Script=Latin}\p{Number}._:/?#%&=+@~-]*|./gu
 
 export type OgTitleLayout = {
   fontSize: 48 | 58 | 68 | 76
@@ -59,8 +64,20 @@ function wrapSegments(
   japanese: boolean,
 ): string[] {
   const maxUnits = 1056 / fontSize
+  const wrappableSegments = japanese
+    ? segments.flatMap((segment) =>
+        measureUnits(segment) > maxUnits
+          ? splitJapaneseSegment(segment)
+          : [segment],
+      )
+    : segments
   for (let lineCount = 1; lineCount <= 3; lineCount += 1) {
-    const balanced = findBalancedLines(segments, lineCount, japanese, maxUnits)
+    const balanced = findBalancedLines(
+      wrappableSegments,
+      lineCount,
+      japanese,
+      maxUnits,
+    )
     if (balanced) {
       return balanced.map((group) => joinLine(group, japanese))
     }
@@ -70,7 +87,7 @@ function wrapSegments(
   // that fits and mark the omission without splitting a URL or identifier.
   const lineGroups: string[][] = []
   let line: string[] = []
-  for (const segment of segments) {
+  for (const segment of wrappableSegments) {
     if (measureUnits(segment) > maxUnits) {
       if (line.length) lineGroups.push(line)
       return overflowLines(lineGroups, japanese, maxUnits)
@@ -88,6 +105,10 @@ function wrapSegments(
   }
   if (line.length) lineGroups.push(line)
   return lineGroups.map((group) => joinLine(group, japanese))
+}
+
+function splitJapaneseSegment(value: string): string[] {
+  return value.match(NON_JAPANESE_TOKEN) ?? [value]
 }
 
 function findBalancedLines(
@@ -111,7 +132,9 @@ function findBalancedLines(
       const group = segments.slice(start)
       const width = measureUnits(joinLine(group, japanese))
       const result =
-        group.length && width <= maxUnits
+        group.length &&
+        width <= maxUnits &&
+        hasValidJapaneseLineEdges(group, japanese)
           ? { cost: (width - targetUnits) ** 2, groups: [group] }
           : null
       memo.set(key, result)
@@ -124,6 +147,7 @@ function findBalancedLines(
       const group = segments.slice(start, end)
       const width = measureUnits(joinLine(group, japanese))
       if (width > maxUnits) break
+      if (!hasValidJapaneseLineEdges(group, japanese)) continue
       const tail = visit(end, remaining - 1)
       if (!tail) continue
       const candidate = {
@@ -137,6 +161,20 @@ function findBalancedLines(
   }
 
   return visit(0, lineCount)?.groups ?? null
+}
+
+function hasValidJapaneseLineEdges(
+  group: string[],
+  japanese: boolean,
+): boolean {
+  if (!japanese) return true
+  const rawLine = joinLine(group, true)
+  const line = rawLine.trim()
+  return (
+    rawLine === line &&
+    !FORBIDDEN_JAPANESE_LINE_START.test(line) &&
+    !FORBIDDEN_JAPANESE_LINE_END.test(line)
+  )
 }
 
 function overflowLines(


### PR DESCRIPTION
## Summary
- wrap oversized Japanese title segments instead of replacing the entire title with an ellipsis
- preserve URLs and Latin/number identifiers as indivisible tokens
- apply Japanese line-start and line-end constraints

## Validation
- `pnpm validate:static`
- targeted OG title and renderer tests
- visual PNG inspection with the reported title