### PR TITLE
fix(web): prefer wider OG title layouts

### DIFF
--- a/apps/web/app/services/preview-image.server.test.ts
+++ b/apps/web/app/services/preview-image.server.test.ts
@@ -73,6 +73,24 @@ describe('renderShareOgImage', () => {
     expect(renderMock.mock.calls[0]?.[1]).toMatchObject({ lang: 'ja' })
   })
 
+  test('uses one smaller type size when it keeps a short title on one line', async () => {
+    renderMock.mockResolvedValueOnce(new Uint8Array([1]))
+
+    await renderShareOgImage({
+      title: 'ソフトウェアファクトリー 2026',
+      ownerLabel: null,
+      ownerAvatarUrl: null,
+      urlLabel: 'artifactshare.com/a/demo',
+      fontKv: undefined,
+    })
+
+    const markup = String(renderMock.mock.calls[0]?.[0])
+    expect(markup).toContain('font-size:68px')
+    expect(markup).toContain(
+      '<span style="display:block;white-space:nowrap">ソフトウェアファクトリー 2026</span>',
+    )
+  })
+
   test('uses English line-breaking rules for English cards', async () => {
     renderMock.mockResolvedValueOnce(new Uint8Array([1]))
 

--- a/apps/web/app/services/preview-image.server.ts
+++ b/apps/web/app/services/preview-image.server.ts
@@ -122,8 +122,14 @@ export function renderHomeOgImage(
 
 async function renderCard(input: CardInput): Promise<Uint8Array> {
   let title = layoutOgTitle(input.title, input.subhead ? 68 : 76)
-  if (title.lines.length === 3) {
-    title = layoutOgTitle(input.title, input.subhead ? 58 : 68)
+  if (title.lines.length > 1) {
+    const compactTitle = layoutOgTitle(input.title, input.subhead ? 58 : 68)
+    if (
+      compactTitle.lines.length < title.lines.length ||
+      title.lines.length === 3
+    ) {
+      title = compactTitle
+    }
   }
   const owner = input.owner ? truncateLabel(input.owner, 48) : null
   const titleMarkup = title.lines


### PR DESCRIPTION
## Summary
- use one smaller title size only when it reduces the OG title line count
- keep the larger size when shrinking would not improve the layout
- cover the one-line Japanese title case

## Validation
- `pnpm validate:static`
- targeted OG title and renderer tests
- visual PNG inspection at 1200×630