### PR TITLE
Stage qm bridge release policy

### DIFF
--- a/config/public-repository-scan.json
+++ b/config/public-repository-scan.json
@@ -120,6 +120,18 @@
     },
     {
       "category": "public-ci-reachability",
+      "path": "^\\.github/workflows/release-qm-bridge\\.yml$",
+      "pattern": "^npm publish$",
+      "reason": "bridge package publishing is isolated to the manual protected release workflow"
+    },
+    {
+      "category": "public-ci-reachability",
+      "path": "^\\.github/workflows/release-qm-bridge\\.yml$",
+      "pattern": "^secrets\\.$",
+      "reason": "the protected release workflow alone may read the one-time npm bootstrap secret before switching to OIDC"
+    },
+    {
+      "category": "public-ci-reachability",
       "path": "^\\.github/workflows/release-npm-reserved\\.yml$",
       "pattern": "^npm publish$",
       "reason": "reserved package publishing is isolated to the protected tag-only OIDC release workflow"

--- a/config/repository-boundary.json
+++ b/config/repository-boundary.json
@@ -158,6 +158,7 @@
       ".github/workflows/deploy-production.yml",
       ".github/workflows/public-ci.yml",
       ".github/workflows/release-cli.yml",
+      ".github/workflows/release-qm-bridge.yml",
       ".github/workflows/release-npm-reserved.yml"
     ]
   }


### PR DESCRIPTION
## Summary

- stage the exact public boundary classification for the qm bridge release workflow
- allow only the workflow's npm publish command and bootstrap secret reference
- split policy from the workflow because the public guard evaluates new workflow files against trusted main policy

## Validation

- `corepack pnpm validate:static`
- `node --test scripts/public-development-guard.test.mjs scripts/public-repository-scan.test.mjs`
- Codex and Claude implementation reviews on `f1601cf976ed4070f493fe1d351ef228df77ad92`
