### PR TITLE
Add protected qm bridge release workflow

### DIFF
--- a/.github/workflows/release-qm-bridge.yml
+++ b/.github/workflows/release-qm-bridge.yml
@@ -1,0 +1,108 @@
+name: Release qm bridge package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact unpublished package version to release
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: release-qm-bridge
+  cancel-in-progress: false
+
+jobs:
+  pack:
+    name: Build release tarball
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - name: Require the current validated public main commit
+        run: |
+          test "$GITHUB_REF_NAME" = "main"
+          git fetch --no-tags origin main
+          test "$GITHUB_SHA" = "$(git rev-parse origin/main)"
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Verify requested version and unpublished state
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          PKG_NAME=$(node -p "require('./packages/qm-bridge/package.json').name")
+          PKG_VERSION=$(node -p "require('./packages/qm-bridge/package.json').version")
+          test "$RELEASE_VERSION" = "$PKG_VERSION"
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "$PKG_NAME@$PKG_VERSION is already published" >&2
+            exit 1
+          fi
+      - run: pnpm --filter @artifactshare/qm-bridge typecheck
+      - run: pnpm --filter @artifactshare/qm-bridge test
+      - name: Pack and smoke test
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/release"
+          TGZ=$(pnpm --filter @artifactshare/qm-bridge pack --pack-destination "$RUNNER_TEMP/release" | tail -1)
+          SMOKE_DIR=$(mktemp -d)
+          trap 'rm -rf "$SMOKE_DIR"' EXIT
+          cd "$SMOKE_DIR"
+          npm init -y >/dev/null
+          npm install "$TGZ" --no-save --ignore-scripts >/dev/null
+          node -e "Promise.all([import('@artifactshare/qm-bridge'), import('@artifactshare/qm-bridge/client'), import('@artifactshare/qm-bridge/qm'), import('@artifactshare/qm-bridge/testing')])"
+          ./node_modules/.bin/artifactshare-qm-bridge check >output.json 2>/dev/null || bridge_exit=$?
+          test "${bridge_exit:-0}" -eq 2
+          node -e "const value=require('./output.json'); if(value.error?.code!=='invalid_cli_usage') process.exit(1)"
+          cd "$RUNNER_TEMP/release"
+          sha256sum "$(basename "$TGZ")" > SHA256SUMS
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: qm-bridge-release
+          path: |
+            ${{ runner.temp }}/release/*.tgz
+            ${{ runner.temp }}/release/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish approved tarball
+    needs: pack
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: qm-bridge-release
+          path: ${{ runner.temp }}/release
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - name: Verify and publish exact tarball
+        working-directory: ${{ runner.temp }}/release
+        env:
+          # Set only for the first publication, then delete after trusted
+          # publishing is configured for this workflow and environment.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_QM_BRIDGE_BOOTSTRAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          sha256sum --check SHA256SUMS
+          mapfile -t tarballs < <(find . -maxdepth 1 -type f -name '*.tgz' -print)
+          test "${#tarballs[@]}" -eq 1
+          npm publish "${tarballs[0]}" --access public --provenance

--- a/scripts/public-ci-contract.test.mjs
+++ b/scripts/public-ci-contract.test.mjs
@@ -19,6 +19,7 @@ const publicPackagePaths = [
   'package.json',
   'apps/web/package.json',
   'packages/cli/package.json',
+  'packages/qm-bridge/package.json',
   'packages/npm-reserved/package.json',
   'tools/static-site-fixtures/package.json',
 ]
@@ -561,6 +562,54 @@ test('reserved package release is protected, tag-only, and OIDC-only', () => {
   assert.match(runs, /test "\$bin_status" -eq 1/)
   assert.match(text, /npm publish --access public --provenance --tag latest/)
   assert.doesNotMatch(text, /secrets\./)
+})
+
+test('qm bridge release is manual, protected, and publishes one verified tarball', () => {
+  const releaseWorkflow = YAML.parse(
+    fs.readFileSync('.github/workflows/release-qm-bridge.yml', 'utf8'),
+  )
+  assert.deepEqual(releaseWorkflow.on.workflow_dispatch.inputs.version, {
+    description: 'Exact unpublished package version to release',
+    required: true,
+    type: 'string',
+  })
+  assert.deepEqual(releaseWorkflow.permissions, {})
+
+  const pack = releaseWorkflow.jobs.pack
+  assert.deepEqual(pack.permissions, { contents: 'read' })
+  const packText = JSON.stringify(pack)
+  const packRuns = pack.steps.map((step) => step.run ?? '').join('\n')
+  assert.match(packRuns, /test "\$GITHUB_REF_NAME" = "main"/)
+  assert.match(
+    packRuns,
+    /test "\$GITHUB_SHA" = "\$\(git rev-parse origin\/main\)"/,
+  )
+  assert.match(packRuns, /pnpm install --frozen-lockfile --ignore-scripts/)
+  assert.match(packRuns, /test "\$RELEASE_VERSION" = "\$PKG_VERSION"/)
+  assert.match(packRuns, /npm view.*PKG_NAME.*PKG_VERSION.*version/)
+  assert.match(packRuns, /@artifactshare\/qm-bridge typecheck/)
+  assert.match(packRuns, /@artifactshare\/qm-bridge test/)
+  assert.match(packRuns, /@artifactshare\/qm-bridge pack/)
+  assert.match(packRuns, /invalid_cli_usage/)
+  assert.match(packText, /actions\/upload-artifact@[0-9a-f]{40}/)
+
+  const publish = releaseWorkflow.jobs.publish
+  assert.equal(publish.needs, 'pack')
+  assert.equal(publish.environment, 'production')
+  assert.deepEqual(publish.permissions, {
+    contents: 'read',
+    'id-token': 'write',
+  })
+  const publishText = JSON.stringify(publish)
+  const publishRuns = publish.steps.map((step) => step.run ?? '').join('\n')
+  assert.match(publishRuns, /sha256sum --check SHA256SUMS/)
+  assert.match(publishRuns, /test "\$\{#tarballs\[@\]\}" -eq 1/)
+  assert.match(
+    publishRuns,
+    /npm publish "\$\{tarballs\[0\]\}" --access public --provenance/,
+  )
+  assert.match(publishText, /secrets\.NPM_QM_BRIDGE_BOOTSTRAP_TOKEN/)
+  assert.equal([...publishText.matchAll(/secrets\.[A-Z0-9_]+/gu)].length, 1)
 })
 
 test('public CI installs Playwright from the web workspace', () => {


### PR DESCRIPTION
## Summary

- add a manual, production-protected release workflow for `@artifactshare/qm-bridge`
- build, install, and smoke-test one tarball before transferring it to the publish job
- verify the checksum and publish only that approved tarball with npm provenance
- lock the release contract and package-script reachability in public CI tests

## Validation

- `corepack pnpm validate:static`
- `node --test scripts/public-ci-contract.test.mjs`
- Codex and Claude implementation reviews on `ebf5e0a5c41a02aa7df86fa320d948c9a53f94fd`

## Operations

Merging this PR does not publish the package. The first publication and bootstrap credential setup remain separate owner-approved production operations.
