### PR TITLE
feat(web): add trusted bridge publishing

### DIFF
--- a/apps/web/app/lib/bridge-api.server.ts
+++ b/apps/web/app/lib/bridge-api.server.ts
@@ -1,0 +1,43 @@
+export type BridgeServerErrorCode =
+  | 'invalid-context'
+  | 'stale-context'
+  | 'unauthorized'
+  | 'unsupported-authority'
+  | 'fallback-invalid'
+  | 'requester-mismatch'
+  | 'mapping-archived'
+  | 'conversation-identity-conflict'
+  | 'project-limit-reached'
+  | 'artifact-viewer-limit-reached'
+  | 'project-name-conflict'
+  | 'idempotency-in-progress'
+  | 'idempotency-mismatch'
+  | 'payload-too-large'
+  | 'upload-failed'
+  | 'forbidden-target'
+  | 'rate-limited'
+  | 'internal-error'
+
+export function bridgeErrorResponse(
+  code: BridgeServerErrorCode,
+  message: string,
+  status: number,
+  options: { retryable?: boolean; retryAfterMs?: number } = {},
+): Response {
+  const retryable = options.retryable ?? false
+  return Response.json(
+    {
+      schema_version: 1,
+      ok: false,
+      error: {
+        code,
+        message,
+        retryable,
+        ...(retryable && options.retryAfterMs !== undefined
+          ? { retry_after_ms: options.retryAfterMs }
+          : {}),
+      },
+    },
+    { status },
+  )
+}

--- a/apps/web/app/lib/cli-agent-operations.test.ts
+++ b/apps/web/app/lib/cli-agent-operations.test.ts
@@ -13,6 +13,18 @@ const agent = {
   agentProfileId: 'agent-1',
 }
 
+const bridge = {
+  kind: 'bridge' as const,
+  familyId: 'family-bridge',
+  bridgeAuthorityId: 'bridge-1',
+  workspaceId: 'ws1',
+  fallbackProjectId: 'fallback-1',
+  agentProfileId: 'agent-bridge',
+  sourceKind: 'qm',
+  sourceInstallationId: 'install-1',
+  externalWorkspaceId: 'slack-ws-1',
+}
+
 describe('agent operation declaration', () => {
   test('allows the bounded read, publish, append and comment surface', () => {
     expect(allowsCliOperation(agent, 'GET', '/api/cli/artifacts')).toBe(true)
@@ -48,6 +60,19 @@ describe('agent operation declaration', () => {
     expect(allowsCliOperation(bootstrap, 'GET', '/api/cli/artifacts')).toBe(
       false,
     )
+  })
+
+  test('limits bridge credentials to the bridge health and request endpoints', () => {
+    expect(allowsCliOperation(bridge, 'GET', '/api/bridge/v1/health')).toBe(
+      true,
+    )
+    expect(allowsCliOperation(bridge, 'POST', '/api/bridge/v1/requests')).toBe(
+      true,
+    )
+    expect(allowsCliOperation(bridge, 'POST', '/api/shareables/uploads')).toBe(
+      false,
+    )
+    expect(allowsCliOperation(bridge, 'GET', '/api/cli/artifacts')).toBe(false)
   })
 
   test('returns the stable default-deny envelope', async () => {

--- a/apps/web/app/lib/cli-agent-operations.ts
+++ b/apps/web/app/lib/cli-agent-operations.ts
@@ -24,13 +24,23 @@ const AGENT_RULES: Rule[] = [
   { method: 'POST', pattern: /^\/api\/shareables\/[^/]+\/versions$/ },
 ]
 
+const BRIDGE_RULES: Rule[] = [
+  { method: 'GET', pattern: /^\/api\/bridge\/v1\/health$/ },
+  { method: 'POST', pattern: /^\/api\/bridge\/v1\/requests$/ },
+]
+
 export function allowsCliOperation(
   authority: CliAuthority,
   method: string,
   pathname: string,
 ) {
   if (authority.kind === 'unrestricted') return true
-  const rules = authority.kind === 'bootstrap' ? BOOTSTRAP_RULES : AGENT_RULES
+  const rules =
+    authority.kind === 'bootstrap'
+      ? BOOTSTRAP_RULES
+      : authority.kind === 'bridge'
+        ? BRIDGE_RULES
+        : AGENT_RULES
   return rules.some(
     (rule) => rule.method === method && rule.pattern.test(pathname),
   )

--- a/apps/web/app/middleware/auth.test.ts
+++ b/apps/web/app/middleware/auth.test.ts
@@ -37,6 +37,7 @@ vi.mock('cloudflare:workers', () => ({
 const {
   authObservationPayload,
   authRouteGroup,
+  requireBridgeBearerMiddleware,
   requireUserApiWithBearerMiddleware,
   requireUserMiddleware,
   sessionMiddleware,
@@ -315,6 +316,53 @@ describe('requireUserApiWithBearerMiddleware', () => {
         vi.fn(),
       ),
     ).rejects.toMatchObject({ status: 401 })
+  })
+
+  test('returns bridge JSON for an invalid bridge bearer', async () => {
+    getSessionUserFromBearerMock.mockResolvedValue(null)
+    const request = new Request('https://example.test/api/bridge/v1/health', {
+      headers: { Authorization: 'Bearer invalid-session-token' },
+    })
+
+    const response = (await requireBridgeBearerMiddleware(
+      createArgs(request),
+      vi.fn(),
+    )) as Response
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toMatchObject({
+      schema_version: 1,
+      ok: false,
+      error: { code: 'unauthorized', retryable: false },
+    })
+  })
+
+  test('returns bridge JSON when a non-bridge authority is scope denied', async () => {
+    getSessionUserFromBearerMock.mockResolvedValue({ id: 'agent-user' })
+    resolveCliAuthorityBySessionTokenMock.mockResolvedValue({
+      kind: 'agent',
+      familyId: 'family-1',
+      workspaceId: 'workspace-1',
+      projectId: 'project-1',
+      projectNameSnapshot: 'Project',
+      agentProfileId: 'agent-1',
+    })
+    const request = new Request('https://example.test/api/bridge/v1/requests', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer session-token' },
+    })
+
+    const response = (await requireBridgeBearerMiddleware(
+      createArgs(request),
+      vi.fn(),
+    )) as Response
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toMatchObject({
+      schema_version: 1,
+      ok: false,
+      error: { code: 'unsupported-authority', retryable: false },
+    })
   })
 })
 

--- a/apps/web/app/middleware/auth.test.ts
+++ b/apps/web/app/middleware/auth.test.ts
@@ -364,6 +364,31 @@ describe('requireUserApiWithBearerMiddleware', () => {
       error: { code: 'unsupported-authority', retryable: false },
     })
   })
+
+  test('returns retryable bridge JSON when bearer resolution throws', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getSessionUserFromBearerMock.mockRejectedValue(new Error('D1 unavailable'))
+    const request = new Request('https://example.test/api/bridge/v1/health', {
+      headers: { Authorization: 'Bearer session-token' },
+    })
+
+    const response = (await requireBridgeBearerMiddleware(
+      createArgs(request),
+      vi.fn(),
+    )) as Response
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({
+      schema_version: 1,
+      ok: false,
+      error: {
+        code: 'internal-error',
+        retryable: true,
+        retry_after_ms: 1_000,
+      },
+    })
+    expect(consoleError).toHaveBeenCalled()
+  })
 })
 
 describe('sessionMiddleware auth observation', () => {

--- a/apps/web/app/middleware/auth.ts
+++ b/apps/web/app/middleware/auth.ts
@@ -14,6 +14,7 @@ import {
   allowsCliOperation,
   cliScopeDeniedResponse,
 } from '~/lib/cli-agent-operations'
+import { bridgeErrorResponse } from '~/lib/bridge-api.server'
 import { authSourceContext, cliAuthorityContext, userContext } from './context'
 
 const AUTH_OBSERVATION_SAMPLE_RATE = 0.05
@@ -133,6 +134,37 @@ export const requireUserApiWithBearerMiddleware: MiddlewareFunction = async (
   if (scopeDenied) throw scopeDenied
   if (context.get(userContext)) return next()
   throw new Response('Unauthorized', { status: 401 })
+}
+
+export const requireBridgeBearerMiddleware: MiddlewareFunction = async (
+  args,
+  next,
+) => {
+  let enteredRoute = false
+  try {
+    return await requireUserApiWithBearerMiddleware(args, () => {
+      enteredRoute = true
+      return next()
+    })
+  } catch (error) {
+    if (!enteredRoute && error instanceof Response) {
+      if (error.status === 401) {
+        return bridgeErrorResponse(
+          'unauthorized',
+          'The bridge credential is invalid or expired.',
+          401,
+        )
+      }
+      if (error.status === 403) {
+        return bridgeErrorResponse(
+          'unsupported-authority',
+          'This credential is not a bridge authority.',
+          403,
+        )
+      }
+    }
+    throw error
+  }
 }
 
 export function authObservationPayload(

--- a/apps/web/app/middleware/auth.ts
+++ b/apps/web/app/middleware/auth.ts
@@ -147,21 +147,28 @@ export const requireBridgeBearerMiddleware: MiddlewareFunction = async (
       return next()
     })
   } catch (error) {
-    if (!enteredRoute && error instanceof Response) {
-      if (error.status === 401) {
+    if (!enteredRoute) {
+      if (error instanceof Response && error.status === 401) {
         return bridgeErrorResponse(
           'unauthorized',
           'The bridge credential is invalid or expired.',
           401,
         )
       }
-      if (error.status === 403) {
+      if (error instanceof Response && error.status === 403) {
         return bridgeErrorResponse(
           'unsupported-authority',
           'This credential is not a bridge authority.',
           403,
         )
       }
+      console.error('bridge_auth_failed', error)
+      return bridgeErrorResponse(
+        'internal-error',
+        'The bridge authentication check failed.',
+        500,
+        { retryable: true, retryAfterMs: 1_000 },
+      )
     }
     throw error
   }

--- a/apps/web/app/routes/api.bridge.v1.health.test.ts
+++ b/apps/web/app/routes/api.bridge.v1.health.test.ts
@@ -47,4 +47,24 @@ describe('/api/bridge/v1/health', () => {
       error: { code: 'fallback-invalid' },
     })
   })
+
+  test('returns a retryable bridge error for unexpected health failures', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    readLiveBridgeAuthorityMock.mockRejectedValue(new Error('D1 unavailable'))
+
+    const response = await loader({ context: new Map() } as never)
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({
+      schema_version: 1,
+      ok: false,
+      error: {
+        code: 'internal-error',
+        retryable: true,
+        retry_after_ms: 1_000,
+      },
+    })
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
 })

--- a/apps/web/app/routes/api.bridge.v1.health.test.ts
+++ b/apps/web/app/routes/api.bridge.v1.health.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const getCliAuthorityMock = vi.hoisted(() => vi.fn())
+const createDbMock = vi.hoisted(() => vi.fn())
+const readLiveBridgeAuthorityMock = vi.hoisted(() => vi.fn())
+
+vi.mock('~/middleware/auth', () => ({
+  requireUserApiWithBearerMiddleware: vi.fn(),
+}))
+vi.mock('~/middleware/context', () => ({
+  getCliAuthority: getCliAuthorityMock,
+}))
+vi.mock('~/services/db.server', () => ({ createDb: createDbMock }))
+vi.mock('~/services/bridge-authorities.server', () => ({
+  readLiveBridgeAuthority: readLiveBridgeAuthorityMock,
+}))
+
+import { loader } from './api.bridge.v1.health'
+
+beforeEach(() => {
+  getCliAuthorityMock.mockReset().mockReturnValue({
+    kind: 'bridge',
+    bridgeAuthorityId: 'bridge-1',
+  })
+  createDbMock.mockReset().mockReturnValue({})
+  readLiveBridgeAuthorityMock.mockReset().mockResolvedValue({ kind: 'ok' })
+})
+
+describe('/api/bridge/v1/health', () => {
+  test('reports the narrow bridge operation surface', async () => {
+    const response = await loader({ context: new Map() } as never)
+    await expect(response.json()).resolves.toEqual({
+      schema_version: 1,
+      ok: true,
+      data: {
+        authority: 'available',
+        operations: ['publish', 'append', 'update', 'set_visibility'],
+      },
+    })
+  })
+
+  test('fails closed when the fallback is no longer valid', async () => {
+    readLiveBridgeAuthorityMock.mockResolvedValue({ kind: 'fallback-invalid' })
+    const response = await loader({ context: new Map() } as never)
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'fallback-invalid' },
+    })
+  })
+})

--- a/apps/web/app/routes/api.bridge.v1.health.test.ts
+++ b/apps/web/app/routes/api.bridge.v1.health.test.ts
@@ -5,7 +5,7 @@ const createDbMock = vi.hoisted(() => vi.fn())
 const readLiveBridgeAuthorityMock = vi.hoisted(() => vi.fn())
 
 vi.mock('~/middleware/auth', () => ({
-  requireUserApiWithBearerMiddleware: vi.fn(),
+  requireBridgeBearerMiddleware: vi.fn(),
 }))
 vi.mock('~/middleware/context', () => ({
   getCliAuthority: getCliAuthorityMock,

--- a/apps/web/app/routes/api.bridge.v1.health.ts
+++ b/apps/web/app/routes/api.bridge.v1.health.ts
@@ -16,10 +16,21 @@ export async function loader({ context }: Route.LoaderArgs) {
       403,
     )
   }
-  const live = await readLiveBridgeAuthority(
-    createDb(),
-    authority.bridgeAuthorityId,
-  )
+  let live: Awaited<ReturnType<typeof readLiveBridgeAuthority>>
+  try {
+    live = await readLiveBridgeAuthority(
+      createDb(),
+      authority.bridgeAuthorityId,
+    )
+  } catch (error) {
+    console.error('bridge_health_failed', error)
+    return bridgeErrorResponse(
+      'internal-error',
+      'The bridge health check failed.',
+      500,
+      { retryable: true, retryAfterMs: 1_000 },
+    )
+  }
   if (live.kind === 'unsupported-authority') {
     return bridgeErrorResponse(
       'unsupported-authority',

--- a/apps/web/app/routes/api.bridge.v1.health.ts
+++ b/apps/web/app/routes/api.bridge.v1.health.ts
@@ -1,11 +1,11 @@
 import { bridgeErrorResponse } from '~/lib/bridge-api.server'
-import { requireUserApiWithBearerMiddleware } from '~/middleware/auth'
+import { requireBridgeBearerMiddleware } from '~/middleware/auth'
 import { getCliAuthority } from '~/middleware/context'
 import { readLiveBridgeAuthority } from '~/services/bridge-authorities.server'
 import { createDb } from '~/services/db.server'
 import type { Route } from './+types/api.bridge.v1.health'
 
-export const middleware = [requireUserApiWithBearerMiddleware]
+export const middleware = [requireBridgeBearerMiddleware]
 
 export async function loader({ context }: Route.LoaderArgs) {
   const authority = getCliAuthority(context)

--- a/apps/web/app/routes/api.bridge.v1.health.ts
+++ b/apps/web/app/routes/api.bridge.v1.health.ts
@@ -1,0 +1,45 @@
+import { bridgeErrorResponse } from '~/lib/bridge-api.server'
+import { requireUserApiWithBearerMiddleware } from '~/middleware/auth'
+import { getCliAuthority } from '~/middleware/context'
+import { readLiveBridgeAuthority } from '~/services/bridge-authorities.server'
+import { createDb } from '~/services/db.server'
+import type { Route } from './+types/api.bridge.v1.health'
+
+export const middleware = [requireUserApiWithBearerMiddleware]
+
+export async function loader({ context }: Route.LoaderArgs) {
+  const authority = getCliAuthority(context)
+  if (authority?.kind !== 'bridge') {
+    return bridgeErrorResponse(
+      'unsupported-authority',
+      'This credential is not a bridge authority.',
+      403,
+    )
+  }
+  const live = await readLiveBridgeAuthority(
+    createDb(),
+    authority.bridgeAuthorityId,
+  )
+  if (live.kind === 'unsupported-authority') {
+    return bridgeErrorResponse(
+      'unsupported-authority',
+      'The bridge authority is unavailable.',
+      403,
+    )
+  }
+  if (live.kind === 'fallback-invalid') {
+    return bridgeErrorResponse(
+      'fallback-invalid',
+      'The bridge fallback project is unavailable.',
+      409,
+    )
+  }
+  return Response.json({
+    schema_version: 1,
+    ok: true,
+    data: {
+      authority: 'available',
+      operations: ['publish', 'append', 'update', 'set_visibility'],
+    },
+  })
+}

--- a/apps/web/app/routes/api.bridge.v1.requests.test.ts
+++ b/apps/web/app/routes/api.bridge.v1.requests.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const getCliAuthorityMock = vi.hoisted(() => vi.fn())
+const requireUserMock = vi.hoisted(() => vi.fn())
+const createDbMock = vi.hoisted(() => vi.fn())
+const executeBridgeRequestMock = vi.hoisted(() => vi.fn())
+
+vi.mock('~/middleware/auth', () => ({
+  requireUserApiWithBearerMiddleware: vi.fn(),
+}))
+vi.mock('~/middleware/context', () => ({
+  getCliAuthority: getCliAuthorityMock,
+  requireUser: requireUserMock,
+}))
+vi.mock('~/services/db.server', () => ({ createDb: createDbMock }))
+vi.mock('~/services/bridge-publishing.server', () => ({
+  executeBridgeRequest: executeBridgeRequestMock,
+}))
+
+import { action } from './api.bridge.v1.requests'
+
+const authority = {
+  kind: 'bridge' as const,
+  familyId: 'family-1',
+  bridgeAuthorityId: 'bridge-1',
+  workspaceId: 'ws1',
+  fallbackProjectId: 'fallback-1',
+  agentProfileId: 'agent-1',
+  sourceKind: 'qm',
+  sourceInstallationId: 'install-1',
+  externalWorkspaceId: 'slack-ws-1',
+}
+
+beforeEach(() => {
+  getCliAuthorityMock.mockReset().mockReturnValue(authority)
+  requireUserMock.mockReset().mockReturnValue({
+    id: 'bot1',
+    workspaceId: 'ws1',
+    emailVerified: true,
+    hd: 'example.com',
+  })
+  createDbMock.mockReset().mockReturnValue({})
+  executeBridgeRequestMock.mockReset().mockResolvedValue({
+    kind: 'ok',
+    result: {
+      artifact: {
+        id: 'artifact-1',
+        url: 'https://artifactshare.test/a/artifact-1',
+        title: 'Report',
+      },
+      project: { id: 'project-1', name: 'Design' },
+      visibility: 'private',
+      versionId: 'version-1',
+      replayed: false,
+      mappingCreated: true,
+      projectCreated: true,
+    },
+  })
+})
+
+describe('/api/bridge/v1/requests', () => {
+  test('passes the bounded multipart request to the bridge service', async () => {
+    const metadata = { schema_version: 1, request_id: 'request-1' }
+    const form = new FormData()
+    form.set('metadata', JSON.stringify(metadata))
+    form.append(
+      'file',
+      new File(['hello'], 'file-0', { type: 'text/markdown' }),
+    )
+
+    const response = await action({
+      context: new Map(),
+      request: new Request(
+        'https://artifactshare.test/api/bridge/v1/requests',
+        {
+          method: 'POST',
+          body: form,
+        },
+      ),
+    } as never)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      schema_version: 1,
+      ok: true,
+      data: {
+        artifact: {
+          id: 'artifact-1',
+          url: 'https://artifactshare.test/a/artifact-1',
+          title: 'Report',
+        },
+        project: { id: 'project-1', name: 'Design' },
+        visibility: 'private',
+        version_id: 'version-1',
+        replayed: false,
+        mapping_created: true,
+        project_created: true,
+      },
+    })
+    expect(executeBridgeRequestMock).toHaveBeenCalledWith(
+      expect.anything(),
+      authority,
+      expect.objectContaining({ id: 'bot1' }),
+      metadata,
+      [expect.any(File)],
+      'https://artifactshare.test',
+    )
+  })
+
+  test('rejects non-bridge credentials before parsing the body', async () => {
+    getCliAuthorityMock.mockReturnValue({ kind: 'unrestricted' })
+    const response = await action({
+      context: new Map(),
+      request: new Request(
+        'https://artifactshare.test/api/bridge/v1/requests',
+        {
+          method: 'POST',
+          body: 'not multipart',
+        },
+      ),
+    } as never)
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'unsupported-authority' },
+    })
+    expect(executeBridgeRequestMock).not.toHaveBeenCalled()
+  })
+
+  test('preserves retry metadata for an in-progress idempotency lease', async () => {
+    executeBridgeRequestMock.mockResolvedValue({
+      kind: 'idempotency-in-progress',
+    })
+    const form = new FormData()
+    form.set('metadata', JSON.stringify({ schema_version: 1 }))
+    const response = await action({
+      context: new Map(),
+      request: new Request(
+        'https://artifactshare.test/api/bridge/v1/requests',
+        {
+          method: 'POST',
+          body: form,
+        },
+      ),
+    } as never)
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'idempotency-in-progress',
+        retryable: true,
+        retry_after_ms: 1_000,
+      },
+    })
+  })
+})

--- a/apps/web/app/routes/api.bridge.v1.requests.test.ts
+++ b/apps/web/app/routes/api.bridge.v1.requests.test.ts
@@ -158,6 +158,56 @@ describe('/api/bridge/v1/requests', () => {
     expect(executeBridgeRequestMock).not.toHaveBeenCalled()
   })
 
+  test('returns bridge JSON for malformed multipart input', async () => {
+    const response = await action({
+      context: new Map(),
+      request: new Request(
+        'https://artifactshare.test/api/bridge/v1/requests',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'multipart/form-data' },
+          body: 'missing boundary',
+        },
+      ),
+    } as never)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      schema_version: 1,
+      ok: false,
+      error: { code: 'invalid-context' },
+    })
+    expect(executeBridgeRequestMock).not.toHaveBeenCalled()
+  })
+
+  test('returns a retryable bridge error for unexpected service failures', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    executeBridgeRequestMock.mockRejectedValue(new Error('D1 unavailable'))
+    const form = new FormData()
+    form.set('metadata', JSON.stringify({ schema_version: 1 }))
+
+    const response = await action({
+      context: new Map(),
+      request: new Request(
+        'https://artifactshare.test/api/bridge/v1/requests',
+        { method: 'POST', body: form },
+      ),
+    } as never)
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({
+      schema_version: 1,
+      ok: false,
+      error: {
+        code: 'internal-error',
+        retryable: true,
+        retry_after_ms: 1_000,
+      },
+    })
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
   test('preserves retry metadata for an in-progress idempotency lease', async () => {
     executeBridgeRequestMock.mockResolvedValue({
       kind: 'idempotency-in-progress',

--- a/apps/web/app/routes/api.bridge.v1.requests.test.ts
+++ b/apps/web/app/routes/api.bridge.v1.requests.test.ts
@@ -180,6 +180,26 @@ describe('/api/bridge/v1/requests', () => {
     expect(executeBridgeRequestMock).not.toHaveBeenCalled()
   })
 
+  test('rejects duplicate metadata parts', async () => {
+    const form = new FormData()
+    form.append('metadata', JSON.stringify({ schema_version: 1 }))
+    form.append('metadata', JSON.stringify({ schema_version: 1 }))
+
+    const response = await action({
+      context: new Map(),
+      request: new Request(
+        'https://artifactshare.test/api/bridge/v1/requests',
+        { method: 'POST', body: form },
+      ),
+    } as never)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'invalid-context' },
+    })
+    expect(executeBridgeRequestMock).not.toHaveBeenCalled()
+  })
+
   test('returns a retryable bridge error for unexpected service failures', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     executeBridgeRequestMock.mockRejectedValue(new Error('D1 unavailable'))

--- a/apps/web/app/routes/api.bridge.v1.requests.test.ts
+++ b/apps/web/app/routes/api.bridge.v1.requests.test.ts
@@ -6,7 +6,7 @@ const createDbMock = vi.hoisted(() => vi.fn())
 const executeBridgeRequestMock = vi.hoisted(() => vi.fn())
 
 vi.mock('~/middleware/auth', () => ({
-  requireUserApiWithBearerMiddleware: vi.fn(),
+  requireBridgeBearerMiddleware: vi.fn(),
 }))
 vi.mock('~/middleware/context', () => ({
   getCliAuthority: getCliAuthorityMock,

--- a/apps/web/app/routes/api.bridge.v1.requests.test.ts
+++ b/apps/web/app/routes/api.bridge.v1.requests.test.ts
@@ -126,6 +126,38 @@ describe('/api/bridge/v1/requests', () => {
     expect(executeBridgeRequestMock).not.toHaveBeenCalled()
   })
 
+  test('returns a bounded 413 for an oversized multipart header', async () => {
+    const boundary = 'bridge-boundary'
+    const body = [
+      `--${boundary}`,
+      `X-Oversized: ${'a'.repeat(8_200)}`,
+      'Content-Disposition: form-data; name="metadata"',
+      '',
+      '{}',
+      `--${boundary}--`,
+      '',
+    ].join('\r\n')
+    const response = await action({
+      context: new Map(),
+      request: new Request(
+        'https://artifactshare.test/api/bridge/v1/requests',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': `multipart/form-data; boundary=${boundary}`,
+          },
+          body,
+        },
+      ),
+    } as never)
+
+    expect(response.status).toBe(413)
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'payload-too-large' },
+    })
+    expect(executeBridgeRequestMock).not.toHaveBeenCalled()
+  })
+
   test('preserves retry metadata for an in-progress idempotency lease', async () => {
     executeBridgeRequestMock.mockResolvedValue({
       kind: 'idempotency-in-progress',

--- a/apps/web/app/routes/api.bridge.v1.requests.ts
+++ b/apps/web/app/routes/api.bridge.v1.requests.ts
@@ -76,8 +76,10 @@ export async function action({ request, context }: Route.ActionArgs) {
       400,
     )
   }
-  const rawMetadata = form.get('metadata')
+  const metadataParts = form.getAll('metadata')
+  const rawMetadata = metadataParts[0]
   if (
+    metadataParts.length !== 1 ||
     typeof rawMetadata !== 'string' ||
     new TextEncoder().encode(rawMetadata).byteLength > MAX_METADATA_BYTES
   ) {

--- a/apps/web/app/routes/api.bridge.v1.requests.ts
+++ b/apps/web/app/routes/api.bridge.v1.requests.ts
@@ -5,6 +5,7 @@ import {
 } from '@remix-run/form-data-parser'
 import {
   MaxFileSizeExceededError,
+  MaxHeaderSizeExceededError,
   MaxPartsExceededError,
   MaxTotalSizeExceededError,
 } from '@remix-run/multipart-parser'
@@ -45,6 +46,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     if (
       error instanceof MaxFilesExceededError ||
       error instanceof MaxFileSizeExceededError ||
+      error instanceof MaxHeaderSizeExceededError ||
       error instanceof MaxTotalSizeExceededError ||
       error instanceof MaxPartsExceededError
     ) {

--- a/apps/web/app/routes/api.bridge.v1.requests.ts
+++ b/apps/web/app/routes/api.bridge.v1.requests.ts
@@ -1,0 +1,202 @@
+import {
+  FormDataParseError,
+  MaxFilesExceededError,
+  parseFormData,
+} from '@remix-run/form-data-parser'
+import {
+  MaxFileSizeExceededError,
+  MaxPartsExceededError,
+  MaxTotalSizeExceededError,
+} from '@remix-run/multipart-parser'
+import { bridgeErrorResponse } from '~/lib/bridge-api.server'
+import { requireUserApiWithBearerMiddleware } from '~/middleware/auth'
+import { getCliAuthority, requireUser } from '~/middleware/context'
+import { executeBridgeRequest } from '~/services/bridge-publishing.server'
+import { createDb } from '~/services/db.server'
+import type { Route } from './+types/api.bridge.v1.requests'
+
+const MAX_METADATA_BYTES = 65_536
+const MAX_CONTENT_BYTES = 26_214_400
+
+export const middleware = [requireUserApiWithBearerMiddleware]
+
+export async function action({ request, context }: Route.ActionArgs) {
+  const authority = getCliAuthority(context)
+  if (authority?.kind !== 'bridge') {
+    return bridgeErrorResponse(
+      'unsupported-authority',
+      'This credential is not a bridge authority.',
+      403,
+    )
+  }
+  let form: FormData
+  try {
+    form = await parseFormData(
+      request,
+      {
+        maxFiles: 50,
+        maxFileSize: MAX_CONTENT_BYTES,
+        maxTotalSize: MAX_CONTENT_BYTES + MAX_METADATA_BYTES,
+        maxParts: 51,
+      },
+      (file) => file,
+    )
+  } catch (error) {
+    if (
+      error instanceof MaxFilesExceededError ||
+      error instanceof MaxFileSizeExceededError ||
+      error instanceof MaxTotalSizeExceededError ||
+      error instanceof MaxPartsExceededError
+    ) {
+      return bridgeErrorResponse(
+        'payload-too-large',
+        'The bridge request exceeds the upload envelope.',
+        413,
+      )
+    }
+    if (error instanceof FormDataParseError) {
+      return bridgeErrorResponse(
+        'invalid-context',
+        'The bridge multipart request is invalid.',
+        400,
+      )
+    }
+    throw error
+  }
+  if ([...form.keys()].some((key) => key !== 'metadata' && key !== 'file')) {
+    return bridgeErrorResponse(
+      'invalid-context',
+      'The bridge multipart fields are invalid.',
+      400,
+    )
+  }
+  const rawMetadata = form.get('metadata')
+  if (
+    typeof rawMetadata !== 'string' ||
+    new TextEncoder().encode(rawMetadata).byteLength > MAX_METADATA_BYTES
+  ) {
+    return bridgeErrorResponse(
+      'invalid-context',
+      'The trusted bridge metadata is missing or invalid.',
+      400,
+    )
+  }
+  let metadata: unknown
+  try {
+    metadata = JSON.parse(rawMetadata)
+  } catch {
+    return bridgeErrorResponse(
+      'invalid-context',
+      'The trusted bridge metadata is not valid JSON.',
+      400,
+    )
+  }
+  const files = form.getAll('file')
+  if (files.some((file) => !(file instanceof File))) {
+    return bridgeErrorResponse(
+      'invalid-context',
+      'The bridge file parts are invalid.',
+      400,
+    )
+  }
+  const result = await executeBridgeRequest(
+    createDb(),
+    authority,
+    requireUser(context),
+    metadata,
+    files as File[],
+    new URL(request.url).origin,
+  )
+  if (result.kind !== 'ok') return failureResponse(result.kind)
+  return Response.json({
+    schema_version: 1,
+    ok: true,
+    data: {
+      artifact: result.result.artifact,
+      project: result.result.project,
+      visibility: result.result.visibility,
+      version_id: result.result.versionId,
+      replayed: result.result.replayed,
+      mapping_created: result.result.mappingCreated,
+      project_created: result.result.projectCreated,
+    },
+  })
+}
+
+function failureResponse(
+  kind: Exclude<Awaited<ReturnType<typeof executeBridgeRequest>>['kind'], 'ok'>,
+) {
+  switch (kind) {
+    case 'invalid-context':
+      return bridgeErrorResponse(
+        kind,
+        'The trusted bridge context is invalid.',
+        400,
+      )
+    case 'stale-context':
+      return bridgeErrorResponse(
+        kind,
+        'The public conversation context is stale.',
+        409,
+      )
+    case 'unsupported-authority':
+      return bridgeErrorResponse(
+        kind,
+        'The bridge authority is unavailable.',
+        403,
+      )
+    case 'fallback-invalid':
+      return bridgeErrorResponse(
+        kind,
+        'The bridge fallback project is unavailable.',
+        409,
+      )
+    case 'requester-mismatch':
+      return bridgeErrorResponse(
+        kind,
+        'The request belongs to another requester.',
+        409,
+      )
+    case 'mapping-archived':
+      return bridgeErrorResponse(kind, 'The mapped project is archived.', 409)
+    case 'conversation-identity-conflict':
+      return bridgeErrorResponse(
+        kind,
+        'The conversation identities conflict.',
+        409,
+      )
+    case 'project-limit-reached':
+    case 'project-name-conflict':
+    case 'artifact-viewer-limit-reached':
+    case 'forbidden-target':
+      return bridgeErrorResponse(
+        kind,
+        'The bridge operation cannot be completed.',
+        409,
+      )
+    case 'idempotency-in-progress':
+      return bridgeErrorResponse(
+        kind,
+        'The same request is still in progress.',
+        409,
+        {
+          retryable: true,
+          retryAfterMs: 1_000,
+        },
+      )
+    case 'idempotency-mismatch':
+      return bridgeErrorResponse(
+        kind,
+        'The request id was reused with different content.',
+        409,
+      )
+    case 'payload-too-large':
+      return bridgeErrorResponse(kind, 'The bridge payload is too large.', 413)
+    case 'upload-failed':
+    case 'internal-error':
+      return bridgeErrorResponse(kind, 'The bridge operation failed.', 500, {
+        retryable: true,
+        retryAfterMs: 1_000,
+      })
+  }
+}

--- a/apps/web/app/routes/api.bridge.v1.requests.ts
+++ b/apps/web/app/routes/api.bridge.v1.requests.ts
@@ -9,7 +9,7 @@ import {
   MaxTotalSizeExceededError,
 } from '@remix-run/multipart-parser'
 import { bridgeErrorResponse } from '~/lib/bridge-api.server'
-import { requireUserApiWithBearerMiddleware } from '~/middleware/auth'
+import { requireBridgeBearerMiddleware } from '~/middleware/auth'
 import { getCliAuthority, requireUser } from '~/middleware/context'
 import { executeBridgeRequest } from '~/services/bridge-publishing.server'
 import { createDb } from '~/services/db.server'
@@ -18,7 +18,7 @@ import type { Route } from './+types/api.bridge.v1.requests'
 const MAX_METADATA_BYTES = 65_536
 const MAX_CONTENT_BYTES = 26_214_400
 
-export const middleware = [requireUserApiWithBearerMiddleware]
+export const middleware = [requireBridgeBearerMiddleware]
 
 export async function action({ request, context }: Route.ActionArgs) {
   const authority = getCliAuthority(context)

--- a/apps/web/app/routes/api.bridge.v1.requests.ts
+++ b/apps/web/app/routes/api.bridge.v1.requests.ts
@@ -6,6 +6,7 @@ import {
 import {
   MaxFileSizeExceededError,
   MaxHeaderSizeExceededError,
+  MultipartParseError,
   MaxPartsExceededError,
   MaxTotalSizeExceededError,
 } from '@remix-run/multipart-parser'
@@ -56,7 +57,10 @@ export async function action({ request, context }: Route.ActionArgs) {
         413,
       )
     }
-    if (error instanceof FormDataParseError) {
+    if (
+      error instanceof FormDataParseError ||
+      error instanceof MultipartParseError
+    ) {
       return bridgeErrorResponse(
         'invalid-context',
         'The bridge multipart request is invalid.',
@@ -101,14 +105,20 @@ export async function action({ request, context }: Route.ActionArgs) {
       400,
     )
   }
-  const result = await executeBridgeRequest(
-    createDb(),
-    authority,
-    requireUser(context),
-    metadata,
-    files as File[],
-    new URL(request.url).origin,
-  )
+  let result: Awaited<ReturnType<typeof executeBridgeRequest>>
+  try {
+    result = await executeBridgeRequest(
+      createDb(),
+      authority,
+      requireUser(context),
+      metadata,
+      files as File[],
+      new URL(request.url).origin,
+    )
+  } catch (error) {
+    console.error('bridge_request_failed', error)
+    return failureResponse('internal-error')
+  }
   if (result.kind !== 'ok') return failureResponse(result.kind)
   return Response.json({
     schema_version: 1,

--- a/apps/web/app/routes/auth-middleware-contract.test.ts
+++ b/apps/web/app/routes/auth-middleware-contract.test.ts
@@ -10,6 +10,8 @@ const expectedMiddleware: Record<string, AuthMiddleware> = {
   '_protected/_layout.tsx': 'requireUserMiddleware',
   'api.artifacts.$id.sharing-context.tsx': 'requireUserApiMiddleware',
   'api.artifacts.$id.tsx': 'requireUserApiMiddleware',
+  'api.bridge.v1.health.ts': 'requireUserApiWithBearerMiddleware',
+  'api.bridge.v1.requests.ts': 'requireUserApiWithBearerMiddleware',
   'api.cli.artifacts.$id.append.tsx': 'requireUserApiWithBearerMiddleware',
   'api.cli.artifacts.$id.comments.tsx': 'requireUserApiWithBearerMiddleware',
   'api.cli.artifacts.$id.download.$.tsx': 'requireUserApiWithBearerMiddleware',

--- a/apps/web/app/routes/auth-middleware-contract.test.ts
+++ b/apps/web/app/routes/auth-middleware-contract.test.ts
@@ -4,14 +4,15 @@ type AuthMiddleware =
   | 'requireUserMiddleware'
   | 'requireUserApiMiddleware'
   | 'requireUserApiWithBearerMiddleware'
+  | 'requireBridgeBearerMiddleware'
 
 const expectedMiddleware: Record<string, AuthMiddleware> = {
   '_home/_protected/_layout.tsx': 'requireUserMiddleware',
   '_protected/_layout.tsx': 'requireUserMiddleware',
   'api.artifacts.$id.sharing-context.tsx': 'requireUserApiMiddleware',
   'api.artifacts.$id.tsx': 'requireUserApiMiddleware',
-  'api.bridge.v1.health.ts': 'requireUserApiWithBearerMiddleware',
-  'api.bridge.v1.requests.ts': 'requireUserApiWithBearerMiddleware',
+  'api.bridge.v1.health.ts': 'requireBridgeBearerMiddleware',
+  'api.bridge.v1.requests.ts': 'requireBridgeBearerMiddleware',
   'api.cli.artifacts.$id.append.tsx': 'requireUserApiWithBearerMiddleware',
   'api.cli.artifacts.$id.comments.tsx': 'requireUserApiWithBearerMiddleware',
   'api.cli.artifacts.$id.download.$.tsx': 'requireUserApiWithBearerMiddleware',
@@ -67,14 +68,14 @@ function importedAuthMiddleware(source: string): AuthMiddleware | null {
     /import\s*\{([^}]*)\}\s*from\s*['"]~\/middleware\/auth['"]/,
   )?.[1]
   const middlewareMatch = namedImport?.match(
-    /\b(requireUserMiddleware|requireUserApiMiddleware|requireUserApiWithBearerMiddleware)\b/,
+    /\b(requireUserMiddleware|requireUserApiMiddleware|requireUserApiWithBearerMiddleware|requireBridgeBearerMiddleware)\b/,
   )
   return (middlewareMatch?.[1] as AuthMiddleware | undefined) ?? null
 }
 
 function declaredMiddleware(source: string): AuthMiddleware | null {
   const exportMatch = source.match(
-    /export\s+const\s+middleware\s*=\s*\[\s*(requireUserMiddleware|requireUserApiMiddleware|requireUserApiWithBearerMiddleware)\s*\]/,
+    /export\s+const\s+middleware\s*=\s*\[\s*(requireUserMiddleware|requireUserApiMiddleware|requireUserApiWithBearerMiddleware|requireBridgeBearerMiddleware)\s*\]/,
   )
   return (exportMatch?.[1] as AuthMiddleware | undefined) ?? null
 }

--- a/apps/web/app/services/bot-members.server.test.ts
+++ b/apps/web/app/services/bot-members.server.test.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from 'node:sqlite'
-import type { Kysely } from 'kysely'
+import type { Compilable, Kysely } from 'kysely'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { seedUser, seedWorkspace } from '~/test/db-seed-fixture'
 import {
@@ -14,10 +14,28 @@ import {
   reissueWorkspaceBotCredential,
   stopWorkspaceBot,
 } from './bot-members.server'
+import { deleteProjectContainer } from './projects.server'
 
 const sqliteRef = vi.hoisted(() => ({
   current: null as DatabaseSync | null,
 }))
+const d1BatchHook = vi.hoisted(() => ({
+  callback: null as null | (() => void),
+}))
+
+vi.mock('~/lib/d1-batch.server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/lib/d1-batch.server')>()
+  return {
+    ...actual,
+    runD1Batch: async (
+      database: Kysely<DB>,
+      ...queries: Compilable<unknown>[]
+    ) => {
+      d1BatchHook.callback?.()
+      return actual.runD1Batch(database, ...queries)
+    },
+  }
+})
 
 vi.mock('cloudflare:workers', () => ({
   env: { DB: createD1MockFromSqliteRef(sqliteRef) },
@@ -79,6 +97,7 @@ function auditRows(action: string) {
 }
 
 beforeEach(() => {
+  d1BatchHook.callback = null
   const created = createMigratedInMemoryDb()
   sqlite = created.sqlite
   db = created.db
@@ -402,6 +421,46 @@ describe('stopWorkspaceBot', () => {
     expect(auditRows('cli.refresh_credential.revoke')).toHaveLength(0)
   })
 
+  test('releases an empty bridge fallback project when the bot stops', async () => {
+    seedProject('proj1')
+    const bot = await createBot()
+    const source = sqlite
+      .prepare(
+        `SELECT family_id, agent_profile_id
+         FROM cli_family_authorities WHERE user_id = ? AND status = 'active'`,
+      )
+      .get(bot.botUserId) as { family_id: string; agent_profile_id: string }
+    sqlite
+      .prepare(
+        `INSERT INTO bridge_authorities (
+          id, workspace_id, bot_user_id, agent_profile_id, source_kind,
+          source_installation_id, external_workspace_id, fallback_project_id,
+          created_at, updated_at
+        ) VALUES ('bridge-1', 'ws1', ?, ?, 'qm', 'install-1', 'slack-ws-1',
+          'proj1', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+      )
+      .run(bot.botUserId, source.agent_profile_id)
+    sqlite
+      .prepare(
+        `UPDATE cli_family_authorities SET bridge_authority_id = 'bridge-1'
+         WHERE family_id = ?`,
+      )
+      .run(source.family_id)
+
+    await stopWorkspaceBot(db, ADMIN, bot.botUserId)
+
+    expect(
+      sqlite
+        .prepare(
+          `SELECT fallback_project_id FROM bridge_authorities WHERE id = 'bridge-1'`,
+        )
+        .get(),
+    ).toEqual({ fallback_project_id: null })
+    await expect(
+      deleteProjectContainer(db, 'ws1', 'proj1', ADMIN.id),
+    ).resolves.toBe('ok')
+  })
+
   test('rejects humans and unknown users as not-found', async () => {
     seedUser(sqlite, 'human1')
     expect((await stopWorkspaceBot(db, ADMIN, 'human1')).kind).toBe('not-found')
@@ -504,6 +563,48 @@ describe('reissueWorkspaceBotCredential', () => {
         )
         .get(bot.botUserId),
     ).toEqual({ bridge_authority_id: 'bridge-1' })
+  })
+
+  test('preserves a bridge authority attached during credential reissue', async () => {
+    const bot = await createBot()
+    const source = sqlite
+      .prepare(
+        `SELECT family_id, agent_profile_id
+         FROM cli_family_authorities WHERE user_id = ? AND status = 'active'`,
+      )
+      .get(bot.botUserId) as { family_id: string; agent_profile_id: string }
+    d1BatchHook.callback = () => {
+      d1BatchHook.callback = null
+      sqlite
+        .prepare(
+          `INSERT INTO bridge_authorities (
+            id, workspace_id, bot_user_id, agent_profile_id, source_kind,
+            source_installation_id, external_workspace_id, fallback_project_id,
+            created_at, updated_at
+          ) VALUES ('bridge-race', 'ws1', ?, ?, 'qm', 'install-1',
+            'slack-ws-1', 'proj1', '2026-01-01T00:00:00.000Z',
+            '2026-01-01T00:00:00.000Z')`,
+        )
+        .run(bot.botUserId, source.agent_profile_id)
+      sqlite
+        .prepare(
+          `UPDATE cli_family_authorities
+           SET bridge_authority_id = 'bridge-race' WHERE family_id = ?`,
+        )
+        .run(source.family_id)
+    }
+
+    const result = await reissueWorkspaceBotCredential(db, ADMIN, bot.botUserId)
+
+    expect(result.kind).toBe('ok')
+    expect(
+      sqlite
+        .prepare(
+          `SELECT bridge_authority_id FROM cli_family_authorities
+           WHERE user_id = ? AND status = 'active'`,
+        )
+        .get(bot.botUserId),
+    ).toEqual({ bridge_authority_id: 'bridge-race' })
   })
 
   test('rejects stopped bots', async () => {

--- a/apps/web/app/services/bot-members.server.test.ts
+++ b/apps/web/app/services/bot-members.server.test.ts
@@ -469,6 +469,43 @@ describe('reissueWorkspaceBotCredential', () => {
     expect(active.c).toBe(1)
   })
 
+  test('preserves the stable bridge authority across credential reissue', async () => {
+    const bot = await createBot()
+    const source = sqlite
+      .prepare(
+        `SELECT family_id, agent_profile_id
+         FROM cli_family_authorities WHERE user_id = ? AND status = 'active'`,
+      )
+      .get(bot.botUserId) as { family_id: string; agent_profile_id: string }
+    sqlite
+      .prepare(
+        `INSERT INTO bridge_authorities (
+          id, workspace_id, bot_user_id, agent_profile_id, source_kind,
+          source_installation_id, external_workspace_id, fallback_project_id,
+          created_at, updated_at
+        ) VALUES ('bridge-1', 'ws1', ?, ?, 'qm', 'install-1', 'slack-ws-1',
+          'proj1', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+      )
+      .run(bot.botUserId, source.agent_profile_id)
+    sqlite
+      .prepare(
+        `UPDATE cli_family_authorities SET bridge_authority_id = 'bridge-1'
+         WHERE family_id = ?`,
+      )
+      .run(source.family_id)
+
+    const result = await reissueWorkspaceBotCredential(db, ADMIN, bot.botUserId)
+    expect(result.kind).toBe('ok')
+    expect(
+      sqlite
+        .prepare(
+          `SELECT bridge_authority_id FROM cli_family_authorities
+           WHERE user_id = ? AND status = 'active'`,
+        )
+        .get(bot.botUserId),
+    ).toEqual({ bridge_authority_id: 'bridge-1' })
+  })
+
   test('rejects stopped bots', async () => {
     const bot = await createBot()
     await stopWorkspaceBot(db, ADMIN, bot.botUserId)

--- a/apps/web/app/services/bot-members.server.ts
+++ b/apps/web/app/services/bot-members.server.ts
@@ -830,6 +830,12 @@ export async function stopWorkspaceBot(
     .where('status', '=', 'active')
     .where(stoppedNow)
 
+  const detachBridgeFallback = db
+    .updateTable('bridge_authorities')
+    .set({ fallback_project_id: null, updated_at: marker })
+    .where('bot_user_id', '=', botUserId)
+    .where(stoppedNow)
+
   const removeMember = db
     .updateTable('workspace_members')
     .set({
@@ -884,6 +890,7 @@ export async function stopWorkspaceBot(
     revokeCredentials,
     deleteSessions,
     revokeAuthorities,
+    detachBridgeFallback,
     removeMember,
     deleteGrants,
     stopAudit,
@@ -1023,7 +1030,10 @@ export async function reissueWorkspaceBotCredential(
           eb.val(source.project_id).as('project_id'),
           eb.val(source.project_name).as('project_name_snapshot'),
           eb.val(source.agent_profile_id).as('agent_profile_id'),
-          eb.val(source.bridge_authority_id).as('bridge_authority_id'),
+          sql<string | null>`(
+            SELECT id FROM bridge_authorities
+            WHERE bot_user_id = ${botUserId}
+          )`.as('bridge_authority_id'),
           eb.val(now).as('approved_at'),
           eb.val(null).as('device_name'),
           eb.val('active' as const).as('status'),

--- a/apps/web/app/services/bot-members.server.ts
+++ b/apps/web/app/services/bot-members.server.ts
@@ -130,6 +130,16 @@ function botCancellationEligible(botUserId: string | Expression<unknown>) {
       JOIN agent_profiles p ON p.id = m.created_by_agent_profile_id
       WHERE p.user_id = ${botUserId}
     )
+    AND NOT EXISTS (
+      SELECT 1 FROM bridge_conversations m
+      JOIN bridge_authorities b ON b.id = m.bridge_authority_id
+      WHERE b.bot_user_id = ${botUserId}
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM bridge_requests r
+      JOIN bridge_authorities b ON b.id = r.bridge_authority_id
+      WHERE b.bot_user_id = ${botUserId}
+    )
   `
 }
 
@@ -681,6 +691,10 @@ export async function cancelWorkspaceBot(
     .deleteFrom('cli_family_authorities')
     .where('user_id', '=', botUserId)
     .where(eligible)
+  const deleteBridgeAuthority = db
+    .deleteFrom('bridge_authorities')
+    .where('bot_user_id', '=', botUserId)
+    .where(eligible)
   const deleteMemberships = db
     .deleteFrom('workspace_members')
     .where('workspace_id', '=', actor.workspaceId)
@@ -705,6 +719,7 @@ export async function cancelWorkspaceBot(
     deleteShareableGrants,
     deleteCredentials,
     deleteAuthorities,
+    deleteBridgeAuthority,
     deleteMemberships,
     deleteProfile,
     deleteUser,
@@ -919,6 +934,7 @@ export async function reissueWorkspaceBotCredential(
     .select([
       'authority.project_id',
       'authority.agent_profile_id',
+      'authority.bridge_authority_id',
       'project.name as project_name',
     ])
     .where('authority.user_id', '=', botUserId)
@@ -977,6 +993,7 @@ export async function reissueWorkspaceBotCredential(
       'project_id',
       'project_name_snapshot',
       'agent_profile_id',
+      'bridge_authority_id',
       'approved_at',
       'device_name',
       'status',
@@ -1006,6 +1023,7 @@ export async function reissueWorkspaceBotCredential(
           eb.val(source.project_id).as('project_id'),
           eb.val(source.project_name).as('project_name_snapshot'),
           eb.val(source.agent_profile_id).as('agent_profile_id'),
+          eb.val(source.bridge_authority_id).as('bridge_authority_id'),
           eb.val(now).as('approved_at'),
           eb.val(null).as('device_name'),
           eb.val('active' as const).as('status'),

--- a/apps/web/app/services/bridge-authorities.server.test.ts
+++ b/apps/web/app/services/bridge-authorities.server.test.ts
@@ -102,6 +102,38 @@ describe('bridge authority provisioning', () => {
     })
   })
 
+  test('rejects source kinds outside the wire contract', async () => {
+    await expect(
+      createBridgeAuthorityForBot(
+        db,
+        { id: 'admin', workspaceId: 'ws1' },
+        {
+          botUserId: 'bot1',
+          fallbackProjectId: 'fallback-1',
+          sourceKind: 'QM',
+          sourceInstallationId: 'install-1',
+          externalWorkspaceId: 'slack-ws-1',
+        },
+      ),
+    ).resolves.toEqual({ kind: 'invalid-input' })
+  })
+
+  test('rejects source identifiers over the UTF-8 byte limit', async () => {
+    await expect(
+      createBridgeAuthorityForBot(
+        db,
+        { id: 'admin', workspaceId: 'ws1' },
+        {
+          botUserId: 'bot1',
+          fallbackProjectId: 'fallback-1',
+          sourceKind: 'qm',
+          sourceInstallationId: 'あ'.repeat(67),
+          externalWorkspaceId: 'slack-ws-1',
+        },
+      ),
+    ).resolves.toEqual({ kind: 'invalid-input' })
+  })
+
   test('fails health when the fallback becomes archived', async () => {
     const created = await createBridgeAuthorityForBot(
       db,

--- a/apps/web/app/services/bridge-authorities.server.test.ts
+++ b/apps/web/app/services/bridge-authorities.server.test.ts
@@ -134,6 +134,60 @@ describe('bridge authority provisioning', () => {
     ).resolves.toEqual({ kind: 'invalid-input' })
   })
 
+  test('rejects a fallback project already used by a conversation mapping', async () => {
+    sqlite
+      .prepare(
+        `INSERT INTO users (
+          id, email, email_verified, name, created_at, updated_at,
+          workspace_id, kind
+        ) VALUES ('bot2', 'bot2@bots.artifactshare.invalid', 1, 'Other bot',
+          '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z',
+          'ws1', 'bot')`,
+      )
+      .run()
+    sqlite
+      .prepare(
+        `INSERT INTO agent_profiles (id, user_id, workspace_id, created_at)
+         VALUES ('agent-2', 'bot2', 'ws1', '2026-01-01T00:00:00.000Z')`,
+      )
+      .run()
+    sqlite
+      .prepare(
+        `INSERT INTO bridge_authorities (
+          id, workspace_id, bot_user_id, agent_profile_id, source_kind,
+          source_installation_id, external_workspace_id, fallback_project_id,
+          created_at, updated_at
+        ) VALUES ('bridge-2', 'ws1', 'bot2', 'agent-2', 'other', 'install-2',
+          'external-2', 'fallback-1', '2026-01-01T00:00:00.000Z',
+          '2026-01-01T00:00:00.000Z')`,
+      )
+      .run()
+    sqlite
+      .prepare(
+        `INSERT INTO bridge_conversations (
+          id, bridge_authority_id, project_id, conversation_kind,
+          privacy_ceiling, privacy_epoch, created_at, updated_at
+        ) VALUES ('mapping-2', 'bridge-2', 'fallback-1', 'private_channel',
+          'private', 1, '2026-01-01T00:00:00.000Z',
+          '2026-01-01T00:00:00.000Z')`,
+      )
+      .run()
+
+    await expect(
+      createBridgeAuthorityForBot(
+        db,
+        { id: 'admin', workspaceId: 'ws1' },
+        {
+          botUserId: 'bot1',
+          fallbackProjectId: 'fallback-1',
+          sourceKind: 'qm',
+          sourceInstallationId: 'install-1',
+          externalWorkspaceId: 'slack-ws-1',
+        },
+      ),
+    ).resolves.toEqual({ kind: 'fallback-invalid' })
+  })
+
   test('fails health when the fallback becomes archived', async () => {
     const created = await createBridgeAuthorityForBot(
       db,

--- a/apps/web/app/services/bridge-authorities.server.test.ts
+++ b/apps/web/app/services/bridge-authorities.server.test.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite'
-import type { Kysely } from 'kysely'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import type { Compilable, Kysely } from 'kysely'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { seedUser, seedWorkspace } from '~/test/db-seed-fixture'
 import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
 import type { DB } from '~/types/db'
@@ -9,10 +9,29 @@ import {
   readLiveBridgeAuthority,
 } from './bridge-authorities.server'
 
+const d1BatchHook = vi.hoisted(() => ({
+  callback: null as null | (() => void),
+}))
+
+vi.mock('~/lib/d1-batch.server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/lib/d1-batch.server')>()
+  return {
+    ...actual,
+    runD1Batch: async (
+      database: Kysely<DB>,
+      ...queries: Compilable<unknown>[]
+    ) => {
+      d1BatchHook.callback?.()
+      return actual.runD1Batch(database, ...queries)
+    },
+  }
+})
+
 let sqlite: DatabaseSync
 let db: Kysely<DB>
 
 beforeEach(() => {
+  d1BatchHook.callback = null
   const fixture = createMigratedInMemoryDb()
   sqlite = fixture.sqlite
   db = fixture.db
@@ -212,5 +231,43 @@ describe('bridge authority provisioning', () => {
     await expect(
       readLiveBridgeAuthority(db, created.authority.id),
     ).resolves.toEqual({ kind: 'fallback-invalid' })
+  })
+
+  test('does not provision an authority if the fallback is archived at commit', async () => {
+    d1BatchHook.callback = () => {
+      d1BatchHook.callback = null
+      sqlite
+        .prepare(
+          `UPDATE artifact_containers
+           SET archived_at = '2026-02-01T00:00:00.000Z'
+           WHERE id = 'fallback-1'`,
+        )
+        .run()
+    }
+
+    await expect(
+      createBridgeAuthorityForBot(
+        db,
+        { id: 'admin', workspaceId: 'ws1' },
+        {
+          botUserId: 'bot1',
+          fallbackProjectId: 'fallback-1',
+          sourceKind: 'qm',
+          sourceInstallationId: 'install-1',
+          externalWorkspaceId: 'slack-ws-1',
+        },
+      ),
+    ).resolves.toEqual({ kind: 'fallback-invalid' })
+    expect(
+      sqlite.prepare(`SELECT COUNT(*) AS count FROM bridge_authorities`).get(),
+    ).toEqual({ count: 0 })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT bridge_authority_id FROM cli_family_authorities
+           WHERE family_id = 'family-1'`,
+        )
+        .get(),
+    ).toEqual({ bridge_authority_id: null })
   })
 })

--- a/apps/web/app/services/bridge-authorities.server.test.ts
+++ b/apps/web/app/services/bridge-authorities.server.test.ts
@@ -1,0 +1,130 @@
+import type { DatabaseSync } from 'node:sqlite'
+import type { Kysely } from 'kysely'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { seedUser, seedWorkspace } from '~/test/db-seed-fixture'
+import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
+import type { DB } from '~/types/db'
+import {
+  createBridgeAuthorityForBot,
+  readLiveBridgeAuthority,
+} from './bridge-authorities.server'
+
+let sqlite: DatabaseSync
+let db: Kysely<DB>
+
+beforeEach(() => {
+  const fixture = createMigratedInMemoryDb()
+  sqlite = fixture.sqlite
+  db = fixture.db
+  seedWorkspace(sqlite)
+  seedUser(sqlite, 'admin')
+  sqlite
+    .prepare(
+      `INSERT INTO workspace_members (
+        workspace_id, user_id, role, status, created_at, updated_at
+      ) VALUES ('ws1', 'admin', 'owner', 'active',
+        '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+    )
+    .run()
+  sqlite
+    .prepare(
+      `INSERT INTO users (
+        id, email, email_verified, name, created_at, updated_at,
+        workspace_id, kind
+      ) VALUES ('bot1', 'bot@bots.artifactshare.invalid', 1, 'Bridge bot',
+        '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z',
+        'ws1', 'bot')`,
+    )
+    .run()
+  sqlite
+    .prepare(
+      `INSERT INTO artifact_containers (
+        id, workspace_id, kind, created_by_id, name, base_visibility,
+        created_at, updated_at
+      ) VALUES ('fallback-1', 'ws1', 'project', 'admin', 'Fallback',
+        'workspace', '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z')`,
+    )
+    .run()
+  sqlite
+    .prepare(
+      `INSERT INTO agent_profiles (id, user_id, workspace_id, created_at)
+       VALUES ('agent-1', 'bot1', 'ws1', '2026-01-01T00:00:00.000Z')`,
+    )
+    .run()
+  sqlite
+    .prepare(
+      `INSERT INTO cli_family_authorities (
+        family_id, user_id, preset, workspace_id, project_id,
+        project_name_snapshot, agent_profile_id, status, created_at, updated_at
+      ) VALUES ('family-1', 'bot1', 'agent', 'ws1', 'fallback-1', 'Fallback',
+        'agent-1', 'active', '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z')`,
+    )
+    .run()
+})
+
+afterEach(async () => {
+  await db.destroy()
+})
+
+describe('bridge authority provisioning', () => {
+  test('binds one source namespace to the active bot credential family', async () => {
+    const result = await createBridgeAuthorityForBot(
+      db,
+      { id: 'admin', workspaceId: 'ws1' },
+      {
+        botUserId: 'bot1',
+        fallbackProjectId: 'fallback-1',
+        sourceKind: 'qm',
+        sourceInstallationId: 'install-1',
+        externalWorkspaceId: 'slack-ws-1',
+      },
+    )
+    expect(result).toMatchObject({
+      kind: 'ok',
+      authority: {
+        botUserId: 'bot1',
+        fallbackProjectId: 'fallback-1',
+        sourceKind: 'qm',
+      },
+    })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT bridge_authority_id FROM cli_family_authorities
+           WHERE family_id = 'family-1'`,
+        )
+        .get(),
+    ).toEqual({
+      bridge_authority_id:
+        result.kind === 'ok' ? result.authority.id : 'unreachable',
+    })
+  })
+
+  test('fails health when the fallback becomes archived', async () => {
+    const created = await createBridgeAuthorityForBot(
+      db,
+      { id: 'admin', workspaceId: 'ws1' },
+      {
+        botUserId: 'bot1',
+        fallbackProjectId: 'fallback-1',
+        sourceKind: 'qm',
+        sourceInstallationId: 'install-1',
+        externalWorkspaceId: 'slack-ws-1',
+      },
+    )
+    expect(created.kind).toBe('ok')
+    if (created.kind !== 'ok') return
+    sqlite
+      .prepare(
+        `UPDATE artifact_containers
+         SET archived_at = '2026-02-01T00:00:00.000Z'
+         WHERE id = 'fallback-1'`,
+      )
+      .run()
+    await expect(
+      readLiveBridgeAuthority(db, created.authority.id),
+    ).resolves.toEqual({ kind: 'fallback-invalid' })
+  })
+})

--- a/apps/web/app/services/bridge-authorities.server.ts
+++ b/apps/web/app/services/bridge-authorities.server.ts
@@ -5,8 +5,9 @@ import { nowIso } from '~/lib/datetime'
 import { requireWorkspaceAdmin } from '~/services/team-management.server'
 import type { DB } from '~/types/db'
 
-const SOURCE_KIND_MAX = 80
+const SOURCE_KIND_MAX = 64
 const SOURCE_ID_MAX = 200
+const encoder = new TextEncoder()
 
 export interface BridgeAuthorityBinding {
   id: string
@@ -43,7 +44,11 @@ export async function createBridgeAuthorityForBot(
 ): Promise<CreateBridgeAuthorityResult> {
   const admin = await requireWorkspaceAdmin(db, actor)
   if (admin.kind !== 'ok') return { kind: 'forbidden' }
-  const sourceKind = normalized(input.sourceKind, SOURCE_KIND_MAX)
+  const sourceKind = normalized(
+    input.sourceKind,
+    SOURCE_KIND_MAX,
+    /^[a-z0-9][a-z0-9_-]*$/,
+  )
   const sourceInstallationId = normalized(
     input.sourceInstallationId,
     SOURCE_ID_MAX,
@@ -100,18 +105,39 @@ export async function createBridgeAuthorityForBot(
 
   const authorityId = nanoid()
   const now = nowIso()
-  const insertAuthority = db.insertInto('bridge_authorities').values({
-    id: authorityId,
-    workspace_id: actor.workspaceId,
-    bot_user_id: input.botUserId,
-    agent_profile_id: family.agentProfileId,
-    source_kind: sourceKind,
-    source_installation_id: sourceInstallationId,
-    external_workspace_id: externalWorkspaceId,
-    fallback_project_id: fallback.id,
-    created_at: now,
-    updated_at: now,
-  })
+  const insertAuthority = db
+    .insertInto('bridge_authorities')
+    .columns([
+      'id',
+      'workspace_id',
+      'bot_user_id',
+      'agent_profile_id',
+      'source_kind',
+      'source_installation_id',
+      'external_workspace_id',
+      'fallback_project_id',
+      'created_at',
+      'updated_at',
+    ])
+    .expression((eb) =>
+      eb
+        .selectFrom('cli_family_authorities as active_family')
+        .select([
+          eb.val(authorityId).as('id'),
+          eb.val(actor.workspaceId).as('workspace_id'),
+          eb.val(input.botUserId).as('bot_user_id'),
+          eb.val(family.agentProfileId).as('agent_profile_id'),
+          eb.val(sourceKind).as('source_kind'),
+          eb.val(sourceInstallationId).as('source_installation_id'),
+          eb.val(externalWorkspaceId).as('external_workspace_id'),
+          eb.val(fallback.id).as('fallback_project_id'),
+          eb.val(now).as('created_at'),
+          eb.val(now).as('updated_at'),
+        ])
+        .where('active_family.family_id', '=', family.familyId)
+        .where('active_family.status', '=', 'active')
+        .where('active_family.bridge_authority_id', 'is', null),
+    )
   const attachFamily = db
     .updateTable('cli_family_authorities')
     .set({ bridge_authority_id: authorityId, updated_at: now })
@@ -278,13 +304,18 @@ export async function readLiveBridgeAuthority(
   }
 }
 
-function normalized(value: string, max: number): string | null {
+function normalized(
+  value: string,
+  maxBytes: number,
+  pattern?: RegExp,
+): string | null {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
   if (
     trimmed.length === 0 ||
-    trimmed.length > max ||
+    encoder.encode(trimmed).byteLength > maxBytes ||
     trimmed !== value ||
+    (pattern !== undefined && !pattern.test(trimmed)) ||
     Array.from(trimmed).some((character) => {
       const codePoint = character.codePointAt(0) ?? 0
       return codePoint <= 0x1f || codePoint === 0x7f

--- a/apps/web/app/services/bridge-authorities.server.ts
+++ b/apps/web/app/services/bridge-authorities.server.ts
@@ -268,6 +268,7 @@ export async function createBridgeAuthorityForBot(
     .select('bridge_authorities.id')
     .where('bridge_authorities.id', '=', authorityId)
     .where('cli_family_authorities.family_id', '=', family.familyId)
+    .where('cli_family_authorities.status', '=', 'active')
     .executeTakeFirst()
   if (!attached) return { kind: 'conflict' }
   return {
@@ -335,6 +336,7 @@ export async function readLiveBridgeAuthority(
     return { kind: 'unsupported-authority' }
   }
   if (
+    !row.fallback_project_id ||
     !row.fallback_name ||
     row.fallback_kind !== 'project' ||
     (row.fallback_visibility !== 'workspace' &&

--- a/apps/web/app/services/bridge-authorities.server.ts
+++ b/apps/web/app/services/bridge-authorities.server.ts
@@ -95,13 +95,25 @@ export async function createBridgeAuthorityForBot(
 
   const fallback = await db
     .selectFrom('artifact_containers')
-    .select(['id', 'name'])
+    .select(({ exists, selectFrom }) => [
+      'id',
+      'name',
+      exists(
+        selectFrom('bridge_conversations')
+          .select('id')
+          .whereRef(
+            'bridge_conversations.project_id',
+            '=',
+            'artifact_containers.id',
+          ),
+      ).as('mapped'),
+    ])
     .where('id', '=', input.fallbackProjectId)
     .where('workspace_id', '=', actor.workspaceId)
     .where('kind', '=', 'project')
     .where('archived_at', 'is', null)
     .executeTakeFirst()
-  if (!fallback) return { kind: 'fallback-invalid' }
+  if (!fallback || fallback.mapped) return { kind: 'fallback-invalid' }
 
   const authorityId = nanoid()
   const now = nowIso()
@@ -136,7 +148,13 @@ export async function createBridgeAuthorityForBot(
         ])
         .where('active_family.family_id', '=', family.familyId)
         .where('active_family.status', '=', 'active')
-        .where('active_family.bridge_authority_id', 'is', null),
+        .where('active_family.bridge_authority_id', 'is', null)
+        .where(
+          sql<boolean>`NOT EXISTS (
+            SELECT 1 FROM bridge_conversations
+            WHERE project_id = ${fallback.id}
+          )`,
+        ),
     )
   const attachFamily = db
     .updateTable('cli_family_authorities')
@@ -191,6 +209,12 @@ export async function createBridgeAuthorityForBot(
   try {
     await runD1Batch(db, insertAuthority, attachFamily, audit)
   } catch {
+    const fallbackMapped = await db
+      .selectFrom('bridge_conversations')
+      .select('id')
+      .where('project_id', '=', fallback.id)
+      .executeTakeFirst()
+    if (fallbackMapped) return { kind: 'fallback-invalid' }
     const duplicate = await db
       .selectFrom('bridge_authorities')
       .select('id')

--- a/apps/web/app/services/bridge-authorities.server.ts
+++ b/apps/web/app/services/bridge-authorities.server.ts
@@ -1,0 +1,296 @@
+import { sql, type Kysely } from 'kysely'
+import { nanoid } from 'nanoid'
+import { runD1Batch } from '~/lib/d1-batch.server'
+import { nowIso } from '~/lib/datetime'
+import { requireWorkspaceAdmin } from '~/services/team-management.server'
+import type { DB } from '~/types/db'
+
+const SOURCE_KIND_MAX = 80
+const SOURCE_ID_MAX = 200
+
+export interface BridgeAuthorityBinding {
+  id: string
+  workspaceId: string
+  botUserId: string
+  agentProfileId: string
+  sourceKind: string
+  sourceInstallationId: string
+  externalWorkspaceId: string
+  fallbackProjectId: string
+}
+
+export type CreateBridgeAuthorityResult =
+  | { kind: 'ok'; authority: BridgeAuthorityBinding }
+  | { kind: 'forbidden' }
+  | { kind: 'invalid-input' }
+  | { kind: 'bot-invalid' }
+  | { kind: 'fallback-invalid' }
+  | { kind: 'namespace-conflict' }
+  | { kind: 'conflict' }
+
+type Actor = { id: string; workspaceId: string }
+
+export async function createBridgeAuthorityForBot(
+  db: Kysely<DB>,
+  actor: Actor,
+  input: {
+    botUserId: string
+    fallbackProjectId: string
+    sourceKind: string
+    sourceInstallationId: string
+    externalWorkspaceId: string
+  },
+): Promise<CreateBridgeAuthorityResult> {
+  const admin = await requireWorkspaceAdmin(db, actor)
+  if (admin.kind !== 'ok') return { kind: 'forbidden' }
+  const sourceKind = normalized(input.sourceKind, SOURCE_KIND_MAX)
+  const sourceInstallationId = normalized(
+    input.sourceInstallationId,
+    SOURCE_ID_MAX,
+  )
+  const externalWorkspaceId = normalized(
+    input.externalWorkspaceId,
+    SOURCE_ID_MAX,
+  )
+  if (!sourceKind || !sourceInstallationId || !externalWorkspaceId) {
+    return { kind: 'invalid-input' }
+  }
+
+  const family = await db
+    .selectFrom('users as bot')
+    .innerJoin('agent_profiles as profile', (join) =>
+      join
+        .onRef('profile.user_id', '=', 'bot.id')
+        .onRef('profile.workspace_id', '=', 'bot.workspace_id'),
+    )
+    .innerJoin('cli_family_authorities as family', (join) =>
+      join
+        .onRef('family.user_id', '=', 'bot.id')
+        .onRef('family.agent_profile_id', '=', 'profile.id'),
+    )
+    .select([
+      'profile.id as agentProfileId',
+      'family.family_id as familyId',
+      'family.project_id as projectId',
+      'family.bridge_authority_id as bridgeAuthorityId',
+    ])
+    .where('bot.id', '=', input.botUserId)
+    .where('bot.workspace_id', '=', actor.workspaceId)
+    .where('bot.kind', '=', 'bot')
+    .where('bot.bot_stopped_at', 'is', null)
+    .where('family.status', '=', 'active')
+    .where('family.preset', '=', 'agent')
+    .executeTakeFirst()
+  if (!family || family.bridgeAuthorityId !== null) {
+    return { kind: 'bot-invalid' }
+  }
+  if (family.projectId !== input.fallbackProjectId) {
+    return { kind: 'fallback-invalid' }
+  }
+
+  const fallback = await db
+    .selectFrom('artifact_containers')
+    .select(['id', 'name'])
+    .where('id', '=', input.fallbackProjectId)
+    .where('workspace_id', '=', actor.workspaceId)
+    .where('kind', '=', 'project')
+    .where('archived_at', 'is', null)
+    .executeTakeFirst()
+  if (!fallback) return { kind: 'fallback-invalid' }
+
+  const authorityId = nanoid()
+  const now = nowIso()
+  const insertAuthority = db.insertInto('bridge_authorities').values({
+    id: authorityId,
+    workspace_id: actor.workspaceId,
+    bot_user_id: input.botUserId,
+    agent_profile_id: family.agentProfileId,
+    source_kind: sourceKind,
+    source_installation_id: sourceInstallationId,
+    external_workspace_id: externalWorkspaceId,
+    fallback_project_id: fallback.id,
+    created_at: now,
+    updated_at: now,
+  })
+  const attachFamily = db
+    .updateTable('cli_family_authorities')
+    .set({ bridge_authority_id: authorityId, updated_at: now })
+    .where('family_id', '=', family.familyId)
+    .where('status', '=', 'active')
+    .where('bridge_authority_id', 'is', null)
+  const audit = db
+    .insertInto('audit_events')
+    .columns([
+      'id',
+      'workspace_id',
+      'actor_user_id',
+      'action',
+      'subject_type',
+      'subject_id',
+      'detail',
+      'created_at',
+    ])
+    .expression((eb) =>
+      eb
+        .selectFrom('bridge_authorities')
+        .where('id', '=', authorityId)
+        .where(
+          sql<boolean>`EXISTS (
+            SELECT 1 FROM cli_family_authorities
+            WHERE family_id = ${family.familyId}
+              AND bridge_authority_id = ${authorityId}
+          )`,
+        )
+        .select([
+          eb.val(nanoid()).as('id'),
+          eb.val(actor.workspaceId).as('workspace_id'),
+          eb.val(actor.id).as('actor_user_id'),
+          eb.val('bridge.authority.create').as('action'),
+          eb.val('bridge_authority').as('subject_type'),
+          eb.val(authorityId).as('subject_id'),
+          eb
+            .val(
+              JSON.stringify({
+                bot_user_id: input.botUserId,
+                fallback_project_id: fallback.id,
+                fallback_project_name: fallback.name,
+                source_kind: sourceKind,
+              }),
+            )
+            .as('detail'),
+          eb.val(now).as('created_at'),
+        ]),
+    )
+
+  try {
+    await runD1Batch(db, insertAuthority, attachFamily, audit)
+  } catch {
+    const duplicate = await db
+      .selectFrom('bridge_authorities')
+      .select('id')
+      .where('workspace_id', '=', actor.workspaceId)
+      .where('source_kind', '=', sourceKind)
+      .where('source_installation_id', '=', sourceInstallationId)
+      .where('external_workspace_id', '=', externalWorkspaceId)
+      .executeTakeFirst()
+    return duplicate ? { kind: 'namespace-conflict' } : { kind: 'conflict' }
+  }
+
+  const attached = await db
+    .selectFrom('bridge_authorities')
+    .innerJoin(
+      'cli_family_authorities',
+      'cli_family_authorities.bridge_authority_id',
+      'bridge_authorities.id',
+    )
+    .select('bridge_authorities.id')
+    .where('bridge_authorities.id', '=', authorityId)
+    .where('cli_family_authorities.family_id', '=', family.familyId)
+    .executeTakeFirst()
+  if (!attached) return { kind: 'conflict' }
+  return {
+    kind: 'ok',
+    authority: {
+      id: authorityId,
+      workspaceId: actor.workspaceId,
+      botUserId: input.botUserId,
+      agentProfileId: family.agentProfileId,
+      sourceKind,
+      sourceInstallationId,
+      externalWorkspaceId,
+      fallbackProjectId: fallback.id,
+    },
+  }
+}
+
+export async function readLiveBridgeAuthority(
+  db: Kysely<DB>,
+  authorityId: string,
+): Promise<
+  | ({ kind: 'ok' } & BridgeAuthorityBinding & {
+        fallbackName: string
+        fallbackVisibility: 'workspace' | 'private'
+      })
+  | { kind: 'unsupported-authority' }
+  | { kind: 'fallback-invalid' }
+> {
+  const row = await db
+    .selectFrom('bridge_authorities as authority')
+    .innerJoin('users as bot', 'bot.id', 'authority.bot_user_id')
+    .leftJoin(
+      'artifact_containers as fallback',
+      'fallback.id',
+      'authority.fallback_project_id',
+    )
+    .select(({ exists, selectFrom }) => [
+      'authority.id',
+      'authority.workspace_id',
+      'authority.bot_user_id',
+      'authority.agent_profile_id',
+      'authority.source_kind',
+      'authority.source_installation_id',
+      'authority.external_workspace_id',
+      'authority.fallback_project_id',
+      'fallback.name as fallback_name',
+      'fallback.base_visibility as fallback_visibility',
+      'fallback.kind as fallback_kind',
+      'fallback.workspace_id as fallback_workspace_id',
+      'fallback.archived_at as fallback_archived_at',
+      'bot.bot_stopped_at',
+      exists(
+        selectFrom('bridge_conversations')
+          .select('id')
+          .whereRef(
+            'bridge_conversations.project_id',
+            '=',
+            'authority.fallback_project_id',
+          ),
+      ).as('fallback_mapped'),
+    ])
+    .where('authority.id', '=', authorityId)
+    .executeTakeFirst()
+  if (!row || row.bot_stopped_at !== null) {
+    return { kind: 'unsupported-authority' }
+  }
+  if (
+    !row.fallback_name ||
+    row.fallback_kind !== 'project' ||
+    (row.fallback_visibility !== 'workspace' &&
+      row.fallback_visibility !== 'private') ||
+    row.fallback_workspace_id !== row.workspace_id ||
+    row.fallback_archived_at !== null ||
+    row.fallback_mapped
+  ) {
+    return { kind: 'fallback-invalid' }
+  }
+  return {
+    kind: 'ok',
+    id: row.id,
+    workspaceId: row.workspace_id,
+    botUserId: row.bot_user_id,
+    agentProfileId: row.agent_profile_id,
+    sourceKind: row.source_kind,
+    sourceInstallationId: row.source_installation_id,
+    externalWorkspaceId: row.external_workspace_id,
+    fallbackProjectId: row.fallback_project_id,
+    fallbackName: row.fallback_name,
+    fallbackVisibility: row.fallback_visibility,
+  }
+}
+
+function normalized(value: string, max: number): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > max ||
+    trimmed !== value ||
+    Array.from(trimmed).some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0
+      return codePoint <= 0x1f || codePoint === 0x7f
+    })
+  ) {
+    return null
+  }
+  return trimmed
+}

--- a/apps/web/app/services/bridge-authorities.server.ts
+++ b/apps/web/app/services/bridge-authorities.server.ts
@@ -134,6 +134,20 @@ export async function createBridgeAuthorityForBot(
     .expression((eb) =>
       eb
         .selectFrom('cli_family_authorities as active_family')
+        .innerJoin('users as live_bot', (join) =>
+          join
+            .onRef('live_bot.id', '=', 'active_family.user_id')
+            .onRef('live_bot.workspace_id', '=', 'active_family.workspace_id'),
+        )
+        .innerJoin('artifact_containers as live_fallback', (join) =>
+          join
+            .onRef('live_fallback.id', '=', 'active_family.project_id')
+            .onRef(
+              'live_fallback.workspace_id',
+              '=',
+              'active_family.workspace_id',
+            ),
+        )
         .select([
           eb.val(authorityId).as('id'),
           eb.val(actor.workspaceId).as('workspace_id'),
@@ -149,6 +163,12 @@ export async function createBridgeAuthorityForBot(
         .where('active_family.family_id', '=', family.familyId)
         .where('active_family.status', '=', 'active')
         .where('active_family.bridge_authority_id', 'is', null)
+        .where('live_bot.id', '=', input.botUserId)
+        .where('live_bot.kind', '=', 'bot')
+        .where('live_bot.bot_stopped_at', 'is', null)
+        .where('live_fallback.id', '=', fallback.id)
+        .where('live_fallback.kind', '=', 'project')
+        .where('live_fallback.archived_at', 'is', null)
         .where(
           sql<boolean>`NOT EXISTS (
             SELECT 1 FROM bridge_conversations
@@ -209,12 +229,24 @@ export async function createBridgeAuthorityForBot(
   try {
     await runD1Batch(db, insertAuthority, attachFamily, audit)
   } catch {
-    const fallbackMapped = await db
-      .selectFrom('bridge_conversations')
-      .select('id')
-      .where('project_id', '=', fallback.id)
+    const liveFallback = await db
+      .selectFrom('artifact_containers as fallback')
+      .select(({ exists, selectFrom }) => [
+        'fallback.id',
+        exists(
+          selectFrom('bridge_conversations')
+            .select('id')
+            .whereRef('bridge_conversations.project_id', '=', 'fallback.id'),
+        ).as('mapped'),
+      ])
+      .where('fallback.id', '=', fallback.id)
+      .where('fallback.workspace_id', '=', actor.workspaceId)
+      .where('fallback.kind', '=', 'project')
+      .where('fallback.archived_at', 'is', null)
       .executeTakeFirst()
-    if (fallbackMapped) return { kind: 'fallback-invalid' }
+    if (!liveFallback || liveFallback.mapped) {
+      return { kind: 'fallback-invalid' }
+    }
     const duplicate = await db
       .selectFrom('bridge_authorities')
       .select('id')

--- a/apps/web/app/services/bridge-conversation-binding.server.ts
+++ b/apps/web/app/services/bridge-conversation-binding.server.ts
@@ -505,7 +505,13 @@ export function conversationProjectName(
 ) {
   const label = name ?? 'Shared conversation'
   const suffix = projectId.slice(-6)
-  return `${label.slice(0, Math.max(1, 117 - suffix.length))} · ${suffix}`
+  const maxLabelLength = Math.max(1, 117 - suffix.length)
+  const boundaryCodeUnit = label.charCodeAt(maxLabelLength - 1)
+  const safeLabelLength =
+    boundaryCodeUnit >= 0xd800 && boundaryCodeUnit <= 0xdbff
+      ? maxLabelLength - 1
+      : maxLabelLength
+  return `${label.slice(0, safeLabelLength)} · ${suffix}`
 }
 
 export async function activeProjectCountAtLimit(

--- a/apps/web/app/services/bridge-conversation-binding.server.ts
+++ b/apps/web/app/services/bridge-conversation-binding.server.ts
@@ -456,6 +456,20 @@ async function insertOrVerifyRequestBinding(
     })
     .onConflict((conflict) => conflict.doNothing())
     .execute()
+  if (input.mappingId !== null) {
+    await db
+      .updateTable('bridge_requests')
+      .set({ mapping_id: input.mappingId, updated_at: now })
+      .where('bridge_authority_id', '=', input.authorityId)
+      .where('request_id', '=', input.requestId)
+      .where('routing_class', '=', input.routingClass)
+      .where('conversation_ids_json', '=', idsJson)
+      .where('requester_stable_id', '=', input.requesterStableId)
+      .where('requester_verified_email', '=', input.requesterVerifiedEmail)
+      .where('mapping_id', 'is', null)
+      .where('status', '!=', 'completed')
+      .execute()
+  }
   const row = await db
     .selectFrom('bridge_requests')
     .select([

--- a/apps/web/app/services/bridge-conversation-binding.server.ts
+++ b/apps/web/app/services/bridge-conversation-binding.server.ts
@@ -1,0 +1,532 @@
+import { sql, type Kysely } from 'kysely'
+import { nanoid } from 'nanoid'
+import { projectLimitForPlan } from '~/lib/billing-plan.server'
+import { runD1Batch } from '~/lib/d1-batch.server'
+import { nowIso } from '~/lib/datetime'
+import type { DB } from '~/types/db'
+import type { CliAuthority } from './cli-authority.server'
+import {
+  readLiveBridgeAuthority,
+  type BridgeAuthorityBinding,
+} from './bridge-authorities.server'
+import type { TrustedBridgeContext } from './bridge-request-validation.server'
+
+const PROJECT_NAME_ATTEMPTS = 3
+
+type BridgeAuthority = Extract<CliAuthority, { kind: 'bridge' }>
+type LiveAuthority = BridgeAuthorityBinding & {
+  fallbackName: string
+  fallbackVisibility: 'workspace' | 'private'
+}
+
+export interface BridgeConversationBinding {
+  id: string
+  projectId: string
+  projectName: string
+  privacyCeiling: 'workspace' | 'private'
+  archived: boolean
+}
+
+export type BoundBridgeRequest = {
+  authority: LiveAuthority
+  routingClass: 'channel' | 'dm'
+  mapping: BridgeConversationBinding | null
+  mappingCreated: boolean
+  projectCreated: boolean
+}
+
+export type BindBridgeRequestResult =
+  | { kind: 'ok'; binding: BoundBridgeRequest }
+  | {
+      kind:
+        | 'unsupported-authority'
+        | 'fallback-invalid'
+        | 'requester-mismatch'
+        | 'mapping-archived'
+        | 'conversation-identity-conflict'
+        | 'project-limit-reached'
+        | 'project-name-conflict'
+        | 'internal-error'
+    }
+
+/**
+ * Establishes only host-owned routing state. This intentionally runs before
+ * model-owned intent validation, digest calculation, replay, or upload staging.
+ */
+export async function bindTrustedBridgeRequest(
+  db: Kysely<DB>,
+  authority: BridgeAuthority,
+  context: TrustedBridgeContext,
+): Promise<BindBridgeRequestResult> {
+  const live = await readLiveBridgeAuthority(db, authority.bridgeAuthorityId)
+  if (live.kind !== 'ok') return { kind: live.kind }
+
+  const routingClass =
+    context.conversation.kind === 'dm' ? ('dm' as const) : ('channel' as const)
+  let mapping: BridgeConversationBinding | null = null
+  if (routingClass === 'channel') {
+    const resolved = await resolveConversation(
+      db,
+      live.id,
+      context.conversation.ids,
+    )
+    if (resolved.kind !== 'ok') return resolved
+    mapping = resolved.mapping
+  }
+
+  const privateChannel = context.conversation.kind === 'private_channel'
+  let mappingCreated = false
+  let projectCreated = false
+  if (privateChannel && mapping === null) {
+    const created = await createPrivateConversationBarrier(db, live, context)
+    if (created.kind === 'project-limit-reached') return created
+    if (created.kind === 'project-name-conflict') return created
+    if (created.kind === 'internal-error') return created
+    if (created.kind === 'concurrent') {
+      const resolved = await resolveConversation(
+        db,
+        live.id,
+        context.conversation.ids,
+      )
+      if (resolved.kind !== 'ok') return resolved
+      if (resolved.mapping === null) return { kind: 'internal-error' }
+      mapping = resolved.mapping
+    } else {
+      mapping = created.mapping
+      mappingCreated = true
+      projectCreated = true
+    }
+  }
+
+  if (privateChannel && mapping !== null) {
+    const narrowed = await narrowConversationBarrier(db, live, mapping)
+    if (narrowed.kind !== 'ok') return narrowed
+    mapping = narrowed.mapping
+  }
+
+  if (mapping?.archived) return { kind: 'mapping-archived' }
+  if (mapping !== null) {
+    const aliases = await attachConversationAliases(
+      db,
+      live.id,
+      mapping.id,
+      context.conversation.ids,
+    )
+    if (!aliases) return { kind: 'conversation-identity-conflict' }
+  }
+
+  const request = await insertOrVerifyRequestBinding(db, {
+    authorityId: live.id,
+    requestId: context.requestId,
+    routingClass,
+    conversationIds: context.conversation.ids,
+    mappingId: mapping?.id ?? null,
+    requesterStableId: context.requester.stableId,
+    requesterVerifiedEmail: context.requester.verifiedEmail,
+  })
+  if (request !== 'ok') return { kind: request }
+
+  return {
+    kind: 'ok',
+    binding: {
+      authority: live,
+      routingClass,
+      mapping,
+      mappingCreated,
+      projectCreated,
+    },
+  }
+}
+
+export async function resolveConversation(
+  db: Kysely<DB>,
+  authorityId: string,
+  ids: readonly string[],
+): Promise<
+  | { kind: 'ok'; mapping: BridgeConversationBinding | null }
+  | { kind: 'conversation-identity-conflict' }
+> {
+  const rows = await db
+    .selectFrom('bridge_conversation_ids as identity')
+    .innerJoin(
+      'bridge_conversations as mapping',
+      'mapping.id',
+      'identity.mapping_id',
+    )
+    .innerJoin(
+      'artifact_containers as project',
+      'project.id',
+      'mapping.project_id',
+    )
+    .select([
+      'mapping.id',
+      'mapping.project_id',
+      'mapping.privacy_ceiling',
+      'project.name',
+      'project.archived_at',
+    ])
+    .where('identity.bridge_authority_id', '=', authorityId)
+    .where('identity.external_conversation_id', 'in', [...ids])
+    .execute()
+  const distinct = new Map(rows.map((row) => [row.id, row]))
+  if (distinct.size > 1) return { kind: 'conversation-identity-conflict' }
+  const row = distinct.values().next().value
+  return {
+    kind: 'ok',
+    mapping: row
+      ? {
+          id: row.id,
+          projectId: row.project_id,
+          projectName: row.name,
+          privacyCeiling: row.privacy_ceiling,
+          archived: row.archived_at !== null,
+        }
+      : null,
+  }
+}
+
+async function createPrivateConversationBarrier(
+  db: Kysely<DB>,
+  authority: LiveAuthority,
+  context: TrustedBridgeContext,
+): Promise<
+  | { kind: 'ok'; mapping: BridgeConversationBinding }
+  | { kind: 'concurrent' }
+  | { kind: 'project-limit-reached' }
+  | { kind: 'project-name-conflict' }
+  | { kind: 'internal-error' }
+> {
+  const workspace = await db
+    .selectFrom('workspaces')
+    .select('plan')
+    .where('id', '=', authority.workspaceId)
+    .executeTakeFirst()
+  if (!workspace) return { kind: 'internal-error' }
+  const projectLimit = projectLimitForPlan(workspace.plan)
+
+  for (let attempt = 0; attempt < PROJECT_NAME_ATTEMPTS; attempt += 1) {
+    const mappingId = nanoid()
+    const projectId = nanoid()
+    const projectName = conversationProjectName(
+      context.conversation.name,
+      projectId,
+    )
+    const now = nowIso()
+    const projectInsert = db
+      .insertInto('artifact_containers')
+      .columns([
+        'id',
+        'workspace_id',
+        'kind',
+        'owner_user_id',
+        'created_by_id',
+        'name',
+        'description',
+        'archived_at',
+        'created_at',
+        'updated_at',
+        'base_visibility',
+      ])
+      .expression((eb) => {
+        let query = eb
+          .selectFrom('workspaces')
+          .select([
+            eb.val(projectId).as('id'),
+            eb.val(authority.workspaceId).as('workspace_id'),
+            eb.val('project' as const).as('kind'),
+            eb.val(null).as('owner_user_id'),
+            eb.val(authority.botUserId).as('created_by_id'),
+            eb.val(projectName).as('name'),
+            eb.val(null).as('description'),
+            eb.val(null).as('archived_at'),
+            eb.val(now).as('created_at'),
+            eb.val(now).as('updated_at'),
+            eb.val('private' as const).as('base_visibility'),
+          ])
+          .where('workspaces.id', '=', authority.workspaceId)
+        if (projectLimit !== null) {
+          query = query.where(
+            sql<boolean>`(
+              SELECT COUNT(*) FROM artifact_containers
+              WHERE workspace_id = ${authority.workspaceId}
+                AND kind = 'project'
+                AND archived_at IS NULL
+            ) < ${projectLimit}`,
+          )
+        }
+        return query
+      })
+    const mappingInsert = db.insertInto('bridge_conversations').values({
+      id: mappingId,
+      bridge_authority_id: authority.id,
+      project_id: projectId,
+      conversation_kind: 'private_channel',
+      conversation_name: context.conversation.name,
+      privacy_ceiling: 'private',
+      privacy_epoch: 1,
+      created_at: now,
+      updated_at: now,
+    })
+    const identityInsert = db.insertInto('bridge_conversation_ids').values(
+      context.conversation.ids.map((id) => ({
+        mapping_id: mappingId,
+        bridge_authority_id: authority.id,
+        external_conversation_id: id,
+        created_at: now,
+      })),
+    )
+    try {
+      await runD1Batch(db, projectInsert, mappingInsert, identityInsert)
+      return {
+        kind: 'ok',
+        mapping: {
+          id: mappingId,
+          projectId,
+          projectName,
+          privacyCeiling: 'private',
+          archived: false,
+        },
+      }
+    } catch {
+      await deleteEmptyProject(db, projectId)
+      const concurrent = await resolveConversation(
+        db,
+        authority.id,
+        context.conversation.ids,
+      )
+      if (concurrent.kind === 'ok' && concurrent.mapping !== null) {
+        return { kind: 'concurrent' }
+      }
+      const atLimit = await activeProjectCountAtLimit(
+        db,
+        authority.workspaceId,
+        projectLimit,
+      )
+      if (atLimit) return { kind: 'project-limit-reached' }
+      const nameTaken = await db
+        .selectFrom('artifact_containers')
+        .select('id')
+        .where('workspace_id', '=', authority.workspaceId)
+        .where('kind', '=', 'project')
+        .where('archived_at', 'is', null)
+        .where(sql<boolean>`name = ${projectName} COLLATE NOCASE`)
+        .executeTakeFirst()
+      if (!nameTaken) return { kind: 'internal-error' }
+    }
+  }
+  return { kind: 'project-name-conflict' }
+}
+
+async function narrowConversationBarrier(
+  db: Kysely<DB>,
+  authority: LiveAuthority,
+  mapping: BridgeConversationBinding,
+): Promise<
+  | { kind: 'ok'; mapping: BridgeConversationBinding }
+  | { kind: 'mapping-archived' | 'internal-error' }
+> {
+  if (mapping.archived) return { kind: 'mapping-archived' }
+  const now = nowIso()
+  try {
+    await runD1Batch(
+      db,
+      db
+        .updateTable('bridge_conversations')
+        .set({
+          conversation_kind: 'private_channel',
+          privacy_ceiling: 'private',
+          privacy_epoch: 1,
+          updated_at: now,
+        })
+        .where('id', '=', mapping.id)
+        .where('bridge_authority_id', '=', authority.id),
+      db
+        .updateTable('artifact_containers')
+        .set({ base_visibility: 'private', updated_at: now })
+        .where('id', '=', mapping.projectId)
+        .where('workspace_id', '=', authority.workspaceId)
+        .where('kind', '=', 'project')
+        .where('archived_at', 'is', null),
+      db
+        .updateTable('shareables')
+        .set({ visibility: 'private', link_expires_at: null, updated_at: now })
+        .where('container_id', '=', mapping.projectId)
+        .where('workspace_id', '=', authority.workspaceId)
+        .where('visibility', '!=', 'private'),
+    )
+  } catch {
+    return { kind: 'internal-error' }
+  }
+  const resolved = await resolveConversation(db, authority.id, [
+    ...(await mappedConversationIds(db, authority.id, mapping.id)),
+  ])
+  if (resolved.kind !== 'ok' || resolved.mapping === null) {
+    return { kind: 'internal-error' }
+  }
+  if (resolved.mapping.archived) return { kind: 'mapping-archived' }
+  if (resolved.mapping.privacyCeiling !== 'private') {
+    return { kind: 'internal-error' }
+  }
+  return { kind: 'ok', mapping: resolved.mapping }
+}
+
+async function mappedConversationIds(
+  db: Kysely<DB>,
+  authorityId: string,
+  mappingId: string,
+): Promise<string[]> {
+  const rows = await db
+    .selectFrom('bridge_conversation_ids')
+    .select('external_conversation_id')
+    .where('bridge_authority_id', '=', authorityId)
+    .where('mapping_id', '=', mappingId)
+    .execute()
+  return rows.map((row) => row.external_conversation_id)
+}
+
+async function attachConversationAliases(
+  db: Kysely<DB>,
+  authorityId: string,
+  mappingId: string,
+  ids: readonly string[],
+): Promise<boolean> {
+  const now = nowIso()
+  try {
+    await db
+      .insertInto('bridge_conversation_ids')
+      .values(
+        ids.map((id) => ({
+          mapping_id: mappingId,
+          bridge_authority_id: authorityId,
+          external_conversation_id: id,
+          created_at: now,
+        })),
+      )
+      .onConflict((conflict) => conflict.doNothing())
+      .execute()
+  } catch {
+    return false
+  }
+  const rows = await db
+    .selectFrom('bridge_conversation_ids')
+    .select(['external_conversation_id', 'mapping_id'])
+    .where('bridge_authority_id', '=', authorityId)
+    .where('external_conversation_id', 'in', [...ids])
+    .execute()
+  return (
+    rows.length === ids.length &&
+    rows.every((row) => row.mapping_id === mappingId)
+  )
+}
+
+async function insertOrVerifyRequestBinding(
+  db: Kysely<DB>,
+  input: {
+    authorityId: string
+    requestId: string
+    routingClass: 'channel' | 'dm'
+    conversationIds: readonly string[]
+    mappingId: string | null
+    requesterStableId: string
+    requesterVerifiedEmail: string
+  },
+): Promise<'ok' | 'requester-mismatch' | 'conversation-identity-conflict'> {
+  const idsJson = JSON.stringify([...input.conversationIds].sort())
+  const now = nowIso()
+  await db
+    .insertInto('bridge_requests')
+    .values({
+      bridge_authority_id: input.authorityId,
+      request_id: input.requestId,
+      routing_class: input.routingClass,
+      conversation_ids_json: idsJson,
+      mapping_id: input.mappingId,
+      requester_stable_id: input.requesterStableId,
+      requester_verified_email: input.requesterVerifiedEmail,
+      stable_digest: null,
+      status: 'binding',
+      lease_generation: null,
+      lease_expires_at: null,
+      result_artifact_id: null,
+      result_version_id: null,
+      mapping_created: 0,
+      project_created: 0,
+      created_at: now,
+      updated_at: now,
+    })
+    .onConflict((conflict) => conflict.doNothing())
+    .execute()
+  const row = await db
+    .selectFrom('bridge_requests')
+    .select([
+      'routing_class',
+      'conversation_ids_json',
+      'mapping_id',
+      'requester_stable_id',
+      'requester_verified_email',
+    ])
+    .where('bridge_authority_id', '=', input.authorityId)
+    .where('request_id', '=', input.requestId)
+    .executeTakeFirst()
+  if (
+    !row ||
+    row.routing_class !== input.routingClass ||
+    row.conversation_ids_json !== idsJson ||
+    row.mapping_id !== input.mappingId
+  ) {
+    return 'conversation-identity-conflict'
+  }
+  if (
+    row.requester_stable_id !== input.requesterStableId ||
+    row.requester_verified_email !== input.requesterVerifiedEmail
+  ) {
+    return 'requester-mismatch'
+  }
+  return 'ok'
+}
+
+export function conversationProjectName(
+  name: string | null,
+  projectId: string,
+) {
+  const label = name ?? 'Shared conversation'
+  const suffix = projectId.slice(-6)
+  return `${label.slice(0, Math.max(1, 117 - suffix.length))} · ${suffix}`
+}
+
+export async function activeProjectCountAtLimit(
+  db: Kysely<DB>,
+  workspaceId: string,
+  limit: number | null,
+) {
+  if (limit === null) return false
+  const row = await db
+    .selectFrom('artifact_containers')
+    .select(({ fn }) => fn.countAll<number>().as('count'))
+    .where('workspace_id', '=', workspaceId)
+    .where('kind', '=', 'project')
+    .where('archived_at', 'is', null)
+    .executeTakeFirstOrThrow()
+  return Number(row.count) >= limit
+}
+
+export async function deleteEmptyProject(db: Kysely<DB>, projectId: string) {
+  try {
+    await db
+      .deleteFrom('artifact_containers')
+      .where('id', '=', projectId)
+      .where(
+        sql<boolean>`NOT EXISTS (
+          SELECT 1 FROM bridge_conversations WHERE project_id = ${projectId}
+        )`,
+      )
+      .where(
+        sql<boolean>`NOT EXISTS (
+          SELECT 1 FROM shareables WHERE container_id = ${projectId}
+        )`,
+      )
+      .execute()
+  } catch {
+    // A surviving reference means the failed path converged elsewhere.
+  }
+}

--- a/apps/web/app/services/bridge-conversation-binding.server.ts
+++ b/apps/web/app/services/bridge-conversation-binding.server.ts
@@ -1,4 +1,4 @@
-import { sql, type Kysely } from 'kysely'
+import { sql, type Compilable, type Kysely } from 'kysely'
 import { nanoid } from 'nanoid'
 import { projectLimitForPlan } from '~/lib/billing-plan.server'
 import { runD1Batch } from '~/lib/d1-batch.server'
@@ -121,6 +121,8 @@ export async function bindTrustedBridgeRequest(
     routingClass,
     conversationIds: context.conversation.ids,
     mappingId: mapping?.id ?? null,
+    mappingCreated,
+    projectCreated,
     requesterStableId: context.requester.stableId,
     requesterVerifiedEmail: context.requester.verifiedEmail,
   })
@@ -413,23 +415,52 @@ async function attachConversationAliases(
   mappingId: string,
   ids: readonly string[],
 ): Promise<boolean> {
+  const existing = await db
+    .selectFrom('bridge_conversation_ids')
+    .select(['external_conversation_id', 'mapping_id'])
+    .where('bridge_authority_id', '=', authorityId)
+    .where('external_conversation_id', 'in', [...ids])
+    .execute()
+  if (existing.some((row) => row.mapping_id !== mappingId)) return false
+  const present = new Set(existing.map((row) => row.external_conversation_id))
+  const missing = ids.filter((id) => !present.has(id))
   const now = nowIso()
   try {
-    await db
-      .insertInto('bridge_conversation_ids')
-      .values(
-        ids.map((id) => ({
-          mapping_id: mappingId,
-          bridge_authority_id: authorityId,
-          external_conversation_id: id,
-          created_at: now,
-        })),
-      )
-      .onConflict((conflict) => conflict.doNothing())
-      .execute()
-  } catch {
-    return false
-  }
+    const inserts: Compilable<unknown>[] = missing.map((id) =>
+      db
+        .insertInto('bridge_conversation_ids')
+        .columns([
+          'mapping_id',
+          'bridge_authority_id',
+          'external_conversation_id',
+          'created_at',
+        ])
+        .expression((eb) =>
+          eb
+            .selectFrom('bridge_conversations as mapping')
+            .select([
+              eb.val(mappingId).as('mapping_id'),
+              eb.val(authorityId).as('bridge_authority_id'),
+              eb.val(id).as('external_conversation_id'),
+              eb.val(now).as('created_at'),
+            ])
+            .where('mapping.id', '=', mappingId)
+            .where('mapping.bridge_authority_id', '=', authorityId)
+            .where(({ not, exists, selectFrom }) =>
+              not(
+                exists(
+                  selectFrom('bridge_conversation_ids as claimed')
+                    .select('claimed.mapping_id')
+                    .where('claimed.bridge_authority_id', '=', authorityId)
+                    .where('claimed.external_conversation_id', 'in', [...ids])
+                    .where('claimed.mapping_id', '!=', mappingId),
+                ),
+              ),
+            ),
+        ),
+    )
+    if (inserts.length > 0) await runD1Batch(db, ...inserts)
+  } catch {}
   const rows = await db
     .selectFrom('bridge_conversation_ids')
     .select(['external_conversation_id', 'mapping_id'])
@@ -450,6 +481,8 @@ async function insertOrVerifyRequestBinding(
     routingClass: 'channel' | 'dm'
     conversationIds: readonly string[]
     mappingId: string | null
+    mappingCreated: boolean
+    projectCreated: boolean
     requesterStableId: string
     requesterVerifiedEmail: string
   },
@@ -472,8 +505,8 @@ async function insertOrVerifyRequestBinding(
       lease_expires_at: null,
       result_artifact_id: null,
       result_version_id: null,
-      mapping_created: 0,
-      project_created: 0,
+      mapping_created: input.mappingCreated ? 1 : 0,
+      project_created: input.projectCreated ? 1 : 0,
       created_at: now,
       updated_at: now,
     })
@@ -482,14 +515,28 @@ async function insertOrVerifyRequestBinding(
   if (input.mappingId !== null) {
     await db
       .updateTable('bridge_requests')
-      .set({ mapping_id: input.mappingId, updated_at: now })
+      .set({
+        mapping_id: input.mappingId,
+        mapping_created: sql<number>`CASE
+          WHEN mapping_created = 1 OR ${input.mappingCreated ? 1 : 0} = 1
+          THEN 1 ELSE 0 END`,
+        project_created: sql<number>`CASE
+          WHEN project_created = 1 OR ${input.projectCreated ? 1 : 0} = 1
+          THEN 1 ELSE 0 END`,
+        updated_at: now,
+      })
       .where('bridge_authority_id', '=', input.authorityId)
       .where('request_id', '=', input.requestId)
       .where('routing_class', '=', input.routingClass)
       .where('conversation_ids_json', '=', idsJson)
       .where('requester_stable_id', '=', input.requesterStableId)
       .where('requester_verified_email', '=', input.requesterVerifiedEmail)
-      .where('mapping_id', 'is', null)
+      .where((eb) =>
+        eb.or([
+          eb('mapping_id', 'is', null),
+          eb('mapping_id', '=', input.mappingId),
+        ]),
+      )
       .where('status', '!=', 'completed')
       .execute()
   }

--- a/apps/web/app/services/bridge-conversation-binding.server.ts
+++ b/apps/web/app/services/bridge-conversation-binding.server.ts
@@ -112,7 +112,7 @@ export async function bindTrustedBridgeRequest(
       mapping.id,
       context.conversation.ids,
     )
-    if (!aliases) return { kind: 'conversation-identity-conflict' }
+    if (aliases !== 'ok') return { kind: aliases }
   }
 
   const request = await insertOrVerifyRequestBinding(db, {
@@ -436,14 +436,16 @@ async function attachConversationAliases(
   authorityId: string,
   mappingId: string,
   ids: readonly string[],
-): Promise<boolean> {
+): Promise<'ok' | 'conversation-identity-conflict' | 'internal-error'> {
   const existing = await db
     .selectFrom('bridge_conversation_ids')
     .select(['external_conversation_id', 'mapping_id'])
     .where('bridge_authority_id', '=', authorityId)
     .where('external_conversation_id', 'in', [...ids])
     .execute()
-  if (existing.some((row) => row.mapping_id !== mappingId)) return false
+  if (existing.some((row) => row.mapping_id !== mappingId)) {
+    return 'conversation-identity-conflict'
+  }
   const present = new Set(existing.map((row) => row.external_conversation_id))
   const missing = ids.filter((id) => !present.has(id))
   const now = nowIso()
@@ -482,17 +484,24 @@ async function attachConversationAliases(
         ),
     )
     if (inserts.length > 0) await runD1Batch(db, ...inserts)
-  } catch {}
-  const rows = await db
-    .selectFrom('bridge_conversation_ids')
-    .select(['external_conversation_id', 'mapping_id'])
-    .where('bridge_authority_id', '=', authorityId)
-    .where('external_conversation_id', 'in', [...ids])
-    .execute()
-  return (
-    rows.length === ids.length &&
-    rows.every((row) => row.mapping_id === mappingId)
-  )
+  } catch {
+    // Re-read below: a uniqueness race is a stable identity conflict, while a
+    // transient batch failure must remain retryable as an internal error.
+  }
+  try {
+    const rows = await db
+      .selectFrom('bridge_conversation_ids')
+      .select(['external_conversation_id', 'mapping_id'])
+      .where('bridge_authority_id', '=', authorityId)
+      .where('external_conversation_id', 'in', [...ids])
+      .execute()
+    if (rows.some((row) => row.mapping_id !== mappingId)) {
+      return 'conversation-identity-conflict'
+    }
+    return rows.length === ids.length ? 'ok' : 'internal-error'
+  } catch {
+    return 'internal-error'
+  }
 }
 
 async function insertOrVerifyRequestBinding(

--- a/apps/web/app/services/bridge-conversation-binding.server.ts
+++ b/apps/web/app/services/bridge-conversation-binding.server.ts
@@ -364,20 +364,23 @@ async function narrowConversationBarrier(
           updated_at: now,
         })
         .where('id', '=', mapping.id)
-        .where('bridge_authority_id', '=', authority.id),
+        .where('bridge_authority_id', '=', authority.id)
+        .where(liveAuthorityExistsSql(authority)),
       db
         .updateTable('artifact_containers')
         .set({ base_visibility: 'private', updated_at: now })
         .where('id', '=', mapping.projectId)
         .where('workspace_id', '=', authority.workspaceId)
         .where('kind', '=', 'project')
-        .where('archived_at', 'is', null),
+        .where('archived_at', 'is', null)
+        .where(liveAuthorityExistsSql(authority)),
       db
         .updateTable('shareables')
         .set({ visibility: 'private', link_expires_at: null, updated_at: now })
         .where('container_id', '=', mapping.projectId)
         .where('workspace_id', '=', authority.workspaceId)
-        .where('visibility', '!=', 'private'),
+        .where('visibility', '!=', 'private')
+        .where(liveAuthorityExistsSql(authority)),
     )
   } catch {
     return { kind: 'internal-error' }
@@ -393,6 +396,25 @@ async function narrowConversationBarrier(
     return { kind: 'internal-error' }
   }
   return { kind: 'ok', mapping: resolved.mapping }
+}
+
+function liveAuthorityExistsSql(authority: LiveAuthority) {
+  return sql<boolean>`EXISTS (
+    SELECT 1
+    FROM bridge_authorities live_authority
+    JOIN users live_bot ON live_bot.id = live_authority.bot_user_id
+    JOIN artifact_containers live_fallback
+      ON live_fallback.id = live_authority.fallback_project_id
+    WHERE live_authority.id = ${authority.id}
+      AND live_authority.workspace_id = ${authority.workspaceId}
+      AND live_authority.bot_user_id = ${authority.botUserId}
+      AND live_bot.workspace_id = live_authority.workspace_id
+      AND live_bot.kind = 'bot'
+      AND live_bot.bot_stopped_at IS NULL
+      AND live_fallback.workspace_id = live_authority.workspace_id
+      AND live_fallback.kind = 'project'
+      AND live_fallback.archived_at IS NULL
+  )`
 }
 
 async function mappedConversationIds(

--- a/apps/web/app/services/bridge-conversation-binding.server.ts
+++ b/apps/web/app/services/bridge-conversation-binding.server.ts
@@ -244,6 +244,29 @@ async function createPrivateConversationBarrier(
             eb.val('private' as const).as('base_visibility'),
           ])
           .where('workspaces.id', '=', authority.workspaceId)
+          .where(
+            sql<boolean>`EXISTS (
+              SELECT 1
+              FROM bridge_authorities AS live_authority
+              INNER JOIN users AS live_bot
+                ON live_bot.id = live_authority.bot_user_id
+              INNER JOIN artifact_containers AS live_fallback
+                ON live_fallback.id = live_authority.fallback_project_id
+              WHERE live_authority.id = ${authority.id}
+                AND live_authority.workspace_id = ${authority.workspaceId}
+                AND live_authority.bot_user_id = ${authority.botUserId}
+                AND live_bot.workspace_id = live_authority.workspace_id
+                AND live_bot.kind = 'bot'
+                AND live_bot.bot_stopped_at IS NULL
+                AND live_fallback.workspace_id = live_authority.workspace_id
+                AND live_fallback.kind = 'project'
+                AND live_fallback.archived_at IS NULL
+                AND NOT EXISTS (
+                  SELECT 1 FROM bridge_conversations
+                  WHERE project_id = live_fallback.id
+                )
+            )`,
+          )
         if (projectLimit !== null) {
           query = query.where(
             sql<boolean>`(

--- a/apps/web/app/services/bridge-publishing.server.test.ts
+++ b/apps/web/app/services/bridge-publishing.server.test.ts
@@ -1,0 +1,1083 @@
+import type { DatabaseSync } from 'node:sqlite'
+import type { Kysely } from 'kysely'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { seedUser, seedWorkspace } from '~/test/db-seed-fixture'
+import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
+import type { DB } from '~/types/db'
+import { bindTrustedBridgeRequest } from './bridge-conversation-binding.server'
+import type { TrustedBridgeContext } from './bridge-request-validation.server'
+
+const bucketState = vi.hoisted(() => new Map<string, Uint8Array>())
+const bucket = vi.hoisted(() => ({
+  put: vi.fn(async (key: string, body: ArrayBuffer | Uint8Array | Blob) => {
+    const buffer =
+      body instanceof Blob
+        ? await body.arrayBuffer()
+        : body instanceof ArrayBuffer
+          ? body
+          : new Uint8Array(body).buffer
+    bucketState.set(key, new Uint8Array(buffer))
+  }),
+  get: vi.fn(async (key: string) => {
+    const bytes = bucketState.get(key)
+    if (!bytes) return null
+    const blob = new Blob([new Uint8Array(bytes)])
+    return {
+      body: blob.stream(),
+      text: () => blob.text(),
+      size: bytes.byteLength,
+      uploaded: new Date(),
+    }
+  }),
+  delete: vi.fn(async (key: string) => {
+    bucketState.delete(key)
+  }),
+  list: vi.fn(async () => ({ objects: [], truncated: false })),
+}))
+
+vi.mock('cloudflare:workers', () => ({ env: { BUCKET: bucket } }))
+
+const authority = {
+  kind: 'bridge' as const,
+  familyId: 'family-1',
+  bridgeAuthorityId: 'bridge-1',
+  workspaceId: 'ws1',
+  fallbackProjectId: 'fallback-1',
+  agentProfileId: 'agent-1',
+  sourceKind: 'qm',
+  sourceInstallationId: 'install-1',
+  externalWorkspaceId: 'slack-ws-1',
+}
+
+let sqlite: DatabaseSync
+let db: Kysely<DB>
+
+function context(
+  overrides: Partial<TrustedBridgeContext> = {},
+): TrustedBridgeContext {
+  return {
+    requestId: 'request-1',
+    source: {
+      kind: 'qm',
+      installationId: 'install-1',
+      externalWorkspaceId: 'slack-ws-1',
+    },
+    conversation: {
+      currentId: 'channel-1',
+      ids: ['channel-1'],
+      kind: 'public_channel',
+      name: 'design',
+      privacyCheckedAt: '2026-08-26T00:00:00.000Z',
+    },
+    requester: {
+      stableId: 'person-1',
+      verifiedEmail: 'person@example.com',
+      displayName: 'Person',
+    },
+    ...overrides,
+  }
+}
+
+function seedProject(id: string, name: string, visibility = 'workspace') {
+  sqlite
+    .prepare(
+      `INSERT INTO artifact_containers (
+        id, workspace_id, kind, created_by_id, name, base_visibility,
+        created_at, updated_at
+      ) VALUES (?, 'ws1', 'project', 'bot1', ?, ?,
+        '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+    )
+    .run(id, name, visibility)
+}
+
+function seedMapping(
+  id: string,
+  projectId: string,
+  conversationId: string,
+  visibility: 'workspace' | 'private' = 'workspace',
+) {
+  sqlite
+    .prepare(
+      `INSERT INTO bridge_conversations (
+        id, bridge_authority_id, project_id, conversation_kind,
+        privacy_ceiling, privacy_epoch, created_at, updated_at
+      ) VALUES (?, 'bridge-1', ?, 'public_channel', ?, ?,
+        '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+    )
+    .run(id, projectId, visibility, visibility === 'private' ? 1 : 0)
+  sqlite
+    .prepare(
+      `INSERT INTO bridge_conversation_ids (
+        mapping_id, bridge_authority_id, external_conversation_id, created_at
+      ) VALUES (?, 'bridge-1', ?, '2026-01-01T00:00:00.000Z')`,
+    )
+    .run(id, conversationId)
+}
+
+beforeEach(() => {
+  bucketState.clear()
+  const fixture = createMigratedInMemoryDb()
+  sqlite = fixture.sqlite
+  db = fixture.db
+  seedWorkspace(sqlite)
+  seedUser(sqlite, 'admin')
+  sqlite
+    .prepare(
+      `INSERT INTO users (
+        id, email, email_verified, name, created_at, updated_at,
+        workspace_id, kind
+      ) VALUES ('bot1', 'bot@bots.artifactshare.invalid', 1, 'Bridge bot',
+        '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z',
+        'ws1', 'bot')`,
+    )
+    .run()
+  sqlite
+    .prepare(
+      `INSERT INTO workspace_members (
+        workspace_id, user_id, role, status, created_at, updated_at
+      ) VALUES ('ws1', 'bot1', 'member', 'active',
+        '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+    )
+    .run()
+  seedProject('fallback-1', 'Fallback')
+  sqlite
+    .prepare(
+      `INSERT INTO agent_profiles (id, user_id, workspace_id, created_at)
+       VALUES ('agent-1', 'bot1', 'ws1', '2026-01-01T00:00:00.000Z')`,
+    )
+    .run()
+  sqlite
+    .prepare(
+      `INSERT INTO bridge_authorities (
+        id, workspace_id, bot_user_id, agent_profile_id, source_kind,
+        source_installation_id, external_workspace_id, fallback_project_id,
+        created_at, updated_at
+      ) VALUES ('bridge-1', 'ws1', 'bot1', 'agent-1', 'qm', 'install-1',
+        'slack-ws-1', 'fallback-1', '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z')`,
+    )
+    .run()
+})
+
+afterEach(async () => {
+  await db.destroy()
+})
+
+describe('trusted bridge conversation binding', () => {
+  test('resolves an existing mapping and records only the request binding', async () => {
+    seedProject('project-1', 'Design')
+    seedMapping('mapping-1', 'project-1', 'channel-1')
+
+    const result = await bindTrustedBridgeRequest(db, authority, context())
+
+    expect(result).toMatchObject({
+      kind: 'ok',
+      binding: {
+        mapping: { id: 'mapping-1', projectId: 'project-1' },
+        mappingCreated: false,
+        projectCreated: false,
+      },
+    })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT status, mapping_id FROM bridge_requests
+           WHERE bridge_authority_id = 'bridge-1' AND request_id = 'request-1'`,
+        )
+        .get(),
+    ).toEqual({ status: 'binding', mapping_id: 'mapping-1' })
+  })
+
+  test('creates a private project and mapping before later intent processing', async () => {
+    const privateContext = context({
+      conversation: {
+        ...context().conversation,
+        kind: 'private_channel',
+        privacyCheckedAt: null,
+      },
+    })
+
+    const result = await bindTrustedBridgeRequest(db, authority, privateContext)
+
+    expect(result).toMatchObject({
+      kind: 'ok',
+      binding: {
+        mapping: { privacyCeiling: 'private' },
+        mappingCreated: true,
+        projectCreated: true,
+      },
+    })
+    const project = sqlite
+      .prepare(
+        `SELECT base_visibility FROM artifact_containers
+         WHERE id = (SELECT project_id FROM bridge_conversations
+           WHERE bridge_authority_id = 'bridge-1')`,
+      )
+      .get()
+    expect(project).toEqual({ base_visibility: 'private' })
+  })
+
+  test('narrows an existing mapping and its artifacts before requester mismatch', async () => {
+    seedProject('project-1', 'Design')
+    seedMapping('mapping-1', 'project-1', 'channel-1')
+    sqlite
+      .prepare(
+        `INSERT INTO shareables (
+          id, workspace_id, owner_user_id, name, artifact_kind, visibility,
+          created_at, updated_at, container_id
+        ) VALUES ('artifact-1', 'ws1', 'bot1', 'Draft', 'markdown_page',
+          'workspace', '2026-01-01T00:00:00.000Z',
+          '2026-01-01T00:00:00.000Z', 'project-1')`,
+      )
+      .run()
+    await bindTrustedBridgeRequest(db, authority, context())
+
+    const changedRequester = context({
+      conversation: {
+        ...context().conversation,
+        kind: 'private_channel',
+        privacyCheckedAt: null,
+      },
+      requester: {
+        stableId: 'person-2',
+        verifiedEmail: 'other@example.com',
+        displayName: 'Other',
+      },
+    })
+    const result = await bindTrustedBridgeRequest(
+      db,
+      authority,
+      changedRequester,
+    )
+
+    expect(result).toEqual({ kind: 'requester-mismatch' })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT privacy_ceiling FROM bridge_conversations
+           WHERE id = 'mapping-1'`,
+        )
+        .get(),
+    ).toEqual({ privacy_ceiling: 'private' })
+    expect(
+      sqlite
+        .prepare(`SELECT visibility FROM shareables WHERE id = 'artifact-1'`)
+        .get(),
+    ).toEqual({ visibility: 'private' })
+  })
+
+  test('rejects aliases that resolve to different mappings', async () => {
+    seedProject('project-1', 'One')
+    seedProject('project-2', 'Two')
+    seedMapping('mapping-1', 'project-1', 'channel-old')
+    seedMapping('mapping-2', 'project-2', 'channel-1')
+
+    const result = await bindTrustedBridgeRequest(
+      db,
+      authority,
+      context({
+        conversation: {
+          ...context().conversation,
+          ids: ['channel-old', 'channel-1'],
+        },
+      }),
+    )
+
+    expect(result).toEqual({ kind: 'conversation-identity-conflict' })
+  })
+
+  test('isolates the same conversation id in different source namespaces', async () => {
+    sqlite
+      .prepare(
+        `INSERT INTO users (
+          id, email, email_verified, name, created_at, updated_at,
+          workspace_id, kind
+        ) VALUES ('bot2', 'bot2@bots.artifactshare.invalid', 1, 'Second bot',
+          '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z',
+          'ws1', 'bot')`,
+      )
+      .run()
+    sqlite
+      .prepare(
+        `INSERT INTO workspace_members (
+          workspace_id, user_id, role, status, created_at, updated_at
+        ) VALUES ('ws1', 'bot2', 'member', 'active',
+          '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+      )
+      .run()
+    sqlite
+      .prepare(
+        `INSERT INTO agent_profiles (id, user_id, workspace_id, created_at)
+         VALUES ('agent-2', 'bot2', 'ws1', '2026-01-01T00:00:00.000Z')`,
+      )
+      .run()
+    sqlite
+      .prepare(
+        `INSERT INTO bridge_authorities (
+          id, workspace_id, bot_user_id, agent_profile_id, source_kind,
+          source_installation_id, external_workspace_id, fallback_project_id,
+          created_at, updated_at
+        ) VALUES ('bridge-2', 'ws1', 'bot2', 'agent-2', 'cloudflare-os',
+          'install-2', 'cf-ws-1', 'fallback-1',
+          '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+      )
+      .run()
+    const privateConversation = {
+      ...context().conversation,
+      kind: 'private_channel' as const,
+      privacyCheckedAt: null,
+    }
+    const first = await bindTrustedBridgeRequest(
+      db,
+      authority,
+      context({ conversation: privateConversation }),
+    )
+    const secondAuthority = {
+      ...authority,
+      bridgeAuthorityId: 'bridge-2',
+      sourceKind: 'cloudflare-os',
+      sourceInstallationId: 'install-2',
+      externalWorkspaceId: 'cf-ws-1',
+    }
+    const second = await bindTrustedBridgeRequest(
+      db,
+      secondAuthority,
+      context({
+        requestId: 'request-2',
+        source: {
+          kind: 'cloudflare-os',
+          installationId: 'install-2',
+          externalWorkspaceId: 'cf-ws-1',
+        },
+        conversation: privateConversation,
+      }),
+    )
+
+    expect(first.kind).toBe('ok')
+    expect(second.kind).toBe('ok')
+    expect(
+      sqlite
+        .prepare(`SELECT COUNT(*) AS count FROM bridge_conversations`)
+        .get(),
+    ).toEqual({ count: 2 })
+  })
+})
+
+describe('bridge file publishing', () => {
+  test('publishes once and replays the same completed request', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const body = new TextEncoder().encode('# Hello')
+    const sha256 = await sha256Hex(body)
+    const value = {
+      schema_version: 1,
+      request_id: 'request-publish',
+      operation: 'publish',
+      requested_audience: 'private',
+      title: 'Reviewed title',
+      source: {
+        kind: 'qm',
+        installation_id: 'install-1',
+        external_workspace_id: 'slack-ws-1',
+      },
+      conversation: {
+        current_id: 'channel-1',
+        ids: ['channel-1'],
+        kind: 'private_channel',
+        name: 'design',
+      },
+      requester: {
+        stable_id: 'person-1',
+        verified_email: 'person@example.com',
+        display_name: 'Person',
+      },
+      content: {
+        kind: 'file',
+        files: [
+          {
+            index: 0,
+            path: 'note.md',
+            media_type: 'text/markdown',
+            size: body.byteLength,
+            sha256,
+          },
+        ],
+      },
+    }
+    const file = new File([body], 'file-0', { type: 'text/markdown' })
+    const user = {
+      id: 'bot1',
+      email: 'bot@bots.artifactshare.invalid',
+      emailVerified: true,
+      workspaceId: 'ws1',
+      hd: 'example.com',
+    }
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+
+    const first = await executeBridgeRequest(
+      db,
+      authority,
+      user,
+      value,
+      [file],
+      'https://artifactshare.com',
+      new Date('2026-08-26T00:00:30.000Z'),
+    )
+    expect(first).toMatchObject({
+      kind: 'ok',
+      result: {
+        artifact: { title: 'Reviewed title' },
+        project: { id: 'project-1' },
+        visibility: 'private',
+        replayed: false,
+      },
+    })
+    const second = await executeBridgeRequest(
+      db,
+      authority,
+      user,
+      value,
+      [file],
+      'https://artifactshare.com',
+      new Date('2026-08-26T00:00:31.000Z'),
+    )
+    expect(second).toMatchObject({
+      kind: 'ok',
+      result: { replayed: true },
+    })
+    expect(
+      sqlite.prepare(`SELECT COUNT(*) AS count FROM shareables`).get(),
+    ).toEqual({ count: 1 })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM bridge_conversation_ids
+           WHERE bridge_authority_id = 'bridge-1'`,
+        )
+        .get(),
+    ).toEqual({ count: 1 })
+    expect(
+      sqlite.prepare(`SELECT COUNT(*) AS count FROM bridge_operations`).get(),
+    ).toEqual({ count: 1 })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT granted_email FROM shareable_grants
+           WHERE granted_email = 'person@example.com'`,
+        )
+        .get(),
+    ).toEqual({ granted_email: 'person@example.com' })
+  })
+
+  test('creates a public conversation project only with the staged publish commit', async () => {
+    const body = new TextEncoder().encode('# Public')
+    const sha256 = await sha256Hex(body)
+    const checkedAt = new Date().toISOString()
+    const value = {
+      schema_version: 1,
+      request_id: 'request-public',
+      operation: 'publish',
+      requested_audience: 'workspace',
+      source: {
+        kind: 'qm',
+        installation_id: 'install-1',
+        external_workspace_id: 'slack-ws-1',
+      },
+      conversation: {
+        current_id: 'channel-public',
+        ids: ['channel-public'],
+        kind: 'public_channel',
+        name: 'announcements',
+        privacy_checked_at: checkedAt,
+      },
+      requester: {
+        stable_id: 'person-1',
+        verified_email: 'person@example.com',
+      },
+      content: {
+        kind: 'file',
+        files: [
+          {
+            index: 0,
+            path: 'note.md',
+            media_type: 'text/markdown',
+            size: body.byteLength,
+            sha256,
+          },
+        ],
+      },
+    }
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const result = await executeBridgeRequest(
+      db,
+      authority,
+      {
+        id: 'bot1',
+        email: 'bot@bots.artifactshare.invalid',
+        emailVerified: true,
+        workspaceId: 'ws1',
+        hd: 'example.com',
+      },
+      value,
+      [new File([body], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+      new Date(checkedAt),
+    )
+
+    expect(result).toMatchObject({
+      kind: 'ok',
+      result: {
+        visibility: 'workspace',
+        mappingCreated: true,
+        projectCreated: true,
+      },
+    })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM bridge_conversations
+           WHERE bridge_authority_id = 'bridge-1'`,
+        )
+        .get(),
+    ).toEqual({ count: 1 })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM artifact_containers
+           WHERE kind = 'project'`,
+        )
+        .get(),
+    ).toEqual({ count: 2 })
+
+    if (result.kind !== 'ok') return
+    sqlite
+      .prepare(
+        `UPDATE bridge_conversations
+         SET privacy_ceiling = 'private', privacy_epoch = 1
+         WHERE bridge_authority_id = 'bridge-1'`,
+      )
+      .run()
+    sqlite
+      .prepare(
+        `UPDATE artifact_containers SET base_visibility = 'private'
+         WHERE id = ?`,
+      )
+      .run(result.result.project.id)
+    sqlite
+      .prepare(`UPDATE shareables SET visibility = 'private' WHERE id = ?`)
+      .run(result.result.artifact.id)
+    const replayed = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      value,
+      [new File([body], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+      new Date(checkedAt),
+    )
+    expect(replayed).toMatchObject({
+      kind: 'ok',
+      result: { visibility: 'private', replayed: true },
+    })
+
+    const renamed = structuredClone(value)
+    renamed.request_id = 'request-public-renamed'
+    renamed.conversation.current_id = 'channel-public-new'
+    renamed.conversation.ids = ['channel-public', 'channel-public-new']
+    renamed.conversation.name = 'company announcements'
+    renamed.conversation.privacy_checked_at = new Date().toISOString()
+    const repeated = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      renamed,
+      [new File([body], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+      new Date(renamed.conversation.privacy_checked_at),
+    )
+    expect(repeated).toMatchObject({
+      kind: 'ok',
+      result: {
+        project: { id: result.result.project.id },
+        mappingCreated: false,
+        projectCreated: false,
+      },
+    })
+  })
+
+  test('converges concurrent first shares on one project and mapping', async () => {
+    const body = new TextEncoder().encode('# Concurrent')
+    const checkedAt = new Date().toISOString()
+    const base = {
+      schema_version: 1,
+      operation: 'publish' as const,
+      requested_audience: 'workspace' as const,
+      source: {
+        kind: 'qm',
+        installation_id: 'install-1',
+        external_workspace_id: 'slack-ws-1',
+      },
+      conversation: {
+        current_id: 'channel-concurrent',
+        ids: ['channel-concurrent'],
+        kind: 'public_channel' as const,
+        name: 'concurrent',
+        privacy_checked_at: checkedAt,
+      },
+      requester: {
+        stable_id: 'person-1',
+        verified_email: 'person@example.com',
+      },
+      content: {
+        kind: 'file' as const,
+        files: [
+          {
+            index: 0,
+            path: 'note.md',
+            media_type: 'text/markdown',
+            size: body.byteLength,
+            sha256: await sha256Hex(body),
+          },
+        ],
+      },
+    }
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const results = await Promise.all(
+      ['concurrent-1', 'concurrent-2'].map((requestId) =>
+        executeBridgeRequest(
+          db,
+          authority,
+          bridgeUser(),
+          { ...base, request_id: requestId },
+          [new File([body], 'file-0', { type: 'text/markdown' })],
+          'https://artifactshare.com',
+          new Date(checkedAt),
+        ),
+      ),
+    )
+
+    expect(results.every((result) => result.kind === 'ok')).toBe(true)
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM bridge_conversations
+           WHERE bridge_authority_id = 'bridge-1'`,
+        )
+        .get(),
+    ).toEqual({ count: 1 })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM artifact_containers
+           WHERE kind = 'project'`,
+        )
+        .get(),
+    ).toEqual({ count: 2 })
+  })
+
+  test('updates a bridge-created artifact without changing its URL', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const user = bridgeUser()
+    const firstBody = new TextEncoder().encode('# First')
+    const first = await executeBridgeRequest(
+      db,
+      authority,
+      user,
+      await fileMetadata({
+        requestId: 'publish-first',
+        body: firstBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([firstBody], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(first.kind).toBe('ok')
+    if (first.kind !== 'ok') return
+
+    const nextBody = new TextEncoder().encode('# Second')
+    const updated = await executeBridgeRequest(
+      db,
+      authority,
+      user,
+      await fileMetadata({
+        requestId: 'update-second',
+        operation: 'update',
+        targetArtifactId: first.result.artifact.id,
+        body: nextBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([nextBody], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(updated).toMatchObject({
+      kind: 'ok',
+      result: { artifact: { id: first.result.artifact.id }, replayed: false },
+    })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM versions WHERE shareable_id = ?`,
+        )
+        .get(first.result.artifact.id),
+    ).toEqual({ count: 2 })
+  })
+
+  test('appends UTF-8 content as a new version on the same URL', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const firstBody = new TextEncoder().encode('# First\n')
+    const published = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'append-base',
+        body: firstBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([firstBody], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(published.kind).toBe('ok')
+    if (published.kind !== 'ok') return
+    const addition = new TextEncoder().encode('Second\n')
+    const appended = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'append-next',
+        operation: 'append',
+        targetArtifactId: published.result.artifact.id,
+        body: addition,
+        conversationKind: 'private_channel',
+      }),
+      [new File([addition], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(appended).toMatchObject({
+      kind: 'ok',
+      result: { artifact: { id: published.result.artifact.id } },
+    })
+    const current = sqlite
+      .prepare(
+        `SELECT versions.r2_key
+         FROM shareables JOIN versions ON versions.id = shareables.current_version_id
+         WHERE shareables.id = ?`,
+      )
+      .get(published.result.artifact.id) as { r2_key: string }
+    expect(new TextDecoder().decode(bucketState.get(current.r2_key))).toBe(
+      '# First\nSecond\n',
+    )
+  })
+
+  test('promotes a requester-owned DM draft on the same URL', async () => {
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const user = bridgeUser()
+    const body = new TextEncoder().encode('# DM draft')
+    const published = await executeBridgeRequest(
+      db,
+      authority,
+      user,
+      await fileMetadata({
+        requestId: 'dm-publish',
+        body,
+        conversationKind: 'dm',
+        conversationId: 'dm-1',
+      }),
+      [new File([body], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(published).toMatchObject({
+      kind: 'ok',
+      result: { visibility: 'private', project: { id: 'fallback-1' } },
+    })
+    if (published.kind !== 'ok') return
+    const visibilityMetadata = {
+      schema_version: 1,
+      request_id: 'dm-promote',
+      operation: 'set_visibility',
+      requested_audience: 'workspace',
+      target_artifact_id: published.result.artifact.id,
+      source: {
+        kind: 'qm',
+        installation_id: 'install-1',
+        external_workspace_id: 'slack-ws-1',
+      },
+      conversation: {
+        current_id: 'dm-1',
+        ids: ['dm-1'],
+        kind: 'dm',
+      },
+      requester: {
+        stable_id: 'person-1',
+        verified_email: 'person@example.com',
+      },
+    }
+    const promoted = await executeBridgeRequest(
+      db,
+      authority,
+      user,
+      visibilityMetadata,
+      [],
+      'https://artifactshare.com',
+    )
+    expect(promoted).toMatchObject({
+      kind: 'ok',
+      result: {
+        artifact: { id: published.result.artifact.id },
+        visibility: 'workspace',
+        versionId: null,
+      },
+    })
+  })
+
+  test('publishes a static-site bundle with one immutable bridge operation', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const html = new TextEncoder().encode('<title>Site</title><h1>Hello</h1>')
+    const css = new TextEncoder().encode('h1 { color: red }')
+    const metadata = {
+      schema_version: 1,
+      request_id: 'static-publish',
+      operation: 'publish',
+      requested_audience: 'private',
+      source: {
+        kind: 'qm',
+        installation_id: 'install-1',
+        external_workspace_id: 'slack-ws-1',
+      },
+      conversation: {
+        current_id: 'channel-1',
+        ids: ['channel-1'],
+        kind: 'private_channel',
+      },
+      requester: {
+        stable_id: 'person-1',
+        verified_email: 'person@example.com',
+      },
+      content: {
+        kind: 'static_site',
+        files: [
+          {
+            index: 0,
+            path: 'index.html',
+            media_type: 'text/html',
+            size: html.byteLength,
+            sha256: await sha256Hex(html),
+          },
+          {
+            index: 1,
+            path: 'styles.css',
+            media_type: 'text/css',
+            size: css.byteLength,
+            sha256: await sha256Hex(css),
+          },
+        ],
+      },
+    }
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const result = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      metadata,
+      [
+        new File([html], 'file-0', { type: 'text/html' }),
+        new File([css], 'file-1', { type: 'text/css' }),
+      ],
+      'https://artifactshare.com',
+    )
+
+    expect(result).toMatchObject({
+      kind: 'ok',
+      result: { artifact: { title: 'Site' }, visibility: 'private' },
+    })
+    expect(
+      sqlite.prepare(`SELECT artifact_kind FROM shareables`).get(),
+    ).toEqual({ artifact_kind: 'static_site' })
+    expect(
+      sqlite.prepare(`SELECT COUNT(*) AS count FROM version_files`).get(),
+    ).toEqual({ count: 2 })
+  })
+
+  test('uses the narrowed mapping at final commit instead of stale public context', async () => {
+    seedProject('project-1', 'Design')
+    seedMapping('mapping-1', 'project-1', 'channel-1')
+    const body = new TextEncoder().encode('# Race')
+    const checkedAt = new Date().toISOString()
+    bucket.put.mockImplementationOnce(async () => {
+      sqlite
+        .prepare(
+          `UPDATE bridge_conversations
+           SET privacy_ceiling = 'private', privacy_epoch = 1
+           WHERE id = 'mapping-1'`,
+        )
+        .run()
+      sqlite
+        .prepare(
+          `UPDATE artifact_containers SET base_visibility = 'private'
+           WHERE id = 'project-1'`,
+        )
+        .run()
+    })
+    const privateMetadata = await fileMetadata({
+      requestId: 'privacy-race',
+      body,
+      conversationKind: 'private_channel',
+    })
+    const metadata = {
+      ...privateMetadata,
+      requested_audience: 'workspace' as const,
+      conversation: {
+        ...privateMetadata.conversation,
+        kind: 'public_channel' as const,
+        privacy_checked_at: checkedAt,
+      },
+    }
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const result = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      metadata,
+      [new File([body], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+      new Date(checkedAt),
+    )
+    expect(result).toMatchObject({
+      kind: 'ok',
+      result: { visibility: 'private' },
+    })
+  })
+
+  test('denies a manually created artifact and releases the failed lease', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    sqlite
+      .prepare(
+        `INSERT INTO shareables (
+          id, workspace_id, owner_user_id, name, artifact_kind, visibility,
+          current_version_id, created_at, updated_at, container_id,
+          created_by_agent_profile_id
+        ) VALUES ('manual-1', 'ws1', 'bot1', 'Manual', 'markdown_page',
+          'private', 'manual-v1', '2026-01-01T00:00:00.000Z',
+          '2026-01-01T00:00:00.000Z', 'project-1', 'agent-1')`,
+      )
+      .run()
+    sqlite
+      .prepare(
+        `INSERT INTO versions (
+          id, shareable_id, artifact_kind, status, entrypoint_path, r2_key,
+          size_bytes, sha256, created_by_id, created_at, published_at
+        ) VALUES ('manual-v1', 'manual-1', 'markdown_page', 'published',
+          '/note.md', 'manual/key', 1, 'sha', 'bot1',
+          '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+      )
+      .run()
+    const body = new TextEncoder().encode('# Changed')
+    const metadata = await fileMetadata({
+      requestId: 'manual-update',
+      operation: 'update',
+      targetArtifactId: 'manual-1',
+      body,
+      conversationKind: 'private_channel',
+    })
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const first = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      metadata,
+      [new File([body], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    const second = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      metadata,
+      [new File([body], 'file-0', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(first).toEqual({ kind: 'forbidden-target' })
+    expect(second).toEqual({ kind: 'forbidden-target' })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT status, stable_digest FROM bridge_requests
+           WHERE request_id = 'manual-update'`,
+        )
+        .get(),
+    ).toEqual({ status: 'binding', stable_digest: null })
+  })
+})
+
+async function sha256Hex(bytes: Uint8Array) {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new Uint8Array(bytes).buffer,
+  )
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function bridgeUser() {
+  return {
+    id: 'bot1',
+    email: 'bot@bots.artifactshare.invalid',
+    emailVerified: true,
+    workspaceId: 'ws1',
+    hd: 'example.com',
+  }
+}
+
+async function fileMetadata(input: {
+  requestId: string
+  body: Uint8Array
+  operation?: 'publish' | 'update' | 'append'
+  targetArtifactId?: string
+  conversationKind: 'private_channel' | 'dm'
+  conversationId?: string
+}) {
+  const conversationId = input.conversationId ?? 'channel-1'
+  return {
+    schema_version: 1,
+    request_id: input.requestId,
+    operation: input.operation ?? 'publish',
+    requested_audience: 'private',
+    ...(input.targetArtifactId
+      ? { target_artifact_id: input.targetArtifactId }
+      : {}),
+    source: {
+      kind: 'qm',
+      installation_id: 'install-1',
+      external_workspace_id: 'slack-ws-1',
+    },
+    conversation: {
+      current_id: conversationId,
+      ids: [conversationId],
+      kind: input.conversationKind,
+    },
+    requester: {
+      stable_id: 'person-1',
+      verified_email: 'person@example.com',
+    },
+    content: {
+      kind: 'file',
+      files: [
+        {
+          index: 0,
+          path: 'note.md',
+          media_type: 'text/markdown',
+          size: input.body.byteLength,
+          sha256: await sha256Hex(input.body),
+        },
+      ],
+    },
+  }
+}

--- a/apps/web/app/services/bridge-publishing.server.test.ts
+++ b/apps/web/app/services/bridge-publishing.server.test.ts
@@ -6,6 +6,7 @@ import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
 import type { DB } from '~/types/db'
 import { bindTrustedBridgeRequest } from './bridge-conversation-binding.server'
 import type { TrustedBridgeContext } from './bridge-request-validation.server'
+import { deleteProjectContainer } from './projects.server'
 
 const bucketState = vi.hoisted(() => new Map<string, Uint8Array>())
 const notifyVersionChanged = vi.hoisted(() => vi.fn())
@@ -224,6 +225,46 @@ describe('trusted bridge conversation binding', () => {
       )
       .get()
     expect(project).toEqual({ base_visibility: 'private' })
+  })
+
+  test('adopts a mapping created after the request was first bound', async () => {
+    const first = await bindTrustedBridgeRequest(db, authority, context())
+    expect(first).toMatchObject({ kind: 'ok', binding: { mapping: null } })
+
+    seedProject('project-1', 'Design')
+    seedMapping('mapping-1', 'project-1', 'channel-1')
+    const retried = await bindTrustedBridgeRequest(db, authority, context())
+
+    expect(retried).toMatchObject({
+      kind: 'ok',
+      binding: { mapping: { id: 'mapping-1', projectId: 'project-1' } },
+    })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT mapping_id FROM bridge_requests
+           WHERE bridge_authority_id = 'bridge-1' AND request_id = 'request-1'`,
+        )
+        .get(),
+    ).toEqual({ mapping_id: 'mapping-1' })
+  })
+
+  test('allows an empty mapped project to be deleted after request binding', async () => {
+    seedProject('project-1', 'Design')
+    seedMapping('mapping-1', 'project-1', 'channel-1')
+    await bindTrustedBridgeRequest(db, authority, context())
+
+    await expect(
+      deleteProjectContainer(db, 'ws1', 'project-1', 'bot1'),
+    ).resolves.toBe('ok')
+    expect(
+      sqlite
+        .prepare(
+          `SELECT mapping_id FROM bridge_requests
+           WHERE bridge_authority_id = 'bridge-1' AND request_id = 'request-1'`,
+        )
+        .get(),
+    ).toEqual({ mapping_id: null })
   })
 
   test('narrows an existing mapping and its artifacts before requester mismatch', async () => {
@@ -901,6 +942,66 @@ describe('bridge file publishing', () => {
     expect(bucketState.size).toBe(1)
   })
 
+  test('recognizes a legacy mixed-case requester grant at the viewer limit', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const firstBody = new TextEncoder().encode('# First')
+    const first = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'mixed-case-base',
+        body: firstBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([firstBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(first.kind).toBe('ok')
+    if (first.kind !== 'ok') return
+    sqlite
+      .prepare(
+        `UPDATE shareable_grants SET granted_email = 'Person@Example.com'
+         WHERE shareable_id = ? AND granted_email = 'person@example.com'`,
+      )
+      .run(first.result.artifact.id)
+    const insertGrant = sqlite.prepare(
+      `INSERT INTO shareable_grants (
+        shareable_id, granted_email, granted_at, granted_by
+      ) VALUES (?, ?, '2026-01-01T00:00:00.000Z', 'bot1')`,
+    )
+    for (let index = 0; index < 49; index += 1) {
+      insertGrant.run(first.result.artifact.id, `viewer-${index}@example.com`)
+    }
+    const nextBody = new TextEncoder().encode('# Second')
+    const updated = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'mixed-case-update',
+        operation: 'update',
+        targetArtifactId: first.result.artifact.id,
+        body: nextBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([nextBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+
+    expect(updated.kind).toBe('ok')
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM shareable_grants
+           WHERE shareable_id = ? AND lower(granted_email) = 'person@example.com'`,
+        )
+        .get(first.result.artifact.id),
+    ).toEqual({ count: 1 })
+  })
+
   test('appends after multibyte HTML content without corrupting UTF-8', async () => {
     seedProject('project-1', 'Private design', 'private')
     seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
@@ -1016,6 +1117,85 @@ describe('bridge file publishing', () => {
         versionId: null,
       },
     })
+  })
+
+  test('does not complete a private visibility change without requester access', async () => {
+    seedProject('project-1', 'Design')
+    seedMapping('mapping-1', 'project-1', 'channel-1')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const body = new TextEncoder().encode('# Workspace artifact')
+    const published = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'visibility-cap-base',
+        body,
+        requestedAudience: 'workspace',
+        conversationKind: 'public_channel',
+      }),
+      [new File([body], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(published.kind).toBe('ok')
+    if (published.kind !== 'ok') return
+    const insertGrant = sqlite.prepare(
+      `INSERT INTO shareable_grants (
+        shareable_id, granted_email, granted_at, granted_by
+      ) VALUES (?, ?, '2026-01-01T00:00:00.000Z', 'bot1')`,
+    )
+    for (let index = 0; index < 50; index += 1) {
+      insertGrant.run(
+        published.result.artifact.id,
+        `viewer-${index}@example.com`,
+      )
+    }
+    const changed = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      {
+        schema_version: 1,
+        request_id: 'visibility-cap-private',
+        operation: 'set_visibility',
+        requested_audience: 'private',
+        target_artifact_id: published.result.artifact.id,
+        source: {
+          kind: 'qm',
+          installation_id: 'install-1',
+          external_workspace_id: 'slack-ws-1',
+        },
+        conversation: {
+          current_id: 'channel-1',
+          ids: ['channel-1'],
+          kind: 'public_channel',
+          name: 'design',
+          privacy_checked_at: new Date().toISOString(),
+        },
+        requester: {
+          stable_id: 'person-2',
+          verified_email: 'person-2@example.com',
+        },
+      },
+      [],
+      'https://artifactshare.com',
+    )
+
+    expect(changed).toEqual({ kind: 'artifact-viewer-limit-reached' })
+    expect(
+      sqlite
+        .prepare(`SELECT visibility FROM shareables WHERE id = ?`)
+        .get(published.result.artifact.id),
+    ).toEqual({ visibility: 'project' })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT status FROM bridge_requests
+           WHERE bridge_authority_id = 'bridge-1'
+             AND request_id = 'visibility-cap-private'`,
+        )
+        .get(),
+    ).toEqual({ status: 'binding' })
   })
 
   test('publishes a static-site bundle with one immutable bridge operation', async () => {
@@ -1223,7 +1403,8 @@ async function fileMetadata(input: {
   body: Uint8Array
   operation?: 'publish' | 'update' | 'append'
   targetArtifactId?: string
-  conversationKind: 'private_channel' | 'dm'
+  conversationKind: 'public_channel' | 'private_channel' | 'dm'
+  requestedAudience?: 'workspace' | 'private'
   conversationId?: string
   path?: string
   mediaType?: string
@@ -1235,7 +1416,7 @@ async function fileMetadata(input: {
     schema_version: 1,
     request_id: input.requestId,
     operation: input.operation ?? 'publish',
-    requested_audience: 'private',
+    requested_audience: input.requestedAudience ?? 'private',
     ...(input.targetArtifactId
       ? { target_artifact_id: input.targetArtifactId }
       : {}),
@@ -1248,6 +1429,9 @@ async function fileMetadata(input: {
       current_id: conversationId,
       ids: [conversationId],
       kind: input.conversationKind,
+      ...(input.conversationKind === 'public_channel'
+        ? { privacy_checked_at: new Date().toISOString() }
+        : {}),
     },
     requester: {
       stable_id: input.requesterStableId ?? 'person-1',

--- a/apps/web/app/services/bridge-publishing.server.test.ts
+++ b/apps/web/app/services/bridge-publishing.server.test.ts
@@ -124,6 +124,7 @@ function seedMapping(
 }
 
 beforeEach(() => {
+  vi.clearAllMocks()
   bucketState.clear()
   notifyVersionChanged.mockReset()
   const fixture = createMigratedInMemoryDb()
@@ -447,7 +448,7 @@ describe('bridge file publishing', () => {
           {
             index: 0,
             path: 'note.md',
-            media_type: 'text/markdown',
+            media_type: 'Text/Markdown',
             size: body.byteLength,
             sha256,
           },
@@ -529,6 +530,17 @@ describe('bridge file publishing', () => {
         )
         .get(),
     ).toEqual({ result_artifact_id: first.result.artifact.id })
+    await expect(
+      executeBridgeRequest(
+        db,
+        authority,
+        user,
+        value,
+        [file],
+        'https://artifactshare.com',
+        new Date('2026-08-26T00:00:33.000Z'),
+      ),
+    ).resolves.toEqual({ kind: 'forbidden-target' })
   })
 
   test('creates a public conversation project only with the staged publish commit', async () => {
@@ -665,6 +677,77 @@ describe('bridge file publishing', () => {
         projectCreated: false,
       },
     })
+  })
+
+  test('does not consume private viewer grants for workspace updates', async () => {
+    seedProject('project-1', 'Design')
+    seedMapping('mapping-1', 'project-1', 'channel-1')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const firstBody = new TextEncoder().encode('# First')
+    const published = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'workspace-base',
+        body: firstBody,
+        requestedAudience: 'workspace',
+        conversationKind: 'public_channel',
+      }),
+      [new File([firstBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(published.kind).toBe('ok')
+    if (published.kind !== 'ok') return
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM shareable_grants WHERE shareable_id = ?`,
+        )
+        .get(published.result.artifact.id),
+    ).toEqual({ count: 0 })
+
+    const insertGrant = sqlite.prepare(
+      `INSERT INTO shareable_grants (
+        shareable_id, granted_email, granted_at, granted_by
+      ) VALUES (?, ?, '2026-01-01T00:00:00.000Z', 'bot1')`,
+    )
+    for (let index = 0; index < 50; index += 1) {
+      insertGrant.run(
+        published.result.artifact.id,
+        `viewer-${index}@example.com`,
+      )
+    }
+    const nextBody = new TextEncoder().encode('# Second')
+    const updated = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'workspace-update',
+        operation: 'update',
+        targetArtifactId: published.result.artifact.id,
+        body: nextBody,
+        requestedAudience: 'workspace',
+        conversationKind: 'public_channel',
+        requesterStableId: 'person-51',
+        requesterEmail: 'person-51@example.com',
+      }),
+      [new File([nextBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+
+    expect(updated).toMatchObject({
+      kind: 'ok',
+      result: { visibility: 'workspace' },
+    })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM shareable_grants WHERE shareable_id = ?`,
+        )
+        .get(published.result.artifact.id),
+    ).toEqual({ count: 50 })
   })
 
   test('bounds a filename fallback title to the bridge response contract', async () => {
@@ -1058,20 +1141,67 @@ describe('bridge file publishing', () => {
     )
   })
 
+  test('rejects an oversized append before loading the stored body', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const body = new TextEncoder().encode('# Base')
+    const published = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'append-limit-base',
+        body,
+        conversationKind: 'private_channel',
+      }),
+      [new File([body], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(published.kind).toBe('ok')
+    if (published.kind !== 'ok') return
+    sqlite
+      .prepare(
+        `UPDATE versions SET size_bytes = 26214400
+         WHERE id = (SELECT current_version_id FROM shareables WHERE id = ?)`,
+      )
+      .run(published.result.artifact.id)
+    bucket.get.mockClear()
+    const addition = new TextEncoder().encode('x')
+    const appended = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'append-limit-next',
+        operation: 'append',
+        targetArtifactId: published.result.artifact.id,
+        body: addition,
+        conversationKind: 'private_channel',
+      }),
+      [new File([addition], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+
+    expect(appended).toEqual({ kind: 'payload-too-large' })
+    expect(bucket.get).not.toHaveBeenCalled()
+  })
+
   test('promotes a requester-owned DM draft on the same URL', async () => {
     const { executeBridgeRequest } = await import('./bridge-publishing.server')
     const user = bridgeUser()
     const body = new TextEncoder().encode('# DM draft')
+    const publishMetadata = await fileMetadata({
+      requestId: 'dm-publish',
+      body,
+      conversationKind: 'dm',
+      conversationId: 'dm-1',
+    })
     const published = await executeBridgeRequest(
       db,
       authority,
       user,
-      await fileMetadata({
-        requestId: 'dm-publish',
-        body,
-        conversationKind: 'dm',
-        conversationId: 'dm-1',
-      }),
+      publishMetadata,
       [new File([body], 'file-0', { type: 'text/markdown' })],
       'https://artifactshare.com',
     )
@@ -1080,6 +1210,19 @@ describe('bridge file publishing', () => {
       result: { visibility: 'private', project: { id: 'fallback-1' } },
     })
     if (published.kind !== 'ok') return
+    sqlite
+      .prepare(`UPDATE shareables SET visibility = 'workspace' WHERE id = ?`)
+      .run(published.result.artifact.id)
+    await expect(
+      executeBridgeRequest(
+        db,
+        authority,
+        user,
+        publishMetadata,
+        [new File([body], 'file-0', { type: 'text/markdown' })],
+        'https://artifactshare.com',
+      ),
+    ).resolves.toEqual({ kind: 'forbidden-target' })
     const visibilityMetadata = {
       schema_version: 1,
       request_id: 'dm-promote',
@@ -1264,6 +1407,73 @@ describe('bridge file publishing', () => {
     expect(
       sqlite.prepare(`SELECT COUNT(*) AS count FROM version_files`).get(),
     ).toEqual({ count: 12 })
+  })
+
+  test('waits for every static-site write before cleaning up a failed stage', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const html = new TextEncoder().encode('<h1>Hello</h1>')
+    const css = new TextEncoder().encode('body { color: red }')
+    const bundle = [
+      { path: 'index.html', mediaType: 'text/html', body: html },
+      { path: 'style.css', mediaType: 'text/css', body: css },
+    ]
+    const metadata = {
+      schema_version: 1,
+      request_id: 'static-write-failure',
+      operation: 'publish',
+      requested_audience: 'private',
+      source: {
+        kind: 'qm',
+        installation_id: 'install-1',
+        external_workspace_id: 'slack-ws-1',
+      },
+      conversation: {
+        current_id: 'channel-1',
+        ids: ['channel-1'],
+        kind: 'private_channel',
+      },
+      requester: {
+        stable_id: 'person-1',
+        verified_email: 'person@example.com',
+      },
+      content: {
+        kind: 'static_site',
+        files: await Promise.all(
+          bundle.map(async (file, index) => ({
+            index,
+            path: file.path,
+            media_type: file.mediaType,
+            size: file.body.byteLength,
+            sha256: await sha256Hex(file.body),
+          })),
+        ),
+      },
+    }
+    let finishSlowWrite: (() => void) | undefined
+    const slowWrite = new Promise<void>((resolve) => {
+      finishSlowWrite = resolve
+    })
+    bucket.put
+      .mockRejectedValueOnce(new Error('write failed'))
+      .mockImplementationOnce(() => slowWrite)
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const pending = executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      metadata,
+      bundle.map(
+        (file) => new File([file.body], file.path, { type: file.mediaType }),
+      ),
+      'https://artifactshare.com',
+    )
+    await vi.waitFor(() => expect(bucket.put).toHaveBeenCalledTimes(2))
+    expect(bucket.list).not.toHaveBeenCalled()
+
+    finishSlowWrite?.()
+    await expect(pending).resolves.toEqual({ kind: 'upload-failed' })
+    expect(bucket.list).toHaveBeenCalled()
   })
 
   test('uses the narrowed mapping at final commit instead of stale public context', async () => {

--- a/apps/web/app/services/bridge-publishing.server.test.ts
+++ b/apps/web/app/services/bridge-publishing.server.test.ts
@@ -324,6 +324,84 @@ describe('trusted bridge conversation binding', () => {
     ).toEqual({ mapping_id: 'mapping-1' })
   })
 
+  test('does not partially attach aliases when one is claimed concurrently', async () => {
+    seedProject('project-1', 'Design')
+    seedMapping('mapping-1', 'project-1', 'channel-1')
+    seedProject('project-2', 'Other')
+    seedMapping('mapping-2', 'project-2', 'channel-2')
+    d1BatchHook.callback = (sqlStatements) => {
+      if (
+        !sqlStatements.some((statement) =>
+          statement.includes('bridge_conversation_ids'),
+        )
+      ) {
+        return
+      }
+      d1BatchHook.callback = null
+      sqlite
+        .prepare(
+          `INSERT INTO bridge_conversation_ids (
+            mapping_id, bridge_authority_id, external_conversation_id, created_at
+          ) VALUES ('mapping-2', 'bridge-1', 'channel-claimed',
+            '2026-01-01T00:00:00.000Z')`,
+        )
+        .run()
+    }
+    const aliased = context({
+      conversation: {
+        ...context().conversation,
+        ids: ['channel-1', 'channel-new', 'channel-claimed'],
+      },
+    })
+
+    await expect(
+      bindTrustedBridgeRequest(db, authority, aliased),
+    ).resolves.toEqual({ kind: 'conversation-identity-conflict' })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT mapping_id FROM bridge_conversation_ids
+           WHERE external_conversation_id = 'channel-new'`,
+        )
+        .get(),
+    ).toBeUndefined()
+  })
+
+  test('preserves private routing creation flags across a failed first attempt', async () => {
+    const body = new TextEncoder().encode('# Retry')
+    const metadata = await fileMetadata({
+      requestId: 'private-routing-retry',
+      body,
+      conversationKind: 'private_channel',
+    })
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+
+    await expect(
+      executeBridgeRequest(
+        db,
+        authority,
+        bridgeUser(),
+        { ...metadata, operation: 'invalid' },
+        [new File([body], 'note.md', { type: 'text/markdown' })],
+        'https://artifactshare.com',
+      ),
+    ).resolves.toEqual({ kind: 'invalid-context' })
+
+    await expect(
+      executeBridgeRequest(
+        db,
+        authority,
+        bridgeUser(),
+        metadata,
+        [new File([body], 'note.md', { type: 'text/markdown' })],
+        'https://artifactshare.com',
+      ),
+    ).resolves.toMatchObject({
+      kind: 'ok',
+      result: { mappingCreated: true, projectCreated: true },
+    })
+  })
+
   test('allows an empty mapped project to be deleted after request binding', async () => {
     seedProject('project-1', 'Design')
     seedMapping('mapping-1', 'project-1', 'channel-1')
@@ -641,6 +719,69 @@ describe('bridge file publishing', () => {
         new Date('2026-08-26T00:00:33.000Z'),
       ),
     ).resolves.toEqual({ kind: 'forbidden-target' })
+  })
+
+  test('does not delete an existing artifact when its generated id races', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    d1BatchHook.callback = (sqlStatements) => {
+      if (
+        !sqlStatements.some((statement) =>
+          statement.includes('insert into "shareables"'),
+        )
+      ) {
+        return
+      }
+      d1BatchHook.callback = null
+      const stagedKey = [...bucketState.keys()][0]
+      const shareableId = stagedKey?.split('/')[1]
+      if (!shareableId) throw new Error('missing staged shareable id')
+      sqlite
+        .prepare(
+          `INSERT INTO shareables (
+            id, workspace_id, owner_user_id, name, artifact_kind, visibility,
+            current_version_id, created_at, updated_at, container_id
+          ) VALUES (?, 'ws1', 'bot1', 'Existing', 'markdown_page', 'private',
+            'existing-v1', '2026-01-01T00:00:00.000Z',
+            '2026-01-01T00:00:00.000Z', 'project-1')`,
+        )
+        .run(shareableId)
+      sqlite
+        .prepare(
+          `INSERT INTO versions (
+            id, shareable_id, artifact_kind, status, entrypoint_path, r2_key,
+            size_bytes, sha256, created_by_id, created_at, published_at
+          ) VALUES ('existing-v1', ?, 'markdown_page', 'published', '/note.md',
+            'existing-key', 1, ?, 'bot1', '2026-01-01T00:00:00.000Z',
+            '2026-01-01T00:00:00.000Z')`,
+        )
+        .run(shareableId, '0'.repeat(64))
+    }
+    const body = new TextEncoder().encode('# New')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+
+    await expect(
+      executeBridgeRequest(
+        db,
+        authority,
+        bridgeUser(),
+        await fileMetadata({
+          requestId: 'shareable-id-race',
+          body,
+          conversationKind: 'private_channel',
+        }),
+        [new File([body], 'note.md', { type: 'text/markdown' })],
+        'https://artifactshare.com',
+      ),
+    ).resolves.toEqual({ kind: 'upload-failed' })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT name, current_version_id FROM shareables
+           WHERE current_version_id = 'existing-v1'`,
+        )
+        .get(),
+    ).toEqual({ name: 'Existing', current_version_id: 'existing-v1' })
   })
 
   test('creates a public conversation project only with the staged publish commit', async () => {

--- a/apps/web/app/services/bridge-publishing.server.test.ts
+++ b/apps/web/app/services/bridge-publishing.server.test.ts
@@ -259,6 +259,49 @@ describe('trusted bridge conversation binding', () => {
     expect(project).toEqual({ base_visibility: 'private' })
   })
 
+  test('does not create private routing state if the bot stops at commit', async () => {
+    const privateContext = context({
+      conversation: {
+        ...context().conversation,
+        kind: 'private_channel',
+        privacyCheckedAt: null,
+      },
+    })
+    d1BatchHook.callback = (sqlStatements) => {
+      if (
+        !sqlStatements.some((statement) =>
+          statement.includes('insert into "artifact_containers"'),
+        )
+      ) {
+        return
+      }
+      d1BatchHook.callback = null
+      sqlite
+        .prepare(
+          `UPDATE users SET bot_stopped_at = '2026-08-26T00:00:00.000Z'
+           WHERE id = 'bot1'`,
+        )
+        .run()
+    }
+
+    await expect(
+      bindTrustedBridgeRequest(db, authority, privateContext),
+    ).resolves.toEqual({ kind: 'internal-error' })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM artifact_containers
+           WHERE id != 'fallback-1'`,
+        )
+        .get(),
+    ).toEqual({ count: 0 })
+    expect(
+      sqlite
+        .prepare(`SELECT COUNT(*) AS count FROM bridge_conversations`)
+        .get(),
+    ).toEqual({ count: 0 })
+  })
+
   test('adopts a mapping created after the request was first bound', async () => {
     const first = await bindTrustedBridgeRequest(db, authority, context())
     expect(first).toMatchObject({ kind: 'ok', binding: { mapping: null } })

--- a/apps/web/app/services/bridge-publishing.server.test.ts
+++ b/apps/web/app/services/bridge-publishing.server.test.ts
@@ -8,6 +8,7 @@ import { bindTrustedBridgeRequest } from './bridge-conversation-binding.server'
 import type { TrustedBridgeContext } from './bridge-request-validation.server'
 
 const bucketState = vi.hoisted(() => new Map<string, Uint8Array>())
+const notifyVersionChanged = vi.hoisted(() => vi.fn())
 const bucket = vi.hoisted(() => ({
   put: vi.fn(async (key: string, body: ArrayBuffer | Uint8Array | Blob) => {
     const buffer =
@@ -35,7 +36,14 @@ const bucket = vi.hoisted(() => ({
   list: vi.fn(async () => ({ objects: [], truncated: false })),
 }))
 
-vi.mock('cloudflare:workers', () => ({ env: { BUCKET: bucket } }))
+vi.mock('cloudflare:workers', () => ({
+  env: {
+    BUCKET: bucket,
+    ARTIFACT_LIVE: {
+      getByName: () => ({ notifyVersionChanged }),
+    },
+  },
+}))
 
 const authority = {
   kind: 'bridge' as const,
@@ -116,6 +124,7 @@ function seedMapping(
 
 beforeEach(() => {
   bucketState.clear()
+  notifyVersionChanged.mockReset()
   const fixture = createMigratedInMemoryDb()
   sqlite = fixture.sqlite
   db = fixture.db
@@ -467,6 +476,18 @@ describe('bridge file publishing', () => {
         )
         .get(),
     ).toEqual({ granted_email: 'person@example.com' })
+    if (first.kind !== 'ok') return
+    sqlite
+      .prepare(`DELETE FROM shareables WHERE id = ?`)
+      .run(first.result.artifact.id)
+    expect(
+      sqlite
+        .prepare(
+          `SELECT result_artifact_id FROM bridge_requests
+           WHERE bridge_authority_id = 'bridge-1' AND request_id = 'request-publish'`,
+        )
+        .get(),
+    ).toEqual({ result_artifact_id: first.result.artifact.id })
   })
 
   test('creates a public conversation project only with the staged publish commit', async () => {
@@ -605,6 +626,33 @@ describe('bridge file publishing', () => {
     })
   })
 
+  test('bounds a filename fallback title to the bridge response contract', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const body = new TextEncoder().encode('\n')
+    const fileName = `${'a'.repeat(217)}.md`
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+
+    const result = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'long-fallback-title',
+        body,
+        conversationKind: 'private_channel',
+        path: fileName,
+        mediaType: 'text/markdown',
+      }),
+      [new File([body], fileName, { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+
+    expect(result.kind).toBe('ok')
+    if (result.kind !== 'ok') return
+    expect(result.result.artifact.title).toHaveLength(200)
+  })
+
   test('converges concurrent first shares on one project and mapping', async () => {
     const body = new TextEncoder().encode('# Concurrent')
     const checkedAt = new Date().toISOString()
@@ -675,6 +723,77 @@ describe('bridge file publishing', () => {
     ).toEqual({ count: 2 })
   })
 
+  test('cleans its staged file when another lease generation completes first', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    sqlite
+      .prepare(
+        `INSERT INTO shareables (
+          id, workspace_id, owner_user_id, name, artifact_kind, visibility,
+          current_version_id, created_at, updated_at, container_id
+        ) VALUES ('winner', 'ws1', 'bot1', 'Winner', 'markdown_page',
+          'private', 'winner-v1', '2026-01-01T00:00:00.000Z',
+          '2026-01-01T00:00:00.000Z', 'project-1')`,
+      )
+      .run()
+    sqlite
+      .prepare(
+        `INSERT INTO versions (
+          id, shareable_id, artifact_kind, status, entrypoint_path, r2_key,
+          size_bytes, sha256, created_by_id, created_at, published_at
+        ) VALUES ('winner-v1', 'winner', 'markdown_page', 'published',
+          '/note.md', 'winner-key', 1, ?, 'bot1',
+          '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+      )
+      .run('0'.repeat(64))
+    sqlite
+      .prepare(
+        `INSERT INTO shareable_grants (
+          shareable_id, granted_email, granted_at, granted_by
+        ) VALUES ('winner', 'person@example.com',
+          '2026-01-01T00:00:00.000Z', 'bot1')`,
+      )
+      .run()
+    bucket.put.mockImplementationOnce(async (key, body) => {
+      bucketState.set(key, new Uint8Array(body as ArrayBuffer))
+      sqlite
+        .prepare(
+          `UPDATE bridge_requests
+           SET status = 'completed', result_artifact_id = 'winner',
+             result_version_id = 'winner-v1'
+           WHERE bridge_authority_id = 'bridge-1'
+             AND request_id = 'lease-loser'`,
+        )
+        .run()
+    })
+    const body = new TextEncoder().encode('# Losing generation')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+
+    const result = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'lease-loser',
+        body,
+        conversationKind: 'private_channel',
+      }),
+      [new File([body], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+
+    expect(result).toMatchObject({
+      kind: 'ok',
+      result: { artifact: { id: 'winner' }, replayed: true },
+    })
+    expect(bucketState.size).toBe(0)
+    expect(
+      sqlite
+        .prepare(`SELECT storage_used_bytes FROM workspaces WHERE id = 'ws1'`)
+        .get(),
+    ).toEqual({ storage_used_bytes: 1024 })
+  })
+
   test('updates a bridge-created artifact without changing its URL', async () => {
     seedProject('project-1', 'Private design', 'private')
     seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
@@ -715,6 +834,9 @@ describe('bridge file publishing', () => {
       kind: 'ok',
       result: { artifact: { id: first.result.artifact.id }, replayed: false },
     })
+    expect(notifyVersionChanged).toHaveBeenLastCalledWith(
+      updated.kind === 'ok' ? updated.result.versionId : 'unreachable',
+    )
     expect(
       sqlite
         .prepare(
@@ -724,11 +846,68 @@ describe('bridge file publishing', () => {
     ).toEqual({ count: 2 })
   })
 
-  test('appends UTF-8 content as a new version on the same URL', async () => {
+  test('keeps the committed version intact when the requester grant limit is reached', async () => {
     seedProject('project-1', 'Private design', 'private')
     seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
     const { executeBridgeRequest } = await import('./bridge-publishing.server')
-    const firstBody = new TextEncoder().encode('# First\n')
+    const firstBody = new TextEncoder().encode('# First')
+    const first = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'grant-limit-base',
+        body: firstBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([firstBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(first.kind).toBe('ok')
+    if (first.kind !== 'ok') return
+    const originalVersionId = first.result.versionId
+    const insertGrant = sqlite.prepare(
+      `INSERT INTO shareable_grants (
+        shareable_id, granted_email, granted_at, granted_by
+      ) VALUES (?, ?, '2026-01-01T00:00:00.000Z', 'bot1')`,
+    )
+    for (let index = 0; index < 49; index += 1) {
+      insertGrant.run(first.result.artifact.id, `viewer-${index}@example.com`)
+    }
+    const nextBody = new TextEncoder().encode('# Second')
+    const updated = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'grant-limit-update',
+        operation: 'update',
+        targetArtifactId: first.result.artifact.id,
+        body: nextBody,
+        conversationKind: 'private_channel',
+        requesterStableId: 'person-2',
+        requesterEmail: 'person-2@example.com',
+      }),
+      [new File([nextBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+
+    expect(updated).toEqual({ kind: 'artifact-viewer-limit-reached' })
+    expect(
+      sqlite
+        .prepare(`SELECT current_version_id FROM shareables WHERE id = ?`)
+        .get(first.result.artifact.id),
+    ).toEqual({ current_version_id: originalVersionId })
+    expect(bucketState.size).toBe(1)
+  })
+
+  test('appends after multibyte HTML content without corrupting UTF-8', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const firstBody = new TextEncoder().encode(
+      '<html><body><p>日本語</p></body></html>',
+    )
     const published = await executeBridgeRequest(
       db,
       authority,
@@ -737,13 +916,15 @@ describe('bridge file publishing', () => {
         requestId: 'append-base',
         body: firstBody,
         conversationKind: 'private_channel',
+        path: 'index.html',
+        mediaType: 'text/html',
       }),
-      [new File([firstBody], 'file-0', { type: 'text/markdown' })],
+      [new File([firstBody], 'index.html', { type: 'text/html' })],
       'https://artifactshare.com',
     )
     expect(published.kind).toBe('ok')
     if (published.kind !== 'ok') return
-    const addition = new TextEncoder().encode('Second\n')
+    const addition = new TextEncoder().encode('<p>追記</p>')
     const appended = await executeBridgeRequest(
       db,
       authority,
@@ -754,8 +935,10 @@ describe('bridge file publishing', () => {
         targetArtifactId: published.result.artifact.id,
         body: addition,
         conversationKind: 'private_channel',
+        path: 'append.html',
+        mediaType: 'text/html',
       }),
-      [new File([addition], 'file-0', { type: 'text/markdown' })],
+      [new File([addition], 'append.html', { type: 'text/html' })],
       'https://artifactshare.com',
     )
     expect(appended).toMatchObject({
@@ -770,7 +953,7 @@ describe('bridge file publishing', () => {
       )
       .get(published.result.artifact.id) as { r2_key: string }
     expect(new TextDecoder().decode(bucketState.get(current.r2_key))).toBe(
-      '# First\nSecond\n',
+      '<html><body><p>日本語</p><p>追記</p></body></html>',
     )
   })
 
@@ -839,7 +1022,14 @@ describe('bridge file publishing', () => {
     seedProject('project-1', 'Private design', 'private')
     seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
     const html = new TextEncoder().encode('<title>Site</title><h1>Hello</h1>')
-    const css = new TextEncoder().encode('h1 { color: red }')
+    const bundle = [
+      { path: 'index.html', mediaType: 'text/html', body: html },
+      ...Array.from({ length: 11 }, (_, index) => ({
+        path: `styles-${index}.css`,
+        mediaType: 'text/css',
+        body: new TextEncoder().encode(`.item-${index} { color: red }`),
+      })),
+    ]
     const metadata = {
       schema_version: 1,
       request_id: 'static-publish',
@@ -861,22 +1051,15 @@ describe('bridge file publishing', () => {
       },
       content: {
         kind: 'static_site',
-        files: [
-          {
-            index: 0,
-            path: 'index.html',
-            media_type: 'text/html',
-            size: html.byteLength,
-            sha256: await sha256Hex(html),
-          },
-          {
-            index: 1,
-            path: 'styles.css',
-            media_type: 'text/css',
-            size: css.byteLength,
-            sha256: await sha256Hex(css),
-          },
-        ],
+        files: await Promise.all(
+          bundle.map(async (file, index) => ({
+            index,
+            path: file.path,
+            media_type: file.mediaType,
+            size: file.body.byteLength,
+            sha256: await sha256Hex(file.body),
+          })),
+        ),
       },
     }
     const { executeBridgeRequest } = await import('./bridge-publishing.server')
@@ -885,10 +1068,9 @@ describe('bridge file publishing', () => {
       authority,
       bridgeUser(),
       metadata,
-      [
-        new File([html], 'file-0', { type: 'text/html' }),
-        new File([css], 'file-1', { type: 'text/css' }),
-      ],
+      bundle.map(
+        (file) => new File([file.body], file.path, { type: file.mediaType }),
+      ),
       'https://artifactshare.com',
     )
 
@@ -901,7 +1083,7 @@ describe('bridge file publishing', () => {
     ).toEqual({ artifact_kind: 'static_site' })
     expect(
       sqlite.prepare(`SELECT COUNT(*) AS count FROM version_files`).get(),
-    ).toEqual({ count: 2 })
+    ).toEqual({ count: 12 })
   })
 
   test('uses the narrowed mapping at final commit instead of stale public context', async () => {
@@ -1043,6 +1225,10 @@ async function fileMetadata(input: {
   targetArtifactId?: string
   conversationKind: 'private_channel' | 'dm'
   conversationId?: string
+  path?: string
+  mediaType?: string
+  requesterStableId?: string
+  requesterEmail?: string
 }) {
   const conversationId = input.conversationId ?? 'channel-1'
   return {
@@ -1064,16 +1250,16 @@ async function fileMetadata(input: {
       kind: input.conversationKind,
     },
     requester: {
-      stable_id: 'person-1',
-      verified_email: 'person@example.com',
+      stable_id: input.requesterStableId ?? 'person-1',
+      verified_email: input.requesterEmail ?? 'person@example.com',
     },
     content: {
       kind: 'file',
       files: [
         {
           index: 0,
-          path: 'note.md',
-          media_type: 'text/markdown',
+          path: input.path ?? 'note.md',
+          media_type: input.mediaType ?? 'text/markdown',
           size: input.body.byteLength,
           sha256: await sha256Hex(input.body),
         },

--- a/apps/web/app/services/bridge-publishing.server.test.ts
+++ b/apps/web/app/services/bridge-publishing.server.test.ts
@@ -16,6 +16,9 @@ const notifyVersionChanged = vi.hoisted(() => vi.fn())
 const d1BatchHook = vi.hoisted(() => ({
   callback: null as null | ((sqlStatements: string[]) => void),
 }))
+const bucketPutHook = vi.hoisted(() => ({
+  callback: null as null | (() => void),
+}))
 const bucket = vi.hoisted(() => ({
   put: vi.fn(async (key: string, body: ArrayBuffer | Uint8Array | Blob) => {
     const buffer =
@@ -25,6 +28,7 @@ const bucket = vi.hoisted(() => ({
           ? body
           : new Uint8Array(body).buffer
     bucketState.set(key, new Uint8Array(buffer))
+    bucketPutHook.callback?.()
   }),
   get: vi.fn(async (key: string) => {
     const bytes = bucketState.get(key)
@@ -146,6 +150,7 @@ function seedMapping(
 beforeEach(() => {
   vi.clearAllMocks()
   d1BatchHook.callback = null
+  bucketPutHook.callback = null
   bucketState.clear()
   notifyVersionChanged.mockReset()
   const fixture = createMigratedInMemoryDb()
@@ -365,6 +370,32 @@ describe('trusted bridge conversation binding', () => {
         )
         .get(),
     ).toBeUndefined()
+  })
+
+  test('reports a transient alias batch failure as retryable internal error', async () => {
+    seedProject('project-1', 'Design')
+    seedMapping('mapping-1', 'project-1', 'channel-1')
+    d1BatchHook.callback = (sqlStatements) => {
+      if (
+        !sqlStatements.some((statement) =>
+          statement.includes('bridge_conversation_ids'),
+        )
+      ) {
+        return
+      }
+      d1BatchHook.callback = null
+      throw new Error('D1 unavailable')
+    }
+    const aliased = context({
+      conversation: {
+        ...context().conversation,
+        ids: ['channel-1', 'channel-new'],
+      },
+    })
+
+    await expect(
+      bindTrustedBridgeRequest(db, authority, aliased),
+    ).resolves.toEqual({ kind: 'internal-error' })
   })
 
   test('preserves private routing creation flags across a failed first attempt', async () => {
@@ -697,6 +728,7 @@ describe('bridge file publishing', () => {
       hd: 'example.com',
     }
     const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const arrayBufferSpy = vi.spyOn(file, 'arrayBuffer')
 
     const first = await executeBridgeRequest(
       db,
@@ -716,6 +748,7 @@ describe('bridge file publishing', () => {
         replayed: false,
       },
     })
+    expect(arrayBufferSpy).toHaveBeenCalledTimes(2)
     const second = await executeBridgeRequest(
       db,
       authority,
@@ -1212,6 +1245,43 @@ describe('bridge file publishing', () => {
         .prepare(`SELECT storage_used_bytes FROM workspaces WHERE id = 'ws1'`)
         .get(),
     ).toEqual({ storage_used_bytes: 1024 })
+  })
+
+  test('cleans staged storage when destination revalidation throws', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const before = sqlite
+      .prepare(`SELECT storage_used_bytes FROM workspaces WHERE id = 'ws1'`)
+      .get()
+    bucketPutHook.callback = () => {
+      bucketPutHook.callback = null
+      vi.spyOn(db, 'selectFrom').mockImplementationOnce(() => {
+        throw new Error('D1 unavailable')
+      })
+    }
+    const body = new TextEncoder().encode('# Retry after D1 recovers')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+
+    const result = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'post-stage-failure',
+        body,
+        conversationKind: 'private_channel',
+      }),
+      [new File([body], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+
+    expect(result).toEqual({ kind: 'internal-error' })
+    expect(bucketState.size).toBe(0)
+    expect(
+      sqlite
+        .prepare(`SELECT storage_used_bytes FROM workspaces WHERE id = 'ws1'`)
+        .get(),
+    ).toEqual(before)
   })
 
   test('updates a bridge-created artifact without changing its URL', async () => {

--- a/apps/web/app/services/bridge-publishing.server.test.ts
+++ b/apps/web/app/services/bridge-publishing.server.test.ts
@@ -1,15 +1,21 @@
 import type { DatabaseSync } from 'node:sqlite'
-import type { Kysely } from 'kysely'
+import type { Compilable, Kysely } from 'kysely'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { seedUser, seedWorkspace } from '~/test/db-seed-fixture'
 import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
 import type { DB } from '~/types/db'
-import { bindTrustedBridgeRequest } from './bridge-conversation-binding.server'
+import {
+  bindTrustedBridgeRequest,
+  conversationProjectName,
+} from './bridge-conversation-binding.server'
 import type { TrustedBridgeContext } from './bridge-request-validation.server'
 import { deleteProjectContainer } from './projects.server'
 
 const bucketState = vi.hoisted(() => new Map<string, Uint8Array>())
 const notifyVersionChanged = vi.hoisted(() => vi.fn())
+const d1BatchHook = vi.hoisted(() => ({
+  callback: null as null | ((sqlStatements: string[]) => void),
+}))
 const bucket = vi.hoisted(() => ({
   put: vi.fn(async (key: string, body: ArrayBuffer | Uint8Array | Blob) => {
     const buffer =
@@ -45,6 +51,20 @@ vi.mock('cloudflare:workers', () => ({
     },
   },
 }))
+
+vi.mock('~/lib/d1-batch.server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/lib/d1-batch.server')>()
+  return {
+    ...actual,
+    runD1Batch: async (
+      database: Kysely<DB>,
+      ...queries: Compilable<unknown>[]
+    ) => {
+      d1BatchHook.callback?.(queries.map((query) => query.compile().sql))
+      return actual.runD1Batch(database, ...queries)
+    },
+  }
+})
 
 const authority = {
   kind: 'bridge' as const,
@@ -125,6 +145,7 @@ function seedMapping(
 
 beforeEach(() => {
   vi.clearAllMocks()
+  d1BatchHook.callback = null
   bucketState.clear()
   notifyVersionChanged.mockReset()
   const fixture = createMigratedInMemoryDb()
@@ -175,6 +196,16 @@ afterEach(async () => {
 })
 
 describe('trusted bridge conversation binding', () => {
+  test('truncates generated project names at a Unicode boundary', () => {
+    const name = `${'a'.repeat(110)}😀tail`
+
+    const result = conversationProjectName(name, 'project-abcdef')
+
+    expect(result).toHaveLength(119)
+    expect(result).not.toContain('\ud83d')
+    expect(result).toBe(`${'a'.repeat(110)} · abcdef`)
+  })
+
   test('resolves an existing mapping and records only the request binding', async () => {
     seedProject('project-1', 'Design')
     seedMapping('mapping-1', 'project-1', 'channel-1')
@@ -415,6 +446,32 @@ describe('trusted bridge conversation binding', () => {
 })
 
 describe('bridge file publishing', () => {
+  test('reports an over-quota publish as a retryable upload failure', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    sqlite
+      .prepare(`UPDATE workspaces SET storage_quota_bytes = 1 WHERE id = 'ws1'`)
+      .run()
+    const body = new TextEncoder().encode('# Too large for quota')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+
+    await expect(
+      executeBridgeRequest(
+        db,
+        authority,
+        bridgeUser(),
+        await fileMetadata({
+          requestId: 'quota-exceeded',
+          body,
+          conversationKind: 'private_channel',
+        }),
+        [new File([body], 'note.md', { type: 'text/markdown' })],
+        'https://artifactshare.com',
+      ),
+    ).resolves.toEqual({ kind: 'upload-failed' })
+    expect(bucket.put).not.toHaveBeenCalled()
+  })
+
   test('publishes once and replays the same completed request', async () => {
     seedProject('project-1', 'Private design', 'private')
     seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
@@ -970,6 +1027,70 @@ describe('bridge file publishing', () => {
     ).toEqual({ count: 2 })
   })
 
+  test('does not commit a channel update after the bridge bot is stopped', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const firstBody = new TextEncoder().encode('# First')
+    const first = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'stop-race-base',
+        body: firstBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([firstBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(first.kind).toBe('ok')
+    if (first.kind !== 'ok') return
+    const originalVersionId = first.result.versionId
+    d1BatchHook.callback = (sqlStatements) => {
+      if (!sqlStatements.some((statement) => statement.includes('versions'))) {
+        return
+      }
+      d1BatchHook.callback = null
+      sqlite
+        .prepare(
+          `UPDATE users SET bot_stopped_at = '2026-08-26T00:00:00.000Z'
+           WHERE id = 'bot1'`,
+        )
+        .run()
+    }
+    const nextBody = new TextEncoder().encode('# Second')
+
+    const updated = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'stop-race-update',
+        operation: 'update',
+        targetArtifactId: first.result.artifact.id,
+        body: nextBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([nextBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+
+    expect(updated).toEqual({ kind: 'upload-failed' })
+    expect(
+      sqlite
+        .prepare(`SELECT current_version_id FROM shareables WHERE id = ?`)
+        .get(first.result.artifact.id),
+    ).toEqual({ current_version_id: originalVersionId })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM versions WHERE shareable_id = ?`,
+        )
+        .get(first.result.artifact.id),
+    ).toEqual({ count: 1 })
+  })
+
   test('keeps the committed version intact when the requester grant limit is reached', async () => {
     seedProject('project-1', 'Private design', 'private')
     seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
@@ -1407,6 +1528,27 @@ describe('bridge file publishing', () => {
     expect(
       sqlite.prepare(`SELECT COUNT(*) AS count FROM version_files`).get(),
     ).toEqual({ count: 12 })
+    if (result.kind !== 'ok') return
+    const fileBody = new TextEncoder().encode('# Replacement')
+    await expect(
+      executeBridgeRequest(
+        db,
+        authority,
+        bridgeUser(),
+        await fileMetadata({
+          requestId: 'static-file-update',
+          operation: 'update',
+          targetArtifactId: result.result.artifact.id,
+          body: fileBody,
+          conversationKind: 'private_channel',
+        }),
+        [new File([fileBody], 'note.md', { type: 'text/markdown' })],
+        'https://artifactshare.com',
+      ),
+    ).resolves.toEqual({ kind: 'forbidden-target' })
+    expect(
+      sqlite.prepare(`SELECT artifact_kind FROM shareables`).get(),
+    ).toEqual({ artifact_kind: 'static_site' })
   })
 
   test('waits for every static-site write before cleaning up a failed stage', async () => {

--- a/apps/web/app/services/bridge-publishing.server.test.ts
+++ b/apps/web/app/services/bridge-publishing.server.test.ts
@@ -469,6 +469,61 @@ describe('trusted bridge conversation binding', () => {
     ).toEqual({ visibility: 'private' })
   })
 
+  test('does not narrow a mapping after the bridge bot is stopped', async () => {
+    seedProject('project-1', 'Design')
+    seedMapping('mapping-1', 'project-1', 'channel-1')
+    sqlite
+      .prepare(
+        `INSERT INTO shareables (
+          id, workspace_id, owner_user_id, name, artifact_kind, visibility,
+          created_at, updated_at, container_id
+        ) VALUES ('artifact-1', 'ws1', 'bot1', 'Draft', 'markdown_page',
+          'workspace', '2026-01-01T00:00:00.000Z',
+          '2026-01-01T00:00:00.000Z', 'project-1')`,
+      )
+      .run()
+    d1BatchHook.callback = (sqlStatements) => {
+      if (
+        !sqlStatements.some((statement) =>
+          statement.includes('update "bridge_conversations"'),
+        )
+      ) {
+        return
+      }
+      d1BatchHook.callback = null
+      sqlite
+        .prepare(
+          `UPDATE users SET bot_stopped_at = '2026-08-26T00:00:00.000Z'
+           WHERE id = 'bot1'`,
+        )
+        .run()
+    }
+    const privateContext = context({
+      conversation: {
+        ...context().conversation,
+        kind: 'private_channel',
+        privacyCheckedAt: null,
+      },
+    })
+
+    await expect(
+      bindTrustedBridgeRequest(db, authority, privateContext),
+    ).resolves.toEqual({ kind: 'internal-error' })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT privacy_ceiling FROM bridge_conversations
+           WHERE id = 'mapping-1'`,
+        )
+        .get(),
+    ).toEqual({ privacy_ceiling: 'workspace' })
+    expect(
+      sqlite
+        .prepare(`SELECT visibility FROM shareables WHERE id = 'artifact-1'`)
+        .get(),
+    ).toEqual({ visibility: 'workspace' })
+  })
+
   test('rejects aliases that resolve to different mappings', async () => {
     seedProject('project-1', 'One')
     seedProject('project-2', 'Two')
@@ -1273,6 +1328,64 @@ describe('bridge file publishing', () => {
         )
         .get(first.result.artifact.id),
     ).toEqual({ count: 1 })
+  })
+
+  test('does not commit a channel update after fallback archival', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const firstBody = new TextEncoder().encode('# First')
+    const first = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'fallback-race-base',
+        body: firstBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([firstBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(first.kind).toBe('ok')
+    if (first.kind !== 'ok') return
+    const originalVersionId = first.result.versionId
+    d1BatchHook.callback = (sqlStatements) => {
+      if (!sqlStatements.some((statement) => statement.includes('versions'))) {
+        return
+      }
+      d1BatchHook.callback = null
+      sqlite
+        .prepare(
+          `UPDATE artifact_containers
+           SET archived_at = '2026-08-26T00:00:00.000Z'
+           WHERE id = 'fallback-1'`,
+        )
+        .run()
+    }
+    const nextBody = new TextEncoder().encode('# Second')
+
+    const updated = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'fallback-race-update',
+        operation: 'update',
+        targetArtifactId: first.result.artifact.id,
+        body: nextBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([nextBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+
+    expect(updated).toEqual({ kind: 'upload-failed' })
+    expect(
+      sqlite
+        .prepare(`SELECT current_version_id FROM shareables WHERE id = ?`)
+        .get(first.result.artifact.id),
+    ).toEqual({ current_version_id: originalVersionId })
   })
 
   test('keeps the committed version intact when the requester grant limit is reached', async () => {

--- a/apps/web/app/services/bridge-publishing.server.test.ts
+++ b/apps/web/app/services/bridge-publishing.server.test.ts
@@ -809,6 +809,54 @@ describe('bridge file publishing', () => {
     ).resolves.toEqual({ kind: 'forbidden-target' })
   })
 
+  test('does not restore replay access after an artifact leaves bridge scope', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedProject('project-2', 'Other private project', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const body = new TextEncoder().encode('# Scoped')
+    const metadata = await fileMetadata({
+      requestId: 'replay-moved',
+      body,
+      conversationKind: 'private_channel',
+    })
+    const file = new File([body], 'note.md', { type: 'text/markdown' })
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const published = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      metadata,
+      [file],
+      'https://artifactshare.com',
+    )
+    expect(published.kind).toBe('ok')
+    if (published.kind !== 'ok') return
+    sqlite
+      .prepare(`UPDATE shareables SET container_id = 'project-2' WHERE id = ?`)
+      .run(published.result.artifact.id)
+    sqlite
+      .prepare(`DELETE FROM shareable_grants WHERE shareable_id = ?`)
+      .run(published.result.artifact.id)
+
+    await expect(
+      executeBridgeRequest(
+        db,
+        authority,
+        bridgeUser(),
+        metadata,
+        [file],
+        'https://artifactshare.com',
+      ),
+    ).resolves.toEqual({ kind: 'forbidden-target' })
+    expect(
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) AS count FROM shareable_grants WHERE shareable_id = ?`,
+        )
+        .get(published.result.artifact.id),
+    ).toEqual({ count: 0 })
+  })
+
   test('does not delete an existing artifact when its generated id races', async () => {
     seedProject('project-1', 'Private design', 'private')
     seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
@@ -1183,10 +1231,11 @@ describe('bridge file publishing', () => {
       .prepare(
         `INSERT INTO shareables (
           id, workspace_id, owner_user_id, name, artifact_kind, visibility,
-          current_version_id, created_at, updated_at, container_id
+          current_version_id, created_at, updated_at, container_id,
+          created_by_agent_profile_id
         ) VALUES ('winner', 'ws1', 'bot1', 'Winner', 'markdown_page',
           'private', 'winner-v1', '2026-01-01T00:00:00.000Z',
-          '2026-01-01T00:00:00.000Z', 'project-1')`,
+          '2026-01-01T00:00:00.000Z', 'project-1', 'agent-1')`,
       )
       .run()
     sqlite
@@ -1209,6 +1258,22 @@ describe('bridge file publishing', () => {
       .run()
     bucket.put.mockImplementationOnce(async (key, body) => {
       bucketState.set(key, new Uint8Array(body as ArrayBuffer))
+      sqlite
+        .prepare(
+          `INSERT INTO bridge_operations (
+            id, bridge_authority_id, request_id, lease_generation, operation,
+            requester_stable_id, requester_verified_email, artifact_id,
+            version_id, created_at
+          )
+          SELECT 'winner-operation', bridge_authority_id, request_id,
+            lease_generation, 'publish', requester_stable_id,
+            requester_verified_email, 'winner', 'winner-v1',
+            '2026-01-01T00:00:00.000Z'
+          FROM bridge_requests
+          WHERE bridge_authority_id = 'bridge-1'
+            AND request_id = 'lease-loser'`,
+        )
+        .run()
       sqlite
         .prepare(
           `UPDATE bridge_requests
@@ -1282,6 +1347,63 @@ describe('bridge file publishing', () => {
         .prepare(`SELECT storage_used_bytes FROM workspaces WHERE id = 'ws1'`)
         .get(),
     ).toEqual(before)
+  })
+
+  test('retains a committed version when the first post-batch read fails', async () => {
+    seedProject('project-1', 'Private design', 'private')
+    seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
+    const { executeBridgeRequest } = await import('./bridge-publishing.server')
+    const firstBody = new TextEncoder().encode('# First')
+    const first = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'post-commit-read-base',
+        body: firstBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([firstBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+    expect(first.kind).toBe('ok')
+    if (first.kind !== 'ok') return
+    const nextBody = new TextEncoder().encode('# Second')
+    d1BatchHook.callback = (sqlStatements) => {
+      if (
+        !sqlStatements.some((statement) =>
+          statement.includes('bridge_operations'),
+        )
+      ) {
+        return
+      }
+      d1BatchHook.callback = null
+      vi.spyOn(db, 'selectFrom').mockImplementationOnce(() => {
+        throw new Error('D1 unavailable after commit')
+      })
+    }
+
+    const result = await executeBridgeRequest(
+      db,
+      authority,
+      bridgeUser(),
+      await fileMetadata({
+        requestId: 'post-commit-read-update',
+        operation: 'update',
+        targetArtifactId: first.result.artifact.id,
+        body: nextBody,
+        conversationKind: 'private_channel',
+      }),
+      [new File([nextBody], 'note.md', { type: 'text/markdown' })],
+      'https://artifactshare.com',
+    )
+
+    expect(result).toEqual({ kind: 'internal-error' })
+    const current = sqlite
+      .prepare(`SELECT current_version_id FROM shareables WHERE id = ?`)
+      .get(first.result.artifact.id) as { current_version_id: string }
+    expect(current.current_version_id).not.toBe(first.result.versionId)
+    expect(bucketState.size).toBe(2)
   })
 
   test('updates a bridge-created artifact without changing its URL', async () => {
@@ -1577,9 +1699,12 @@ describe('bridge file publishing', () => {
     seedProject('project-1', 'Private design', 'private')
     seedMapping('mapping-1', 'project-1', 'channel-1', 'private')
     const { executeBridgeRequest } = await import('./bridge-publishing.server')
-    const firstBody = new TextEncoder().encode(
-      '<html><body><p>日本語</p></body></html>',
-    )
+    const firstBody = new Uint8Array([
+      0xef,
+      0xbb,
+      0xbf,
+      ...new TextEncoder().encode('<html><body><p>日本語</p></body></html>'),
+    ])
     const published = await executeBridgeRequest(
       db,
       authority,
@@ -1626,6 +1751,9 @@ describe('bridge file publishing', () => {
       .get(published.result.artifact.id) as { r2_key: string }
     expect(new TextDecoder().decode(bucketState.get(current.r2_key))).toBe(
       '<html><body><p>日本語</p><p>追記</p></body></html>',
+    )
+    expect(bucketState.get(current.r2_key)?.slice(0, 3)).toEqual(
+      new Uint8Array([0xef, 0xbb, 0xbf]),
     )
   })
 
@@ -1835,6 +1963,11 @@ describe('bridge file publishing', () => {
     const html = new TextEncoder().encode('<title>Site</title><h1>Hello</h1>')
     const bundle = [
       { path: 'index.html', mediaType: 'text/html', body: html },
+      {
+        path: '.DS_Store',
+        mediaType: 'application/octet-stream',
+        body: new Uint8Array([1, 2, 3]),
+      },
       ...Array.from({ length: 11 }, (_, index) => ({
         path: `styles-${index}.css`,
         mediaType: 'text/css',

--- a/apps/web/app/services/bridge-publishing.server.ts
+++ b/apps/web/app/services/bridge-publishing.server.ts
@@ -226,11 +226,11 @@ async function verifyMultipartFiles(
   intent: BridgeIntent,
   files: readonly File[],
 ): Promise<
-  | { kind: 'ok'; files: File[] }
+  | { kind: 'ok'; files: VerifiedBridgeFile[] }
   | { kind: 'invalid-context' | 'payload-too-large' }
 > {
   if (files.length !== intent.files.length) return { kind: 'invalid-context' }
-  const owned: File[] = []
+  const owned: VerifiedBridgeFile[] = []
   let total = 0
   for (const [index, descriptor] of intent.files.entries()) {
     const file = files[index]
@@ -248,13 +248,15 @@ async function verifyMultipartFiles(
     if ((await fileSha256Hex(file)) !== descriptor.sha256) {
       return { kind: 'invalid-context' }
     }
-    owned.push(
-      new File([await file.arrayBuffer()], descriptor.path, {
-        type: descriptor.mediaType,
-      }),
-    )
+    owned.push({ file, path: descriptor.path, mediaType: descriptor.mediaType })
   }
   return { kind: 'ok', files: owned }
+}
+
+type VerifiedBridgeFile = {
+  file: File
+  path: string
+  mediaType: string
 }
 
 type PreparedBridgeFile = Extract<
@@ -381,7 +383,7 @@ async function publishBridgeFileVersion(
   intent: BridgeIntent,
   binding: BoundBridgeRequest,
   leaseGeneration: string,
-  requestFile: File,
+  requestFile: VerifiedBridgeFile,
   origin: string,
 ): Promise<ExecuteBridgeRequestResult> {
   if (!intent.targetArtifactId) return { kind: 'forbidden-target' }
@@ -396,7 +398,8 @@ async function publishBridgeFileVersion(
   if (target.artifactKind === 'static_site') {
     return { kind: 'forbidden-target' }
   }
-  let file = requestFile
+  let file = requestFile.file
+  let logicalFile = { name: requestFile.path, type: requestFile.mediaType }
   if (intent.operation === 'append') {
     if (
       target.artifactKind !== 'markdown_page' &&
@@ -405,20 +408,22 @@ async function publishBridgeFileVersion(
       return { kind: 'forbidden-target' }
     }
     if (
-      target.currentSizeBytes + requestFile.size >
+      target.currentSizeBytes + requestFile.file.size >
       ARTIFACT_UPLOAD_LIMITS.totalBytes
     ) {
       return { kind: 'payload-too-large' }
     }
-    const appended = await appendBridgeFile(target, requestFile)
+    const appended = await appendBridgeFile(target, requestFile.file)
     if (!appended) return { kind: 'upload-failed' }
     file = appended
+    logicalFile = appended
   }
   const prepared = await prepareUpload(
     db,
     authority.workspaceId,
     target.id,
     file,
+    logicalFile,
   )
   if (prepared.kind !== 'ok') {
     if (prepared.kind === 'too-large') return { kind: 'payload-too-large' }
@@ -447,66 +452,79 @@ async function publishBridgeFileVersion(
     return { kind: 'upload-failed' }
   }
 
-  const final = await resolveFinalDestination(db, authority, context, binding)
   let failure: ExecuteBridgeRequestResult = { kind: 'upload-failed' }
-  if (final.kind !== 'ok') {
-    failure = final
-  } else if (
-    context.conversation.kind === 'public_channel' &&
-    !publicContextFresh(context, new Date())
-  ) {
-    failure = { kind: 'stale-context' }
-  } else {
-    const committed = await commitBridgeVersion(db, {
-      authority,
-      context,
-      intent,
-      binding: final.binding,
-      target,
-      leaseGeneration,
-      prepared,
-    })
-    if (committed) {
-      await notifyArtifactVersionChanged(target.id, prepared.versionId)
-      const result = await readBridgeResult(
-        db,
-        authority.bridgeAuthorityId,
-        context.requestId,
-        context.requester.verifiedEmail,
-        origin,
-        false,
-      )
-      if (result) return result
-      return (await bridgeGrantLimitReached(
-        db,
-        target.id,
-        context.requester.verifiedEmail,
-      ))
-        ? { kind: 'artifact-viewer-limit-reached' }
-        : { kind: 'upload-failed' }
-    }
-    if (
-      await bridgeGrantLimitReached(
-        db,
-        target.id,
-        context.requester.verifiedEmail,
-      )
+  let replay: { kind: 'ok'; result: BridgeRequestSuccess } | null = null
+  let retained = false
+  try {
+    const final = await resolveFinalDestination(db, authority, context, binding)
+    if (final.kind !== 'ok') {
+      failure = final
+    } else if (
+      context.conversation.kind === 'public_channel' &&
+      !publicContextFresh(context, new Date())
     ) {
-      failure = { kind: 'artifact-viewer-limit-reached' }
+      failure = { kind: 'stale-context' }
+    } else {
+      const committed = await commitBridgeVersion(db, {
+        authority,
+        context,
+        intent,
+        binding: final.binding,
+        target,
+        leaseGeneration,
+        prepared,
+      })
+      if (committed) {
+        retained = true
+        await notifyArtifactVersionChanged(target.id, prepared.versionId)
+        const result = await readBridgeResult(
+          db,
+          authority.bridgeAuthorityId,
+          context.requestId,
+          context.requester.verifiedEmail,
+          origin,
+          false,
+        )
+        if (result) return result
+        return (await bridgeGrantLimitReached(
+          db,
+          target.id,
+          context.requester.verifiedEmail,
+        ))
+          ? { kind: 'artifact-viewer-limit-reached' }
+          : { kind: 'upload-failed' }
+      }
+      if (
+        await bridgeGrantLimitReached(
+          db,
+          target.id,
+          context.requester.verifiedEmail,
+        )
+      ) {
+        failure = { kind: 'artifact-viewer-limit-reached' }
+      }
     }
+    replay = await readBridgeResult(
+      db,
+      authority.bridgeAuthorityId,
+      context.requestId,
+      context.requester.verifiedEmail,
+      origin,
+      true,
+    )
+  } catch (error) {
+    console.error('bridge_post_stage_failed', {
+      request_id: context.requestId,
+      error,
+    })
+    failure = { kind: 'internal-error' }
   }
-  const replay = await readBridgeResult(
-    db,
-    authority.bridgeAuthorityId,
-    context.requestId,
-    context.requester.verifiedEmail,
-    origin,
-    true,
-  )
-  await Promise.all([
-    deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
-    releaseQuota(db, authority.workspaceId, prepared.sizeBytes, prepared.now),
-  ])
+  if (!retained) {
+    await Promise.all([
+      deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
+      releaseQuota(db, authority.workspaceId, prepared.sizeBytes, prepared.now),
+    ])
+  }
   if (replay) return replay
   return failure
 }
@@ -518,7 +536,7 @@ async function publishBridgeStaticSite(
   intent: BridgeIntent,
   binding: BoundBridgeRequest,
   leaseGeneration: string,
-  files: readonly File[],
+  files: readonly VerifiedBridgeFile[],
   origin: string,
 ): Promise<ExecuteBridgeRequestResult> {
   let target: BridgeTarget | null = null
@@ -556,70 +574,31 @@ async function publishBridgeStaticSite(
   )
   if (staged.kind !== 'ok') return staged
 
-  const final = await resolveFinalDestination(db, authority, context, binding)
   let failure: ExecuteBridgeRequestResult = { kind: 'upload-failed' }
-  if (final.kind !== 'ok') {
-    failure = final
-  } else if (
-    context.conversation.kind === 'public_channel' &&
-    !publicContextFresh(context, new Date())
-  ) {
-    failure = { kind: 'stale-context' }
-  } else if (target) {
-    const committed = await commitBridgeVersion(db, {
-      authority,
-      context,
-      intent,
-      binding: final.binding,
-      target,
-      leaseGeneration,
-      prepared: staged.prepared,
-    })
-    if (committed) {
-      await notifyArtifactVersionChanged(target.id, staged.prepared.versionId)
-      const result = await readBridgeResult(
-        db,
-        authority.bridgeAuthorityId,
-        context.requestId,
-        context.requester.verifiedEmail,
-        origin,
-        false,
-      )
-      if (result) return result
-      return (await bridgeGrantLimitReached(
-        db,
-        target.id,
-        context.requester.verifiedEmail,
-      ))
-        ? { kind: 'artifact-viewer-limit-reached' }
-        : { kind: 'upload-failed' }
-    }
-    if (
-      await bridgeGrantLimitReached(
-        db,
-        target.id,
-        context.requester.verifiedEmail,
-      )
+  let replay: { kind: 'ok'; result: BridgeRequestSuccess } | null = null
+  let retained = false
+  try {
+    const final = await resolveFinalDestination(db, authority, context, binding)
+    if (final.kind !== 'ok') {
+      failure = final
+    } else if (
+      context.conversation.kind === 'public_channel' &&
+      !publicContextFresh(context, new Date())
     ) {
-      failure = { kind: 'artifact-viewer-limit-reached' }
-    }
-  } else {
-    let currentBinding = final.binding
-    for (let attempt = 0; attempt < PROJECT_NAME_ATTEMPTS; attempt += 1) {
-      const committed = await commitBridgePublish(db, {
+      failure = { kind: 'stale-context' }
+    } else if (target) {
+      const committed = await commitBridgeVersion(db, {
         authority,
         context,
         intent,
-        binding: currentBinding,
+        binding: final.binding,
+        target,
         leaseGeneration,
         prepared: staged.prepared,
-        shareableId,
       })
-      if (committed.kind === 'ok') {
-        await notifyArtifactVersionChanged(
-          shareableId,
-          staged.prepared.versionId,
-        )
+      if (committed) {
+        retained = true
+        await notifyArtifactVersionChanged(target.id, staged.prepared.versionId)
         const result = await readBridgeResult(
           db,
           authority.bridgeAuthorityId,
@@ -629,42 +608,95 @@ async function publishBridgeStaticSite(
           false,
         )
         if (result) return result
-        return { kind: 'upload-failed' }
+        return (await bridgeGrantLimitReached(
+          db,
+          target.id,
+          context.requester.verifiedEmail,
+        ))
+          ? { kind: 'artifact-viewer-limit-reached' }
+          : { kind: 'upload-failed' }
       }
-      failure = committed
-      if (committed.kind === 'project-name-conflict') continue
-      if (committed.kind !== 'conversation-identity-conflict') break
-      const resolved = await resolveConversation(
-        db,
-        authority.bridgeAuthorityId,
-        context.conversation.ids,
-      )
-      if (resolved.kind !== 'ok' || !resolved.mapping) break
-      currentBinding = {
-        ...currentBinding,
-        mapping: resolved.mapping,
-        mappingCreated: false,
-        projectCreated: false,
+      if (
+        await bridgeGrantLimitReached(
+          db,
+          target.id,
+          context.requester.verifiedEmail,
+        )
+      ) {
+        failure = { kind: 'artifact-viewer-limit-reached' }
+      }
+    } else {
+      let currentBinding = final.binding
+      for (let attempt = 0; attempt < PROJECT_NAME_ATTEMPTS; attempt += 1) {
+        const committed = await commitBridgePublish(db, {
+          authority,
+          context,
+          intent,
+          binding: currentBinding,
+          leaseGeneration,
+          prepared: staged.prepared,
+          shareableId,
+        })
+        if (committed.kind === 'ok') {
+          retained = true
+          await notifyArtifactVersionChanged(
+            shareableId,
+            staged.prepared.versionId,
+          )
+          const result = await readBridgeResult(
+            db,
+            authority.bridgeAuthorityId,
+            context.requestId,
+            context.requester.verifiedEmail,
+            origin,
+            false,
+          )
+          if (result) return result
+          return { kind: 'upload-failed' }
+        }
+        failure = committed
+        if (committed.kind === 'project-name-conflict') continue
+        if (committed.kind !== 'conversation-identity-conflict') break
+        const resolved = await resolveConversation(
+          db,
+          authority.bridgeAuthorityId,
+          context.conversation.ids,
+        )
+        if (resolved.kind !== 'ok' || !resolved.mapping) break
+        currentBinding = {
+          ...currentBinding,
+          mapping: resolved.mapping,
+          mappingCreated: false,
+          projectCreated: false,
+        }
       }
     }
-  }
-  const replay = await readBridgeResult(
-    db,
-    authority.bridgeAuthorityId,
-    context.requestId,
-    context.requester.verifiedEmail,
-    origin,
-    true,
-  )
-  await Promise.all([
-    deleteArtifactsByPrefix(env.BUCKET, staged.prefix).catch(() => undefined),
-    releaseQuota(
+    replay = await readBridgeResult(
       db,
-      authority.workspaceId,
-      staged.prepared.sizeBytes,
-      staged.prepared.now,
-    ),
-  ])
+      authority.bridgeAuthorityId,
+      context.requestId,
+      context.requester.verifiedEmail,
+      origin,
+      true,
+    )
+  } catch (error) {
+    console.error('bridge_static_site_post_stage_failed', {
+      request_id: context.requestId,
+      error,
+    })
+    failure = { kind: 'internal-error' }
+  }
+  if (!retained) {
+    await Promise.all([
+      deleteArtifactsByPrefix(env.BUCKET, staged.prefix).catch(() => undefined),
+      releaseQuota(
+        db,
+        authority.workspaceId,
+        staged.prepared.sizeBytes,
+        staged.prepared.now,
+      ),
+    ])
+  }
   if (replay) return replay
   return failure
 }
@@ -673,7 +705,7 @@ async function stageBridgeStaticSite(
   db: Kysely<DB>,
   workspaceId: string,
   shareableId: string,
-  files: readonly File[],
+  files: readonly VerifiedBridgeFile[],
 ): Promise<
   | {
       kind: 'ok'
@@ -697,17 +729,17 @@ async function stageBridgeStaticSite(
     entrypointKind: 'html' | 'md' | null
   }> = []
   let total = 0
-  for (const file of files) {
-    if (file.size > STATIC_SITE_UPLOAD_LIMITS.fileBytes) {
+  for (const verified of files) {
+    if (verified.file.size > STATIC_SITE_UPLOAD_LIMITS.fileBytes) {
       return { kind: 'payload-too-large' }
     }
-    total += file.size
+    total += verified.file.size
     if (total > STATIC_SITE_UPLOAD_LIMITS.totalBytes) {
       return { kind: 'payload-too-large' }
     }
-    const validation = validateBundlePath(file.name)
+    const validation = validateBundlePath(verified.path)
     if (validation.kind === 'blocked') return { kind: 'invalid-context' }
-    const path = normalizeBundlePath(file.name)
+    const path = normalizeBundlePath(verified.path)
     const key = path.toLowerCase()
     const depth = Math.max(path.split('/').filter(Boolean).length - 1, 0)
     if (
@@ -721,7 +753,7 @@ async function stageBridgeStaticSite(
     if (!mimeType) return { kind: 'invalid-context' }
     const r2Key = `${prefix}${path.slice(1)}`
     validated.push({
-      file,
+      file: verified.file,
       path,
       r2Key,
       mimeType,
@@ -1330,7 +1362,7 @@ async function publishBridgeFile(
   intent: BridgeIntent,
   initialBinding: BoundBridgeRequest,
   leaseGeneration: string,
-  file: File,
+  file: VerifiedBridgeFile,
   origin: string,
 ): Promise<ExecuteBridgeRequestResult> {
   let shareableId = ''
@@ -1351,7 +1383,8 @@ async function publishBridgeFile(
     db,
     authority.workspaceId,
     shareableId,
-    file,
+    file.file,
+    { name: file.path, type: file.mediaType },
   )
   if (prepared.kind !== 'ok') {
     if (prepared.kind === 'too-large') return { kind: 'payload-too-large' }
@@ -1380,73 +1413,90 @@ async function publishBridgeFile(
     return { kind: 'upload-failed' }
   }
 
-  let binding = initialBinding
   let lastFailure: ExecuteBridgeRequestResult = { kind: 'upload-failed' }
-  for (let attempt = 0; attempt < PROJECT_NAME_ATTEMPTS; attempt += 1) {
-    const final = await resolveFinalDestination(db, authority, context, binding)
-    if (final.kind !== 'ok') {
-      lastFailure = final
-      break
-    }
-    binding = final.binding
-    if (
-      context.conversation.kind === 'public_channel' &&
-      !publicContextFresh(context, new Date())
-    ) {
-      lastFailure = { kind: 'stale-context' }
-      break
-    }
-    const committed = await commitBridgePublish(db, {
-      authority,
-      context,
-      intent,
-      binding,
-      leaseGeneration,
-      prepared,
-      shareableId,
-    })
-    if (committed.kind === 'ok') {
-      await notifyArtifactVersionChanged(shareableId, prepared.versionId)
-      const result = await readBridgeResult(
+  let replay: { kind: 'ok'; result: BridgeRequestSuccess } | null = null
+  let retained = false
+  try {
+    let binding = initialBinding
+    for (let attempt = 0; attempt < PROJECT_NAME_ATTEMPTS; attempt += 1) {
+      const final = await resolveFinalDestination(
+        db,
+        authority,
+        context,
+        binding,
+      )
+      if (final.kind !== 'ok') {
+        lastFailure = final
+        break
+      }
+      binding = final.binding
+      if (
+        context.conversation.kind === 'public_channel' &&
+        !publicContextFresh(context, new Date())
+      ) {
+        lastFailure = { kind: 'stale-context' }
+        break
+      }
+      const committed = await commitBridgePublish(db, {
+        authority,
+        context,
+        intent,
+        binding,
+        leaseGeneration,
+        prepared,
+        shareableId,
+      })
+      if (committed.kind === 'ok') {
+        retained = true
+        await notifyArtifactVersionChanged(shareableId, prepared.versionId)
+        const result = await readBridgeResult(
+          db,
+          authority.bridgeAuthorityId,
+          context.requestId,
+          context.requester.verifiedEmail,
+          origin,
+          false,
+        )
+        if (result) return result
+        return { kind: 'upload-failed' }
+      }
+      lastFailure = committed
+      if (committed.kind === 'project-name-conflict') continue
+      if (committed.kind !== 'conversation-identity-conflict') break
+      const rebound = await resolveConversation(
         db,
         authority.bridgeAuthorityId,
-        context.requestId,
-        context.requester.verifiedEmail,
-        origin,
-        false,
+        context.conversation.ids,
       )
-      if (result) return result
-      return { kind: 'upload-failed' }
+      if (rebound.kind !== 'ok' || rebound.mapping === null) break
+      binding = {
+        ...binding,
+        mapping: rebound.mapping,
+        mappingCreated: false,
+        projectCreated: false,
+      }
     }
-    lastFailure = committed
-    if (committed.kind === 'project-name-conflict') continue
-    if (committed.kind !== 'conversation-identity-conflict') break
-    const rebound = await resolveConversation(
+    replay = await readBridgeResult(
       db,
       authority.bridgeAuthorityId,
-      context.conversation.ids,
+      context.requestId,
+      context.requester.verifiedEmail,
+      origin,
+      true,
     )
-    if (rebound.kind !== 'ok' || rebound.mapping === null) break
-    binding = {
-      ...binding,
-      mapping: rebound.mapping,
-      mappingCreated: false,
-      projectCreated: false,
-    }
+  } catch (error) {
+    console.error('bridge_publish_post_stage_failed', {
+      request_id: context.requestId,
+      error,
+    })
+    lastFailure = { kind: 'internal-error' }
   }
-
-  const replay = await readBridgeResult(
-    db,
-    authority.bridgeAuthorityId,
-    context.requestId,
-    context.requester.verifiedEmail,
-    origin,
-    true,
-  )
-  await Promise.all([
-    deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
-    releaseQuota(db, authority.workspaceId, prepared.sizeBytes, prepared.now),
-  ])
+  if (!retained) {
+    await Promise.all([
+      deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
+      releaseQuota(db, authority.workspaceId, prepared.sizeBytes, prepared.now),
+    ])
+  }
   if (replay) return replay
   return lastFailure
 }

--- a/apps/web/app/services/bridge-publishing.server.ts
+++ b/apps/web/app/services/bridge-publishing.server.ts
@@ -1627,8 +1627,12 @@ async function commitBridgePublish(
         mapping_id: mappingId,
         result_artifact_id: input.shareableId,
         result_version_id: prepared.versionId,
-        mapping_created: createMapping || input.binding.mappingCreated ? 1 : 0,
-        project_created: createMapping || input.binding.projectCreated ? 1 : 0,
+        mapping_created: sql<number>`CASE
+          WHEN mapping_created = 1 OR ${createMapping || input.binding.mappingCreated ? 1 : 0} = 1
+          THEN 1 ELSE 0 END`,
+        project_created: sql<number>`CASE
+          WHEN project_created = 1 OR ${createMapping || input.binding.projectCreated ? 1 : 0} = 1
+          THEN 1 ELSE 0 END`,
         updated_at: prepared.now,
       })
       .where('bridge_authority_id', '=', authority.bridgeAuthorityId)
@@ -1646,7 +1650,11 @@ async function commitBridgePublish(
       shareable_id: input.shareableId,
       error,
     })
-    await cleanupFailedShareable(db, input.shareableId)
+    await cleanupFailedShareable(
+      db,
+      input.shareableId,
+      input.prepared.versionId,
+    )
     if (createMapping) {
       await cleanupFailedMapping(db, mappingId!, projectId)
       const concurrent = await resolveConversation(
@@ -1918,9 +1926,17 @@ function publicContextFresh(context: TrustedBridgeContext, now: Date) {
   return Number.isFinite(checkedAt) && age <= 60_000 && age >= -5_000
 }
 
-async function cleanupFailedShareable(db: Kysely<DB>, shareableId: string) {
+async function cleanupFailedShareable(
+  db: Kysely<DB>,
+  shareableId: string,
+  versionId: string,
+) {
   try {
-    await db.deleteFrom('shareables').where('id', '=', shareableId).execute()
+    await db
+      .deleteFrom('shareables')
+      .where('id', '=', shareableId)
+      .where('current_version_id', '=', versionId)
+      .execute()
   } catch {
     // Production D1 batches are atomic; this is test-adapter compensation.
   }

--- a/apps/web/app/services/bridge-publishing.server.ts
+++ b/apps/web/app/services/bridge-publishing.server.ts
@@ -393,6 +393,9 @@ async function publishBridgeFileVersion(
     intent.targetArtifactId,
   )
   if (!target) return { kind: 'forbidden-target' }
+  if (target.artifactKind === 'static_site') {
+    return { kind: 'forbidden-target' }
+  }
   let file = requestFile
   if (intent.operation === 'append') {
     if (
@@ -418,8 +421,9 @@ async function publishBridgeFileVersion(
     file,
   )
   if (prepared.kind !== 'ok') {
-    return prepared.kind === 'too-large'
-      ? { kind: 'payload-too-large' }
+    if (prepared.kind === 'too-large') return { kind: 'payload-too-large' }
+    return prepared.kind === 'quota-exceeded'
+      ? { kind: 'upload-failed' }
       : { kind: 'invalid-context' }
   }
   const reserved = await reserveQuota(
@@ -1048,9 +1052,12 @@ function bridgeTargetScopeSql(
   return sql<boolean>`EXISTS (
     SELECT 1
     FROM bridge_conversations mapping
+    JOIN bridge_authorities bridge ON bridge.id = mapping.bridge_authority_id
+    JOIN users bot ON bot.id = bridge.bot_user_id
     JOIN artifact_containers project ON project.id = mapping.project_id
     WHERE mapping.id = ${input.binding.mapping?.id ?? ''}
       AND mapping.bridge_authority_id = ${input.authority.bridgeAuthorityId}
+      AND bot.bot_stopped_at IS NULL
       AND project.workspace_id = ${input.authority.workspaceId}
       AND project.kind = 'project'
       AND project.archived_at IS NULL
@@ -1342,8 +1349,9 @@ async function publishBridgeFile(
     file,
   )
   if (prepared.kind !== 'ok') {
-    return prepared.kind === 'too-large'
-      ? { kind: 'payload-too-large' }
+    if (prepared.kind === 'too-large') return { kind: 'payload-too-large' }
+    return prepared.kind === 'quota-exceeded'
+      ? { kind: 'upload-failed' }
       : { kind: 'invalid-context' }
   }
   const reserved = await reserveQuota(

--- a/apps/web/app/services/bridge-publishing.server.ts
+++ b/apps/web/app/services/bridge-publishing.server.ts
@@ -34,6 +34,7 @@ import {
 import {
   prepareUpload,
   normalizeBundlePath,
+  notifyArtifactVersionChanged,
   releaseQuota,
   reserveQuota,
   staticSiteEntrypointKind,
@@ -49,6 +50,7 @@ import { validateBundlePath } from '../../workers/lib/path-validator'
 
 const PROJECT_NAME_ATTEMPTS = 3
 const REQUEST_LEASE_MS = 60_000
+const VERSION_FILE_INSERT_CHUNK_SIZE = 8
 
 type BridgeAuthority = Extract<CliAuthority, { kind: 'bridge' }>
 export interface BridgeRequestSuccess {
@@ -439,6 +441,7 @@ async function publishBridgeFileVersion(
       prepared,
     })
     if (committed) {
+      await notifyArtifactVersionChanged(target.id, prepared.versionId)
       const result = await readBridgeResult(
         db,
         authority.bridgeAuthorityId,
@@ -448,6 +451,13 @@ async function publishBridgeFileVersion(
         false,
       )
       if (result) return result
+      return (await bridgeGrantLimitReached(
+        db,
+        target.id,
+        context.requester.verifiedEmail,
+      ))
+        ? { kind: 'artifact-viewer-limit-reached' }
+        : { kind: 'upload-failed' }
     }
     if (
       await bridgeGrantLimitReached(
@@ -467,11 +477,11 @@ async function publishBridgeFileVersion(
     origin,
     true,
   )
-  if (replay) return replay
   await Promise.all([
     deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
     releaseQuota(db, authority.workspaceId, prepared.sizeBytes, prepared.now),
   ])
+  if (replay) return replay
   return failure
 }
 
@@ -540,6 +550,7 @@ async function publishBridgeStaticSite(
       prepared: staged.prepared,
     })
     if (committed) {
+      await notifyArtifactVersionChanged(target.id, staged.prepared.versionId)
       const result = await readBridgeResult(
         db,
         authority.bridgeAuthorityId,
@@ -549,6 +560,13 @@ async function publishBridgeStaticSite(
         false,
       )
       if (result) return result
+      return (await bridgeGrantLimitReached(
+        db,
+        target.id,
+        context.requester.verifiedEmail,
+      ))
+        ? { kind: 'artifact-viewer-limit-reached' }
+        : { kind: 'upload-failed' }
     }
     if (
       await bridgeGrantLimitReached(
@@ -572,6 +590,10 @@ async function publishBridgeStaticSite(
         shareableId,
       })
       if (committed.kind === 'ok') {
+        await notifyArtifactVersionChanged(
+          shareableId,
+          staged.prepared.versionId,
+        )
         const result = await readBridgeResult(
           db,
           authority.bridgeAuthorityId,
@@ -581,8 +603,9 @@ async function publishBridgeStaticSite(
           false,
         )
         if (result) return result
+        return { kind: 'upload-failed' }
       }
-      failure = committed.kind === 'ok' ? { kind: 'upload-failed' } : committed
+      failure = committed
       if (committed.kind === 'project-name-conflict') continue
       if (committed.kind !== 'conversation-identity-conflict') break
       const resolved = await resolveConversation(
@@ -607,7 +630,6 @@ async function publishBridgeStaticSite(
     origin,
     true,
   )
-  if (replay) return replay
   await Promise.all([
     deleteArtifactsByPrefix(env.BUCKET, staged.prefix).catch(() => undefined),
     releaseQuota(
@@ -617,6 +639,7 @@ async function publishBridgeStaticSite(
       staged.prepared.now,
     ),
   ])
+  if (replay) return replay
   return failure
 }
 
@@ -778,10 +801,17 @@ async function appendBridgeFile(
   const sourceBytes = new Uint8Array(source.body)
   let insertAt = sourceBytes.byteLength
   if (target.artifactKind === 'html_page') {
-    const text = new TextDecoder().decode(sourceBytes)
+    let text: string
+    try {
+      text = new TextDecoder('utf-8', { fatal: true }).decode(sourceBytes)
+    } catch {
+      return null
+    }
     const match = /<\/body\s*>/giu
     let found: RegExpExecArray | null
-    while ((found = match.exec(text)) !== null) insertAt = found.index
+    while ((found = match.exec(text)) !== null) {
+      insertAt = new TextEncoder().encode(text.slice(0, found.index)).byteLength
+    }
   }
   return new File(
     [source.body.slice(0, insertAt), additionText, source.body.slice(insertAt)],
@@ -823,10 +853,19 @@ async function commitBridgeVersion(
     .where('id', '=', input.target.id)
     .where('current_version_id', '=', input.target.currentVersionId)
     .where(scope)
+    .where(
+      bridgeGrantAvailableSql(
+        input.target.id,
+        input.context.requester.verifiedEmail,
+      ),
+    )
   const queries: Compilable<unknown>[] = [versionInsert]
   if (input.prepared.versionFiles?.length) {
     queries.push(
-      db.insertInto('version_files').values(input.prepared.versionFiles),
+      ...chunkArray(
+        input.prepared.versionFiles,
+        VERSION_FILE_INSERT_CHUNK_SIZE,
+      ).map((rows) => db.insertInto('version_files').values(rows)),
     )
   }
   queries.push(
@@ -943,6 +982,12 @@ function guardedVersionInsert(
         )
         .where('request.status', '=', 'leased')
         .where('request.lease_generation', '=', input.leaseGeneration)
+        .where(
+          bridgeGrantAvailableSql(
+            input.target.id,
+            input.context.requester.verifiedEmail,
+          ),
+        )
         .where(bridgeTargetScopeSql(input, 'artifact')),
     )
 }
@@ -1132,12 +1177,27 @@ async function setBridgeVisibility(
         .updateTable('shareables')
         .set({ visibility, link_expires_at: null, updated_at: now })
         .where('id', '=', target.id)
-        .where(scope),
+        .where(scope)
+        .where(
+          bridgeGrantAvailableSql(target.id, context.requester.verifiedEmail),
+        )
+        .where(
+          bridgeLeaseActiveSql({
+            authorityId: authority.bridgeAuthorityId,
+            requestId: context.requestId,
+            generation: leaseGeneration,
+          }),
+        ),
       bridgeGrantQuery(db, {
         artifactId: target.id,
         email: context.requester.verifiedEmail,
         grantedAt: now,
         grantedBy: final.binding.authority.botUserId,
+        lease: {
+          authorityId: authority.bridgeAuthorityId,
+          requestId: context.requestId,
+          generation: leaseGeneration,
+        },
       }),
       operationInsert,
       db
@@ -1267,6 +1327,7 @@ async function publishBridgeFile(
       shareableId,
     })
     if (committed.kind === 'ok') {
+      await notifyArtifactVersionChanged(shareableId, prepared.versionId)
       const result = await readBridgeResult(
         db,
         authority.bridgeAuthorityId,
@@ -1276,8 +1337,7 @@ async function publishBridgeFile(
         false,
       )
       if (result) return result
-      lastFailure = { kind: 'upload-failed' }
-      break
+      return { kind: 'upload-failed' }
     }
     lastFailure = committed
     if (committed.kind === 'project-name-conflict') continue
@@ -1304,11 +1364,11 @@ async function publishBridgeFile(
     origin,
     true,
   )
-  if (replay) return replay
   await Promise.all([
     deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
     releaseQuota(db, authority.workspaceId, prepared.sizeBytes, prepared.now),
   ])
+  if (replay) return replay
   return lastFailure
 }
 
@@ -1468,7 +1528,11 @@ async function commitBridgePublish(
     }),
   )
   if (prepared.versionFiles?.length) {
-    queries.push(db.insertInto('version_files').values(prepared.versionFiles))
+    queries.push(
+      ...chunkArray(prepared.versionFiles, VERSION_FILE_INSERT_CHUNK_SIZE).map(
+        (rows) => db.insertInto('version_files').values(rows),
+      ),
+    )
   }
   if (input.binding.routingClass === 'dm') {
     queries.push(
@@ -1963,7 +2027,9 @@ async function readBridgeResult(
       artifact: {
         id: row.artifact_id,
         url: `${cleanOrigin}/a/${row.artifact_id}`,
-        title: row.title_override ?? row.derived_title ?? row.artifact_name,
+        title: truncateBridgeTitle(
+          row.title_override ?? row.derived_title ?? row.artifact_name,
+        ),
       },
       project: { id: row.project_id, name: row.project_name },
       visibility,
@@ -1982,13 +2048,18 @@ function bridgeGrantQuery(
     email: string
     grantedAt: string
     grantedBy: string
+    lease?: {
+      authorityId: string
+      requestId: string
+      generation: string
+    }
   },
 ) {
   return db
     .insertInto('shareable_grants')
     .columns(['shareable_id', 'granted_email', 'granted_at', 'granted_by'])
-    .expression((eb) =>
-      eb
+    .expression((eb) => {
+      let query = eb
         .selectFrom('shareables')
         .select([
           eb.val(input.artifactId).as('shareable_id'),
@@ -1997,23 +2068,39 @@ function bridgeGrantQuery(
           eb.val(input.grantedBy).as('granted_by'),
         ])
         .where('id', '=', input.artifactId)
-        .where((where) =>
-          where.or([
-            where.exists(
-              where
-                .selectFrom('shareable_grants as existing')
-                .select('existing.shareable_id')
-                .where('existing.shareable_id', '=', input.artifactId)
-                .where('existing.granted_email', '=', input.email),
-            ),
-            sql<boolean>`(
-              SELECT COUNT(*) FROM shareable_grants
-              WHERE shareable_id = ${input.artifactId}
-            ) < 50`,
-          ]),
-        ),
-    )
+        .where(bridgeGrantAvailableSql(input.artifactId, input.email))
+      if (input.lease) query = query.where(bridgeLeaseActiveSql(input.lease))
+      return query
+    })
     .onConflict((conflict) => conflict.doNothing())
+}
+
+function bridgeGrantAvailableSql(artifactId: string, email: string) {
+  return sql<boolean>`(
+    EXISTS (
+      SELECT 1 FROM shareable_grants existing
+      WHERE existing.shareable_id = ${artifactId}
+        AND existing.granted_email = ${email}
+    )
+    OR (
+      SELECT COUNT(*) FROM shareable_grants
+      WHERE shareable_id = ${artifactId}
+    ) < 50
+  )`
+}
+
+function bridgeLeaseActiveSql(input: {
+  authorityId: string
+  requestId: string
+  generation: string
+}) {
+  return sql<boolean>`EXISTS (
+    SELECT 1 FROM bridge_requests active_request
+    WHERE active_request.bridge_authority_id = ${input.authorityId}
+      AND active_request.request_id = ${input.requestId}
+      AND active_request.status = 'leased'
+      AND active_request.lease_generation = ${input.generation}
+  )`
 }
 
 async function bridgeGrantLimitReached(
@@ -2076,4 +2163,21 @@ async function ensureReplayGrant(
     return false
   }
   return true
+}
+
+function chunkArray<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+function truncateBridgeTitle(value: string): string {
+  if (value.length <= 200) return value
+  const end =
+    value.charCodeAt(199) >= 0xd800 && value.charCodeAt(199) <= 0xdbff
+      ? 199
+      : 200
+  return value.slice(0, end)
 }

--- a/apps/web/app/services/bridge-publishing.server.ts
+++ b/apps/web/app/services/bridge-publishing.server.ts
@@ -4,6 +4,7 @@ import { nanoid } from 'nanoid'
 import { projectLimitForPlan } from '~/lib/billing-plan.server'
 import { runD1Batch } from '~/lib/d1-batch.server'
 import { nowIso } from '~/lib/datetime'
+import { lowerEmail } from '~/lib/grant-emails.server'
 import { computeFileSha256, computeTextSha256 } from '~/lib/sha256'
 import { createShareableId } from '~/lib/shareable-id'
 import { extractTitleFromBytes } from '~/lib/extract-title'
@@ -1164,6 +1165,9 @@ async function setBridgeVisibility(
         .where('request.status', '=', 'leased')
         .where('request.lease_generation', '=', leaseGeneration)
         .where(
+          bridgeGrantAvailableSql(target.id, context.requester.verifiedEmail),
+        )
+        .where(
           bridgeTargetScopeSql(
             { authority, context, binding: final.binding, target },
             'artifact',
@@ -1241,7 +1245,14 @@ async function setBridgeVisibility(
     origin,
     false,
   )
-  return result ?? { kind: 'upload-failed' }
+  if (result) return result
+  return (await bridgeGrantLimitReached(
+    db,
+    target.id,
+    context.requester.verifiedEmail,
+  ))
+    ? { kind: 'artifact-viewer-limit-reached' }
+    : { kind: 'upload-failed' }
 }
 
 async function publishBridgeFile(
@@ -2055,6 +2066,7 @@ function bridgeGrantQuery(
     }
   },
 ) {
+  const normalizedEmail = input.email.toLowerCase()
   return db
     .insertInto('shareable_grants')
     .columns(['shareable_id', 'granted_email', 'granted_at', 'granted_by'])
@@ -2063,12 +2075,19 @@ function bridgeGrantQuery(
         .selectFrom('shareables')
         .select([
           eb.val(input.artifactId).as('shareable_id'),
-          eb.val(input.email).as('granted_email'),
+          eb.val(normalizedEmail).as('granted_email'),
           eb.val(input.grantedAt).as('granted_at'),
           eb.val(input.grantedBy).as('granted_by'),
         ])
         .where('id', '=', input.artifactId)
-        .where(bridgeGrantAvailableSql(input.artifactId, input.email))
+        .where(bridgeGrantAvailableSql(input.artifactId, normalizedEmail))
+        .where(
+          sql<boolean>`NOT EXISTS (
+            SELECT 1 FROM shareable_grants existing
+            WHERE existing.shareable_id = ${input.artifactId}
+              AND ${lowerEmail('existing.granted_email')} = ${normalizedEmail}
+          )`,
+        )
       if (input.lease) query = query.where(bridgeLeaseActiveSql(input.lease))
       return query
     })
@@ -2076,11 +2095,12 @@ function bridgeGrantQuery(
 }
 
 function bridgeGrantAvailableSql(artifactId: string, email: string) {
+  const normalizedEmail = email.toLowerCase()
   return sql<boolean>`(
     EXISTS (
       SELECT 1 FROM shareable_grants existing
       WHERE existing.shareable_id = ${artifactId}
-        AND existing.granted_email = ${email}
+        AND ${lowerEmail('existing.granted_email')} = ${normalizedEmail}
     )
     OR (
       SELECT COUNT(*) FROM shareable_grants
@@ -2108,13 +2128,14 @@ async function bridgeGrantLimitReached(
   artifactId: string,
   email: string,
 ) {
+  const normalizedEmail = email.toLowerCase()
   const row = await db
     .selectFrom('shareable_grants')
     .select(({ fn }) => [
       fn.countAll<number>().as('count'),
       fn
         .max<number>(
-          sql<number>`CASE WHEN granted_email = ${email} THEN 1 ELSE 0 END`,
+          sql<number>`CASE WHEN ${lowerEmail('granted_email')} = ${normalizedEmail} THEN 1 ELSE 0 END`,
         )
         .as('has_requester'),
     ])
@@ -2129,11 +2150,12 @@ async function ensureReplayGrant(
   email: string,
   authorityId: string,
 ): Promise<boolean> {
+  const normalizedEmail = email.toLowerCase()
   const existing = await db
     .selectFrom('shareable_grants')
     .select('shareable_id')
     .where('shareable_id', '=', artifactId)
-    .where('granted_email', '=', email)
+    .where(lowerEmail('granted_email'), '=', normalizedEmail)
     .executeTakeFirst()
   if (existing) return true
   const count = await db
@@ -2153,7 +2175,7 @@ async function ensureReplayGrant(
       .insertInto('shareable_grants')
       .values({
         shareable_id: artifactId,
-        granted_email: email,
+        granted_email: normalizedEmail,
         granted_at: nowIso(),
         granted_by: authority.bot_user_id,
       })

--- a/apps/web/app/services/bridge-publishing.server.ts
+++ b/apps/web/app/services/bridge-publishing.server.ts
@@ -37,6 +37,7 @@ import {
 } from './bridge-request-validation.server'
 import {
   prepareUpload,
+  isIgnoredStaticSiteUploadPath,
   normalizeBundlePath,
   notifyArtifactVersionChanged,
   releaseQuota,
@@ -730,6 +731,7 @@ async function stageBridgeStaticSite(
   }> = []
   let total = 0
   for (const verified of files) {
+    if (isIgnoredStaticSiteUploadPath(verified.path)) continue
     if (verified.file.size > STATIC_SITE_UPLOAD_LIMITS.fileBytes) {
       return { kind: 'payload-too-large' }
     }
@@ -860,14 +862,23 @@ async function appendBridgeFile(
   if (target.artifactKind === 'html_page') {
     let text: string
     try {
-      text = new TextDecoder('utf-8', { fatal: true }).decode(sourceBytes)
+      text = new TextDecoder('utf-8', {
+        fatal: true,
+        ignoreBOM: true,
+      }).decode(sourceBytes)
     } catch {
       return null
     }
     const match = /<\/body\s*>/giu
     let found: RegExpExecArray | null
+    let finalMatchIndex: number | null = null
     while ((found = match.exec(text)) !== null) {
-      insertAt = new TextEncoder().encode(text.slice(0, found.index)).byteLength
+      finalMatchIndex = found.index
+    }
+    if (finalMatchIndex !== null) {
+      insertAt = new TextEncoder().encode(
+        text.slice(0, finalMatchIndex),
+      ).byteLength
     }
   }
   return new File(
@@ -971,12 +982,10 @@ async function commitBridgeVersion(
     })
     return false
   }
-  const committed = await db
-    .selectFrom('versions')
-    .select('id')
-    .where('id', '=', input.prepared.versionId)
-    .executeTakeFirst()
-  return Boolean(committed)
+  // The production D1 batch is atomic, and bridge_operations has a foreign key
+  // to this version. A resolved batch therefore proves that the version exists;
+  // a follow-up read must not turn a committed object into cleanup work.
+  return true
 }
 
 function guardedVersionInsert(
@@ -2134,6 +2143,12 @@ async function readBridgeResult(
       'project.id',
       'artifact.container_id',
     )
+    .innerJoin(
+      'bridge_authorities as authority',
+      'authority.id',
+      'request.bridge_authority_id',
+    )
+    .innerJoin('users as bot', 'bot.id', 'authority.bot_user_id')
     .select([
       'request.result_version_id',
       'request.mapping_created',
@@ -2150,6 +2165,43 @@ async function readBridgeResult(
     .where('request.bridge_authority_id', '=', authorityId)
     .where('request.request_id', '=', requestId)
     .where('request.status', '=', 'completed')
+    .where('bot.bot_stopped_at', 'is', null)
+    .where('project.archived_at', 'is', null)
+    .where(
+      sql<boolean>`(
+        (
+          request.routing_class = 'channel'
+          AND EXISTS (
+            SELECT 1
+            FROM bridge_conversations mapping
+            WHERE mapping.id = request.mapping_id
+              AND mapping.bridge_authority_id = request.bridge_authority_id
+              AND mapping.project_id = artifact.container_id
+          )
+        )
+        OR (
+          request.routing_class = 'dm'
+          AND artifact.container_id = authority.fallback_project_id
+          AND artifact.created_by_agent_profile_id = authority.agent_profile_id
+          AND EXISTS (
+            SELECT 1
+            FROM bridge_dm_artifacts dm
+            WHERE dm.artifact_id = artifact.id
+              AND dm.bridge_authority_id = request.bridge_authority_id
+              AND dm.requester_stable_id = request.requester_stable_id
+          )
+        )
+      )`,
+    )
+    .where(
+      sql<boolean>`EXISTS (
+        SELECT 1
+        FROM bridge_operations provenance
+        WHERE provenance.bridge_authority_id = request.bridge_authority_id
+          AND provenance.request_id = request.request_id
+          AND provenance.artifact_id = artifact.id
+      )`,
+    )
     .executeTakeFirst()
   if (!row) return null
   const visibility =

--- a/apps/web/app/services/bridge-publishing.server.ts
+++ b/apps/web/app/services/bridge-publishing.server.ts
@@ -1054,10 +1054,15 @@ function bridgeTargetScopeSql(
     FROM bridge_conversations mapping
     JOIN bridge_authorities bridge ON bridge.id = mapping.bridge_authority_id
     JOIN users bot ON bot.id = bridge.bot_user_id
+    JOIN artifact_containers fallback ON fallback.id = bridge.fallback_project_id
     JOIN artifact_containers project ON project.id = mapping.project_id
     WHERE mapping.id = ${input.binding.mapping?.id ?? ''}
       AND mapping.bridge_authority_id = ${input.authority.bridgeAuthorityId}
       AND bot.bot_stopped_at IS NULL
+      AND fallback.id = ${input.binding.authority.fallbackProjectId}
+      AND fallback.workspace_id = ${input.authority.workspaceId}
+      AND fallback.kind = 'project'
+      AND fallback.archived_at IS NULL
       AND project.workspace_id = ${input.authority.workspaceId}
       AND project.kind = 'project'
       AND project.archived_at IS NULL

--- a/apps/web/app/services/bridge-publishing.server.ts
+++ b/apps/web/app/services/bridge-publishing.server.ts
@@ -1,4 +1,4 @@
-import { sql, type Compilable, type Kysely } from 'kysely'
+import { sql, type Compilable, type Kysely, type RawBuilder } from 'kysely'
 import { env } from 'cloudflare:workers'
 import { nanoid } from 'nanoid'
 import { projectLimitForPlan } from '~/lib/billing-plan.server'
@@ -8,7 +8,10 @@ import { lowerEmail } from '~/lib/grant-emails.server'
 import { computeFileSha256, computeTextSha256 } from '~/lib/sha256'
 import { createShareableId } from '~/lib/shareable-id'
 import { extractTitleFromBytes } from '~/lib/extract-title'
-import { STATIC_SITE_UPLOAD_LIMITS } from '~/lib/product-contracts'
+import {
+  ARTIFACT_UPLOAD_LIMITS,
+  STATIC_SITE_UPLOAD_LIMITS,
+} from '~/lib/product-contracts'
 import type { DB } from '~/types/db'
 import {
   artifactCreatedEventQuery,
@@ -143,7 +146,14 @@ export async function executeBridgeRequest(
       origin,
       true,
     )
-    return replay ?? { kind: 'upload-failed' }
+    if (!replay) return { kind: 'forbidden-target' }
+    if (
+      intentResult.intent.requestedAudience === 'private' &&
+      replay.result.visibility !== 'private'
+    ) {
+      return { kind: 'forbidden-target' }
+    }
+    return replay
   }
   if (lease.kind !== 'acquired') return lease
 
@@ -227,12 +237,14 @@ async function verifyMultipartFiles(
     if (
       !file ||
       file.size !== descriptor.size ||
-      file.type !== descriptor.mediaType
+      file.type.toLowerCase() !== descriptor.mediaType.toLowerCase()
     ) {
       return { kind: 'invalid-context' }
     }
     total += file.size
-    if (total > 26_214_400) return { kind: 'payload-too-large' }
+    if (total > ARTIFACT_UPLOAD_LIMITS.totalBytes) {
+      return { kind: 'payload-too-large' }
+    }
     if ((await fileSha256Hex(file)) !== descriptor.sha256) {
       return { kind: 'invalid-context' }
     }
@@ -282,6 +294,7 @@ type BridgeTarget = {
   visibility: 'private' | 'workspace' | 'project' | 'link'
   currentVersionId: string
   currentR2Key: string
+  currentSizeBytes: number
   projectId: string
   projectName: string
 }
@@ -312,6 +325,7 @@ async function resolveBridgeTarget(
       'artifact.visibility',
       'artifact.current_version_id',
       'version.r2_key',
+      'version.size_bytes',
       'project.id as project_id',
       'project.name as project_name',
     ])
@@ -354,6 +368,7 @@ async function resolveBridgeTarget(
     visibility: row.visibility,
     currentVersionId: row.current_version_id,
     currentR2Key: row.r2_key,
+    currentSizeBytes: row.size_bytes,
     projectId: row.project_id,
     projectName: row.project_name,
   }
@@ -385,6 +400,12 @@ async function publishBridgeFileVersion(
       target.artifactKind !== 'html_page'
     ) {
       return { kind: 'forbidden-target' }
+    }
+    if (
+      target.currentSizeBytes + requestFile.size >
+      ARTIFACT_UPLOAD_LIMITS.totalBytes
+    ) {
+      return { kind: 'payload-too-large' }
     }
     const appended = await appendBridgeFile(target, requestFile)
     if (!appended) return { kind: 'upload-failed' }
@@ -741,15 +762,14 @@ async function stageBridgeStaticSite(
   if (!entrypoint) return { kind: 'invalid-context' }
   const reserved = await reserveQuota(db, workspaceId, total, now)
   if (reserved !== 'ok') return { kind: 'upload-failed' }
-  try {
-    await Promise.all(
-      stagedWithBodies.map(({ body, row }) =>
-        putArtifact(env.BUCKET, row.r2_key, body, {
-          contentType: row.mime_type,
-        }),
-      ),
-    )
-  } catch {
+  const writes = await Promise.allSettled(
+    stagedWithBodies.map(({ body, row }) =>
+      putArtifact(env.BUCKET, row.r2_key, body, {
+        contentType: row.mime_type,
+      }),
+    ),
+  )
+  if (writes.some((write) => write.status === 'rejected')) {
     await Promise.all([
       deleteArtifactsByPrefix(env.BUCKET, prefix).catch(() => undefined),
       releaseQuota(db, workspaceId, total, now),
@@ -855,7 +875,8 @@ async function commitBridgeVersion(
     .where('current_version_id', '=', input.target.currentVersionId)
     .where(scope)
     .where(
-      bridgeGrantAvailableSql(
+      bridgeGrantAvailableForVisibilitySql(
+        visibility,
         input.target.id,
         input.context.requester.verifiedEmail,
       ),
@@ -927,6 +948,7 @@ function guardedVersionInsert(
   input: {
     authority: BridgeAuthority
     context: TrustedBridgeContext
+    intent: BridgeIntent
     binding: BoundBridgeRequest
     target: BridgeTarget
     leaseGeneration: string
@@ -984,7 +1006,8 @@ function guardedVersionInsert(
         .where('request.status', '=', 'leased')
         .where('request.lease_generation', '=', input.leaseGeneration)
         .where(
-          bridgeGrantAvailableSql(
+          bridgeGrantAvailableForVisibilitySql(
+            bridgeTargetVisibilitySql(input, 'artifact'),
             input.target.id,
             input.context.requester.verifiedEmail,
           ),
@@ -1041,15 +1064,19 @@ function bridgeTargetScopeSql(
   )`
 }
 
-function bridgeTargetVisibilitySql(input: {
-  authority: BridgeAuthority
-  intent: BridgeIntent
-  binding: BoundBridgeRequest
-}) {
+function bridgeTargetVisibilitySql(
+  input: {
+    authority: BridgeAuthority
+    intent: BridgeIntent
+    binding: BoundBridgeRequest
+  },
+  artifactAlias = 'shareables',
+) {
+  const artifact = sql.ref(artifactAlias)
   if (input.binding.routingClass === 'dm') {
     return sql<'private' | 'workspace'>`CASE
       WHEN ${input.intent.requestedAudience} = 'workspace'
-        AND shareables.visibility = 'workspace'
+        AND ${artifact}.visibility = 'workspace'
         AND EXISTS (
           SELECT 1 FROM artifact_containers fallback
           WHERE fallback.id = ${input.binding.authority.fallbackProjectId}
@@ -1077,6 +1104,30 @@ function bridgeTargetVisibilitySql(input: {
     THEN 'private'
     ELSE 'project'
   END`
+}
+
+function bridgeSetVisibilitySql(
+  input: {
+    authority: BridgeAuthority
+    intent: BridgeIntent
+    binding: BoundBridgeRequest
+  },
+  artifactAlias = 'shareables',
+) {
+  if (
+    input.binding.routingClass === 'dm' &&
+    input.intent.requestedAudience === 'workspace'
+  ) {
+    return sql<'private' | 'workspace'>`CASE WHEN EXISTS (
+      SELECT 1 FROM artifact_containers fallback
+      WHERE fallback.id = ${input.binding.authority.fallbackProjectId}
+        AND fallback.workspace_id = ${input.authority.workspaceId}
+        AND fallback.kind = 'project'
+        AND fallback.archived_at IS NULL
+        AND fallback.base_visibility = 'workspace'
+    ) THEN 'workspace' ELSE 'private' END`
+  }
+  return bridgeTargetVisibilitySql(input, artifactAlias)
 }
 
 async function setBridgeVisibility(
@@ -1111,18 +1162,11 @@ async function setBridgeVisibility(
     { authority, context, binding: final.binding, target },
     'shareables',
   )
-  const visibility =
-    final.binding.routingClass === 'dm' &&
-    intent.requestedAudience === 'workspace'
-      ? sql<'private' | 'workspace'>`CASE WHEN EXISTS (
-          SELECT 1 FROM artifact_containers fallback
-          WHERE fallback.id = ${final.binding.authority.fallbackProjectId}
-            AND fallback.workspace_id = ${authority.workspaceId}
-            AND fallback.kind = 'project'
-            AND fallback.archived_at IS NULL
-            AND fallback.base_visibility = 'workspace'
-        ) THEN 'workspace' ELSE 'private' END`
-      : bridgeTargetVisibilitySql({ authority, intent, binding: final.binding })
+  const visibility = bridgeSetVisibilitySql({
+    authority,
+    intent,
+    binding: final.binding,
+  })
   const operationInsert = db
     .insertInto('bridge_operations')
     .columns([
@@ -1165,7 +1209,14 @@ async function setBridgeVisibility(
         .where('request.status', '=', 'leased')
         .where('request.lease_generation', '=', leaseGeneration)
         .where(
-          bridgeGrantAvailableSql(target.id, context.requester.verifiedEmail),
+          bridgeGrantAvailableForVisibilitySql(
+            bridgeSetVisibilitySql(
+              { authority, intent, binding: final.binding },
+              'artifact',
+            ),
+            target.id,
+            context.requester.verifiedEmail,
+          ),
         )
         .where(
           bridgeTargetScopeSql(
@@ -1183,7 +1234,11 @@ async function setBridgeVisibility(
         .where('id', '=', target.id)
         .where(scope)
         .where(
-          bridgeGrantAvailableSql(target.id, context.requester.verifiedEmail),
+          bridgeGrantAvailableForVisibilitySql(
+            visibility,
+            target.id,
+            context.requester.verifiedEmail,
+          ),
         )
         .where(
           bridgeLeaseActiveSql({
@@ -2019,7 +2074,8 @@ async function readBridgeResult(
     .executeTakeFirst()
   if (!row) return null
   const visibility =
-    row.visibility === 'private' || row.base_visibility === 'private'
+    row.visibility === 'private' ||
+    (row.visibility === 'project' && row.base_visibility === 'private')
       ? ('private' as const)
       : ('workspace' as const)
   if (visibility === 'private') {
@@ -2080,6 +2136,19 @@ function bridgeGrantQuery(
           eb.val(input.grantedBy).as('granted_by'),
         ])
         .where('id', '=', input.artifactId)
+        .where(
+          sql<boolean>`(
+            shareables.visibility = 'private'
+            OR (
+              shareables.visibility = 'project'
+              AND EXISTS (
+                SELECT 1 FROM artifact_containers project
+                WHERE project.id = shareables.container_id
+                  AND project.base_visibility = 'private'
+              )
+            )
+          )`,
+        )
         .where(bridgeGrantAvailableSql(input.artifactId, normalizedEmail))
         .where(
           sql<boolean>`NOT EXISTS (
@@ -2092,6 +2161,17 @@ function bridgeGrantQuery(
       return query
     })
     .onConflict((conflict) => conflict.doNothing())
+}
+
+function bridgeGrantAvailableForVisibilitySql<T extends string>(
+  visibility: RawBuilder<T>,
+  artifactId: string,
+  email: string,
+) {
+  return sql<boolean>`(
+    ${visibility} <> 'private'
+    OR ${bridgeGrantAvailableSql(artifactId, email)}
+  )`
 }
 
 function bridgeGrantAvailableSql(artifactId: string, email: string) {
@@ -2151,19 +2231,6 @@ async function ensureReplayGrant(
   authorityId: string,
 ): Promise<boolean> {
   const normalizedEmail = email.toLowerCase()
-  const existing = await db
-    .selectFrom('shareable_grants')
-    .select('shareable_id')
-    .where('shareable_id', '=', artifactId)
-    .where(lowerEmail('granted_email'), '=', normalizedEmail)
-    .executeTakeFirst()
-  if (existing) return true
-  const count = await db
-    .selectFrom('shareable_grants')
-    .select(({ fn }) => fn.countAll<number>().as('count'))
-    .where('shareable_id', '=', artifactId)
-    .executeTakeFirstOrThrow()
-  if (Number(count.count) >= 50) return false
   const authority = await db
     .selectFrom('bridge_authorities')
     .select('bot_user_id')
@@ -2173,18 +2240,38 @@ async function ensureReplayGrant(
   try {
     await db
       .insertInto('shareable_grants')
-      .values({
-        shareable_id: artifactId,
-        granted_email: normalizedEmail,
-        granted_at: nowIso(),
-        granted_by: authority.bot_user_id,
-      })
+      .columns(['shareable_id', 'granted_email', 'granted_at', 'granted_by'])
+      .expression((eb) =>
+        eb
+          .selectFrom('shareables')
+          .select([
+            eb.val(artifactId).as('shareable_id'),
+            eb.val(normalizedEmail).as('granted_email'),
+            eb.val(nowIso()).as('granted_at'),
+            eb.val(authority.bot_user_id).as('granted_by'),
+          ])
+          .where('id', '=', artifactId)
+          .where(bridgeGrantAvailableSql(artifactId, normalizedEmail))
+          .where(
+            sql<boolean>`NOT EXISTS (
+              SELECT 1 FROM shareable_grants existing
+              WHERE existing.shareable_id = ${artifactId}
+                AND ${lowerEmail('existing.granted_email')} = ${normalizedEmail}
+            )`,
+          ),
+      )
       .onConflict((conflict) => conflict.doNothing())
       .execute()
   } catch {
     return false
   }
-  return true
+  const granted = await db
+    .selectFrom('shareable_grants')
+    .select('shareable_id')
+    .where('shareable_id', '=', artifactId)
+    .where(lowerEmail('granted_email'), '=', normalizedEmail)
+    .executeTakeFirst()
+  return Boolean(granted)
 }
 
 function chunkArray<T>(items: readonly T[], size: number): T[][] {

--- a/apps/web/app/services/bridge-publishing.server.ts
+++ b/apps/web/app/services/bridge-publishing.server.ts
@@ -1,0 +1,2079 @@
+import { sql, type Compilable, type Kysely } from 'kysely'
+import { env } from 'cloudflare:workers'
+import { nanoid } from 'nanoid'
+import { projectLimitForPlan } from '~/lib/billing-plan.server'
+import { runD1Batch } from '~/lib/d1-batch.server'
+import { nowIso } from '~/lib/datetime'
+import { computeFileSha256, computeTextSha256 } from '~/lib/sha256'
+import { createShareableId } from '~/lib/shareable-id'
+import { extractTitleFromBytes } from '~/lib/extract-title'
+import { STATIC_SITE_UPLOAD_LIMITS } from '~/lib/product-contracts'
+import type { DB } from '~/types/db'
+import {
+  artifactCreatedEventQuery,
+  versionPublishedEventQuery,
+} from './events.server'
+import { fetchArtifactSourceBytes } from './content.server'
+import type { CliAuthority } from './cli-authority.server'
+import { readLiveBridgeAuthority } from './bridge-authorities.server'
+import {
+  activeProjectCountAtLimit,
+  bindTrustedBridgeRequest,
+  conversationProjectName,
+  deleteEmptyProject,
+  resolveConversation,
+  type BindBridgeRequestResult,
+  type BoundBridgeRequest,
+} from './bridge-conversation-binding.server'
+import {
+  parseBridgeIntent,
+  parseTrustedBridgeContext,
+  type BridgeIntent,
+  type TrustedBridgeContext,
+} from './bridge-request-validation.server'
+import {
+  prepareUpload,
+  normalizeBundlePath,
+  releaseQuota,
+  reserveQuota,
+  staticSiteEntrypointKind,
+  staticSiteMimeType,
+  staticSiteR2Prefix,
+} from './shareables.server'
+import {
+  deleteArtifact,
+  deleteArtifactsByPrefix,
+  putArtifact,
+} from './storage.server'
+import { validateBundlePath } from '../../workers/lib/path-validator'
+
+const PROJECT_NAME_ATTEMPTS = 3
+const REQUEST_LEASE_MS = 60_000
+
+type BridgeAuthority = Extract<CliAuthority, { kind: 'bridge' }>
+export interface BridgeRequestSuccess {
+  artifact: { id: string; url: string; title: string }
+  project: { id: string; name: string }
+  visibility: 'private' | 'workspace'
+  versionId: string | null
+  replayed: boolean
+  mappingCreated: boolean
+  projectCreated: boolean
+}
+
+export type ExecuteBridgeRequestResult =
+  | { kind: 'ok'; result: BridgeRequestSuccess }
+  | {
+      kind:
+        | Exclude<BindBridgeRequestResult['kind'], 'ok'>
+        | 'invalid-context'
+        | 'stale-context'
+        | 'idempotency-in-progress'
+        | 'idempotency-mismatch'
+        | 'payload-too-large'
+        | 'upload-failed'
+        | 'forbidden-target'
+        | 'artifact-viewer-limit-reached'
+    }
+
+type BridgeUser = {
+  id: string
+  email?: string | null
+  emailVerified: boolean
+  workspaceId: string
+  hd: string | null
+  msTenantId?: string | null
+}
+
+export async function executeBridgeRequest(
+  db: Kysely<DB>,
+  authority: BridgeAuthority,
+  user: BridgeUser,
+  metadata: unknown,
+  files: readonly File[],
+  origin: string,
+  now = new Date(),
+): Promise<ExecuteBridgeRequestResult> {
+  const contextResult = parseTrustedBridgeContext(metadata, authority, now)
+  if (contextResult.kind !== 'ok') return contextResult
+
+  const bound = await bindTrustedBridgeRequest(
+    db,
+    authority,
+    contextResult.context,
+  )
+  if (bound.kind !== 'ok') return bound
+  if (
+    user.id !== bound.binding.authority.botUserId ||
+    user.workspaceId !== bound.binding.authority.workspaceId
+  ) {
+    return { kind: 'unsupported-authority' }
+  }
+
+  const intentResult = parseBridgeIntent(metadata)
+  if (intentResult.kind !== 'ok') return intentResult
+  const ownedFiles = await verifyMultipartFiles(intentResult.intent, files)
+  if (ownedFiles.kind !== 'ok') return ownedFiles
+  const digest = await computeTextSha256(
+    JSON.stringify({
+      operation: intentResult.intent.operation,
+      requestedAudience: intentResult.intent.requestedAudience,
+      targetArtifactId: intentResult.intent.targetArtifactId,
+      title: intentResult.intent.title,
+      contentKind: intentResult.intent.contentKind,
+      files: intentResult.intent.files,
+    }),
+  )
+  const lease = await acquireRequestLease(
+    db,
+    authority.bridgeAuthorityId,
+    contextResult.context.requestId,
+    digest,
+    now,
+  )
+  if (lease.kind === 'completed') {
+    const replay = await readBridgeResult(
+      db,
+      authority.bridgeAuthorityId,
+      contextResult.context.requestId,
+      contextResult.context.requester.verifiedEmail,
+      origin,
+      true,
+    )
+    return replay ?? { kind: 'upload-failed' }
+  }
+  if (lease.kind !== 'acquired') return lease
+
+  let execution: ExecuteBridgeRequestResult
+  if (intentResult.intent.operation === 'set_visibility') {
+    execution = await setBridgeVisibility(
+      db,
+      authority,
+      contextResult.context,
+      intentResult.intent,
+      bound.binding,
+      lease.generation,
+      origin,
+    )
+  } else if (intentResult.intent.contentKind === 'static_site') {
+    execution =
+      intentResult.intent.operation === 'publish' ||
+      intentResult.intent.operation === 'update'
+        ? await publishBridgeStaticSite(
+            db,
+            authority,
+            contextResult.context,
+            intentResult.intent,
+            bound.binding,
+            lease.generation,
+            ownedFiles.files,
+            origin,
+          )
+        : { kind: 'forbidden-target' }
+  } else if (
+    intentResult.intent.contentKind !== 'file' ||
+    ownedFiles.files.length !== 1
+  ) {
+    execution = { kind: 'forbidden-target' }
+  } else if (intentResult.intent.operation === 'publish') {
+    execution = await publishBridgeFile(
+      db,
+      authority,
+      user,
+      contextResult.context,
+      intentResult.intent,
+      bound.binding,
+      lease.generation,
+      ownedFiles.files[0]!,
+      origin,
+    )
+  } else {
+    execution = await publishBridgeFileVersion(
+      db,
+      authority,
+      contextResult.context,
+      intentResult.intent,
+      bound.binding,
+      lease.generation,
+      ownedFiles.files[0]!,
+      origin,
+    )
+  }
+  if (execution.kind !== 'ok') {
+    await releaseRequestLease(
+      db,
+      authority.bridgeAuthorityId,
+      contextResult.context.requestId,
+      lease.generation,
+    )
+  }
+  return execution
+}
+async function verifyMultipartFiles(
+  intent: BridgeIntent,
+  files: readonly File[],
+): Promise<
+  | { kind: 'ok'; files: File[] }
+  | { kind: 'invalid-context' | 'payload-too-large' }
+> {
+  if (files.length !== intent.files.length) return { kind: 'invalid-context' }
+  const owned: File[] = []
+  let total = 0
+  for (const [index, descriptor] of intent.files.entries()) {
+    const file = files[index]
+    if (
+      !file ||
+      file.size !== descriptor.size ||
+      file.type !== descriptor.mediaType
+    ) {
+      return { kind: 'invalid-context' }
+    }
+    total += file.size
+    if (total > 26_214_400) return { kind: 'payload-too-large' }
+    if ((await fileSha256Hex(file)) !== descriptor.sha256) {
+      return { kind: 'invalid-context' }
+    }
+    owned.push(
+      new File([await file.arrayBuffer()], descriptor.path, {
+        type: descriptor.mediaType,
+      }),
+    )
+  }
+  return { kind: 'ok', files: owned }
+}
+
+type PreparedBridgeFile = Extract<
+  Awaited<ReturnType<typeof prepareUpload>>,
+  { kind: 'ok' }
+>
+
+type PreparedBridgeArtifact = Pick<
+  PreparedBridgeFile,
+  | 'versionId'
+  | 'now'
+  | 'sha256'
+  | 'sizeBytes'
+  | 'entrypointPath'
+  | 'r2Key'
+  | 'derivedTitle'
+> & {
+  artifactKind: 'html_page' | 'markdown_page' | 'static_site'
+  fallbackToIndex?: number
+  versionFiles?: Array<{
+    id: string
+    version_id: string
+    path: string
+    r2_key: string
+    mime_type: string
+    size_bytes: number
+    sha256: string
+    scan_flags: string | null
+    created_at: string
+  }>
+}
+
+type BridgeTarget = {
+  id: string
+  name: string
+  artifactKind: string
+  visibility: 'private' | 'workspace' | 'project' | 'link'
+  currentVersionId: string
+  currentR2Key: string
+  projectId: string
+  projectName: string
+}
+
+async function resolveBridgeTarget(
+  db: Kysely<DB>,
+  authority: BridgeAuthority,
+  context: TrustedBridgeContext,
+  binding: BoundBridgeRequest,
+  artifactId: string,
+): Promise<BridgeTarget | null> {
+  let query = db
+    .selectFrom('shareables as artifact')
+    .innerJoin(
+      'versions as version',
+      'version.id',
+      'artifact.current_version_id',
+    )
+    .innerJoin(
+      'artifact_containers as project',
+      'project.id',
+      'artifact.container_id',
+    )
+    .select([
+      'artifact.id',
+      'artifact.name',
+      'artifact.artifact_kind',
+      'artifact.visibility',
+      'artifact.current_version_id',
+      'version.r2_key',
+      'project.id as project_id',
+      'project.name as project_name',
+    ])
+    .where('artifact.id', '=', artifactId)
+    .where('artifact.workspace_id', '=', authority.workspaceId)
+    .where(
+      'artifact.created_by_agent_profile_id',
+      '=',
+      authority.agentProfileId,
+    )
+    .where('project.archived_at', 'is', null)
+    .where(
+      sql<boolean>`EXISTS (
+        SELECT 1 FROM bridge_operations operation
+        WHERE operation.artifact_id = artifact.id
+          AND operation.bridge_authority_id = ${authority.bridgeAuthorityId}
+      )`,
+    )
+  if (binding.routingClass === 'channel') {
+    if (!binding.mapping) return null
+    query = query.where('artifact.container_id', '=', binding.mapping.projectId)
+  } else {
+    query = query
+      .where('artifact.container_id', '=', binding.authority.fallbackProjectId)
+      .where(
+        sql<boolean>`EXISTS (
+          SELECT 1 FROM bridge_dm_artifacts dm
+          WHERE dm.artifact_id = artifact.id
+            AND dm.bridge_authority_id = ${authority.bridgeAuthorityId}
+            AND dm.requester_stable_id = ${context.requester.stableId}
+        )`,
+      )
+  }
+  const row = await query.executeTakeFirst()
+  if (!row?.current_version_id) return null
+  return {
+    id: row.id,
+    name: row.name,
+    artifactKind: row.artifact_kind,
+    visibility: row.visibility,
+    currentVersionId: row.current_version_id,
+    currentR2Key: row.r2_key,
+    projectId: row.project_id,
+    projectName: row.project_name,
+  }
+}
+
+async function publishBridgeFileVersion(
+  db: Kysely<DB>,
+  authority: BridgeAuthority,
+  context: TrustedBridgeContext,
+  intent: BridgeIntent,
+  binding: BoundBridgeRequest,
+  leaseGeneration: string,
+  requestFile: File,
+  origin: string,
+): Promise<ExecuteBridgeRequestResult> {
+  if (!intent.targetArtifactId) return { kind: 'forbidden-target' }
+  const target = await resolveBridgeTarget(
+    db,
+    authority,
+    context,
+    binding,
+    intent.targetArtifactId,
+  )
+  if (!target) return { kind: 'forbidden-target' }
+  let file = requestFile
+  if (intent.operation === 'append') {
+    if (
+      target.artifactKind !== 'markdown_page' &&
+      target.artifactKind !== 'html_page'
+    ) {
+      return { kind: 'forbidden-target' }
+    }
+    const appended = await appendBridgeFile(target, requestFile)
+    if (!appended) return { kind: 'upload-failed' }
+    file = appended
+  }
+  const prepared = await prepareUpload(
+    db,
+    authority.workspaceId,
+    target.id,
+    file,
+  )
+  if (prepared.kind !== 'ok') {
+    return prepared.kind === 'too-large'
+      ? { kind: 'payload-too-large' }
+      : { kind: 'invalid-context' }
+  }
+  const reserved = await reserveQuota(
+    db,
+    authority.workspaceId,
+    prepared.sizeBytes,
+    prepared.now,
+  )
+  if (reserved !== 'ok') return { kind: 'upload-failed' }
+  try {
+    await putArtifact(env.BUCKET, prepared.r2Key, prepared.body, {
+      contentType: prepared.contentType,
+    })
+  } catch {
+    await releaseQuota(
+      db,
+      authority.workspaceId,
+      prepared.sizeBytes,
+      prepared.now,
+    )
+    return { kind: 'upload-failed' }
+  }
+
+  const final = await resolveFinalDestination(db, authority, context, binding)
+  let failure: ExecuteBridgeRequestResult = { kind: 'upload-failed' }
+  if (final.kind !== 'ok') {
+    failure = final
+  } else if (
+    context.conversation.kind === 'public_channel' &&
+    !publicContextFresh(context, new Date())
+  ) {
+    failure = { kind: 'stale-context' }
+  } else {
+    const committed = await commitBridgeVersion(db, {
+      authority,
+      context,
+      intent,
+      binding: final.binding,
+      target,
+      leaseGeneration,
+      prepared,
+    })
+    if (committed) {
+      const result = await readBridgeResult(
+        db,
+        authority.bridgeAuthorityId,
+        context.requestId,
+        context.requester.verifiedEmail,
+        origin,
+        false,
+      )
+      if (result) return result
+    }
+    if (
+      await bridgeGrantLimitReached(
+        db,
+        target.id,
+        context.requester.verifiedEmail,
+      )
+    ) {
+      failure = { kind: 'artifact-viewer-limit-reached' }
+    }
+  }
+  const replay = await readBridgeResult(
+    db,
+    authority.bridgeAuthorityId,
+    context.requestId,
+    context.requester.verifiedEmail,
+    origin,
+    true,
+  )
+  if (replay) return replay
+  await Promise.all([
+    deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
+    releaseQuota(db, authority.workspaceId, prepared.sizeBytes, prepared.now),
+  ])
+  return failure
+}
+
+async function publishBridgeStaticSite(
+  db: Kysely<DB>,
+  authority: BridgeAuthority,
+  context: TrustedBridgeContext,
+  intent: BridgeIntent,
+  binding: BoundBridgeRequest,
+  leaseGeneration: string,
+  files: readonly File[],
+  origin: string,
+): Promise<ExecuteBridgeRequestResult> {
+  let target: BridgeTarget | null = null
+  let shareableId: string
+  if (intent.operation === 'update') {
+    if (!intent.targetArtifactId) return { kind: 'forbidden-target' }
+    target = await resolveBridgeTarget(
+      db,
+      authority,
+      context,
+      binding,
+      intent.targetArtifactId,
+    )
+    if (!target || target.artifactKind !== 'static_site') {
+      return { kind: 'forbidden-target' }
+    }
+    shareableId = target.id
+  } else {
+    shareableId = createShareableId()
+    if (
+      await db
+        .selectFrom('shareables')
+        .select('id')
+        .where('id', '=', shareableId)
+        .executeTakeFirst()
+    ) {
+      return { kind: 'upload-failed' }
+    }
+  }
+  const staged = await stageBridgeStaticSite(
+    db,
+    authority.workspaceId,
+    shareableId,
+    files,
+  )
+  if (staged.kind !== 'ok') return staged
+
+  const final = await resolveFinalDestination(db, authority, context, binding)
+  let failure: ExecuteBridgeRequestResult = { kind: 'upload-failed' }
+  if (final.kind !== 'ok') {
+    failure = final
+  } else if (
+    context.conversation.kind === 'public_channel' &&
+    !publicContextFresh(context, new Date())
+  ) {
+    failure = { kind: 'stale-context' }
+  } else if (target) {
+    const committed = await commitBridgeVersion(db, {
+      authority,
+      context,
+      intent,
+      binding: final.binding,
+      target,
+      leaseGeneration,
+      prepared: staged.prepared,
+    })
+    if (committed) {
+      const result = await readBridgeResult(
+        db,
+        authority.bridgeAuthorityId,
+        context.requestId,
+        context.requester.verifiedEmail,
+        origin,
+        false,
+      )
+      if (result) return result
+    }
+    if (
+      await bridgeGrantLimitReached(
+        db,
+        target.id,
+        context.requester.verifiedEmail,
+      )
+    ) {
+      failure = { kind: 'artifact-viewer-limit-reached' }
+    }
+  } else {
+    let currentBinding = final.binding
+    for (let attempt = 0; attempt < PROJECT_NAME_ATTEMPTS; attempt += 1) {
+      const committed = await commitBridgePublish(db, {
+        authority,
+        context,
+        intent,
+        binding: currentBinding,
+        leaseGeneration,
+        prepared: staged.prepared,
+        shareableId,
+      })
+      if (committed.kind === 'ok') {
+        const result = await readBridgeResult(
+          db,
+          authority.bridgeAuthorityId,
+          context.requestId,
+          context.requester.verifiedEmail,
+          origin,
+          false,
+        )
+        if (result) return result
+      }
+      failure = committed.kind === 'ok' ? { kind: 'upload-failed' } : committed
+      if (committed.kind === 'project-name-conflict') continue
+      if (committed.kind !== 'conversation-identity-conflict') break
+      const resolved = await resolveConversation(
+        db,
+        authority.bridgeAuthorityId,
+        context.conversation.ids,
+      )
+      if (resolved.kind !== 'ok' || !resolved.mapping) break
+      currentBinding = {
+        ...currentBinding,
+        mapping: resolved.mapping,
+        mappingCreated: false,
+        projectCreated: false,
+      }
+    }
+  }
+  const replay = await readBridgeResult(
+    db,
+    authority.bridgeAuthorityId,
+    context.requestId,
+    context.requester.verifiedEmail,
+    origin,
+    true,
+  )
+  if (replay) return replay
+  await Promise.all([
+    deleteArtifactsByPrefix(env.BUCKET, staged.prefix).catch(() => undefined),
+    releaseQuota(
+      db,
+      authority.workspaceId,
+      staged.prepared.sizeBytes,
+      staged.prepared.now,
+    ),
+  ])
+  return failure
+}
+
+async function stageBridgeStaticSite(
+  db: Kysely<DB>,
+  workspaceId: string,
+  shareableId: string,
+  files: readonly File[],
+): Promise<
+  | {
+      kind: 'ok'
+      prefix: string
+      prepared: PreparedBridgeArtifact
+    }
+  | { kind: 'invalid-context' | 'payload-too-large' | 'upload-failed' }
+> {
+  if (files.length === 0 || files.length > STATIC_SITE_UPLOAD_LIMITS.files) {
+    return { kind: 'invalid-context' }
+  }
+  const versionId = nanoid(16)
+  const now = nowIso()
+  const prefix = staticSiteR2Prefix(workspaceId, shareableId, versionId)
+  const seen = new Set<string>()
+  const validated: Array<{
+    file: File
+    path: string
+    r2Key: string
+    mimeType: string
+    entrypointKind: 'html' | 'md' | null
+  }> = []
+  let total = 0
+  for (const file of files) {
+    if (file.size > STATIC_SITE_UPLOAD_LIMITS.fileBytes) {
+      return { kind: 'payload-too-large' }
+    }
+    total += file.size
+    if (total > STATIC_SITE_UPLOAD_LIMITS.totalBytes) {
+      return { kind: 'payload-too-large' }
+    }
+    const validation = validateBundlePath(file.name)
+    if (validation.kind === 'blocked') return { kind: 'invalid-context' }
+    const path = normalizeBundlePath(file.name)
+    const key = path.toLowerCase()
+    const depth = Math.max(path.split('/').filter(Boolean).length - 1, 0)
+    if (
+      path.length > STATIC_SITE_UPLOAD_LIMITS.pathChars ||
+      depth > STATIC_SITE_UPLOAD_LIMITS.folderDepth ||
+      seen.has(key)
+    ) {
+      return { kind: 'invalid-context' }
+    }
+    const mimeType = staticSiteMimeType(path)
+    if (!mimeType) return { kind: 'invalid-context' }
+    const r2Key = `${prefix}${path.slice(1)}`
+    validated.push({
+      file,
+      path,
+      r2Key,
+      mimeType,
+      entrypointKind: staticSiteEntrypointKind(path),
+    })
+    seen.add(key)
+  }
+  const stagedWithBodies = await Promise.all(
+    validated.map(async ({ file, path, r2Key, mimeType, entrypointKind }) => {
+      const body = await file.arrayBuffer()
+      return {
+        body,
+        entrypointKind,
+        row: {
+          id: nanoid(16),
+          version_id: versionId,
+          path,
+          r2_key: r2Key,
+          mime_type: mimeType,
+          size_bytes: file.size,
+          sha256: await computeFileSha256(body),
+          scan_flags: null,
+          created_at: now,
+        },
+      }
+    }),
+  )
+  const staged = stagedWithBodies.map(({ row }) => row)
+  const entrypointFile =
+    stagedWithBodies.find(
+      ({ row }) => row.path.toLowerCase() === '/index.html',
+    ) ?? stagedWithBodies.find(({ entrypointKind }) => entrypointKind !== null)
+  const entrypoint =
+    entrypointFile?.entrypointKind === null || entrypointFile === undefined
+      ? null
+      : {
+          path: entrypointFile.row.path,
+          r2Key: entrypointFile.row.r2_key,
+          body: entrypointFile.body,
+          kind: entrypointFile.entrypointKind,
+        }
+  if (!entrypoint) return { kind: 'invalid-context' }
+  const reserved = await reserveQuota(db, workspaceId, total, now)
+  if (reserved !== 'ok') return { kind: 'upload-failed' }
+  try {
+    await Promise.all(
+      stagedWithBodies.map(({ body, row }) =>
+        putArtifact(env.BUCKET, row.r2_key, body, {
+          contentType: row.mime_type,
+        }),
+      ),
+    )
+  } catch {
+    await Promise.all([
+      deleteArtifactsByPrefix(env.BUCKET, prefix).catch(() => undefined),
+      releaseQuota(db, workspaceId, total, now),
+    ])
+    return { kind: 'upload-failed' }
+  }
+  const bundleSha = await computeFileSha256(
+    new TextEncoder().encode(
+      staged
+        .map((row) => `${row.path}\0${row.size_bytes}\0${row.sha256}`)
+        .sort()
+        .join('\n'),
+    ).buffer,
+  )
+  return {
+    kind: 'ok',
+    prefix,
+    prepared: {
+      versionId,
+      now,
+      sha256: bundleSha,
+      sizeBytes: total,
+      artifactKind: 'static_site',
+      entrypointPath: entrypoint.path,
+      r2Key: entrypoint.r2Key,
+      derivedTitle: extractTitleFromBytes(entrypoint.body, entrypoint.kind, {
+        shareableId,
+        fileName: entrypoint.path,
+      }),
+      fallbackToIndex: entrypoint.kind === 'html' ? 1 : 0,
+      versionFiles: staged,
+    },
+  }
+}
+
+async function appendBridgeFile(
+  target: BridgeTarget,
+  addition: File,
+): Promise<File | null> {
+  const source = await fetchArtifactSourceBytes(target.currentR2Key)
+  if (source.kind !== 'ok') return null
+  let additionText: string
+  try {
+    additionText = new TextDecoder('utf-8', { fatal: true }).decode(
+      await addition.arrayBuffer(),
+    )
+  } catch {
+    return null
+  }
+  const sourceBytes = new Uint8Array(source.body)
+  let insertAt = sourceBytes.byteLength
+  if (target.artifactKind === 'html_page') {
+    const text = new TextDecoder().decode(sourceBytes)
+    const match = /<\/body\s*>/giu
+    let found: RegExpExecArray | null
+    while ((found = match.exec(text)) !== null) insertAt = found.index
+  }
+  return new File(
+    [source.body.slice(0, insertAt), additionText, source.body.slice(insertAt)],
+    target.name,
+    {
+      type:
+        target.artifactKind === 'markdown_page' ? 'text/markdown' : 'text/html',
+    },
+  )
+}
+
+async function commitBridgeVersion(
+  db: Kysely<DB>,
+  input: {
+    authority: BridgeAuthority
+    context: TrustedBridgeContext
+    intent: BridgeIntent
+    binding: BoundBridgeRequest
+    target: BridgeTarget
+    leaseGeneration: string
+    prepared: PreparedBridgeArtifact
+  },
+): Promise<boolean> {
+  const operationId = nanoid()
+  const versionInsert = guardedVersionInsert(db, input)
+  const scope = bridgeTargetScopeSql(input)
+  const visibility = bridgeTargetVisibilitySql(input)
+  const update = db
+    .updateTable('shareables')
+    .set({
+      artifact_kind: input.prepared.artifactKind,
+      derived_title: input.prepared.derivedTitle,
+      ...(input.intent.title ? { title_override: input.intent.title } : {}),
+      visibility,
+      link_expires_at: null,
+      current_version_id: input.prepared.versionId,
+      updated_at: input.prepared.now,
+    })
+    .where('id', '=', input.target.id)
+    .where('current_version_id', '=', input.target.currentVersionId)
+    .where(scope)
+  const queries: Compilable<unknown>[] = [versionInsert]
+  if (input.prepared.versionFiles?.length) {
+    queries.push(
+      db.insertInto('version_files').values(input.prepared.versionFiles),
+    )
+  }
+  queries.push(
+    update,
+    bridgeGrantQuery(db, {
+      artifactId: input.target.id,
+      email: input.context.requester.verifiedEmail,
+      grantedAt: input.prepared.now,
+      grantedBy: input.binding.authority.botUserId,
+    }),
+    db.insertInto('bridge_operations').values({
+      id: operationId,
+      bridge_authority_id: input.authority.bridgeAuthorityId,
+      request_id: input.context.requestId,
+      lease_generation: input.leaseGeneration,
+      operation: input.intent.operation,
+      requester_stable_id: input.context.requester.stableId,
+      requester_verified_email: input.context.requester.verifiedEmail,
+      requester_display_name: input.context.requester.displayName,
+      artifact_id: input.target.id,
+      version_id: input.prepared.versionId,
+      created_at: input.prepared.now,
+    }),
+    versionPublishedEventQuery(db, { versionId: input.prepared.versionId }),
+    db
+      .updateTable('bridge_requests')
+      .set({
+        status: 'completed',
+        result_artifact_id: input.target.id,
+        result_version_id: input.prepared.versionId,
+        updated_at: input.prepared.now,
+      })
+      .where('bridge_authority_id', '=', input.authority.bridgeAuthorityId)
+      .where('request_id', '=', input.context.requestId)
+      .where('status', '=', 'leased')
+      .where('lease_generation', '=', input.leaseGeneration),
+  )
+  try {
+    await runD1Batch(db, ...queries)
+  } catch (error) {
+    console.error('bridge_version_commit_failed', {
+      request_id: input.context.requestId,
+      artifact_id: input.target.id,
+      error,
+    })
+    return false
+  }
+  const committed = await db
+    .selectFrom('versions')
+    .select('id')
+    .where('id', '=', input.prepared.versionId)
+    .executeTakeFirst()
+  return Boolean(committed)
+}
+
+function guardedVersionInsert(
+  db: Kysely<DB>,
+  input: {
+    authority: BridgeAuthority
+    context: TrustedBridgeContext
+    binding: BoundBridgeRequest
+    target: BridgeTarget
+    leaseGeneration: string
+    prepared: PreparedBridgeArtifact
+  },
+) {
+  return db
+    .insertInto('versions')
+    .columns([
+      'id',
+      'shareable_id',
+      'artifact_kind',
+      'status',
+      'entrypoint_path',
+      'r2_key',
+      'size_bytes',
+      'sha256',
+      'fallback_to_index',
+      'created_by_id',
+      'created_at',
+      'published_at',
+    ])
+    .expression((eb) =>
+      eb
+        .selectFrom('shareables as artifact')
+        .innerJoin('bridge_requests as request', (join) =>
+          join
+            .on(
+              'request.bridge_authority_id',
+              '=',
+              input.authority.bridgeAuthorityId,
+            )
+            .on('request.request_id', '=', input.context.requestId),
+        )
+        .select([
+          eb.val(input.prepared.versionId).as('id'),
+          eb.val(input.target.id).as('shareable_id'),
+          eb.val(input.prepared.artifactKind).as('artifact_kind'),
+          eb.val('published').as('status'),
+          eb.val(input.prepared.entrypointPath).as('entrypoint_path'),
+          eb.val(input.prepared.r2Key).as('r2_key'),
+          eb.val(input.prepared.sizeBytes).as('size_bytes'),
+          eb.val(input.prepared.sha256).as('sha256'),
+          eb.val(input.prepared.fallbackToIndex ?? 0).as('fallback_to_index'),
+          eb.val(input.binding.authority.botUserId).as('created_by_id'),
+          eb.val(input.prepared.now).as('created_at'),
+          eb.val(input.prepared.now).as('published_at'),
+        ])
+        .where('artifact.id', '=', input.target.id)
+        .where(
+          'artifact.current_version_id',
+          '=',
+          input.target.currentVersionId,
+        )
+        .where('request.status', '=', 'leased')
+        .where('request.lease_generation', '=', input.leaseGeneration)
+        .where(bridgeTargetScopeSql(input, 'artifact')),
+    )
+}
+
+function bridgeTargetScopeSql(
+  input: {
+    authority: BridgeAuthority
+    context: TrustedBridgeContext
+    binding: BoundBridgeRequest
+    target: BridgeTarget
+  },
+  artifactAlias = 'shareables',
+) {
+  const artifact = sql.ref(artifactAlias)
+  if (input.binding.routingClass === 'dm') {
+    return sql<boolean>`EXISTS (
+      SELECT 1
+      FROM bridge_authorities bridge
+      JOIN users bot ON bot.id = bridge.bot_user_id
+      JOIN artifact_containers fallback ON fallback.id = bridge.fallback_project_id
+      JOIN bridge_dm_artifacts dm ON dm.bridge_authority_id = bridge.id
+      WHERE bridge.id = ${input.authority.bridgeAuthorityId}
+        AND bot.bot_stopped_at IS NULL
+        AND fallback.id = ${input.binding.authority.fallbackProjectId}
+        AND fallback.workspace_id = ${input.authority.workspaceId}
+        AND fallback.kind = 'project'
+        AND fallback.archived_at IS NULL
+        AND dm.artifact_id = ${artifact}.id
+        AND dm.requester_stable_id = ${input.context.requester.stableId}
+        AND ${artifact}.container_id = fallback.id
+        AND ${artifact}.created_by_agent_profile_id = ${input.authority.agentProfileId}
+    )`
+  }
+  return sql<boolean>`EXISTS (
+    SELECT 1
+    FROM bridge_conversations mapping
+    JOIN artifact_containers project ON project.id = mapping.project_id
+    WHERE mapping.id = ${input.binding.mapping?.id ?? ''}
+      AND mapping.bridge_authority_id = ${input.authority.bridgeAuthorityId}
+      AND project.workspace_id = ${input.authority.workspaceId}
+      AND project.kind = 'project'
+      AND project.archived_at IS NULL
+      AND ${artifact}.container_id = project.id
+      AND ${artifact}.created_by_agent_profile_id = ${input.authority.agentProfileId}
+      AND EXISTS (
+        SELECT 1 FROM bridge_operations provenance
+        WHERE provenance.artifact_id = ${artifact}.id
+          AND provenance.bridge_authority_id = ${input.authority.bridgeAuthorityId}
+      )
+  )`
+}
+
+function bridgeTargetVisibilitySql(input: {
+  authority: BridgeAuthority
+  intent: BridgeIntent
+  binding: BoundBridgeRequest
+}) {
+  if (input.binding.routingClass === 'dm') {
+    return sql<'private' | 'workspace'>`CASE
+      WHEN ${input.intent.requestedAudience} = 'workspace'
+        AND shareables.visibility = 'workspace'
+        AND EXISTS (
+          SELECT 1 FROM artifact_containers fallback
+          WHERE fallback.id = ${input.binding.authority.fallbackProjectId}
+            AND fallback.workspace_id = ${input.authority.workspaceId}
+            AND fallback.kind = 'project'
+            AND fallback.archived_at IS NULL
+            AND fallback.base_visibility = 'workspace'
+        )
+      THEN 'workspace'
+      ELSE 'private'
+    END`
+  }
+  return sql<'private' | 'project'>`CASE
+    WHEN ${input.intent.requestedAudience} = 'private'
+      OR EXISTS (
+        SELECT 1
+        FROM bridge_conversations mapping
+        JOIN artifact_containers project ON project.id = mapping.project_id
+        WHERE mapping.id = ${input.binding.mapping?.id ?? ''}
+          AND (
+            mapping.privacy_ceiling = 'private'
+            OR project.base_visibility = 'private'
+          )
+      )
+    THEN 'private'
+    ELSE 'project'
+  END`
+}
+
+async function setBridgeVisibility(
+  db: Kysely<DB>,
+  authority: BridgeAuthority,
+  context: TrustedBridgeContext,
+  intent: BridgeIntent,
+  binding: BoundBridgeRequest,
+  leaseGeneration: string,
+  origin: string,
+): Promise<ExecuteBridgeRequestResult> {
+  if (!intent.targetArtifactId) return { kind: 'forbidden-target' }
+  const target = await resolveBridgeTarget(
+    db,
+    authority,
+    context,
+    binding,
+    intent.targetArtifactId,
+  )
+  if (!target) return { kind: 'forbidden-target' }
+  const final = await resolveFinalDestination(db, authority, context, binding)
+  if (final.kind !== 'ok') return final
+  if (
+    context.conversation.kind === 'public_channel' &&
+    !publicContextFresh(context, new Date())
+  ) {
+    return { kind: 'stale-context' }
+  }
+  const operationId = nanoid()
+  const now = nowIso()
+  const scope = bridgeTargetScopeSql(
+    { authority, context, binding: final.binding, target },
+    'shareables',
+  )
+  const visibility =
+    final.binding.routingClass === 'dm' &&
+    intent.requestedAudience === 'workspace'
+      ? sql<'private' | 'workspace'>`CASE WHEN EXISTS (
+          SELECT 1 FROM artifact_containers fallback
+          WHERE fallback.id = ${final.binding.authority.fallbackProjectId}
+            AND fallback.workspace_id = ${authority.workspaceId}
+            AND fallback.kind = 'project'
+            AND fallback.archived_at IS NULL
+            AND fallback.base_visibility = 'workspace'
+        ) THEN 'workspace' ELSE 'private' END`
+      : bridgeTargetVisibilitySql({ authority, intent, binding: final.binding })
+  const operationInsert = db
+    .insertInto('bridge_operations')
+    .columns([
+      'id',
+      'bridge_authority_id',
+      'request_id',
+      'lease_generation',
+      'operation',
+      'requester_stable_id',
+      'requester_verified_email',
+      'requester_display_name',
+      'artifact_id',
+      'version_id',
+      'created_at',
+    ])
+    .expression((eb) =>
+      eb
+        .selectFrom('shareables as artifact')
+        .innerJoin('bridge_requests as request', (join) =>
+          join
+            .on('request.bridge_authority_id', '=', authority.bridgeAuthorityId)
+            .on('request.request_id', '=', context.requestId),
+        )
+        .select([
+          eb.val(operationId).as('id'),
+          eb.val(authority.bridgeAuthorityId).as('bridge_authority_id'),
+          eb.val(context.requestId).as('request_id'),
+          eb.val(leaseGeneration).as('lease_generation'),
+          eb.val('set_visibility' as const).as('operation'),
+          eb.val(context.requester.stableId).as('requester_stable_id'),
+          eb
+            .val(context.requester.verifiedEmail)
+            .as('requester_verified_email'),
+          eb.val(context.requester.displayName).as('requester_display_name'),
+          eb.val(target.id).as('artifact_id'),
+          eb.val(null).as('version_id'),
+          eb.val(now).as('created_at'),
+        ])
+        .where('artifact.id', '=', target.id)
+        .where('request.status', '=', 'leased')
+        .where('request.lease_generation', '=', leaseGeneration)
+        .where(
+          bridgeTargetScopeSql(
+            { authority, context, binding: final.binding, target },
+            'artifact',
+          ),
+        ),
+    )
+  try {
+    await runD1Batch(
+      db,
+      db
+        .updateTable('shareables')
+        .set({ visibility, link_expires_at: null, updated_at: now })
+        .where('id', '=', target.id)
+        .where(scope),
+      bridgeGrantQuery(db, {
+        artifactId: target.id,
+        email: context.requester.verifiedEmail,
+        grantedAt: now,
+        grantedBy: final.binding.authority.botUserId,
+      }),
+      operationInsert,
+      db
+        .updateTable('bridge_requests')
+        .set({
+          status: 'completed',
+          result_artifact_id: target.id,
+          result_version_id: null,
+          updated_at: now,
+        })
+        .where('bridge_authority_id', '=', authority.bridgeAuthorityId)
+        .where('request_id', '=', context.requestId)
+        .where('status', '=', 'leased')
+        .where('lease_generation', '=', leaseGeneration)
+        .where(
+          sql<boolean>`EXISTS (
+            SELECT 1 FROM bridge_operations
+            WHERE id = ${operationId}
+          )`,
+        ),
+    )
+  } catch (error) {
+    console.error('bridge_visibility_commit_failed', {
+      request_id: context.requestId,
+      artifact_id: target.id,
+      error,
+    })
+    return (await bridgeGrantLimitReached(
+      db,
+      target.id,
+      context.requester.verifiedEmail,
+    ))
+      ? { kind: 'artifact-viewer-limit-reached' }
+      : { kind: 'upload-failed' }
+  }
+  const result = await readBridgeResult(
+    db,
+    authority.bridgeAuthorityId,
+    context.requestId,
+    context.requester.verifiedEmail,
+    origin,
+    false,
+  )
+  return result ?? { kind: 'upload-failed' }
+}
+
+async function publishBridgeFile(
+  db: Kysely<DB>,
+  authority: BridgeAuthority,
+  user: BridgeUser,
+  context: TrustedBridgeContext,
+  intent: BridgeIntent,
+  initialBinding: BoundBridgeRequest,
+  leaseGeneration: string,
+  file: File,
+  origin: string,
+): Promise<ExecuteBridgeRequestResult> {
+  let shareableId = ''
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const candidate = createShareableId()
+    const exists = await db
+      .selectFrom('shareables')
+      .select('id')
+      .where('id', '=', candidate)
+      .executeTakeFirst()
+    if (!exists) {
+      shareableId = candidate
+      break
+    }
+  }
+  if (!shareableId) return { kind: 'upload-failed' }
+  const prepared = await prepareUpload(
+    db,
+    authority.workspaceId,
+    shareableId,
+    file,
+  )
+  if (prepared.kind !== 'ok') {
+    return prepared.kind === 'too-large'
+      ? { kind: 'payload-too-large' }
+      : { kind: 'invalid-context' }
+  }
+  const reserved = await reserveQuota(
+    db,
+    authority.workspaceId,
+    prepared.sizeBytes,
+    prepared.now,
+  )
+  if (reserved !== 'ok') return { kind: 'upload-failed' }
+  try {
+    await putArtifact(env.BUCKET, prepared.r2Key, prepared.body, {
+      contentType: prepared.contentType,
+    })
+  } catch {
+    await releaseQuota(
+      db,
+      authority.workspaceId,
+      prepared.sizeBytes,
+      prepared.now,
+    )
+    return { kind: 'upload-failed' }
+  }
+
+  let binding = initialBinding
+  let lastFailure: ExecuteBridgeRequestResult = { kind: 'upload-failed' }
+  for (let attempt = 0; attempt < PROJECT_NAME_ATTEMPTS; attempt += 1) {
+    const final = await resolveFinalDestination(db, authority, context, binding)
+    if (final.kind !== 'ok') {
+      lastFailure = final
+      break
+    }
+    binding = final.binding
+    if (
+      context.conversation.kind === 'public_channel' &&
+      !publicContextFresh(context, new Date())
+    ) {
+      lastFailure = { kind: 'stale-context' }
+      break
+    }
+    const committed = await commitBridgePublish(db, {
+      authority,
+      context,
+      intent,
+      binding,
+      leaseGeneration,
+      prepared,
+      shareableId,
+    })
+    if (committed.kind === 'ok') {
+      const result = await readBridgeResult(
+        db,
+        authority.bridgeAuthorityId,
+        context.requestId,
+        context.requester.verifiedEmail,
+        origin,
+        false,
+      )
+      if (result) return result
+      lastFailure = { kind: 'upload-failed' }
+      break
+    }
+    lastFailure = committed
+    if (committed.kind === 'project-name-conflict') continue
+    if (committed.kind !== 'conversation-identity-conflict') break
+    const rebound = await resolveConversation(
+      db,
+      authority.bridgeAuthorityId,
+      context.conversation.ids,
+    )
+    if (rebound.kind !== 'ok' || rebound.mapping === null) break
+    binding = {
+      ...binding,
+      mapping: rebound.mapping,
+      mappingCreated: false,
+      projectCreated: false,
+    }
+  }
+
+  const replay = await readBridgeResult(
+    db,
+    authority.bridgeAuthorityId,
+    context.requestId,
+    context.requester.verifiedEmail,
+    origin,
+    true,
+  )
+  if (replay) return replay
+  await Promise.all([
+    deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
+    releaseQuota(db, authority.workspaceId, prepared.sizeBytes, prepared.now),
+  ])
+  return lastFailure
+}
+
+async function resolveFinalDestination(
+  db: Kysely<DB>,
+  authority: BridgeAuthority,
+  context: TrustedBridgeContext,
+  binding: BoundBridgeRequest,
+): Promise<
+  | { kind: 'ok'; binding: BoundBridgeRequest }
+  | {
+      kind:
+        | 'unsupported-authority'
+        | 'fallback-invalid'
+        | 'mapping-archived'
+        | 'conversation-identity-conflict'
+    }
+> {
+  const live = await readLiveBridgeAuthority(db, authority.bridgeAuthorityId)
+  if (live.kind !== 'ok') return { kind: live.kind }
+  if (binding.routingClass === 'dm') {
+    return { kind: 'ok', binding: { ...binding, authority: live } }
+  }
+  const resolved = await resolveConversation(
+    db,
+    authority.bridgeAuthorityId,
+    context.conversation.ids,
+  )
+  if (resolved.kind !== 'ok') return resolved
+  if (resolved.mapping?.archived) return { kind: 'mapping-archived' }
+  return {
+    kind: 'ok',
+    binding: { ...binding, authority: live, mapping: resolved.mapping },
+  }
+}
+
+async function commitBridgePublish(
+  db: Kysely<DB>,
+  input: {
+    authority: BridgeAuthority
+    context: TrustedBridgeContext
+    intent: BridgeIntent
+    binding: BoundBridgeRequest
+    leaseGeneration: string
+    prepared: PreparedBridgeArtifact
+    shareableId: string
+  },
+): Promise<
+  | { kind: 'ok' }
+  | {
+      kind:
+        | 'conversation-identity-conflict'
+        | 'project-limit-reached'
+        | 'project-name-conflict'
+        | 'upload-failed'
+    }
+> {
+  const { authority, context, intent, prepared } = input
+  const createMapping =
+    input.binding.routingClass === 'channel' && input.binding.mapping === null
+  const mappingId = createMapping
+    ? nanoid()
+    : (input.binding.mapping?.id ?? null)
+  const projectId = createMapping
+    ? nanoid()
+    : (input.binding.mapping?.projectId ??
+      input.binding.authority.fallbackProjectId)
+  const projectName = createMapping
+    ? conversationProjectName(context.conversation.name, projectId)
+    : (input.binding.mapping?.projectName ??
+      input.binding.authority.fallbackName)
+  const operationId = nanoid()
+  const queries: Compilable<unknown>[] = []
+  if (createMapping) {
+    const workspace = await db
+      .selectFrom('workspaces')
+      .select('plan')
+      .where('id', '=', authority.workspaceId)
+      .executeTakeFirst()
+    if (!workspace) return { kind: 'upload-failed' }
+    const limit = projectLimitForPlan(workspace.plan)
+    queries.push(
+      guardedProjectInsert(
+        db,
+        authority,
+        context,
+        projectId,
+        projectName,
+        prepared.now,
+        limit,
+      ),
+      db.insertInto('bridge_conversations').values({
+        id: mappingId!,
+        bridge_authority_id: authority.bridgeAuthorityId,
+        project_id: projectId,
+        conversation_kind: 'public_channel',
+        conversation_name: context.conversation.name,
+        privacy_ceiling: 'workspace',
+        privacy_epoch: 0,
+        created_at: prepared.now,
+        updated_at: prepared.now,
+      }),
+      db.insertInto('bridge_conversation_ids').values(
+        context.conversation.ids.map((id) => ({
+          mapping_id: mappingId!,
+          bridge_authority_id: authority.bridgeAuthorityId,
+          external_conversation_id: id,
+          created_at: prepared.now,
+        })),
+      ),
+    )
+  }
+  queries.push(
+    guardedShareableInsert(db, {
+      authority,
+      context,
+      intent,
+      binding: input.binding,
+      mappingId,
+      projectId,
+      shareableId: input.shareableId,
+      prepared,
+      leaseGeneration: input.leaseGeneration,
+    }),
+    db.insertInto('versions').values({
+      id: prepared.versionId,
+      shareable_id: input.shareableId,
+      artifact_kind: prepared.artifactKind,
+      status: 'published',
+      entrypoint_path: prepared.entrypointPath,
+      r2_key: prepared.r2Key,
+      size_bytes: prepared.sizeBytes,
+      sha256: prepared.sha256,
+      fallback_to_index: prepared.fallbackToIndex ?? 0,
+      created_by_id: input.binding.authority.botUserId,
+      created_at: prepared.now,
+      published_at: prepared.now,
+    }),
+    bridgeGrantQuery(db, {
+      artifactId: input.shareableId,
+      email: context.requester.verifiedEmail,
+      grantedAt: prepared.now,
+      grantedBy: input.binding.authority.botUserId,
+    }),
+    db.insertInto('bridge_operations').values({
+      id: operationId,
+      bridge_authority_id: authority.bridgeAuthorityId,
+      request_id: context.requestId,
+      lease_generation: input.leaseGeneration,
+      operation: 'publish',
+      requester_stable_id: context.requester.stableId,
+      requester_verified_email: context.requester.verifiedEmail,
+      requester_display_name: context.requester.displayName,
+      artifact_id: input.shareableId,
+      version_id: prepared.versionId,
+      created_at: prepared.now,
+    }),
+  )
+  if (prepared.versionFiles?.length) {
+    queries.push(db.insertInto('version_files').values(prepared.versionFiles))
+  }
+  if (input.binding.routingClass === 'dm') {
+    queries.push(
+      db.insertInto('bridge_dm_artifacts').values({
+        artifact_id: input.shareableId,
+        bridge_authority_id: authority.bridgeAuthorityId,
+        requester_stable_id: context.requester.stableId,
+        created_at: prepared.now,
+      }),
+    )
+  }
+  queries.push(
+    artifactCreatedEventQuery(db, { versionId: prepared.versionId }),
+    db
+      .updateTable('bridge_requests')
+      .set({
+        status: 'completed',
+        mapping_id: mappingId,
+        result_artifact_id: input.shareableId,
+        result_version_id: prepared.versionId,
+        mapping_created: createMapping || input.binding.mappingCreated ? 1 : 0,
+        project_created: createMapping || input.binding.projectCreated ? 1 : 0,
+        updated_at: prepared.now,
+      })
+      .where('bridge_authority_id', '=', authority.bridgeAuthorityId)
+      .where('request_id', '=', context.requestId)
+      .where('status', '=', 'leased')
+      .where('lease_generation', '=', input.leaseGeneration),
+  )
+  try {
+    await runD1Batch(db, ...queries)
+    return { kind: 'ok' }
+  } catch (error) {
+    console.error('bridge_publish_commit_failed', {
+      authority_id: authority.bridgeAuthorityId,
+      request_id: context.requestId,
+      shareable_id: input.shareableId,
+      error,
+    })
+    await cleanupFailedShareable(db, input.shareableId)
+    if (createMapping) {
+      await cleanupFailedMapping(db, mappingId!, projectId)
+      const concurrent = await resolveConversation(
+        db,
+        authority.bridgeAuthorityId,
+        context.conversation.ids,
+      )
+      if (concurrent.kind === 'ok' && concurrent.mapping !== null) {
+        return { kind: 'conversation-identity-conflict' }
+      }
+      const workspace = await db
+        .selectFrom('workspaces')
+        .select('plan')
+        .where('id', '=', authority.workspaceId)
+        .executeTakeFirst()
+      if (
+        workspace &&
+        (await activeProjectCountAtLimit(
+          db,
+          authority.workspaceId,
+          projectLimitForPlan(workspace.plan),
+        ))
+      ) {
+        return { kind: 'project-limit-reached' }
+      }
+      const nameTaken = await db
+        .selectFrom('artifact_containers')
+        .select('id')
+        .where('workspace_id', '=', authority.workspaceId)
+        .where(sql<boolean>`name = ${projectName} COLLATE NOCASE`)
+        .where('archived_at', 'is', null)
+        .executeTakeFirst()
+      if (nameTaken) return { kind: 'project-name-conflict' }
+    }
+    return { kind: 'upload-failed' }
+  }
+}
+
+function guardedProjectInsert(
+  db: Kysely<DB>,
+  authority: BridgeAuthority,
+  context: TrustedBridgeContext,
+  projectId: string,
+  projectName: string,
+  now: string,
+  limit: number | null,
+) {
+  let query = db
+    .selectFrom('bridge_requests as request')
+    .innerJoin(
+      'bridge_authorities as bridge',
+      'bridge.id',
+      'request.bridge_authority_id',
+    )
+    .innerJoin('users as bot', 'bot.id', 'bridge.bot_user_id')
+    .innerJoin(
+      'artifact_containers as fallback',
+      'fallback.id',
+      'bridge.fallback_project_id',
+    )
+    .select((eb) => [
+      eb.val(projectId).as('id'),
+      eb.val(authority.workspaceId).as('workspace_id'),
+      eb.val('project' as const).as('kind'),
+      eb.val(null).as('owner_user_id'),
+      eb.ref('bridge.bot_user_id').as('created_by_id'),
+      eb.val(projectName).as('name'),
+      eb.val(null).as('description'),
+      eb.val(null).as('archived_at'),
+      eb.val(now).as('created_at'),
+      eb.val(now).as('updated_at'),
+      eb.val('workspace' as const).as('base_visibility'),
+    ])
+    .where('request.bridge_authority_id', '=', authority.bridgeAuthorityId)
+    .where('request.request_id', '=', context.requestId)
+    .where('request.status', '=', 'leased')
+    .where('bridge.workspace_id', '=', authority.workspaceId)
+    .where('bridge.agent_profile_id', '=', authority.agentProfileId)
+    .where('bridge.source_kind', '=', authority.sourceKind)
+    .where('bridge.source_installation_id', '=', authority.sourceInstallationId)
+    .where('bridge.external_workspace_id', '=', authority.externalWorkspaceId)
+    .where('bot.bot_stopped_at', 'is', null)
+    .where('fallback.workspace_id', '=', authority.workspaceId)
+    .where('fallback.kind', '=', 'project')
+    .where('fallback.archived_at', 'is', null)
+  if (limit !== null) {
+    query = query.where(
+      sql<boolean>`(
+        SELECT COUNT(*) FROM artifact_containers
+        WHERE workspace_id = ${authority.workspaceId}
+          AND kind = 'project'
+          AND archived_at IS NULL
+      ) < ${limit}`,
+    )
+  }
+  return db
+    .insertInto('artifact_containers')
+    .columns([
+      'id',
+      'workspace_id',
+      'kind',
+      'owner_user_id',
+      'created_by_id',
+      'name',
+      'description',
+      'archived_at',
+      'created_at',
+      'updated_at',
+      'base_visibility',
+    ])
+    .expression(query)
+}
+
+function guardedShareableInsert(
+  db: Kysely<DB>,
+  input: {
+    authority: BridgeAuthority
+    context: TrustedBridgeContext
+    intent: BridgeIntent
+    binding: BoundBridgeRequest
+    mappingId: string | null
+    projectId: string
+    shareableId: string
+    prepared: PreparedBridgeArtifact
+    leaseGeneration: string
+  },
+) {
+  const common = [
+    sql<string>`${input.shareableId}`.as('id'),
+    sql<string>`${input.authority.workspaceId}`.as('workspace_id'),
+    sql<string>`${input.binding.authority.botUserId}`.as('owner_user_id'),
+    sql<null>`NULL`.as('slug'),
+    sql<string>`${input.prepared.entrypointPath.slice(1)}`.as('name'),
+    sql<string | null>`${input.prepared.derivedTitle}`.as('derived_title'),
+    sql<string | null>`${input.intent.title}`.as('title_override'),
+    sql<null>`NULL`.as('description'),
+    sql<string>`${input.prepared.artifactKind}`.as('artifact_kind'),
+  ]
+  const tail = [
+    sql<null>`NULL`.as('link_expires_at'),
+    sql<string>`${input.prepared.versionId}`.as('current_version_id'),
+    sql<string>`${input.prepared.now}`.as('created_at'),
+    sql<string>`${input.prepared.now}`.as('updated_at'),
+    sql<string>`${input.projectId}`.as('container_id'),
+    sql<null>`NULL`.as('last_accessed_at'),
+    sql<string>`${input.authority.agentProfileId}`.as(
+      'created_by_agent_profile_id',
+    ),
+  ]
+  const columns = [
+    'id',
+    'workspace_id',
+    'owner_user_id',
+    'slug',
+    'name',
+    'derived_title',
+    'title_override',
+    'description',
+    'artifact_kind',
+    'visibility',
+    'link_expires_at',
+    'current_version_id',
+    'created_at',
+    'updated_at',
+    'container_id',
+    'last_accessed_at',
+    'created_by_agent_profile_id',
+  ] as const
+
+  if (input.binding.routingClass === 'dm') {
+    return db
+      .insertInto('shareables')
+      .columns(columns)
+      .expression((eb) =>
+        eb
+          .selectFrom('bridge_requests as request')
+          .innerJoin(
+            'bridge_authorities as bridge',
+            'bridge.id',
+            'request.bridge_authority_id',
+          )
+          .innerJoin('users as bot', 'bot.id', 'bridge.bot_user_id')
+          .innerJoin(
+            'artifact_containers as fallback',
+            'fallback.id',
+            'bridge.fallback_project_id',
+          )
+          .select([
+            ...common,
+            eb.val('private' as const).as('visibility'),
+            ...tail,
+          ])
+          .where(
+            'request.bridge_authority_id',
+            '=',
+            input.authority.bridgeAuthorityId,
+          )
+          .where('request.request_id', '=', input.context.requestId)
+          .where('request.status', '=', 'leased')
+          .where('request.lease_generation', '=', input.leaseGeneration)
+          .where('bridge.fallback_project_id', '=', input.projectId)
+          .where('bridge.workspace_id', '=', input.authority.workspaceId)
+          .where('bot.bot_stopped_at', 'is', null)
+          .where('fallback.workspace_id', '=', input.authority.workspaceId)
+          .where('fallback.kind', '=', 'project')
+          .where('fallback.archived_at', 'is', null),
+      )
+  }
+  return db
+    .insertInto('shareables')
+    .columns(columns)
+    .expression((eb) =>
+      eb
+        .selectFrom('bridge_requests as request')
+        .innerJoin(
+          'bridge_authorities as bridge',
+          'bridge.id',
+          'request.bridge_authority_id',
+        )
+        .innerJoin('users as bot', 'bot.id', 'bridge.bot_user_id')
+        .innerJoin('bridge_conversations as mapping', (join) =>
+          join
+            .on('mapping.id', '=', input.mappingId!)
+            .onRef(
+              'mapping.bridge_authority_id',
+              '=',
+              'request.bridge_authority_id',
+            ),
+        )
+        .innerJoin(
+          'artifact_containers as project',
+          'project.id',
+          'mapping.project_id',
+        )
+        .select([
+          ...common,
+          sql<'private' | 'project'>`CASE
+            WHEN ${input.intent.requestedAudience} = 'private'
+              OR mapping.privacy_ceiling = 'private'
+              OR project.base_visibility = 'private'
+            THEN 'private'
+            ELSE 'project'
+          END`.as('visibility'),
+          ...tail,
+        ])
+        .where(
+          'request.bridge_authority_id',
+          '=',
+          input.authority.bridgeAuthorityId,
+        )
+        .where('request.request_id', '=', input.context.requestId)
+        .where('request.status', '=', 'leased')
+        .where('request.lease_generation', '=', input.leaseGeneration)
+        .where('mapping.id', '=', input.mappingId!)
+        .where('mapping.project_id', '=', input.projectId)
+        .where('bridge.workspace_id', '=', input.authority.workspaceId)
+        .where('bot.bot_stopped_at', 'is', null)
+        .where('project.workspace_id', '=', input.authority.workspaceId)
+        .where('project.kind', '=', 'project')
+        .where('project.archived_at', 'is', null),
+    )
+}
+
+function publicContextFresh(context: TrustedBridgeContext, now: Date) {
+  const value = context.conversation.privacyCheckedAt
+  if (!value) return false
+  const checkedAt = Date.parse(value)
+  const age = now.getTime() - checkedAt
+  return Number.isFinite(checkedAt) && age <= 60_000 && age >= -5_000
+}
+
+async function cleanupFailedShareable(db: Kysely<DB>, shareableId: string) {
+  try {
+    await db.deleteFrom('shareables').where('id', '=', shareableId).execute()
+  } catch {
+    // Production D1 batches are atomic; this is test-adapter compensation.
+  }
+}
+
+async function cleanupFailedMapping(
+  db: Kysely<DB>,
+  mappingId: string,
+  projectId: string,
+) {
+  try {
+    await db
+      .deleteFrom('bridge_conversation_ids')
+      .where('mapping_id', '=', mappingId)
+      .execute()
+    await db
+      .deleteFrom('bridge_conversations')
+      .where('id', '=', mappingId)
+      .execute()
+  } catch {
+    // A surviving reference means the failed path converged elsewhere.
+  }
+  await deleteEmptyProject(db, projectId)
+}
+
+async function fileSha256Hex(file: File): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', await file.arrayBuffer())
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+async function acquireRequestLease(
+  db: Kysely<DB>,
+  authorityId: string,
+  requestId: string,
+  digest: string,
+  now: Date,
+): Promise<
+  | { kind: 'acquired'; generation: string }
+  | { kind: 'completed' }
+  | { kind: 'idempotency-in-progress' }
+  | { kind: 'idempotency-mismatch' }
+> {
+  const current = await db
+    .selectFrom('bridge_requests')
+    .select(['stable_digest', 'status', 'lease_expires_at'])
+    .where('bridge_authority_id', '=', authorityId)
+    .where('request_id', '=', requestId)
+    .executeTakeFirst()
+  if (!current) return { kind: 'idempotency-mismatch' }
+  if (current.stable_digest !== null && current.stable_digest !== digest) {
+    return { kind: 'idempotency-mismatch' }
+  }
+  if (current.status === 'completed') return { kind: 'completed' }
+  if (
+    current.status === 'leased' &&
+    current.lease_expires_at !== null &&
+    current.lease_expires_at > now.toISOString()
+  ) {
+    return { kind: 'idempotency-in-progress' }
+  }
+  const generation = nanoid()
+  const expiresAt = new Date(now.getTime() + REQUEST_LEASE_MS).toISOString()
+  const updated = await db
+    .updateTable('bridge_requests')
+    .set({
+      stable_digest: digest,
+      status: 'leased',
+      lease_generation: generation,
+      lease_expires_at: expiresAt,
+      updated_at: now.toISOString(),
+    })
+    .where('bridge_authority_id', '=', authorityId)
+    .where('request_id', '=', requestId)
+    .where((eb) =>
+      eb.or([
+        eb('status', '=', 'binding'),
+        eb.and([
+          eb('status', '=', 'leased'),
+          eb('lease_expires_at', '<=', now.toISOString()),
+        ]),
+      ]),
+    )
+    .executeTakeFirst()
+  if (Number(updated.numUpdatedRows ?? 0n) === 1) {
+    return { kind: 'acquired', generation }
+  }
+  const raced = await db
+    .selectFrom('bridge_requests')
+    .select(['stable_digest', 'status'])
+    .where('bridge_authority_id', '=', authorityId)
+    .where('request_id', '=', requestId)
+    .executeTakeFirst()
+  if (raced?.stable_digest !== digest) return { kind: 'idempotency-mismatch' }
+  return raced?.status === 'completed'
+    ? { kind: 'completed' }
+    : { kind: 'idempotency-in-progress' }
+}
+
+async function releaseRequestLease(
+  db: Kysely<DB>,
+  authorityId: string,
+  requestId: string,
+  generation: string,
+) {
+  await db
+    .updateTable('bridge_requests')
+    .set({
+      stable_digest: null,
+      status: 'binding',
+      lease_generation: null,
+      lease_expires_at: null,
+      updated_at: nowIso(),
+    })
+    .where('bridge_authority_id', '=', authorityId)
+    .where('request_id', '=', requestId)
+    .where('status', '=', 'leased')
+    .where('lease_generation', '=', generation)
+    .execute()
+}
+
+async function readBridgeResult(
+  db: Kysely<DB>,
+  authorityId: string,
+  requestId: string,
+  requesterEmail: string,
+  origin: string,
+  replayed: boolean,
+): Promise<{ kind: 'ok'; result: BridgeRequestSuccess } | null> {
+  const row = await db
+    .selectFrom('bridge_requests as request')
+    .innerJoin(
+      'shareables as artifact',
+      'artifact.id',
+      'request.result_artifact_id',
+    )
+    .innerJoin(
+      'artifact_containers as project',
+      'project.id',
+      'artifact.container_id',
+    )
+    .select([
+      'request.result_version_id',
+      'request.mapping_created',
+      'request.project_created',
+      'artifact.id as artifact_id',
+      'artifact.name as artifact_name',
+      'artifact.derived_title',
+      'artifact.title_override',
+      'artifact.visibility',
+      'project.id as project_id',
+      'project.name as project_name',
+      'project.base_visibility',
+    ])
+    .where('request.bridge_authority_id', '=', authorityId)
+    .where('request.request_id', '=', requestId)
+    .where('request.status', '=', 'completed')
+    .executeTakeFirst()
+  if (!row) return null
+  const visibility =
+    row.visibility === 'private' || row.base_visibility === 'private'
+      ? ('private' as const)
+      : ('workspace' as const)
+  if (visibility === 'private') {
+    const granted = await ensureReplayGrant(
+      db,
+      row.artifact_id,
+      requesterEmail,
+      authorityId,
+    )
+    if (!granted) return null
+  }
+  const cleanOrigin = origin.replace(/\/$/, '')
+  return {
+    kind: 'ok',
+    result: {
+      artifact: {
+        id: row.artifact_id,
+        url: `${cleanOrigin}/a/${row.artifact_id}`,
+        title: row.title_override ?? row.derived_title ?? row.artifact_name,
+      },
+      project: { id: row.project_id, name: row.project_name },
+      visibility,
+      versionId: row.result_version_id,
+      replayed,
+      mappingCreated: row.mapping_created === 1,
+      projectCreated: row.project_created === 1,
+    },
+  }
+}
+
+function bridgeGrantQuery(
+  db: Kysely<DB>,
+  input: {
+    artifactId: string
+    email: string
+    grantedAt: string
+    grantedBy: string
+  },
+) {
+  return db
+    .insertInto('shareable_grants')
+    .columns(['shareable_id', 'granted_email', 'granted_at', 'granted_by'])
+    .expression((eb) =>
+      eb
+        .selectFrom('shareables')
+        .select([
+          eb.val(input.artifactId).as('shareable_id'),
+          eb.val(input.email).as('granted_email'),
+          eb.val(input.grantedAt).as('granted_at'),
+          eb.val(input.grantedBy).as('granted_by'),
+        ])
+        .where('id', '=', input.artifactId)
+        .where((where) =>
+          where.or([
+            where.exists(
+              where
+                .selectFrom('shareable_grants as existing')
+                .select('existing.shareable_id')
+                .where('existing.shareable_id', '=', input.artifactId)
+                .where('existing.granted_email', '=', input.email),
+            ),
+            sql<boolean>`(
+              SELECT COUNT(*) FROM shareable_grants
+              WHERE shareable_id = ${input.artifactId}
+            ) < 50`,
+          ]),
+        ),
+    )
+    .onConflict((conflict) => conflict.doNothing())
+}
+
+async function bridgeGrantLimitReached(
+  db: Kysely<DB>,
+  artifactId: string,
+  email: string,
+) {
+  const row = await db
+    .selectFrom('shareable_grants')
+    .select(({ fn }) => [
+      fn.countAll<number>().as('count'),
+      fn
+        .max<number>(
+          sql<number>`CASE WHEN granted_email = ${email} THEN 1 ELSE 0 END`,
+        )
+        .as('has_requester'),
+    ])
+    .where('shareable_id', '=', artifactId)
+    .executeTakeFirst()
+  return Number(row?.count ?? 0) >= 50 && Number(row?.has_requester ?? 0) === 0
+}
+
+async function ensureReplayGrant(
+  db: Kysely<DB>,
+  artifactId: string,
+  email: string,
+  authorityId: string,
+): Promise<boolean> {
+  const existing = await db
+    .selectFrom('shareable_grants')
+    .select('shareable_id')
+    .where('shareable_id', '=', artifactId)
+    .where('granted_email', '=', email)
+    .executeTakeFirst()
+  if (existing) return true
+  const count = await db
+    .selectFrom('shareable_grants')
+    .select(({ fn }) => fn.countAll<number>().as('count'))
+    .where('shareable_id', '=', artifactId)
+    .executeTakeFirstOrThrow()
+  if (Number(count.count) >= 50) return false
+  const authority = await db
+    .selectFrom('bridge_authorities')
+    .select('bot_user_id')
+    .where('id', '=', authorityId)
+    .executeTakeFirst()
+  if (!authority) return false
+  try {
+    await db
+      .insertInto('shareable_grants')
+      .values({
+        shareable_id: artifactId,
+        granted_email: email,
+        granted_at: nowIso(),
+        granted_by: authority.bot_user_id,
+      })
+      .onConflict((conflict) => conflict.doNothing())
+      .execute()
+  } catch {
+    return false
+  }
+  return true
+}

--- a/apps/web/app/services/bridge-request-validation.server.test.ts
+++ b/apps/web/app/services/bridge-request-validation.server.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'vitest'
+import {
+  parseBridgeIntent,
+  parseTrustedBridgeContext,
+} from './bridge-request-validation.server'
+
+const authority = {
+  kind: 'bridge' as const,
+  familyId: 'family-1',
+  bridgeAuthorityId: 'bridge-1',
+  workspaceId: 'ws1',
+  fallbackProjectId: 'fallback-1',
+  agentProfileId: 'agent-1',
+  sourceKind: 'qm',
+  sourceInstallationId: 'install-1',
+  externalWorkspaceId: 'slack-ws-1',
+}
+
+function metadata() {
+  return {
+    schema_version: 1,
+    request_id: 'request-1',
+    operation: 'publish',
+    requested_audience: 'workspace',
+    source: {
+      kind: 'qm',
+      installation_id: 'install-1',
+      external_workspace_id: 'slack-ws-1',
+    },
+    conversation: {
+      current_id: 'channel-1',
+      ids: ['channel-old', 'channel-1'],
+      kind: 'public_channel',
+      name: 'design',
+      privacy_checked_at: '2026-08-26T00:00:00.000Z',
+    },
+    requester: {
+      stable_id: 'person-1',
+      verified_email: 'Person@Example.com',
+      display_name: 'Person',
+    },
+    content: {
+      kind: 'file',
+      files: [
+        {
+          index: 0,
+          path: 'note.md',
+          media_type: 'text/markdown',
+          size: 5,
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    },
+  }
+}
+
+describe('trusted bridge request validation', () => {
+  test('validates and normalizes the host-owned context separately', () => {
+    const result = parseTrustedBridgeContext(
+      metadata(),
+      authority,
+      new Date('2026-08-26T00:00:30.000Z'),
+    )
+    expect(result).toEqual({
+      kind: 'ok',
+      context: {
+        requestId: 'request-1',
+        source: {
+          kind: 'qm',
+          installationId: 'install-1',
+          externalWorkspaceId: 'slack-ws-1',
+        },
+        conversation: {
+          currentId: 'channel-1',
+          ids: ['channel-old', 'channel-1'],
+          kind: 'public_channel',
+          name: 'design',
+          privacyCheckedAt: '2026-08-26T00:00:00.000Z',
+        },
+        requester: {
+          stableId: 'person-1',
+          verifiedEmail: 'person@example.com',
+          displayName: 'Person',
+        },
+      },
+    })
+  })
+
+  test('rejects a source outside the credential namespace', () => {
+    const value = metadata()
+    value.source.external_workspace_id = 'other-workspace'
+    expect(
+      parseTrustedBridgeContext(
+        value,
+        authority,
+        new Date('2026-08-26T00:00:30.000Z'),
+      ),
+    ).toEqual({ kind: 'invalid-context' })
+  })
+
+  test('rejects stale or future public privacy evidence', () => {
+    expect(
+      parseTrustedBridgeContext(
+        metadata(),
+        authority,
+        new Date('2026-08-26T00:01:00.001Z'),
+      ),
+    ).toEqual({ kind: 'stale-context' })
+    expect(
+      parseTrustedBridgeContext(
+        metadata(),
+        authority,
+        new Date('2026-08-25T23:59:54.999Z'),
+      ),
+    ).toEqual({ kind: 'stale-context' })
+  })
+
+  test('accepts private context without public freshness evidence', () => {
+    const value = metadata()
+    value.conversation.kind = 'private_channel'
+    delete (value.conversation as Partial<typeof value.conversation>)
+      .privacy_checked_at
+    expect(
+      parseTrustedBridgeContext(
+        value,
+        authority,
+        new Date('2026-08-26T01:00:00.000Z'),
+      ).kind,
+    ).toBe('ok')
+  })
+
+  test('validates operation shape and exact file descriptors', () => {
+    expect(parseBridgeIntent(metadata())).toMatchObject({
+      kind: 'ok',
+      intent: {
+        operation: 'publish',
+        requestedAudience: 'workspace',
+        contentKind: 'file',
+      },
+    })
+    const value = metadata()
+    value.content.files[0]!.index = 1
+    expect(parseBridgeIntent(value)).toEqual({ kind: 'invalid-context' })
+  })
+})

--- a/apps/web/app/services/bridge-request-validation.server.test.ts
+++ b/apps/web/app/services/bridge-request-validation.server.test.ts
@@ -142,4 +142,14 @@ describe('trusted bridge request validation', () => {
     value.content.files[0]!.index = 1
     expect(parseBridgeIntent(value)).toEqual({ kind: 'invalid-context' })
   })
+
+  test('preserves valid edge whitespace in a file path', () => {
+    const value = metadata()
+    value.content.files[0]!.path = ' report.md'
+
+    expect(parseBridgeIntent(value)).toMatchObject({
+      kind: 'ok',
+      intent: { files: [{ path: ' report.md' }] },
+    })
+  })
 })

--- a/apps/web/app/services/bridge-request-validation.server.ts
+++ b/apps/web/app/services/bridge-request-validation.server.ts
@@ -1,0 +1,364 @@
+import type { CliAuthority } from './cli-authority.server'
+
+const CONTEXT_FRESHNESS_MS = 60_000
+const CONTEXT_FUTURE_SKEW_MS = 5_000
+const encoder = new TextEncoder()
+
+type BridgeAuthority = Extract<CliAuthority, { kind: 'bridge' }>
+type ConversationKind = 'public_channel' | 'private_channel' | 'dm'
+type BridgeOperation = 'publish' | 'append' | 'update' | 'set_visibility'
+type RequestedAudience = 'private' | 'workspace'
+
+export interface TrustedBridgeContext {
+  requestId: string
+  source: {
+    kind: string
+    installationId: string
+    externalWorkspaceId: string
+  }
+  conversation: {
+    currentId: string
+    ids: string[]
+    kind: ConversationKind
+    name: string | null
+    privacyCheckedAt: string | null
+  }
+  requester: {
+    stableId: string
+    verifiedEmail: string
+    displayName: string | null
+  }
+}
+
+export interface BridgeContentFile {
+  index: number
+  path: string
+  mediaType: string
+  size: number
+  sha256: string
+}
+
+export interface BridgeIntent {
+  operation: BridgeOperation
+  requestedAudience: RequestedAudience
+  targetArtifactId: string | null
+  title: string | null
+  contentKind: 'file' | 'static_site' | null
+  files: BridgeContentFile[]
+}
+
+export type ContextValidationResult =
+  | { kind: 'ok'; context: TrustedBridgeContext }
+  | { kind: 'invalid-context' | 'stale-context' }
+
+export type IntentValidationResult =
+  | { kind: 'ok'; intent: BridgeIntent }
+  | { kind: 'invalid-context' }
+
+export function parseTrustedBridgeContext(
+  value: unknown,
+  authority: BridgeAuthority,
+  now = new Date(),
+): ContextValidationResult {
+  const root = exactRecord(value, [
+    'schema_version',
+    'request_id',
+    'operation',
+    'requested_audience',
+    'target_artifact_id',
+    'title',
+    'source',
+    'conversation',
+    'requester',
+    'content',
+  ])
+  if (!root || root.schema_version !== 1) return { kind: 'invalid-context' }
+  const source = exactRecord(root.source, [
+    'kind',
+    'installation_id',
+    'external_workspace_id',
+  ])
+  const conversation = exactRecord(root.conversation, [
+    'current_id',
+    'ids',
+    'kind',
+    'name',
+    'privacy_checked_at',
+  ])
+  const requester = exactRecord(root.requester, [
+    'stable_id',
+    'verified_email',
+    'display_name',
+  ])
+  if (!source || !conversation || !requester) {
+    return { kind: 'invalid-context' }
+  }
+
+  const sourceKind = boundedString(source.kind, 64)
+  const installationId = boundedString(source.installation_id, 200)
+  const externalWorkspaceId = boundedString(source.external_workspace_id, 200)
+  const requestId = boundedString(root.request_id, 200)
+  const currentId = boundedString(conversation.current_id, 200)
+  const stableId = boundedString(requester.stable_id, 200)
+  const verifiedEmail = normalizedEmail(requester.verified_email)
+  if (
+    !sourceKind ||
+    !/^[a-z0-9][a-z0-9_-]*$/.test(sourceKind) ||
+    !installationId ||
+    !externalWorkspaceId ||
+    !requestId ||
+    !currentId ||
+    !stableId ||
+    !verifiedEmail ||
+    sourceKind !== authority.sourceKind ||
+    installationId !== authority.sourceInstallationId ||
+    externalWorkspaceId !== authority.externalWorkspaceId
+  ) {
+    return { kind: 'invalid-context' }
+  }
+  if (!Array.isArray(conversation.ids) || conversation.ids.length === 0) {
+    return { kind: 'invalid-context' }
+  }
+  const ids = conversation.ids.map((id) => boundedString(id, 200))
+  if (
+    ids.length > 16 ||
+    ids.some((id) => id === null) ||
+    new Set(ids).size !== ids.length ||
+    ids.filter((id) => id === currentId).length !== 1
+  ) {
+    return { kind: 'invalid-context' }
+  }
+  const kind = conversation.kind
+  if (
+    kind !== 'public_channel' &&
+    kind !== 'private_channel' &&
+    kind !== 'dm'
+  ) {
+    return { kind: 'invalid-context' }
+  }
+  const name = optionalBoundedString(conversation.name, 200)
+  const displayName = optionalBoundedString(requester.display_name, 200)
+  const privacyCheckedAt = optionalBoundedString(
+    conversation.privacy_checked_at,
+    64,
+  )
+  if (name === false || displayName === false || privacyCheckedAt === false) {
+    return { kind: 'invalid-context' }
+  }
+  if (kind === 'public_channel') {
+    if (privacyCheckedAt === null) return { kind: 'invalid-context' }
+    const checkedAt = Date.parse(privacyCheckedAt)
+    if (
+      !Number.isFinite(checkedAt) ||
+      new Date(checkedAt).toISOString() !== privacyCheckedAt
+    ) {
+      return { kind: 'invalid-context' }
+    }
+    const age = now.getTime() - checkedAt
+    if (age > CONTEXT_FRESHNESS_MS || age < -CONTEXT_FUTURE_SKEW_MS) {
+      return { kind: 'stale-context' }
+    }
+  }
+
+  return {
+    kind: 'ok',
+    context: {
+      requestId,
+      source: { kind: sourceKind, installationId, externalWorkspaceId },
+      conversation: {
+        currentId,
+        ids: ids as string[],
+        kind,
+        name,
+        privacyCheckedAt,
+      },
+      requester: { stableId, verifiedEmail, displayName },
+    },
+  }
+}
+
+export function parseBridgeIntent(value: unknown): IntentValidationResult {
+  const root = exactRecord(value, [
+    'schema_version',
+    'request_id',
+    'operation',
+    'requested_audience',
+    'target_artifact_id',
+    'title',
+    'source',
+    'conversation',
+    'requester',
+    'content',
+  ])
+  if (!root || root.schema_version !== 1) return { kind: 'invalid-context' }
+  const operation = root.operation
+  const requestedAudience = root.requested_audience
+  if (
+    (operation !== 'publish' &&
+      operation !== 'append' &&
+      operation !== 'update' &&
+      operation !== 'set_visibility') ||
+    (requestedAudience !== 'private' && requestedAudience !== 'workspace')
+  ) {
+    return { kind: 'invalid-context' }
+  }
+  const targetArtifactId = optionalBoundedString(root.target_artifact_id, 200)
+  const title = optionalBoundedCharacters(root.title, 200)
+  if (targetArtifactId === false || title === false) {
+    return { kind: 'invalid-context' }
+  }
+  let contentKind: BridgeIntent['contentKind'] = null
+  let files: BridgeContentFile[] = []
+  if (root.content !== undefined) {
+    const content = exactRecord(root.content, ['kind', 'files'])
+    if (
+      !content ||
+      (content.kind !== 'file' && content.kind !== 'static_site') ||
+      !Array.isArray(content.files) ||
+      content.files.length > 50
+    ) {
+      return { kind: 'invalid-context' }
+    }
+    contentKind = content.kind
+    const parsed = content.files.map(parseFileDescriptor)
+    if (parsed.some((file) => file === null)) {
+      return { kind: 'invalid-context' }
+    }
+    files = parsed as BridgeContentFile[]
+    if (
+      files.some((file, index) => file.index !== index) ||
+      new Set(files.map((file) => file.path.toLowerCase())).size !==
+        files.length
+    ) {
+      return { kind: 'invalid-context' }
+    }
+  }
+  const hasContent = contentKind !== null
+  if (
+    (operation === 'publish' && (targetArtifactId !== null || !hasContent)) ||
+    (operation === 'append' &&
+      (targetArtifactId === null ||
+        contentKind !== 'file' ||
+        files.length !== 1)) ||
+    (operation === 'update' && (targetArtifactId === null || !hasContent)) ||
+    (operation === 'set_visibility' &&
+      (targetArtifactId === null || hasContent || title !== null)) ||
+    (contentKind === 'file' && files.length !== 1) ||
+    (contentKind === 'static_site' && files.length === 0)
+  ) {
+    return { kind: 'invalid-context' }
+  }
+  return {
+    kind: 'ok',
+    intent: {
+      operation,
+      requestedAudience,
+      targetArtifactId,
+      title,
+      contentKind,
+      files,
+    },
+  }
+}
+
+function parseFileDescriptor(value: unknown): BridgeContentFile | null {
+  const file = exactRecord(value, [
+    'index',
+    'path',
+    'media_type',
+    'size',
+    'sha256',
+  ])
+  if (!file) return null
+  const path = boundedCharacters(file.path, 256)
+  const mediaType = boundedString(file.media_type, 127)
+  if (
+    !Number.isSafeInteger(file.index) ||
+    (file.index as number) < 0 ||
+    !path ||
+    !mediaType ||
+    !/^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(
+      mediaType,
+    ) ||
+    !Number.isSafeInteger(file.size) ||
+    (file.size as number) < 0 ||
+    typeof file.sha256 !== 'string' ||
+    !/^[0-9a-f]{64}$/.test(file.sha256)
+  ) {
+    return null
+  }
+  return {
+    index: file.index as number,
+    path,
+    mediaType,
+    size: file.size as number,
+    sha256: file.sha256,
+  }
+}
+
+function exactRecord(
+  value: unknown,
+  allowedKeys: readonly string[],
+): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null
+  }
+  const record = value as Record<string, unknown>
+  const allowed = new Set(allowedKeys)
+  if (Object.keys(record).some((key) => !allowed.has(key))) return null
+  return record
+}
+
+function boundedString(value: unknown, maxBytes: number): string | null {
+  if (typeof value !== 'string' || value.trim() !== value) return null
+  if (
+    value.length === 0 ||
+    encoder.encode(value).byteLength > maxBytes ||
+    containsControlCharacters(value)
+  ) {
+    return null
+  }
+  return value
+}
+
+function boundedCharacters(value: unknown, max: number): string | null {
+  if (typeof value !== 'string' || value.trim() !== value) return null
+  if (
+    value.length === 0 ||
+    value.length > max ||
+    containsControlCharacters(value)
+  ) {
+    return null
+  }
+  return value
+}
+
+function containsControlCharacters(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0
+    return codePoint <= 0x1f || codePoint === 0x7f
+  })
+}
+
+function optionalBoundedString(
+  value: unknown,
+  maxBytes: number,
+): string | null | false {
+  if (value === undefined) return null
+  return boundedString(value, maxBytes) ?? false
+}
+
+function optionalBoundedCharacters(
+  value: unknown,
+  max: number,
+): string | null | false {
+  if (value === undefined) return null
+  return boundedCharacters(value, max) ?? false
+}
+
+function normalizedEmail(value: unknown): string | null {
+  const email = boundedString(value, 320)
+  if (!email) return null
+  const normalized = email.toLowerCase()
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(normalized) ? normalized : null
+}

--- a/apps/web/app/services/bridge-request-validation.server.ts
+++ b/apps/web/app/services/bridge-request-validation.server.ts
@@ -270,7 +270,7 @@ function parseFileDescriptor(value: unknown): BridgeContentFile | null {
     'sha256',
   ])
   if (!file) return null
-  const path = boundedCharacters(file.path, 256)
+  const path = boundedPath(file.path, 256)
   const mediaType = boundedString(file.media_type, 127)
   if (
     !Number.isSafeInteger(file.index) ||
@@ -330,6 +330,12 @@ function boundedCharacters(value: unknown, max: number): string | null {
   ) {
     return null
   }
+  return value
+}
+
+function boundedPath(value: unknown, max: number): string | null {
+  if (typeof value !== 'string' || value.trim().length === 0) return null
+  if (value.length > max || containsControlCharacters(value)) return null
   return value
 }
 

--- a/apps/web/app/services/cli-authority.server.test.ts
+++ b/apps/web/app/services/cli-authority.server.test.ts
@@ -237,6 +237,42 @@ describe('bot CLI authority resolution', () => {
     )
   })
 
+  test('resolves a bridge family only through its bounded bridge authority', async () => {
+    seedBotFamily()
+    sqlite
+      .prepare(
+        `INSERT INTO bridge_authorities (
+          id, workspace_id, bot_user_id, agent_profile_id, source_kind,
+          source_installation_id, external_workspace_id, fallback_project_id,
+          created_at, updated_at
+        ) VALUES ('bridge-b', 'ws1', 'bot1', 'agent-b', 'qm', 'install-1',
+          'slack-ws-1', 'project-b', '2026-01-01T00:00:00.000Z',
+          '2026-01-01T00:00:00.000Z')`,
+      )
+      .run()
+    sqlite
+      .prepare(
+        `UPDATE cli_family_authorities
+         SET bridge_authority_id = 'bridge-b'
+         WHERE family_id = 'family-b'`,
+      )
+      .run()
+
+    await expect(resolveCliAuthorityBySessionToken('ass_bot')).resolves.toEqual(
+      {
+        kind: 'bridge',
+        familyId: 'family-b',
+        bridgeAuthorityId: 'bridge-b',
+        workspaceId: 'ws1',
+        fallbackProjectId: 'project-b',
+        agentProfileId: 'agent-b',
+        sourceKind: 'qm',
+        sourceInstallationId: 'install-1',
+        externalWorkspaceId: 'slack-ws-1',
+      },
+    )
+  })
+
   test('a bot whose credential expired is denied per request even with a live session', async () => {
     // Credential seeded just at the boundary: expired credential with a
     // still-valid session must be rejected on every request.

--- a/apps/web/app/services/cli-authority.server.ts
+++ b/apps/web/app/services/cli-authority.server.ts
@@ -21,6 +21,17 @@ export type CliAuthority =
       projectNameSnapshot: string
       agentProfileId: string
     }
+  | {
+      kind: 'bridge'
+      familyId: string
+      bridgeAuthorityId: string
+      workspaceId: string
+      fallbackProjectId: string
+      agentProfileId: string
+      sourceKind: string
+      sourceInstallationId: string
+      externalWorkspaceId: string
+    }
 
 /**
  * Resolution result. `denied` is distinct from `null` ("no session"): bot
@@ -52,8 +63,14 @@ export async function resolveCliAuthorityBySessionToken(
         'cli_family_authorities.family_id',
         'cli_session_authorities.family_id',
       )
+      .leftJoin(
+        'bridge_authorities',
+        'bridge_authorities.id',
+        'cli_family_authorities.bridge_authority_id',
+      )
       .select(({ exists, selectFrom }) => [
         'sessions.user_agent',
+        'users.id as user_id',
         'users.kind as user_kind',
         'users.bot_stopped_at',
         'cli_session_authorities.kind',
@@ -68,7 +85,16 @@ export async function resolveCliAuthorityBySessionToken(
         'cli_family_authorities.project_id',
         'cli_family_authorities.project_name_snapshot',
         'cli_family_authorities.agent_profile_id',
+        'cli_family_authorities.bridge_authority_id',
         'cli_family_authorities.status',
+        'bridge_authorities.workspace_id as bridge_workspace_id',
+        'bridge_authorities.id as bridge_row_id',
+        'bridge_authorities.bot_user_id as bridge_bot_user_id',
+        'bridge_authorities.agent_profile_id as bridge_agent_profile_id',
+        'bridge_authorities.source_kind as bridge_source_kind',
+        'bridge_authorities.source_installation_id as bridge_source_installation_id',
+        'bridge_authorities.external_workspace_id as bridge_external_workspace_id',
+        'bridge_authorities.fallback_project_id as bridge_fallback_project_id',
         // Bot sessions are re-validated on every request against the family's
         // credential liveness so a stopped or expired bot cannot keep using a
         // previously issued session.
@@ -106,6 +132,31 @@ export async function resolveCliAuthorityBySessionToken(
         !row.family_credential_live
       ) {
         return 'denied'
+      }
+      if (row.bridge_authority_id !== null) {
+        if (
+          row.bridge_row_id !== row.bridge_authority_id ||
+          row.bridge_workspace_id !== row.workspace_id ||
+          row.bridge_bot_user_id !== row.user_id ||
+          row.bridge_agent_profile_id !== row.agent_profile_id ||
+          row.bridge_fallback_project_id !== row.project_id ||
+          !row.bridge_source_kind ||
+          !row.bridge_source_installation_id ||
+          !row.bridge_external_workspace_id
+        ) {
+          return 'denied'
+        }
+        return {
+          kind: 'bridge',
+          familyId: row.family_id,
+          bridgeAuthorityId: row.bridge_authority_id,
+          workspaceId: row.workspace_id,
+          fallbackProjectId: row.project_id,
+          agentProfileId: row.agent_profile_id,
+          sourceKind: row.bridge_source_kind,
+          sourceInstallationId: row.bridge_source_installation_id,
+          externalWorkspaceId: row.bridge_external_workspace_id,
+        }
       }
       return {
         kind: 'agent',

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -2564,7 +2564,7 @@ async function compensateStaticSiteR2(
 // trailing `/`, applies NFC Unicode normalization, and ensures a leading `/`.
 // `..` segments are rejected upstream by validateBundlePath so are not
 // expected to appear here.
-function normalizeBundlePath(path: string): string {
+export function normalizeBundlePath(path: string): string {
   const slashOnly = path.replaceAll('\\', '/')
   const segments = slashOnly.split('/').filter((s) => s !== '' && s !== '.')
   if (segments.length === 1) {
@@ -2608,7 +2608,7 @@ function validatePreparedStaticSitePath(
   return null
 }
 
-function staticSiteR2Prefix(
+export function staticSiteR2Prefix(
   workspaceId: string,
   shareableId: string,
   versionId: string,
@@ -2624,7 +2624,7 @@ function chunkArray<T>(items: ReadonlyArray<T>, size: number): T[][] {
   return chunks
 }
 
-function staticSiteMimeType(path: string): string | null {
+export function staticSiteMimeType(path: string): string | null {
   const extension = path.toLowerCase().match(/\.[^.\\/]+$/)?.[0]
   switch (extension) {
     case '.html':
@@ -2688,7 +2688,7 @@ function isIgnoredStaticSiteUploadPath(path: string): boolean {
   )
 }
 
-function staticSiteEntrypointKind(path: string): 'html' | 'md' | null {
+export function staticSiteEntrypointKind(path: string): 'html' | 'md' | null {
   switch (path.toLowerCase()) {
     case '/index.html':
       return 'html'
@@ -2699,7 +2699,7 @@ function staticSiteEntrypointKind(path: string): 'html' | 'md' | null {
   }
 }
 
-async function prepareUpload(
+export async function prepareUpload(
   db: Kysely<DB>,
   workspaceId: string,
   shareableId: string,
@@ -3044,7 +3044,7 @@ function shouldEnforceStorageQuotaPreCheck(
   return !allowsStorageOverage(plan, subscriptionStatus)
 }
 
-async function reserveQuota(
+export async function reserveQuota(
   db: Kysely<DB>,
   workspaceId: string,
   sizeBytes: number,
@@ -3075,7 +3075,7 @@ async function reserveQuota(
   return exists ? 'over-quota' : 'workspace-missing'
 }
 
-async function releaseQuota(
+export async function releaseQuota(
   db: Kysely<DB>,
   workspaceId: string,
   sizeBytes: number,

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -2679,7 +2679,7 @@ export function staticSiteMimeType(path: string): string | null {
   }
 }
 
-function isIgnoredStaticSiteUploadPath(path: string): boolean {
+export function isIgnoredStaticSiteUploadPath(path: string): boolean {
   const segments = path.split('/').filter(Boolean)
   const fileName = segments.at(-1) ?? path
   return (

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -2704,12 +2704,16 @@ export async function prepareUpload(
   workspaceId: string,
   shareableId: string,
   file: File,
+  logicalFile: { name: string; type: string } = file,
 ) {
   if (file.size > MAX_CONTENT_BYTES) return { kind: 'too-large' } as const
 
-  const renderType = detectArtifactTypeForUpload(file.type, file.name)
+  const renderType = detectArtifactTypeForUpload(
+    logicalFile.type,
+    logicalFile.name,
+  )
   if (!renderType) return { kind: 'unsupported-type' } as const
-  const pathValidation = validateBundlePath(file.name)
+  const pathValidation = validateBundlePath(logicalFile.name)
   if (pathValidation.kind === 'blocked') {
     return { kind: 'invalid-path' } as const
   }
@@ -2751,14 +2755,14 @@ export async function prepareUpload(
   const buffer = await file.arrayBuffer()
   const derivedTitle = extractTitleFromBytes(buffer, renderType, {
     shareableId,
-    fileName: file.name,
+    fileName: logicalFile.name,
   })
   const sha256 = await computeFileSha256(buffer)
   const versionId = nanoid(16)
   const now = new Date().toISOString()
   const artifactKind: ArtifactKind =
     renderType === 'md' ? 'markdown_page' : 'html_page'
-  const entrypointPath = normalizeBundlePath(file.name)
+  const entrypointPath = normalizeBundlePath(logicalFile.name)
   return {
     kind: 'ok' as const,
     versionId,

--- a/apps/web/app/types/db.ts
+++ b/apps/web/app/types/db.ts
@@ -29,6 +29,12 @@ export interface DB {
   cli_refresh_credentials: CliRefreshCredentialsTable
   cli_refresh_sessions: CliRefreshSessionsTable
   agent_profiles: AgentProfilesTable
+  bridge_authorities: BridgeAuthoritiesTable
+  bridge_conversations: BridgeConversationsTable
+  bridge_conversation_ids: BridgeConversationIdsTable
+  bridge_requests: BridgeRequestsTable
+  bridge_operations: BridgeOperationsTable
+  bridge_dm_artifacts: BridgeDmArtifactsTable
   cli_family_authorities: CliFamilyAuthoritiesTable
   cli_session_authorities: CliSessionAuthoritiesTable
   deviceCode: DeviceCodeTable
@@ -282,6 +288,79 @@ interface AgentProfilesTable {
   created_at: string
 }
 
+interface BridgeAuthoritiesTable {
+  id: string
+  workspace_id: string
+  bot_user_id: string
+  agent_profile_id: string
+  source_kind: string
+  source_installation_id: string
+  external_workspace_id: string
+  fallback_project_id: string
+  created_at: string
+  updated_at: string
+}
+
+interface BridgeConversationsTable {
+  id: string
+  bridge_authority_id: string
+  project_id: string
+  conversation_kind: 'public_channel' | 'private_channel'
+  conversation_name: string | null
+  privacy_ceiling: 'workspace' | 'private'
+  privacy_epoch: Generated<number>
+  created_at: string
+  updated_at: string
+}
+
+interface BridgeConversationIdsTable {
+  mapping_id: string
+  bridge_authority_id: string
+  external_conversation_id: string
+  created_at: string
+}
+
+interface BridgeRequestsTable {
+  bridge_authority_id: string
+  request_id: string
+  routing_class: 'channel' | 'dm'
+  conversation_ids_json: string
+  mapping_id: string | null
+  requester_stable_id: string
+  requester_verified_email: string
+  stable_digest: string | null
+  status: 'binding' | 'leased' | 'completed'
+  lease_generation: string | null
+  lease_expires_at: string | null
+  result_artifact_id: string | null
+  result_version_id: string | null
+  mapping_created: Generated<number>
+  project_created: Generated<number>
+  created_at: string
+  updated_at: string
+}
+
+interface BridgeOperationsTable {
+  id: string
+  bridge_authority_id: string
+  request_id: string
+  lease_generation: string
+  operation: 'publish' | 'append' | 'update' | 'set_visibility'
+  requester_stable_id: string
+  requester_verified_email: string
+  requester_display_name: string | null
+  artifact_id: string
+  version_id: string | null
+  created_at: string
+}
+
+interface BridgeDmArtifactsTable {
+  artifact_id: string
+  bridge_authority_id: string
+  requester_stable_id: string
+  created_at: string
+}
+
 interface CliFamilyAuthoritiesTable {
   family_id: string
   user_id: string
@@ -290,6 +369,7 @@ interface CliFamilyAuthoritiesTable {
   project_id: string | null
   project_name_snapshot: string | null
   agent_profile_id: string | null
+  bridge_authority_id: Generated<string | null>
   approved_at: string | null
   device_name: string | null
   status: 'active' | 'revoked' | 'superseded'

--- a/apps/web/app/types/db.ts
+++ b/apps/web/app/types/db.ts
@@ -296,7 +296,7 @@ interface BridgeAuthoritiesTable {
   source_kind: string
   source_installation_id: string
   external_workspace_id: string
-  fallback_project_id: string
+  fallback_project_id: string | null
   created_at: string
   updated_at: string
 }

--- a/apps/web/db/migrations/0092_trusted_bridge_publishing.sql
+++ b/apps/web/db/migrations/0092_trusted_bridge_publishing.sql
@@ -6,7 +6,7 @@ CREATE TABLE bridge_authorities (
   source_kind              TEXT NOT NULL,
   source_installation_id   TEXT NOT NULL,
   external_workspace_id    TEXT NOT NULL,
-  fallback_project_id      TEXT NOT NULL REFERENCES artifact_containers(id) ON DELETE RESTRICT,
+  fallback_project_id      TEXT REFERENCES artifact_containers(id) ON DELETE SET NULL,
   created_at               TEXT NOT NULL,
   updated_at               TEXT NOT NULL,
   UNIQUE (workspace_id, source_kind, source_installation_id, external_workspace_id),

--- a/apps/web/db/migrations/0092_trusted_bridge_publishing.sql
+++ b/apps/web/db/migrations/0092_trusted_bridge_publishing.sql
@@ -62,7 +62,7 @@ CREATE TABLE bridge_requests (
   request_id                TEXT NOT NULL,
   routing_class             TEXT NOT NULL CHECK (routing_class IN ('channel', 'dm')),
   conversation_ids_json     TEXT NOT NULL,
-  mapping_id                TEXT REFERENCES bridge_conversations(id) ON DELETE RESTRICT,
+  mapping_id                TEXT REFERENCES bridge_conversations(id) ON DELETE SET NULL,
   requester_stable_id       TEXT NOT NULL,
   requester_verified_email  TEXT NOT NULL,
   stable_digest             TEXT,
@@ -118,7 +118,7 @@ WHEN EXISTS (
 AND NOT EXISTS (
   SELECT 1 FROM shareable_grants
   WHERE shareable_id = NEW.artifact_id
-    AND granted_email = NEW.requester_verified_email
+    AND lower(granted_email) = lower(NEW.requester_verified_email)
 )
 BEGIN
   SELECT RAISE(ABORT, 'private bridge artifact requires requester grant');

--- a/apps/web/db/migrations/0092_trusted_bridge_publishing.sql
+++ b/apps/web/db/migrations/0092_trusted_bridge_publishing.sql
@@ -1,0 +1,134 @@
+CREATE TABLE bridge_authorities (
+  id                       TEXT PRIMARY KEY,
+  workspace_id             TEXT NOT NULL REFERENCES workspaces(id) ON DELETE RESTRICT,
+  bot_user_id              TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE RESTRICT,
+  agent_profile_id         TEXT NOT NULL UNIQUE REFERENCES agent_profiles(id) ON DELETE RESTRICT,
+  source_kind              TEXT NOT NULL,
+  source_installation_id   TEXT NOT NULL,
+  external_workspace_id    TEXT NOT NULL,
+  fallback_project_id      TEXT NOT NULL REFERENCES artifact_containers(id) ON DELETE RESTRICT,
+  created_at               TEXT NOT NULL,
+  updated_at               TEXT NOT NULL,
+  UNIQUE (workspace_id, source_kind, source_installation_id, external_workspace_id),
+  CHECK (source_kind = trim(source_kind) AND length(source_kind) BETWEEN 1 AND 80),
+  CHECK (source_installation_id = trim(source_installation_id) AND length(source_installation_id) BETWEEN 1 AND 200),
+  CHECK (external_workspace_id = trim(external_workspace_id) AND length(external_workspace_id) BETWEEN 1 AND 200)
+);
+CREATE INDEX bridge_authorities_fallback_project_id
+  ON bridge_authorities(fallback_project_id);
+
+ALTER TABLE cli_family_authorities
+  ADD COLUMN bridge_authority_id TEXT REFERENCES bridge_authorities(id) ON DELETE RESTRICT;
+CREATE INDEX cli_family_authorities_bridge_authority_id
+  ON cli_family_authorities(bridge_authority_id);
+
+CREATE TABLE bridge_conversations (
+  id                    TEXT PRIMARY KEY,
+  bridge_authority_id   TEXT NOT NULL REFERENCES bridge_authorities(id) ON DELETE RESTRICT,
+  project_id            TEXT NOT NULL UNIQUE REFERENCES artifact_containers(id) ON DELETE CASCADE,
+  conversation_kind     TEXT NOT NULL CHECK (conversation_kind IN ('public_channel', 'private_channel')),
+  conversation_name     TEXT,
+  privacy_ceiling       TEXT NOT NULL CHECK (privacy_ceiling IN ('workspace', 'private')),
+  privacy_epoch         INTEGER NOT NULL DEFAULT 0 CHECK (privacy_epoch IN (0, 1)),
+  created_at            TEXT NOT NULL,
+  updated_at            TEXT NOT NULL,
+  UNIQUE (id, bridge_authority_id)
+);
+CREATE INDEX bridge_conversations_authority_updated
+  ON bridge_conversations(bridge_authority_id, updated_at DESC);
+
+CREATE TRIGGER bridge_conversations_privacy_monotonic
+BEFORE UPDATE OF privacy_ceiling, privacy_epoch ON bridge_conversations
+WHEN (OLD.privacy_ceiling = 'private' AND NEW.privacy_ceiling <> 'private')
+  OR NEW.privacy_epoch < OLD.privacy_epoch
+BEGIN
+  SELECT RAISE(ABORT, 'bridge conversation privacy cannot widen');
+END;
+
+CREATE TABLE bridge_conversation_ids (
+  mapping_id                TEXT NOT NULL,
+  bridge_authority_id       TEXT NOT NULL,
+  external_conversation_id  TEXT NOT NULL,
+  created_at                TEXT NOT NULL,
+  PRIMARY KEY (bridge_authority_id, external_conversation_id),
+  FOREIGN KEY (mapping_id, bridge_authority_id)
+    REFERENCES bridge_conversations(id, bridge_authority_id) ON DELETE CASCADE
+);
+CREATE INDEX bridge_conversation_ids_mapping_id
+  ON bridge_conversation_ids(mapping_id);
+
+CREATE TABLE bridge_requests (
+  bridge_authority_id       TEXT NOT NULL REFERENCES bridge_authorities(id) ON DELETE RESTRICT,
+  request_id                TEXT NOT NULL,
+  routing_class             TEXT NOT NULL CHECK (routing_class IN ('channel', 'dm')),
+  conversation_ids_json     TEXT NOT NULL,
+  mapping_id                TEXT REFERENCES bridge_conversations(id) ON DELETE RESTRICT,
+  requester_stable_id       TEXT NOT NULL,
+  requester_verified_email  TEXT NOT NULL,
+  stable_digest             TEXT,
+  status                    TEXT NOT NULL CHECK (status IN ('binding', 'leased', 'completed')),
+  lease_generation          TEXT,
+  lease_expires_at          TEXT,
+  result_artifact_id        TEXT REFERENCES shareables(id) ON DELETE RESTRICT,
+  result_version_id         TEXT REFERENCES versions(id) ON DELETE RESTRICT,
+  mapping_created           INTEGER NOT NULL DEFAULT 0 CHECK (mapping_created IN (0, 1)),
+  project_created           INTEGER NOT NULL DEFAULT 0 CHECK (project_created IN (0, 1)),
+  created_at                TEXT NOT NULL,
+  updated_at                TEXT NOT NULL,
+  PRIMARY KEY (bridge_authority_id, request_id),
+  UNIQUE (bridge_authority_id, request_id, lease_generation),
+  CHECK (
+    (status = 'binding' AND stable_digest IS NULL AND lease_generation IS NULL AND lease_expires_at IS NULL)
+    OR (status = 'leased' AND stable_digest IS NOT NULL AND lease_generation IS NOT NULL AND lease_expires_at IS NOT NULL)
+    OR (status = 'completed' AND stable_digest IS NOT NULL AND lease_generation IS NOT NULL AND lease_expires_at IS NOT NULL AND result_artifact_id IS NOT NULL)
+  )
+);
+CREATE INDEX bridge_requests_mapping_id ON bridge_requests(mapping_id);
+CREATE INDEX bridge_requests_lease_expiry
+  ON bridge_requests(status, lease_expires_at);
+
+CREATE TABLE bridge_operations (
+  id                         TEXT PRIMARY KEY,
+  bridge_authority_id        TEXT NOT NULL,
+  request_id                 TEXT NOT NULL,
+  lease_generation           TEXT NOT NULL,
+  operation                  TEXT NOT NULL CHECK (operation IN ('publish', 'append', 'update', 'set_visibility')),
+  requester_stable_id        TEXT NOT NULL,
+  requester_verified_email   TEXT NOT NULL,
+  requester_display_name     TEXT,
+  artifact_id                TEXT NOT NULL REFERENCES shareables(id) ON DELETE CASCADE,
+  version_id                 TEXT REFERENCES versions(id) ON DELETE CASCADE,
+  created_at                 TEXT NOT NULL,
+  UNIQUE (bridge_authority_id, request_id),
+  FOREIGN KEY (bridge_authority_id, request_id, lease_generation)
+    REFERENCES bridge_requests(bridge_authority_id, request_id, lease_generation) ON DELETE RESTRICT,
+  CHECK ((operation = 'set_visibility') = (version_id IS NULL))
+);
+CREATE INDEX bridge_operations_artifact_created
+  ON bridge_operations(artifact_id, created_at DESC);
+CREATE UNIQUE INDEX bridge_operations_version_id
+  ON bridge_operations(version_id) WHERE version_id IS NOT NULL;
+
+CREATE TRIGGER bridge_operations_private_grant_insert
+BEFORE INSERT ON bridge_operations
+WHEN EXISTS (
+  SELECT 1 FROM shareables
+  WHERE id = NEW.artifact_id AND visibility = 'private'
+)
+AND NOT EXISTS (
+  SELECT 1 FROM shareable_grants
+  WHERE shareable_id = NEW.artifact_id
+    AND granted_email = NEW.requester_verified_email
+)
+BEGIN
+  SELECT RAISE(ABORT, 'private bridge artifact requires requester grant');
+END;
+
+CREATE TABLE bridge_dm_artifacts (
+  artifact_id          TEXT PRIMARY KEY REFERENCES shareables(id) ON DELETE CASCADE,
+  bridge_authority_id  TEXT NOT NULL REFERENCES bridge_authorities(id) ON DELETE RESTRICT,
+  requester_stable_id  TEXT NOT NULL,
+  created_at           TEXT NOT NULL
+);
+CREATE INDEX bridge_dm_artifacts_authority_requester
+  ON bridge_dm_artifacts(bridge_authority_id, requester_stable_id);

--- a/apps/web/db/migrations/0092_trusted_bridge_publishing.sql
+++ b/apps/web/db/migrations/0092_trusted_bridge_publishing.sql
@@ -69,8 +69,8 @@ CREATE TABLE bridge_requests (
   status                    TEXT NOT NULL CHECK (status IN ('binding', 'leased', 'completed')),
   lease_generation          TEXT,
   lease_expires_at          TEXT,
-  result_artifact_id        TEXT REFERENCES shareables(id) ON DELETE RESTRICT,
-  result_version_id         TEXT REFERENCES versions(id) ON DELETE RESTRICT,
+  result_artifact_id        TEXT, -- tombstone survives normal artifact deletion
+  result_version_id         TEXT, -- tombstone survives normal version deletion
   mapping_created           INTEGER NOT NULL DEFAULT 0 CHECK (mapping_created IN (0, 1)),
   project_created           INTEGER NOT NULL DEFAULT 0 CHECK (project_created IN (0, 1)),
   created_at                TEXT NOT NULL,

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -452,7 +452,7 @@ CREATE TABLE bridge_requests (
   request_id                TEXT NOT NULL,
   routing_class             TEXT NOT NULL CHECK (routing_class IN ('channel', 'dm')),
   conversation_ids_json     TEXT NOT NULL,
-  mapping_id                TEXT REFERENCES bridge_conversations(id) ON DELETE RESTRICT,
+  mapping_id                TEXT REFERENCES bridge_conversations(id) ON DELETE SET NULL,
   requester_stable_id       TEXT NOT NULL,
   requester_verified_email  TEXT NOT NULL,
   stable_digest             TEXT,
@@ -631,7 +631,7 @@ WHEN EXISTS (
 AND NOT EXISTS (
   SELECT 1 FROM shareable_grants
   WHERE shareable_id = NEW.artifact_id
-    AND granted_email = NEW.requester_verified_email
+    AND lower(granted_email) = lower(NEW.requester_verified_email)
 )
 BEGIN
   SELECT RAISE(ABORT, 'private bridge artifact requires requester grant');

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -348,6 +348,7 @@ CREATE TABLE cli_family_authorities (
   project_id TEXT REFERENCES artifact_containers(id) ON DELETE RESTRICT,
   project_name_snapshot TEXT,
   agent_profile_id TEXT REFERENCES agent_profiles(id) ON DELETE RESTRICT,
+  bridge_authority_id TEXT REFERENCES bridge_authorities(id) ON DELETE RESTRICT,
   approved_at TEXT,
   device_name TEXT,
   status TEXT NOT NULL CHECK (status IN ('active', 'revoked', 'superseded')),
@@ -359,6 +360,8 @@ CREATE TABLE cli_family_authorities (
 );
 CREATE INDEX cli_family_authorities_user_id ON cli_family_authorities(user_id);
 CREATE INDEX cli_family_authorities_agent_profile_id ON cli_family_authorities(agent_profile_id);
+CREATE INDEX cli_family_authorities_bridge_authority_id
+  ON cli_family_authorities(bridge_authority_id);
 
 -- Bots only ever hold restricted agent-preset credential families.
 CREATE TRIGGER cli_family_authorities_bot_agent_only_insert
@@ -389,6 +392,90 @@ CREATE TABLE cli_session_authorities (
   CHECK ((kind = 'bootstrap' AND family_id IS NULL AND expires_at IS NOT NULL) OR (kind = 'family' AND family_id IS NOT NULL AND expires_at IS NULL))
 );
 CREATE INDEX cli_session_authorities_family_id ON cli_session_authorities(family_id);
+
+CREATE TABLE bridge_authorities (
+  id                       TEXT PRIMARY KEY,
+  workspace_id             TEXT NOT NULL REFERENCES workspaces(id) ON DELETE RESTRICT,
+  bot_user_id              TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE RESTRICT,
+  agent_profile_id         TEXT NOT NULL UNIQUE REFERENCES agent_profiles(id) ON DELETE RESTRICT,
+  source_kind              TEXT NOT NULL,
+  source_installation_id   TEXT NOT NULL,
+  external_workspace_id    TEXT NOT NULL,
+  fallback_project_id      TEXT NOT NULL REFERENCES artifact_containers(id) ON DELETE RESTRICT,
+  created_at               TEXT NOT NULL,
+  updated_at               TEXT NOT NULL,
+  UNIQUE (workspace_id, source_kind, source_installation_id, external_workspace_id),
+  CHECK (source_kind = trim(source_kind) AND length(source_kind) BETWEEN 1 AND 80),
+  CHECK (source_installation_id = trim(source_installation_id) AND length(source_installation_id) BETWEEN 1 AND 200),
+  CHECK (external_workspace_id = trim(external_workspace_id) AND length(external_workspace_id) BETWEEN 1 AND 200)
+);
+CREATE INDEX bridge_authorities_fallback_project_id
+  ON bridge_authorities(fallback_project_id);
+
+CREATE TABLE bridge_conversations (
+  id                       TEXT PRIMARY KEY,
+  bridge_authority_id      TEXT NOT NULL REFERENCES bridge_authorities(id) ON DELETE RESTRICT,
+  project_id               TEXT NOT NULL UNIQUE REFERENCES artifact_containers(id) ON DELETE CASCADE,
+  conversation_kind        TEXT NOT NULL CHECK (conversation_kind IN ('public_channel', 'private_channel')),
+  conversation_name        TEXT,
+  privacy_ceiling          TEXT NOT NULL CHECK (privacy_ceiling IN ('workspace', 'private')),
+  privacy_epoch            INTEGER NOT NULL DEFAULT 0 CHECK (privacy_epoch IN (0, 1)),
+  created_at               TEXT NOT NULL,
+  updated_at               TEXT NOT NULL,
+  UNIQUE (id, bridge_authority_id)
+);
+CREATE INDEX bridge_conversations_authority_updated
+  ON bridge_conversations(bridge_authority_id, updated_at DESC);
+
+CREATE TRIGGER bridge_conversations_privacy_monotonic
+BEFORE UPDATE OF privacy_ceiling, privacy_epoch ON bridge_conversations
+WHEN (OLD.privacy_ceiling = 'private' AND NEW.privacy_ceiling <> 'private')
+  OR NEW.privacy_epoch < OLD.privacy_epoch
+BEGIN
+  SELECT RAISE(ABORT, 'bridge conversation privacy cannot widen');
+END;
+
+CREATE TABLE bridge_conversation_ids (
+  mapping_id                TEXT NOT NULL,
+  bridge_authority_id       TEXT NOT NULL,
+  external_conversation_id  TEXT NOT NULL,
+  created_at                TEXT NOT NULL,
+  PRIMARY KEY (bridge_authority_id, external_conversation_id),
+  FOREIGN KEY (mapping_id, bridge_authority_id)
+    REFERENCES bridge_conversations(id, bridge_authority_id) ON DELETE CASCADE
+);
+CREATE INDEX bridge_conversation_ids_mapping_id
+  ON bridge_conversation_ids(mapping_id);
+
+CREATE TABLE bridge_requests (
+  bridge_authority_id       TEXT NOT NULL REFERENCES bridge_authorities(id) ON DELETE RESTRICT,
+  request_id                TEXT NOT NULL,
+  routing_class             TEXT NOT NULL CHECK (routing_class IN ('channel', 'dm')),
+  conversation_ids_json     TEXT NOT NULL,
+  mapping_id                TEXT REFERENCES bridge_conversations(id) ON DELETE RESTRICT,
+  requester_stable_id       TEXT NOT NULL,
+  requester_verified_email  TEXT NOT NULL,
+  stable_digest             TEXT,
+  status                    TEXT NOT NULL CHECK (status IN ('binding', 'leased', 'completed')),
+  lease_generation          TEXT,
+  lease_expires_at          TEXT,
+  result_artifact_id        TEXT REFERENCES shareables(id) ON DELETE RESTRICT,
+  result_version_id         TEXT REFERENCES versions(id) ON DELETE RESTRICT,
+  mapping_created           INTEGER NOT NULL DEFAULT 0 CHECK (mapping_created IN (0, 1)),
+  project_created           INTEGER NOT NULL DEFAULT 0 CHECK (project_created IN (0, 1)),
+  created_at                TEXT NOT NULL,
+  updated_at                TEXT NOT NULL,
+  PRIMARY KEY (bridge_authority_id, request_id),
+  UNIQUE (bridge_authority_id, request_id, lease_generation),
+  CHECK (
+    (status = 'binding' AND stable_digest IS NULL AND lease_generation IS NULL AND lease_expires_at IS NULL)
+    OR (status = 'leased' AND stable_digest IS NOT NULL AND lease_generation IS NOT NULL AND lease_expires_at IS NOT NULL)
+    OR (status = 'completed' AND stable_digest IS NOT NULL AND lease_generation IS NOT NULL AND lease_expires_at IS NOT NULL AND result_artifact_id IS NOT NULL)
+  )
+);
+CREATE INDEX bridge_requests_mapping_id ON bridge_requests(mapping_id);
+CREATE INDEX bridge_requests_lease_expiry
+  ON bridge_requests(status, lease_expires_at);
 
 -- ────────────────────────────────────────────────
 -- deviceCode (better-auth device authorization plugin)
@@ -512,6 +599,52 @@ CREATE TABLE versions (
 );
 CREATE INDEX versions_shareable_id ON versions(shareable_id);
 CREATE INDEX versions_r2_key ON versions(r2_key);
+
+CREATE TABLE bridge_operations (
+  id                         TEXT PRIMARY KEY,
+  bridge_authority_id        TEXT NOT NULL,
+  request_id                 TEXT NOT NULL,
+  lease_generation           TEXT NOT NULL,
+  operation                  TEXT NOT NULL CHECK (operation IN ('publish', 'append', 'update', 'set_visibility')),
+  requester_stable_id        TEXT NOT NULL,
+  requester_verified_email   TEXT NOT NULL,
+  requester_display_name     TEXT,
+  artifact_id                TEXT NOT NULL REFERENCES shareables(id) ON DELETE CASCADE,
+  version_id                 TEXT REFERENCES versions(id) ON DELETE CASCADE,
+  created_at                 TEXT NOT NULL,
+  UNIQUE (bridge_authority_id, request_id),
+  FOREIGN KEY (bridge_authority_id, request_id, lease_generation)
+    REFERENCES bridge_requests(bridge_authority_id, request_id, lease_generation) ON DELETE RESTRICT,
+  CHECK ((operation = 'set_visibility') = (version_id IS NULL))
+);
+CREATE INDEX bridge_operations_artifact_created
+  ON bridge_operations(artifact_id, created_at DESC);
+CREATE UNIQUE INDEX bridge_operations_version_id
+  ON bridge_operations(version_id) WHERE version_id IS NOT NULL;
+
+CREATE TRIGGER bridge_operations_private_grant_insert
+BEFORE INSERT ON bridge_operations
+WHEN EXISTS (
+  SELECT 1 FROM shareables
+  WHERE id = NEW.artifact_id AND visibility = 'private'
+)
+AND NOT EXISTS (
+  SELECT 1 FROM shareable_grants
+  WHERE shareable_id = NEW.artifact_id
+    AND granted_email = NEW.requester_verified_email
+)
+BEGIN
+  SELECT RAISE(ABORT, 'private bridge artifact requires requester grant');
+END;
+
+CREATE TABLE bridge_dm_artifacts (
+  artifact_id          TEXT PRIMARY KEY REFERENCES shareables(id) ON DELETE CASCADE,
+  bridge_authority_id  TEXT NOT NULL REFERENCES bridge_authorities(id) ON DELETE RESTRICT,
+  requester_stable_id  TEXT NOT NULL,
+  created_at           TEXT NOT NULL
+);
+CREATE INDEX bridge_dm_artifacts_authority_requester
+  ON bridge_dm_artifacts(bridge_authority_id, requester_stable_id);
 
 -- ────────────────────────────────────────────────
 -- version_files

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -401,7 +401,7 @@ CREATE TABLE bridge_authorities (
   source_kind              TEXT NOT NULL,
   source_installation_id   TEXT NOT NULL,
   external_workspace_id    TEXT NOT NULL,
-  fallback_project_id      TEXT NOT NULL REFERENCES artifact_containers(id) ON DELETE RESTRICT,
+  fallback_project_id      TEXT REFERENCES artifact_containers(id) ON DELETE SET NULL,
   created_at               TEXT NOT NULL,
   updated_at               TEXT NOT NULL,
   UNIQUE (workspace_id, source_kind, source_installation_id, external_workspace_id),

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -459,8 +459,8 @@ CREATE TABLE bridge_requests (
   status                    TEXT NOT NULL CHECK (status IN ('binding', 'leased', 'completed')),
   lease_generation          TEXT,
   lease_expires_at          TEXT,
-  result_artifact_id        TEXT REFERENCES shareables(id) ON DELETE RESTRICT,
-  result_version_id         TEXT REFERENCES versions(id) ON DELETE RESTRICT,
+  result_artifact_id        TEXT, -- tombstone survives normal artifact deletion
+  result_version_id         TEXT, -- tombstone survives normal version deletion
   mapping_created           INTEGER NOT NULL DEFAULT 0 CHECK (mapping_created IN (0, 1)),
   project_created           INTEGER NOT NULL DEFAULT 0 CHECK (project_created IN (0, 1)),
   created_at                TEXT NOT NULL,


### PR DESCRIPTION
## Summary

- Add authenticated bridge-only health and publishing endpoints for trusted host context.
- Resolve channel conversations to projects automatically and keep direct-message artifacts requester-scoped.
- Enforce bot authority, idempotency, visibility narrowing, destination checks, grant limits, and lifecycle revocation at commit boundaries.
- Preserve bridge authority across credential reissue and stop it cleanly with the bot lifecycle.

## Validation

- `pnpm validate:static`
- Codex and Claude deep implementation review on `8ec72c5`; no unresolved blockers.
