### PR TITLE
fix: unify verified workspace claims

### DIFF
--- a/apps/web/app/services/auth.server.bearer.test.ts
+++ b/apps/web/app/services/auth.server.bearer.test.ts
@@ -149,6 +149,46 @@ describe('getSessionUserFromBearer', () => {
       workspaceId: 'ws-personal',
     })
   })
+
+  test('session bearer clears signup creation analytics after a claim move', async () => {
+    const sessionToken = 'sess_claim_move'
+    seedSession(sqlite, 'u1', sessionToken)
+    sqlite.exec(`
+      UPDATE workspaces
+      SET hd = NULL, email_domain = NULL, self_upload_enabled = 0,
+          storage_quota_bytes = 0, storage_used_bytes = 0,
+          name = 'u1@example.com''s workspace'
+      WHERE id = 'ws1';
+      INSERT INTO workspaces (
+        id, hd, name, created_at, email_domain, self_upload_enabled
+      ) VALUES (
+        'ws-claimed', NULL, 'example.com', '2026-06-26T00:00:00.000Z',
+        'example.com', 1
+      );
+      INSERT INTO workspace_domain_claims (
+        domain, workspace_id, source, provider_tenant_id, created_at, updated_at
+      ) VALUES (
+        'example.com', 'ws-claimed', 'google_hd', NULL,
+        '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z'
+      );
+      INSERT INTO pending_signup_analytics (
+        user_id, method, workspace_created, created_at, claimed_at, tracked_at
+      ) VALUES (
+        'u1', 'email', 1, '2026-06-26T00:00:00.000Z', NULL, NULL
+      );
+    `)
+
+    await expect(
+      getSessionUserFromBearer(bearerRequest(sessionToken)),
+    ).resolves.toMatchObject({ workspaceId: 'ws-claimed' })
+    expect(
+      sqlite
+        .prepare(
+          "SELECT workspace_created FROM pending_signup_analytics WHERE user_id = 'u1'",
+        )
+        .get(),
+    ).toEqual({ workspace_created: 0 })
+  })
 })
 
 function bearerRequest(token: string): Request {

--- a/apps/web/app/services/auth.server.cookie-cache.test.ts
+++ b/apps/web/app/services/auth.server.cookie-cache.test.ts
@@ -152,7 +152,7 @@ describe('getSessionUser cookie cache', () => {
       INSERT INTO workspace_domain_claims (
         domain, workspace_id, source, provider_tenant_id, created_at, updated_at
       ) VALUES (
-        'first.example', 'ws1', 'google_hd', NULL,
+        'example.com', 'ws1', 'google_hd', NULL,
         '2026-07-20T00:00:00.000Z', '2026-07-20T00:00:00.000Z'
       );
     `)
@@ -163,12 +163,13 @@ describe('getSessionUser cookie cache', () => {
       })
 
     await expect(getSessionUser(request())).resolves.toMatchObject({
-      hd: 'first.example',
+      hd: 'example.com',
     })
     sqlite.exec(`
       UPDATE workspace_domain_claims
       SET domain = 'second.example'
-      WHERE domain = 'first.example'
+      WHERE domain = 'example.com';
+      UPDATE users SET email = 'u1@second.example' WHERE id = 'u1';
     `)
     await expect(getSessionUser(request())).resolves.toMatchObject({
       hd: 'second.example',
@@ -238,6 +239,7 @@ describe('getSessionUser cookie cache', () => {
         'example.com', 'ws1', 'microsoft_verified_domain', 'tenant-1',
         '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z'
       );
+
     `)
 
     const user = await getSessionUser(
@@ -254,11 +256,139 @@ describe('getSessionUser cookie cache', () => {
     })
   })
 
-  test('does not move a self-upload disabled viewer into a claimed workspace', async () => {
+  test('preserves a Google hosted domain that differs from the user email domain', async () => {
+    seedSession(sqlite, 'u1', 'sess_cookie_cache')
+    sqlite.exec(`
+      UPDATE users SET email = 'u1@alias.example' WHERE id = 'u1';
+      UPDATE workspaces SET hd = NULL, email_domain = 'corp.com' WHERE id = 'ws1';
+      INSERT INTO workspace_domain_claims (
+        domain, workspace_id, source, provider_tenant_id, created_at, updated_at
+      ) VALUES
+      (
+        'corp.com', 'ws1', 'google_hd', NULL,
+        '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z'
+      ),
+      (
+        'alias.example', 'ws1', 'microsoft_verified_domain', 'tenant-other',
+        '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z'
+      );
+    `)
+
+    await expect(
+      getSessionUser(
+        cachedSessionRequest({
+          sessionToken: 'sess_cookie_cache',
+          userId: 'u1',
+        }),
+      ),
+    ).resolves.toMatchObject({ workspaceId: 'ws1', hd: 'corp.com' })
+  })
+
+  test('repairs an ownerless claimed workspace during browser session resolution', async () => {
+    seedSession(sqlite, 'u1', 'sess_cookie_cache')
+    sqlite.exec(`
+      UPDATE workspaces SET hd = NULL, email_domain = 'example.com' WHERE id = 'ws1';
+      UPDATE workspace_members
+      SET role = 'member', status = 'active'
+      WHERE workspace_id = 'ws1' AND user_id = 'u1';
+      INSERT INTO users (
+        id, email, email_verified, name, created_at, updated_at, workspace_id
+      ) VALUES (
+        'u-admin', 'admin@example.com', 1, 'Admin',
+        '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z', 'ws1'
+      );
+      INSERT INTO workspace_members (
+        workspace_id, user_id, role, status, created_at, updated_at
+      ) VALUES (
+        'ws1', 'u-admin', 'admin', 'active',
+        '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z'
+      );
+      INSERT INTO workspace_domain_claims (
+        domain, workspace_id, source, provider_tenant_id, created_at, updated_at
+      ) VALUES (
+        'example.com', 'ws1', 'google_hd', NULL,
+        '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z'
+      );
+    `)
+
+    await expect(
+      getSessionUser(
+        cachedSessionRequest({
+          sessionToken: 'sess_cookie_cache',
+          userId: 'u1',
+        }),
+      ),
+    ).resolves.toMatchObject({ workspaceId: 'ws1', hd: 'example.com' })
+    expect(
+      sqlite
+        .prepare(
+          "SELECT user_id, role FROM workspace_members WHERE workspace_id = 'ws1' ORDER BY user_id",
+        )
+        .all(),
+    ).toEqual([{ user_id: 'u-admin', role: 'owner' }])
+  })
+
+  test('uses the claim matching the user email in a multi-domain workspace', async () => {
+    seedSession(sqlite, 'u1', 'sess_cookie_cache')
+    sqlite.exec(`
+      UPDATE workspaces SET hd = NULL, email_domain = NULL WHERE id = 'ws1';
+      INSERT INTO workspace_domain_claims (
+        domain, workspace_id, source, provider_tenant_id, created_at, updated_at
+      ) VALUES
+        ('another.example', 'ws1', 'microsoft_verified_domain', 'tenant-1',
+         '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z'),
+        ('example.com', 'ws1', 'microsoft_verified_domain', 'tenant-1',
+         '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z');
+    `)
+
+    await expect(
+      getSessionUser(
+        cachedSessionRequest({
+          sessionToken: 'sess_cookie_cache',
+          userId: 'u1',
+        }),
+      ),
+    ).resolves.toMatchObject({ hd: 'example.com' })
+  })
+
+  test('uses a legacy duplicate claim through the canonical Microsoft tenant', async () => {
     seedSession(sqlite, 'u1', 'sess_cookie_cache')
     sqlite.exec(`
       UPDATE workspaces
-      SET hd = NULL, email_domain = NULL, self_upload_enabled = 0, storage_quota_bytes = 0
+      SET hd = NULL, email_domain = NULL, ms_tenant_id = 'tenant-1'
+      WHERE id = 'ws1';
+      INSERT INTO workspaces (id, hd, name, created_at, email_domain)
+      VALUES ('ws-duplicate', NULL, 'example.com',
+              '2026-06-26T00:00:00.000Z', 'example.com');
+      INSERT INTO workspace_domain_claims (
+        domain, workspace_id, source, provider_tenant_id, created_at, updated_at
+      ) VALUES (
+        'example.com', 'ws-duplicate', 'microsoft_verified_domain', 'tenant-1',
+        '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z'
+      );
+    `)
+
+    await expect(
+      getSessionUser(
+        cachedSessionRequest({
+          sessionToken: 'sess_cookie_cache',
+          userId: 'u1',
+        }),
+      ),
+    ).resolves.toMatchObject({
+      workspaceId: 'ws1',
+      hd: 'example.com',
+      msTenantId: 'tenant-1',
+    })
+  })
+
+  test('moves a verified viewer into its claimed workspace on session resolution', async () => {
+    seedSession(sqlite, 'u1', 'sess_cookie_cache')
+    sqlite.exec(`
+      UPDATE workspaces
+      SET hd = NULL, email_domain = NULL, self_upload_enabled = 0,
+          storage_quota_bytes = 0, storage_used_bytes = 0,
+          name = 'u1@example.com''s workspace'
       WHERE id = 'ws1';
 
       INSERT INTO workspaces (
@@ -276,6 +406,12 @@ describe('getSessionUser cookie cache', () => {
         'example.com', 'ws-claimed', 'microsoft_verified_domain', 'tenant-1',
         '2026-06-26T00:00:00.000Z', '2026-06-26T00:00:00.000Z'
       );
+
+      INSERT INTO pending_signup_analytics (
+        user_id, method, workspace_created, created_at, claimed_at, tracked_at
+      ) VALUES (
+        'u1', 'email', 1, '2026-06-26T00:00:00.000Z', NULL, NULL
+      );
     `)
 
     const user = await getSessionUser(
@@ -286,12 +422,19 @@ describe('getSessionUser cookie cache', () => {
     )
 
     expect(user).toMatchObject({
-      workspaceId: 'ws1',
-      selfUploadEnabled: false,
+      workspaceId: 'ws-claimed',
+      selfUploadEnabled: true,
     })
     expect(
       sqlite.prepare("SELECT workspace_id FROM users WHERE id = 'u1'").get(),
-    ).toEqual({ workspace_id: 'ws1' })
+    ).toEqual({ workspace_id: 'ws-claimed' })
+    expect(
+      sqlite
+        .prepare(
+          "SELECT workspace_created FROM pending_signup_analytics WHERE user_id = 'u1'",
+        )
+        .get(),
+    ).toEqual({ workspace_created: 0 })
   })
 })
 

--- a/apps/web/app/services/auth.server.free-quota-identity.test.ts
+++ b/apps/web/app/services/auth.server.free-quota-identity.test.ts
@@ -36,6 +36,16 @@ function createGoogleIdToken(payload: Record<string, unknown>): string {
   return `${header}.${body}.sig`
 }
 
+function createMicrosoftIdToken(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'RS256', typ: 'JWT' }),
+  ).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+    'base64url',
+  )
+  return `${header}.${body}.sig`
+}
+
 describe('workspaceCreationPolicyForAuthRoute', () => {
   test('email OTP without a marker gets viewer provisioning', () => {
     expect(VIEWER_POLICY).toEqual({
@@ -81,7 +91,7 @@ describe('OAuth account workspace resolution', () => {
       .values({
         id: input.workspaceId,
         hd: null,
-        name: input.workspaceId,
+        name: `${input.email}'s workspace`,
         created_at: '2026-06-26T00:00:00.000Z',
         email_domain: null,
         self_upload_enabled: input.selfUploadEnabled,
@@ -227,7 +237,59 @@ describe('OAuth account workspace resolution', () => {
     }
   })
 
-  test('OAuth account resolution reactivates a removed row for the current claim workspace', async () => {
+  test('Microsoft tenant identity wins over a duplicate domain claim workspace', async () => {
+    const { db } = createMigratedInMemoryDb()
+    try {
+      await seedUser(db, {
+        userId: 'user-ms',
+        email: 'alice@corp.com',
+        workspaceId: 'ws-ms-tenant',
+        selfUploadEnabled: 1,
+        membershipRole: 'owner',
+      })
+      await db
+        .updateTable('workspaces')
+        .set({ ms_tenant_id: 'tenant-1' })
+        .where('id', '=', 'ws-ms-tenant')
+        .execute()
+      await db
+        .insertInto('workspaces')
+        .values({
+          id: 'ws-empty-claim',
+          hd: null,
+          name: 'corp.com',
+          created_at: '2026-06-26T00:00:00.000Z',
+          email_domain: 'corp.com',
+        })
+        .execute()
+      await seedClaim(db, 'ws-empty-claim')
+
+      await expect(
+        resolveOAuthWorkspaceAfterAccountCreate(db, {
+          providerId: 'microsoft',
+          userId: 'user-ms',
+          idToken: createMicrosoftIdToken({
+            tid: 'tenant-1',
+            oid: 'object-1',
+            email: 'alice@corp.com',
+            email_verified: true,
+          }),
+        }),
+      ).resolves.toBe('ws-ms-tenant')
+
+      await expect(
+        db
+          .selectFrom('users')
+          .select('workspace_id')
+          .where('id', '=', 'user-ms')
+          .executeTakeFirstOrThrow(),
+      ).resolves.toEqual({ workspace_id: 'ws-ms-tenant' })
+    } finally {
+      await db.destroy()
+    }
+  })
+
+  test('OAuth account resolution reactivates membership and repairs ownership for the current claim workspace', async () => {
     const { db } = createMigratedInMemoryDb()
     try {
       await seedUser(db, {
@@ -265,7 +327,7 @@ describe('OAuth account workspace resolution', () => {
           .where('user_id', '=', 'user-removed-membership')
           .executeTakeFirstOrThrow(),
       ).resolves.toEqual({
-        role: 'member',
+        role: 'owner',
         status: 'active',
         removed_at: null,
         removed_by: null,
@@ -351,6 +413,66 @@ describe('OAuth account workspace resolution', () => {
           .where('workspace_id', '=', 'ws-claimed')
           .execute(),
       ).resolves.toEqual([])
+    } finally {
+      await db.destroy()
+    }
+  })
+
+  test('verified email signup joins an existing claimed workspace without changing its upload policy', async () => {
+    const { db } = createMigratedInMemoryDb()
+    try {
+      await db
+        .insertInto('workspaces')
+        .values({
+          id: 'ws-claimed-email',
+          hd: null,
+          name: 'corp.com',
+          created_at: '2026-06-26T00:00:00.000Z',
+          email_domain: 'corp.com',
+          self_upload_enabled: 1,
+          storage_quota_bytes: PLAN_STORAGE_QUOTA_BYTES.free,
+        })
+        .execute()
+      await db
+        .insertInto('workspace_domain_claims')
+        .values({
+          domain: 'corp.com',
+          workspace_id: 'ws-claimed-email',
+          source: 'google_hd',
+          provider_tenant_id: null,
+          created_at: '2026-06-26T00:00:00.000Z',
+          updated_at: '2026-06-26T00:00:00.000Z',
+        })
+        .execute()
+
+      await expect(
+        ensureWorkspace(
+          db,
+          'new-user@corp.com',
+          null,
+          null,
+          null,
+          true,
+          VIEWER_POLICY,
+          true,
+        ),
+      ).resolves.toEqual({
+        workspaceId: 'ws-claimed-email',
+        created: false,
+      })
+
+      await expect(
+        db
+          .selectFrom('workspaces')
+          .select(['id', 'self_upload_enabled', 'storage_quota_bytes'])
+          .execute(),
+      ).resolves.toEqual([
+        {
+          id: 'ws-claimed-email',
+          self_upload_enabled: 1,
+          storage_quota_bytes: PLAN_STORAGE_QUOTA_BYTES.free,
+        },
+      ])
     } finally {
       await db.destroy()
     }
@@ -636,6 +758,58 @@ describe('OAuth account re-login boundary', () => {
         .where('id', '=', 'ws-custom')
         .executeTakeFirstOrThrow()
       expect(workspace).toEqual({
+        self_upload_enabled: 1,
+        storage_quota_bytes: 1234,
+      })
+    } finally {
+      await db.destroy()
+    }
+  })
+
+  test('OAuth account resolution enables a customized viewer workspace without moving it', async () => {
+    const { db } = createMigratedInMemoryDb()
+    try {
+      await db
+        .insertInto('workspaces')
+        .values({
+          id: 'ws-custom-resolve',
+          hd: null,
+          name: 'Customized viewer workspace',
+          created_at: '2026-06-26T00:00:00.000Z',
+          email_domain: null,
+          self_upload_enabled: 0,
+          storage_quota_bytes: 1234,
+        })
+        .execute()
+      await db
+        .insertInto('users')
+        .values({
+          id: 'user-custom-resolve',
+          email: 'viewer@gmail.com',
+          email_verified: 1,
+          name: 'Viewer',
+          image: null,
+          created_at: '2026-06-26T00:00:00.000Z',
+          updated_at: '2026-06-26T00:00:00.000Z',
+          workspace_id: 'ws-custom-resolve',
+          locale: null,
+        })
+        .execute()
+
+      await expect(
+        resolveOAuthWorkspaceAfterAccountCreate(db, {
+          providerId: 'microsoft',
+          userId: 'user-custom-resolve',
+          idToken: null,
+        }),
+      ).resolves.toBe('ws-custom-resolve')
+      await expect(
+        db
+          .selectFrom('workspaces')
+          .select(['self_upload_enabled', 'storage_quota_bytes'])
+          .where('id', '=', 'ws-custom-resolve')
+          .executeTakeFirstOrThrow(),
+      ).resolves.toEqual({
         self_upload_enabled: 1,
         storage_quota_bytes: 1234,
       })

--- a/apps/web/app/services/auth.server.microsoft.test.ts
+++ b/apps/web/app/services/auth.server.microsoft.test.ts
@@ -354,7 +354,7 @@ describe('persistGoogleHostedDomainClaimForAccount', () => {
         .values({
           id: 'ws-personal',
           hd: null,
-          name: 'Personal',
+          name: "alice@corp.com's workspace",
           created_at: '2026-06-26T00:00:00.000Z',
           email_domain: null,
           self_upload_enabled: 0,

--- a/apps/web/app/services/auth.server.oauth-workspace-integration.test.ts
+++ b/apps/web/app/services/auth.server.oauth-workspace-integration.test.ts
@@ -296,7 +296,38 @@ describe('Better Auth OAuth workspace integration', () => {
     await expectUserWorkspaceMember(db, userId, 'ws-hosted-domain', 'owner')
   })
 
-  test('email code first login stays in a viewer workspace without claim membership', async () => {
+  test('Microsoft without an id token falls back to a claimed email domain', async () => {
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
+    sqliteRef.current = fixture.sqlite
+    const { db } = fixture
+    await seedClaim(db, 'ws-email-domain')
+    const context = await getAuthContext()
+
+    const userId = await runWithEndpointContext(
+      {
+        path: '/callback/:id',
+        params: { id: 'microsoft' },
+        context: context as any,
+      },
+      async () => {
+        const user = await context.internalAdapter.createUser({
+          email: 'alice@corp.com',
+          emailVerified: true,
+          name: 'Alice',
+        })
+        await context.internalAdapter.createAccount({
+          userId: user.id,
+          providerId: 'microsoft',
+          accountId: 'microsoft-no-id-token',
+        })
+        return user.id
+      },
+    )
+
+    await expectUserWorkspaceMember(db, userId, 'ws-email-domain', 'owner')
+  })
+
+  test('verified email code signup joins the claimed workspace', async () => {
     fixture = createD1BatchFixture({ sqlite: sqliteRef })
     sqliteRef.current = fixture.sqlite
     const { db } = fixture
@@ -324,24 +355,68 @@ describe('Better Auth OAuth workspace integration', () => {
       .select('workspace_id')
       .where('id', '=', userId)
       .executeTakeFirstOrThrow()
-    expect(user.workspace_id).not.toBe('ws-claimed')
-    await expectUserWorkspaceMember(db, userId, user.workspace_id, 'owner')
-    await expect(
-      db
-        .selectFrom('workspace_members')
-        .select('user_id')
-        .where('workspace_id', '=', 'ws-claimed')
-        .where('user_id', '=', userId)
-        .where('status', '=', 'active')
-        .execute(),
-    ).resolves.toEqual([])
+    expect(user.workspace_id).toBe('ws-claimed')
+    await expectUserWorkspaceMember(db, userId, 'ws-claimed', 'owner')
     await expect(
       db
         .selectFrom('workspaces')
         .select('self_upload_enabled')
-        .where('id', '=', user.workspace_id)
+        .where('id', '=', 'ws-claimed')
         .executeTakeFirstOrThrow(),
-    ).resolves.toEqual({ self_upload_enabled: 0 })
+    ).resolves.toEqual({ self_upload_enabled: 1 })
+  })
+
+  test('verified email signup avoids a legacy duplicate Microsoft claim workspace', async () => {
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
+    sqliteRef.current = fixture.sqlite
+    const { db } = fixture
+    await seedClaim(db, 'ws-duplicate')
+    await db
+      .updateTable('workspace_domain_claims')
+      .set({
+        source: 'microsoft_verified_domain',
+        provider_tenant_id: 'tenant-1',
+      })
+      .where('domain', '=', 'corp.com')
+      .execute()
+    await db
+      .insertInto('workspaces')
+      .values({
+        id: 'ws-tenant',
+        hd: null,
+        ms_tenant_id: 'tenant-1',
+        name: 'corp.com',
+        created_at: NOW,
+        email_domain: 'corp.com',
+        self_upload_enabled: 1,
+      })
+      .execute()
+    const context = await getAuthContext()
+
+    const userId = await runWithEndpointContext(
+      {
+        path: '/sign-in/email-otp',
+        params: {},
+        context: context as any,
+      },
+      async () => {
+        const user = await context.internalAdapter.createUser({
+          email: 'viewer@corp.com',
+          emailVerified: true,
+          name: 'Viewer',
+        })
+        return user.id
+      },
+    )
+
+    await expectUserWorkspaceMember(db, userId, 'ws-tenant', 'owner')
+    await expect(
+      db
+        .selectFrom('users')
+        .select('id')
+        .where('workspace_id', '=', 'ws-duplicate')
+        .execute(),
+    ).resolves.toEqual([])
   })
 
   test('Microsoft account update restores the avatar object on repeat sign-in', async () => {

--- a/apps/web/app/services/auth.server.ts
+++ b/apps/web/app/services/auth.server.ts
@@ -58,10 +58,13 @@ import {
   type SignupMethod,
 } from './signup-analytics.server'
 import {
+  canEnableOAuthWorkspaceSelfUpload,
   canAutoMoveUserWorkspace,
   ensureDomainClaimWorkspace,
   ensureWorkspaceDomainClaim,
   findWorkspaceIdByDomainClaim,
+  findWorkspaceIdForMicrosoftTenantDomain,
+  findWorkspaceIdByProviderTenant,
   maybeMoveUserToClaimedWorkspace,
   moveUserToWorkspaceForOAuth,
 } from './workspace-domain-claims.server'
@@ -89,6 +92,8 @@ interface SessionWorkspaceContext {
   selfUploadEnabled: boolean
   hd: string | null
   msTenantId: string | null
+  hasActiveOwner: boolean
+  claimBackedIdentity: boolean
   kind: 'human' | 'bot'
 }
 
@@ -642,6 +647,7 @@ export async function resolveOAuthWorkspaceAfterAccountCreate(
       nowIso(),
       { reactivateRemoved: true },
     )
+    await ensureWorkspaceAdmin(db, targetWorkspaceId, nowIso())
     return targetWorkspaceId
   }
 
@@ -653,9 +659,11 @@ export async function resolveOAuthWorkspaceAfterAccountCreate(
     .executeTakeFirst()
   if (
     currentWorkspace?.self_upload_enabled === 0 &&
-    !(await canAutoMoveUserWorkspace(db, input.userId, {
-      allowCurrentWorkspaceAdmin: currentWorkspaceId,
-    }))
+    !(await canEnableOAuthWorkspaceSelfUpload(
+      db,
+      input.userId,
+      currentWorkspaceId,
+    ))
   ) {
     return null
   }
@@ -717,24 +725,34 @@ async function resolveOAuthTargetWorkspace(
     }
   }
 
-  const emailDomain = normalizeEmailDomain(input.email)
-  const existingClaim = await findWorkspaceIdByDomainClaim(db, emailDomain)
-  if (existingClaim) return existingClaim
-
-  if (!input.idToken) return null
-  let tenantId: string
-  try {
-    tenantId = decodeMicrosoftIdTokenPayload(input.idToken).tid
-  } catch {
-    return null
+  if (input.providerId === 'microsoft') {
+    let tenantId: string | null = null
+    if (input.idToken) {
+      try {
+        tenantId = decodeMicrosoftIdTokenPayload(input.idToken).tid || null
+      } catch {
+        tenantId = null
+      }
+    }
+    if (tenantId) {
+      const canonicalTenantWorkspaceId = await findWorkspaceIdByProviderTenant(
+        db,
+        tenantId,
+      )
+      if (canonicalTenantWorkspaceId === input.currentWorkspaceId) {
+        return canonicalTenantWorkspaceId
+      }
+      const tenantWorkspaceId = await findWorkspaceIdForMicrosoftTenantDomain(
+        db,
+        tenantId,
+        normalizeEmailDomain(input.email),
+      )
+      if (tenantWorkspaceId) return tenantWorkspaceId
+    }
   }
-  if (!tenantId) return null
-  const fallback = await db
-    .selectFrom('workspaces')
-    .select('id')
-    .where('ms_tenant_id', '=', tenantId)
-    .executeTakeFirst()
-  return fallback?.id ?? null
+
+  const emailDomain = normalizeEmailDomain(input.email)
+  return await findWorkspaceIdByDomainClaim(db, emailDomain)
 }
 
 // Safe to build once per isolate: the `cloudflare:workers` env (and its D1
@@ -1033,10 +1051,13 @@ async function resolveSessionUser(
     // authority; any cookie session that maps onto a bot row is treated as
     // unauthenticated regardless of entry point.
     if (context.kind === 'bot') return null
+    if (context.claimBackedIdentity && !context.hasActiveOwner) {
+      await ensureWorkspaceAdmin(getDb(), context.workspaceId, nowIso())
+      context = { ...context, hasActiveOwner: true }
+    }
     const emailDomain = normalizeEmailDomain(sessionUser.email)
     const shouldCheckClaimMove =
       emailDomain &&
-      context.selfUploadEnabled &&
       !isPublicEmailDomain(emailDomain) &&
       normalizeEmailDomain(context.hd) !== emailDomain
     const movedWorkspaceId = shouldCheckClaimMove
@@ -1047,6 +1068,11 @@ async function resolveSessionUser(
         })
       : null
     if (movedWorkspaceId) {
+      await clearWorkspaceCreatedIfMoved(getDb(), {
+        userId: sessionUser.id,
+        originalWorkspaceId: context.workspaceId,
+        finalWorkspaceId: movedWorkspaceId,
+      })
       const movedContext = await loadWorkspaceContextByUserId(
         getDb(),
         sessionUser.id,
@@ -1069,7 +1095,12 @@ async function resolveSessionUser(
       )
         ? await readUserImage(getDb(), sessionUser.id)
         : null)
-    return { ...sessionUser, ...context, emailVerified, image }
+    const {
+      hasActiveOwner: _hasActiveOwner,
+      claimBackedIdentity: _claimBackedIdentity,
+      ...sessionContext
+    } = context
+    return { ...sessionUser, ...sessionContext, emailVerified, image }
   } finally {
     if (sessionDb) await sessionDb.destroy()
   }
@@ -1092,17 +1123,31 @@ async function buildSessionUserFromBearerRow(
   if (!context) return null
   // Domain-claim workspace moves are a human-only mechanism: a bot's
   // workspace_id is its host workspace and must never move.
-  if (context.selfUploadEnabled && context.kind === 'human') {
+  if (context.kind === 'human') {
+    if (context.claimBackedIdentity && !context.hasActiveOwner) {
+      await ensureWorkspaceAdmin(db, context.workspaceId, nowIso())
+      context = { ...context, hasActiveOwner: true }
+    }
     const movedWorkspaceId = await maybeMoveUserToClaimedWorkspace(db, {
       userId: user.id,
       email: user.email,
       currentWorkspaceId: context.workspaceId,
     })
     if (movedWorkspaceId) {
+      await clearWorkspaceCreatedIfMoved(db, {
+        userId: user.id,
+        originalWorkspaceId: context.workspaceId,
+        finalWorkspaceId: movedWorkspaceId,
+      })
       context = await loadWorkspaceContextByUserId(db, user.id)
       if (!context) return null
     }
   }
+  const {
+    hasActiveOwner: _hasActiveOwner,
+    claimBackedIdentity: _claimBackedIdentity,
+    ...sessionContext
+  } = context
   return {
     id: user.id,
     email: user.email,
@@ -1110,7 +1155,7 @@ async function buildSessionUserFromBearerRow(
     name: user.name,
     image: user.image,
     locale: user.locale,
-    ...context,
+    ...sessionContext,
   }
 }
 
@@ -1220,18 +1265,40 @@ async function loadWorkspaceContextByUserId(
   const row = await db
     .selectFrom('users')
     .innerJoin('workspaces', 'workspaces.id', 'users.workspace_id')
-    .leftJoin(
-      'workspace_domain_claims',
-      'workspace_domain_claims.workspace_id',
-      'workspaces.id',
-    )
-    .select([
+    .select((eb) => [
       'users.workspace_id',
       'users.kind',
       'workspaces.hd',
       'workspaces.ms_tenant_id',
       'workspaces.self_upload_enabled',
-      'workspace_domain_claims.domain as claimed_domain',
+      sql<string | null>`(
+        SELECT claims.domain
+        FROM workspace_domain_claims AS claims
+        WHERE (
+          claims.source = 'google_hd'
+          AND claims.workspace_id = workspaces.id
+        ) OR (
+          claims.source = 'microsoft_verified_domain'
+          AND claims.domain = lower(substr(users.email, instr(users.email, '@') + 1))
+          AND (
+            claims.workspace_id = workspaces.id
+            OR claims.provider_tenant_id = workspaces.ms_tenant_id
+          )
+        )
+        ORDER BY CASE WHEN claims.source = 'google_hd' THEN 0 ELSE 1 END,
+                 claims.domain
+        LIMIT 1
+      )`.as('claimed_domain'),
+      eb
+        .exists(
+          eb
+            .selectFrom('workspace_members')
+            .select('user_id')
+            .whereRef('workspace_members.workspace_id', '=', 'workspaces.id')
+            .where('workspace_members.status', '=', 'active')
+            .where('workspace_members.role', '=', 'owner'),
+        )
+        .as('has_active_owner'),
     ])
     .where('users.id', '=', userId)
     .executeTakeFirst()
@@ -1241,6 +1308,8 @@ async function loadWorkspaceContextByUserId(
     selfUploadEnabled: row.self_upload_enabled === 1,
     hd: row.hd ?? row.claimed_domain ?? null,
     msTenantId: row.ms_tenant_id ?? null,
+    hasActiveOwner: Boolean(row.has_active_owner),
+    claimBackedIdentity: row.claimed_domain !== null,
     kind: row.kind,
   }
 }
@@ -1394,7 +1463,7 @@ export async function ensureWorkspace(
     if (workspaceId) return { workspaceId, created: false }
   }
 
-  if (!microsoftTid && createsUploadEnabledWorkspace && allowEmailDomainClaim) {
+  if (!microsoftTid && _emailVerified && allowEmailDomainClaim) {
     const claimedWorkspaceId = await findWorkspaceIdByDomainClaim(
       db,
       emailDomain,

--- a/apps/web/app/services/mcp/identity.server.ts
+++ b/apps/web/app/services/mcp/identity.server.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from 'kysely'
+import { type Kysely, sql } from 'kysely'
 import type { SessionUser } from '~/lib/user'
 import type { DB } from '~/types/db'
 
@@ -63,11 +63,6 @@ export async function loadMcpUser(
   const row = await db
     .selectFrom('users')
     .innerJoin('workspaces', 'workspaces.id', 'users.workspace_id')
-    .leftJoin(
-      'workspace_domain_claims',
-      'workspace_domain_claims.workspace_id',
-      'workspaces.id',
-    )
     .select([
       'users.id as id',
       'users.email as email',
@@ -77,7 +72,24 @@ export async function loadMcpUser(
       'users.locale as locale',
       'users.kind as kind',
       'workspaces.hd as hd',
-      'workspace_domain_claims.domain as claimed_domain',
+      sql<string | null>`(
+        SELECT claims.domain
+        FROM workspace_domain_claims AS claims
+        WHERE (
+          claims.source = 'google_hd'
+          AND claims.workspace_id = workspaces.id
+        ) OR (
+          claims.source = 'microsoft_verified_domain'
+          AND claims.domain = lower(substr(users.email, instr(users.email, '@') + 1))
+          AND (
+            claims.workspace_id = workspaces.id
+            OR claims.provider_tenant_id = workspaces.ms_tenant_id
+          )
+        )
+        ORDER BY CASE WHEN claims.source = 'google_hd' THEN 0 ELSE 1 END,
+                 claims.domain
+        LIMIT 1
+      )`.as('claimed_domain'),
       'workspaces.ms_tenant_id as ms_tenant_id',
       'workspaces.name as workspace_name',
       'workspaces.plan as plan',

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -592,14 +592,24 @@ describe('headless publish wiring', () => {
     })
     await db
       .insertInto('workspace_domain_claims')
-      .values({
-        domain: 'corp.com',
-        workspace_id: 'ws-claim',
-        source: 'microsoft_verified_domain',
-        provider_tenant_id: 'tenant-1',
-        created_at: NOW,
-        updated_at: NOW,
-      })
+      .values([
+        {
+          domain: 'another.example',
+          workspace_id: 'ws-claim',
+          source: 'microsoft_verified_domain',
+          provider_tenant_id: 'tenant-1',
+          created_at: NOW,
+          updated_at: NOW,
+        },
+        {
+          domain: 'corp.com',
+          workspace_id: 'ws-claim',
+          source: 'microsoft_verified_domain',
+          provider_tenant_id: 'tenant-1',
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ])
       .execute()
 
     const user = await loadMcpUser(db, 'claim-user')
@@ -610,6 +620,73 @@ describe('headless publish wiring', () => {
       hd: 'corp.com',
       msTenantId: null,
       kind: 'human',
+    })
+  })
+
+  test('loadMcpUser preserves a Google hosted-domain alias', async () => {
+    await seedWorkspace(db, { id: 'ws-google-alias', hd: null })
+    await seedUser(db, {
+      id: 'google-alias-user',
+      workspaceId: 'ws-google-alias',
+      email: 'user@alias.example',
+    })
+    await db
+      .insertInto('workspace_domain_claims')
+      .values([
+        {
+          domain: 'corp.com',
+          workspace_id: 'ws-google-alias',
+          source: 'google_hd',
+          provider_tenant_id: null,
+          created_at: NOW,
+          updated_at: NOW,
+        },
+        {
+          domain: 'alias.example',
+          workspace_id: 'ws-google-alias',
+          source: 'microsoft_verified_domain',
+          provider_tenant_id: 'tenant-other',
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ])
+      .execute()
+
+    await expect(loadMcpUser(db, 'google-alias-user')).resolves.toMatchObject({
+      workspaceId: 'ws-google-alias',
+      hd: 'corp.com',
+    })
+  })
+
+  test('loadMcpUser resolves a duplicate claim through the canonical tenant', async () => {
+    await seedWorkspace(db, { id: 'ws-tenant', hd: null })
+    await db
+      .updateTable('workspaces')
+      .set({ ms_tenant_id: 'tenant-1' })
+      .where('id', '=', 'ws-tenant')
+      .execute()
+    await seedWorkspace(db, { id: 'ws-duplicate', hd: null })
+    await seedUser(db, {
+      id: 'tenant-user',
+      workspaceId: 'ws-tenant',
+      email: 'tenant-user@example.com',
+    })
+    await db
+      .insertInto('workspace_domain_claims')
+      .values({
+        domain: 'example.com',
+        workspace_id: 'ws-duplicate',
+        source: 'microsoft_verified_domain',
+        provider_tenant_id: 'tenant-1',
+        created_at: NOW,
+        updated_at: NOW,
+      })
+      .execute()
+
+    await expect(loadMcpUser(db, 'tenant-user')).resolves.toMatchObject({
+      workspaceId: 'ws-tenant',
+      hd: 'example.com',
+      msTenantId: 'tenant-1',
     })
   })
 

--- a/apps/web/app/services/oauth-workspace-integration.server.test.ts
+++ b/apps/web/app/services/oauth-workspace-integration.server.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { DatabaseSync } from 'node:sqlite'
-import type { Kysely } from 'kysely'
+import type { Compilable, Kysely } from 'kysely'
 import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
 import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
+import { runD1Batch } from '~/lib/d1-batch.server'
 import type { DB } from '~/types/db'
 import {
   applyOAuthWorkspaceIntegration,
@@ -72,7 +73,7 @@ describe('OAuth workspace integration', () => {
         .where('workspace_id', '=', 'ws-org')
         .where('user_id', '=', 'u1')
         .executeTakeFirst(),
-    ).resolves.toEqual({ role: 'member', status: 'active' })
+    ).resolves.toEqual({ role: 'owner', status: 'active' })
     await expect(
       db
         .selectFrom('workspace_members')
@@ -81,6 +82,533 @@ describe('OAuth workspace integration', () => {
         .where('user_id', '=', 'u1')
         .executeTakeFirstOrThrow(),
     ).resolves.toEqual({ status: 'removed' })
+  })
+
+  test('repairs a Microsoft claim onto its tenant workspace and removes the empty duplicate', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-empty-claim', name: 'corp.com' })
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-tenant')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-other')
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-empty-claim', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+    })
+
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+
+    expect(plan.executable).toBe(true)
+    expect(plan.claim.previousWorkspaceId).toBe('ws-empty-claim')
+    expect(plan.targetWorkspace?.id).toBe('ws-tenant')
+    expect(plan.requiredConfirmations.shareables).toEqual([])
+
+    const result = await applyOAuthWorkspaceIntegration(
+      db,
+      plan,
+      {},
+      {
+        batch: async (...queries) => {
+          await runD1Batch(db, ...(queries as unknown as Compilable<unknown>[]))
+        },
+      },
+    )
+    expect(result.kind).toBe('applied')
+    await expect(
+      db
+        .selectFrom('workspace_members')
+        .select(['role', 'status'])
+        .where('workspace_id', '=', 'ws-tenant')
+        .where('user_id', '=', 'u-ms')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ role: 'owner', status: 'active' })
+    await db
+      .deleteFrom('workspace_members')
+      .where('workspace_id', '=', 'ws-tenant')
+      .where('user_id', '=', 'u-ms')
+      .execute()
+    await expect(applyOAuthWorkspaceIntegration(db, plan)).resolves.toEqual({
+      kind: 'already-applied',
+      planId: plan.planId,
+      auditEventId: `oauth-workspace-integration:${plan.planId}`,
+    })
+    await expect(
+      db
+        .selectFrom('workspace_members')
+        .select(['role', 'status'])
+        .where('workspace_id', '=', 'ws-tenant')
+        .where('user_id', '=', 'u-ms')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ role: 'owner', status: 'active' })
+    await expect(
+      db
+        .selectFrom('workspace_domain_claims')
+        .select(['workspace_id', 'provider_tenant_id'])
+        .where('domain', '=', 'corp.com')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({
+      workspace_id: 'ws-tenant',
+      provider_tenant_id: 'tenant-1',
+    })
+    await expect(
+      db
+        .selectFrom('workspaces')
+        .select('id')
+        .where('id', '=', 'ws-empty-claim')
+        .executeTakeFirst(),
+    ).resolves.toBeUndefined()
+  })
+
+  test('blocks a missing Microsoft claim without persisted tenant-domain proof', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'new-corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedUser(db, 'u-ms', 'alice@new-corp.com', 'ws-tenant')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@new-corp.com', 'tenant-other')
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@new-corp.com', 'tenant-1')
+
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'new-corp.com',
+      email: 'alice@new-corp.com',
+      source: 'microsoft_verified_domain',
+    })
+
+    expect(plan.executable).toBe(false)
+    expect(plan.claim.willCreate).toBe(true)
+    expect(plan.stopReasons).toContain('microsoft_verified_domain_not_verified')
+    expect(await countClaims(db)).toBe(0)
+  })
+
+  test('blocks a tenantless Microsoft claim without tenant-domain proof', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-empty-claim', name: 'corp.com' })
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-tenant')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-other')
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-empty-claim', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: null,
+    })
+
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+
+    expect(plan.executable).toBe(false)
+    expect(plan.stopReasons).toContain('microsoft_verified_domain_not_verified')
+    expect(plan.claim.providerTenantId).toBeNull()
+  })
+
+  test('repairs a Microsoft claim when the audit is inserted concurrently', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-empty-claim', name: 'corp.com' })
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-tenant')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-empty-claim', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+    })
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+    const auditEventId = `oauth-workspace-integration:${plan.planId}`
+
+    const result = await applyOAuthWorkspaceIntegration(
+      db,
+      plan,
+      {},
+      {
+        batch: async (...queries) => {
+          await db
+            .insertInto('audit_events')
+            .values({
+              id: auditEventId,
+              workspace_id: 'ws-tenant',
+              actor_user_id: null,
+              action: 'workspace.integration.apply',
+              subject_type: 'workspace_domain_claim',
+              subject_id: 'corp.com',
+              detail: null,
+              created_at: NOW,
+            })
+            .execute()
+          await runD1Batch(db, ...(queries as unknown as Compilable<unknown>[]))
+        },
+      },
+    )
+
+    expect(result.kind).toBe('applied')
+    expect(await countAudits(db)).toBe(1)
+    await expect(
+      db
+        .selectFrom('workspace_domain_claims')
+        .select(['workspace_id', 'provider_tenant_id'])
+        .where('domain', '=', 'corp.com')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({
+      workspace_id: 'ws-tenant',
+      provider_tenant_id: 'tenant-1',
+    })
+  })
+
+  test('repairs only the claim when the tenant workspace contains shared project data', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-empty-claim', name: 'corp.com' })
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-tenant')
+    await seedUser(db, 'u-other', 'other@example.com', 'ws-tenant')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-empty-claim', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+    })
+    await db
+      .insertInto('artifact_containers')
+      .values({
+        id: 'shared-project',
+        workspace_id: 'ws-tenant',
+        kind: 'project',
+        owner_user_id: 'u-other',
+        created_by_id: 'u-other',
+        name: 'Shared project',
+        description: null,
+        archived_at: null,
+        base_visibility: 'private',
+        created_at: NOW,
+        updated_at: NOW,
+      })
+      .execute()
+    await db
+      .insertInto('shareables')
+      .values([
+        {
+          id: 'owned-by-user',
+          workspace_id: 'ws-tenant',
+          owner_user_id: 'u-ms',
+          name: 'User artifact',
+          artifact_kind: 'markdown_page',
+          visibility: 'project',
+          current_version_id: null,
+          container_id: 'shared-project',
+          created_at: NOW,
+          updated_at: NOW,
+        },
+        {
+          id: 'owned-by-other',
+          workspace_id: 'ws-tenant',
+          owner_user_id: 'u-other',
+          name: 'Other artifact',
+          artifact_kind: 'markdown_page',
+          visibility: 'project',
+          current_version_id: null,
+          container_id: 'shared-project',
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ])
+      .execute()
+
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+
+    expect(plan.executable).toBe(true)
+    expect(plan.shareables).toEqual([])
+    expect(plan.projects).toEqual([])
+    await expect(
+      applyOAuthWorkspaceIntegration(db, plan),
+    ).resolves.toMatchObject({ kind: 'applied' })
+  })
+
+  test('blocks Microsoft claim repair when the duplicate workspace contains data', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-duplicate', name: 'corp.com' })
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-tenant')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-duplicate', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+    })
+    await db
+      .insertInto('workspace_storage_daily_usage')
+      .values({
+        workspace_id: 'ws-duplicate',
+        date: '2026-08-26',
+        used_bytes: 0,
+        included_bytes: 0,
+        billable_overage_gb: 0,
+      })
+      .execute()
+
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+
+    expect(plan.executable).toBe(false)
+    expect(plan.stopReasons).toContain('duplicate_claim_workspace_not_empty')
+    const result = await applyOAuthWorkspaceIntegration(db, plan)
+    expect(result.kind).toBe('blocked')
+    await expect(
+      db
+        .selectFrom('workspace_domain_claims')
+        .select('workspace_id')
+        .where('domain', '=', 'corp.com')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-duplicate' })
+    await expect(
+      db
+        .selectFrom('workspace_storage_daily_usage')
+        .select('workspace_id')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-duplicate' })
+  })
+
+  test('blocks Microsoft claim repair for a configured duplicate workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-configured', name: 'corp.com' })
+    await db
+      .updateTable('workspaces')
+      .set({ link_sharing_enabled: 1 })
+      .where('id', '=', 'ws-configured')
+      .execute()
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-tenant')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-configured', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+    })
+
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+
+    expect(plan.executable).toBe(false)
+    expect(plan.stopReasons).toContain('duplicate_claim_workspace_not_empty')
+  })
+
+  test('blocks Microsoft claim repair when the duplicate changes during apply', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-racing', name: 'corp.com' })
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-tenant')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-racing', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+    })
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+    expect(plan.executable).toBe(true)
+
+    const result = await applyOAuthWorkspaceIntegration(
+      db,
+      plan,
+      {},
+      {
+        batch: async (...queries) => {
+          await db
+            .insertInto('workspace_storage_daily_usage')
+            .values({
+              workspace_id: 'ws-racing',
+              date: '2026-08-26',
+              used_bytes: 0,
+              included_bytes: 0,
+              billable_overage_gb: 0,
+            })
+            .execute()
+          await runD1Batch(db, ...(queries as unknown as Compilable<unknown>[]))
+        },
+      },
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: 'blocked',
+        reasons: ['plan_changed_during_apply'],
+      }),
+    )
+    await expect(
+      db
+        .selectFrom('workspace_domain_claims')
+        .select('workspace_id')
+        .where('domain', '=', 'corp.com')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-racing' })
+  })
+
+  test('leaves the claim unchanged when the verified user leaves during repair apply', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-duplicate', name: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-other', name: 'Other' })
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-tenant')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-duplicate', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+    })
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+
+    const result = await applyOAuthWorkspaceIntegration(
+      db,
+      plan,
+      {},
+      {
+        batch: async (...queries) => {
+          await db
+            .updateTable('users')
+            .set({ workspace_id: 'ws-other' })
+            .where('id', '=', 'u-ms')
+            .execute()
+          await runD1Batch(db, ...(queries as unknown as Compilable<unknown>[]))
+        },
+      },
+    )
+
+    expect(result).toMatchObject({
+      kind: 'blocked',
+      reasons: ['plan_changed_during_apply'],
+    })
+    await expect(
+      db
+        .selectFrom('workspace_domain_claims')
+        .select('workspace_id')
+        .where('domain', '=', 'corp.com')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-duplicate' })
+    await expect(
+      db
+        .selectFrom('workspaces')
+        .select('id')
+        .where('id', '=', 'ws-duplicate')
+        .executeTakeFirst(),
+    ).resolves.toEqual({ id: 'ws-duplicate' })
+  })
+
+  test('blocks Microsoft repair while the verified user is still in the duplicate workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-duplicate-user', name: 'corp.com' })
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-duplicate-user')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-duplicate-user', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+    })
+
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+
+    expect(plan.executable).toBe(false)
+    expect(plan.stopReasons).toContain(
+      'microsoft_claim_user_not_in_tenant_workspace',
+    )
+  })
+
+  test('blocks Microsoft repair while the verified user is in a third workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-duplicate', name: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', name: 'Alice' })
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-personal')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-duplicate', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+    })
+
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+
+    expect(plan.executable).toBe(false)
+    expect(plan.stopReasons).toContain(
+      'microsoft_claim_user_not_in_tenant_workspace',
+    )
   })
 
   test('plans a missing Google hd claim without writing, then creates it on apply', async () => {
@@ -810,6 +1338,67 @@ describe('OAuth workspace integration', () => {
     await expectUserWorkspace(db, 'u1', 'ws-org')
   })
 
+  test('blocks migration while delegated OAuth tokens remain active', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-personal', name: 'Alice' })
+    await seedWorkspace(db, { id: 'ws-org', name: 'corp.com' })
+    await seedUser(db, 'u1', 'alice@corp.com', 'ws-personal')
+    await seedClaim(db, 'corp.com', 'ws-org')
+    sqliteRef.current?.exec(`
+      INSERT INTO oauthClient (id, clientId, redirectUris)
+      VALUES ('client-row', 'client-1', '[]');
+      INSERT INTO oauthRefreshToken (
+        id, token, clientId, userId, scopes
+      ) VALUES (
+        'refresh-1', 'refresh-token', 'client-1', 'u1', 'openid'
+      );
+    `)
+
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'google_hd',
+    })
+    expect(plan.executable).toBe(false)
+    expect(plan.blockingResources.delegatedOAuthTokenCount).toBe(1)
+    expect(plan.stopReasons).toContain('delegated_oauth_token_present')
+    const result = await applyOAuthWorkspaceIntegration(db, plan)
+    expect(result.kind).toBe('blocked')
+    await expectUserWorkspace(db, 'u1', 'ws-personal')
+
+    sqliteRef.current
+      ?.prepare(
+        `UPDATE oauthRefreshToken SET revoked = '2026-06-26T00:00:00.000Z'
+         WHERE id = 'refresh-1'`,
+      )
+      .run()
+    const unblockedPlan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'google_hd',
+    })
+    expect(unblockedPlan.blockingResources.delegatedOAuthTokenCount).toBe(0)
+    expect(unblockedPlan.stopReasons).not.toContain(
+      'delegated_oauth_token_present',
+    )
+
+    sqliteRef.current?.exec(`
+      INSERT INTO oauthConsent (id, clientId, userId, scopes)
+      VALUES ('consent-1', 'client-1', 'u1', 'openid');
+    `)
+    const consentBlockedPlan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'google_hd',
+    })
+    expect(consentBlockedPlan.blockingResources.delegatedOAuthTokenCount).toBe(
+      1,
+    )
+    expect(consentBlockedPlan.stopReasons).toContain(
+      'delegated_oauth_token_present',
+    )
+  })
+
   test('rejects public domains and email/domain mismatches without writing', async () => {
     const db = setup()
     await seedWorkspace(db, { id: 'ws-personal', name: 'Alice' })
@@ -1166,14 +1755,14 @@ const NOW = '2026-07-19T00:00:00.000Z'
 
 async function seedWorkspace(
   db: Kysely<DB>,
-  input: { id: string; name: string },
+  input: { id: string; name: string; microsoftTenantId?: string },
 ) {
   await db
     .insertInto('workspaces')
     .values({
       id: input.id,
       hd: null,
-      ms_tenant_id: null,
+      ms_tenant_id: input.microsoftTenantId ?? null,
       email_domain: input.name === 'corp.com' ? input.name : null,
       name: input.name,
       created_at: NOW,
@@ -1181,14 +1770,50 @@ async function seedWorkspace(
     .execute()
 }
 
-async function seedClaim(db: Kysely<DB>, domain: string, workspaceId: string) {
+async function seedClaim(
+  db: Kysely<DB>,
+  domain: string,
+  workspaceId: string,
+  options: {
+    source?: 'google_hd' | 'microsoft_verified_domain'
+    providerTenantId?: string | null
+  } = {},
+) {
   await db
     .insertInto('workspace_domain_claims')
     .values({
       domain,
       workspace_id: workspaceId,
-      source: 'google_hd',
-      provider_tenant_id: null,
+      source: options.source ?? 'google_hd',
+      provider_tenant_id: options.providerTenantId ?? null,
+      created_at: NOW,
+      updated_at: NOW,
+    })
+    .execute()
+}
+
+async function seedMicrosoftAccount(
+  db: Kysely<DB>,
+  userId: string,
+  email: string,
+  tenantId: string,
+) {
+  const payload = Buffer.from(
+    JSON.stringify({
+      tid: tenantId,
+      oid: `object-${userId}`,
+      email,
+      email_verified: true,
+    }),
+  ).toString('base64url')
+  await db
+    .insertInto('accounts')
+    .values({
+      id: `microsoft-${userId}-${tenantId}`,
+      user_id: userId,
+      provider_id: 'microsoft',
+      account_id: `${tenantId}:object-${userId}`,
+      id_token: `header.${payload}.signature`,
       created_at: NOW,
       updated_at: NOW,
     })

--- a/apps/web/app/services/oauth-workspace-integration.server.ts
+++ b/apps/web/app/services/oauth-workspace-integration.server.ts
@@ -6,9 +6,13 @@ import {
 } from '~/lib/workspace-domains'
 import { nowIso } from '~/lib/datetime'
 import { decodeBase64Url } from '~/lib/base64url'
+import { runD1Batch } from '~/lib/d1-batch.server'
 import type { DB } from '~/types/db'
+import { ensureWorkspaceAdmin } from './team-management.server'
 
-export type OAuthWorkspaceIntegrationSource = 'google_hd'
+export type OAuthWorkspaceIntegrationSource =
+  | 'google_hd'
+  | 'microsoft_verified_domain'
 
 const UTF8_DECODER = new TextDecoder()
 
@@ -23,6 +27,8 @@ export interface OAuthWorkspaceIntegrationPlan {
     domain: string
     source: OAuthWorkspaceIntegrationSource
     workspaceId: string | null
+    previousWorkspaceId: string | null
+    providerTenantId: string | null
     willCreate: boolean
   }
   sourceWorkspace: { id: string; name: string; plan: string } | null
@@ -50,6 +56,7 @@ export interface OAuthWorkspaceIntegrationPlan {
     projectCount: number
     commentCount: number
     apiTokenCount: number
+    delegatedOAuthTokenCount: number
     adminMembershipCount: number
   }
   requiredConfirmations: {
@@ -187,6 +194,9 @@ export async function applyOAuthWorkspaceIntegration(
     .where('id', '=', auditEventId)
     .executeTakeFirst()
   if (existingAudit) {
+    if (plan.targetWorkspace?.id) {
+      await ensureWorkspaceAdmin(db, plan.targetWorkspace.id, nowIso())
+    }
     return {
       kind: 'already-applied',
       planId: plan.planId,
@@ -215,6 +225,130 @@ export async function applyOAuthWorkspaceIntegration(
       plan: current,
       reasons: ['plan_not_executable'],
     }
+  }
+
+  const microsoftClaimRepair =
+    current.input.source === 'microsoft_verified_domain' &&
+    current.user.sourceWorkspaceId === current.targetWorkspace.id &&
+    current.claim.previousWorkspaceId !== current.targetWorkspace.id
+  if (microsoftClaimRepair) {
+    const now = nowIso()
+    const targetWorkspaceId = current.targetWorkspace.id
+    const previousClaimWorkspaceId = current.claim.previousWorkspaceId
+    const repairAuditEventId = `oauth-workspace-integration:${current.planId}`
+    if (!previousClaimWorkspaceId) {
+      return {
+        kind: 'blocked',
+        plan: current,
+        reasons: ['plan_not_executable'],
+      }
+    }
+    const repairTargetIsSafe = sql<boolean>`
+      EXISTS (
+        SELECT 1 FROM workspaces
+        WHERE id = ${targetWorkspaceId}
+          AND ms_tenant_id = ${current.claim.providerTenantId}
+      )
+      AND EXISTS (
+        SELECT 1 FROM users
+        WHERE id = ${current.user.id}
+          AND workspace_id = ${targetWorkspaceId}
+          AND email_verified = 1
+      )
+    `
+    const claimWrite = db
+      .updateTable('workspace_domain_claims')
+      .set({
+        workspace_id: targetWorkspaceId,
+        source: 'microsoft_verified_domain',
+        provider_tenant_id: current.claim.providerTenantId,
+        updated_at: now,
+      })
+      .where('domain', '=', current.claim.domain)
+      .where('workspace_id', '=', previousClaimWorkspaceId)
+      .where('source', '=', 'microsoft_verified_domain')
+      .where(
+        disposableEmptyWorkspaceCondition(
+          previousClaimWorkspaceId,
+          current.claim.domain,
+        ),
+      )
+      .where(repairTargetIsSafe)
+    const repairGuard = sql`
+      INSERT OR IGNORE INTO audit_events (
+        id, workspace_id, actor_user_id, action, subject_type, subject_id,
+        detail, created_at
+      )
+      SELECT
+        ${repairAuditEventId},
+        ${targetWorkspaceId},
+        ${confirmations.actorUserId ?? null},
+        'workspace.integration.apply',
+        'workspace_domain_claim',
+        ${current.claim.domain},
+        ${JSON.stringify({
+          plan_id: current.planId,
+          source: current.input.source,
+          domain: current.claim.domain,
+          previous_workspace_id: previousClaimWorkspaceId,
+          target_workspace_id: targetWorkspaceId,
+        })},
+        ${now}
+      WHERE EXISTS (
+        SELECT 1 FROM workspace_domain_claims
+        WHERE domain = ${current.claim.domain}
+          AND workspace_id = ${targetWorkspaceId}
+          AND source = 'microsoft_verified_domain'
+          AND provider_tenant_id = ${current.claim.providerTenantId}
+      )
+      AND EXISTS (
+        SELECT 1 FROM workspaces
+        WHERE id = ${targetWorkspaceId}
+          AND ms_tenant_id = ${current.claim.providerTenantId}
+      )
+      AND EXISTS (
+        SELECT 1 FROM users
+        WHERE id = ${current.user.id}
+          AND workspace_id = ${targetWorkspaceId}
+          AND email_verified = 1
+      )
+    `
+    const queries: ExecutableQuery[] = [
+      claimWrite,
+      {
+        compile: () => repairGuard.compile(db),
+        execute: () => repairGuard.execute(db),
+      },
+    ]
+    if (
+      previousClaimWorkspaceId &&
+      previousClaimWorkspaceId !== targetWorkspaceId
+    ) {
+      queries.push(deleteWorkspaceOnlyWhenEmpty(db, previousClaimWorkspaceId))
+    }
+    const executeBatch =
+      options.batch ??
+      ((...batchQueries: ExecutableQuery[]) =>
+        runD1Batch(db, ...(batchQueries as Array<Compilable<unknown>>)))
+    await executeBatch(...queries)
+
+    const audit = await db
+      .selectFrom('audit_events')
+      .select('id')
+      .where('id', '=', repairAuditEventId)
+      .executeTakeFirst()
+    if (audit) await ensureWorkspaceAdmin(db, targetWorkspaceId, now)
+    return audit
+      ? {
+          kind: 'applied',
+          planId: current.planId,
+          auditEventId: repairAuditEventId,
+        }
+      : {
+          kind: 'blocked',
+          plan: current,
+          reasons: ['plan_changed_during_apply'],
+        }
   }
 
   const now = nowIso()
@@ -422,6 +556,18 @@ export async function applyOAuthWorkspaceIntegration(
       OR EXISTS (SELECT 1 FROM comment_threads WHERE created_by_id = ${userId})
       OR EXISTS (SELECT 1 FROM comment_messages WHERE created_by_id = ${userId})
       OR EXISTS (SELECT 1 FROM api_tokens WHERE user_id = ${userId})
+      OR EXISTS (
+        SELECT 1 FROM oauthAccessToken
+        WHERE userId = ${userId}
+          AND (expiresAt IS NULL OR expiresAt > ${now})
+      )
+      OR EXISTS (
+        SELECT 1 FROM oauthRefreshToken
+        WHERE userId = ${userId}
+          AND revoked IS NULL
+          AND (expiresAt IS NULL OR expiresAt > ${now})
+      )
+      OR EXISTS (SELECT 1 FROM oauthConsent WHERE userId = ${userId})
       OR EXISTS (
         SELECT 1 FROM workspace_members
         WHERE user_id = ${userId}
@@ -652,11 +798,11 @@ export async function applyOAuthWorkspaceIntegration(
       .onConflict((oc) => oc.column('id').doNothing()),
   )
 
-  if (options.batch) {
-    await options.batch(...queries)
-  } else {
-    for (const query of queries) await query.execute()
-  }
+  const executeBatch =
+    options.batch ??
+    ((...batchQueries: ExecutableQuery[]) =>
+      runD1Batch(db, ...(batchQueries as Array<Compilable<unknown>>)))
+  await executeBatch(...queries)
 
   const audit = await db
     .selectFrom('audit_events')
@@ -670,7 +816,64 @@ export async function applyOAuthWorkspaceIntegration(
       reasons: ['plan_changed_during_apply'],
     }
   }
+  await ensureWorkspaceAdmin(db, targetWorkspaceId, now)
   return { kind: 'applied', planId: current.planId, auditEventId }
+}
+
+function deleteWorkspaceOnlyWhenEmpty(db: Kysely<DB>, workspaceId: string) {
+  return db
+    .deleteFrom('workspaces')
+    .where('id', '=', workspaceId)
+    .where(disposableEmptyWorkspaceCondition(workspaceId))
+}
+
+function disposableEmptyWorkspaceCondition(
+  workspaceId: string,
+  movingClaimDomain?: string,
+) {
+  const movingClaimExclusion = movingClaimDomain
+    ? sql`AND domain != ${movingClaimDomain}`
+    : sql``
+  return sql<boolean>`
+      EXISTS (
+        SELECT 1 FROM workspaces
+        WHERE id = ${workspaceId}
+          AND hd IS NULL
+          AND ms_tenant_id IS NULL
+          AND plan = 'free'
+          AND storage_used_bytes = 0
+          AND stripe_customer_id IS NULL
+          AND stripe_subscription_id IS NULL
+          AND stripe_subscription_status = 'none'
+          AND link_sharing_enabled = 0
+          AND external_posting_enabled = 0
+          AND link_expiry_default_days = 30
+          AND link_expiry_max_days = 90
+          AND (
+            (self_upload_enabled = 1 AND storage_quota_bytes = 104857600)
+            OR (self_upload_enabled = 0 AND storage_quota_bytes = 0)
+          )
+      )
+      AND
+      NOT EXISTS (SELECT 1 FROM users WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (
+        SELECT 1 FROM workspace_domain_claims
+        WHERE workspace_id = ${workspaceId} ${movingClaimExclusion}
+      )
+      AND NOT EXISTS (SELECT 1 FROM workspace_members WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM workspace_storage_daily_usage WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM billing_overage_charges WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM artifact_containers WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM shareables WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM agent_profiles WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM cli_family_authorities WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM cli_session_authorities WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM bridge_authorities WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM slack_workspaces WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM artifact_keys WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (SELECT 1 FROM events WHERE workspace_id = ${workspaceId})
+    `
 }
 
 async function buildPlan(
@@ -698,12 +901,17 @@ async function buildPlan(
   }
   if (domain && isPublicEmailDomain(domain))
     stopReasons.push('public_email_domain')
-  if (rawInput.source !== 'google_hd') stopReasons.push('untrusted_source')
+  if (
+    rawInput.source !== 'google_hd' &&
+    rawInput.source !== 'microsoft_verified_domain'
+  ) {
+    stopReasons.push('untrusted_source')
+  }
 
   const claimRow = domain
     ? await db
         .selectFrom('workspace_domain_claims')
-        .select(['domain', 'workspace_id', 'source'])
+        .select(['domain', 'workspace_id', 'source', 'provider_tenant_id'])
         .where('domain', '=', domain)
         .executeTakeFirst()
     : undefined
@@ -722,23 +930,66 @@ async function buildPlan(
   if (userRow && userRow.email_verified !== 1)
     stopReasons.push('email_not_verified')
 
-  const googleAccount = userRow
+  const oauthAccounts = userRow
     ? await db
         .selectFrom('accounts')
         .select('id_token')
         .where('user_id', '=', userRow.id)
-        .where('provider_id', '=', 'google')
+        .where(
+          'provider_id',
+          '=',
+          rawInput.source === 'google_hd' ? 'google' : 'microsoft',
+        )
         .where('id_token', 'is not', null)
-        .executeTakeFirst()
-    : undefined
-  const trustedGoogleClaim = decodeStoredGoogleClaim(googleAccount?.id_token)
+        .execute()
+    : []
+  const trustedGoogleClaim =
+    rawInput.source === 'google_hd'
+      ? (oauthAccounts
+          .map((account) => decodeStoredGoogleClaim(account.id_token))
+          .find(
+            (candidate) =>
+              candidate?.emailVerified === true &&
+              candidate.email === email &&
+              candidate.domain === domain,
+          ) ?? null)
+      : null
+  const trustedMicrosoftClaims =
+    rawInput.source === 'microsoft_verified_domain'
+      ? oauthAccounts
+          .map((account) =>
+            decodeStoredMicrosoftClaim(account.id_token, email, domain),
+          )
+          .filter(
+            (candidate): candidate is { tenantId: string } =>
+              candidate !== null,
+          )
+      : []
+  const trustedMicrosoftClaim =
+    claimRow?.source === 'microsoft_verified_domain' &&
+    claimRow.provider_tenant_id
+      ? (trustedMicrosoftClaims.find(
+          (candidate) => candidate.tenantId === claimRow.provider_tenant_id,
+        ) ?? null)
+      : null
+  if (rawInput.source === 'google_hd') {
+    if (
+      !trustedGoogleClaim ||
+      trustedGoogleClaim.emailVerified !== true ||
+      trustedGoogleClaim.email !== email ||
+      trustedGoogleClaim.domain !== domain
+    ) {
+      stopReasons.push('google_hd_not_verified')
+    }
+  } else if (!trustedMicrosoftClaim) {
+    stopReasons.push('microsoft_verified_domain_not_verified')
+  }
   if (
-    !trustedGoogleClaim ||
-    trustedGoogleClaim.emailVerified !== true ||
-    trustedGoogleClaim.email !== email ||
-    trustedGoogleClaim.domain !== domain
+    trustedMicrosoftClaim &&
+    claimRow?.provider_tenant_id &&
+    claimRow.provider_tenant_id !== trustedMicrosoftClaim.tenantId
   ) {
-    stopReasons.push('google_hd_not_verified')
+    stopReasons.push('provider_tenant_mismatch')
   }
 
   const sourceWorkspace = userRow
@@ -751,63 +1002,112 @@ async function buildPlan(
   if (userRow && !sourceWorkspace)
     stopReasons.push('source_workspace_not_found')
 
-  const targetId =
-    claimRow?.workspace_id ?? options.proposedTargetWorkspaceId ?? nanoid()
-  const proposedTargetWorkspace =
-    !claimRow && domain
-      ? { id: targetId, name: domain, plan: 'free', willCreate: true }
-      : undefined
-  const existingTargetWorkspace = claimRow
+  const microsoftTenantWorkspace = trustedMicrosoftClaim
     ? await db
         .selectFrom('workspaces')
         .select(['id', 'name', 'plan'])
-        .where('id', '=', claimRow.workspace_id)
+        .where('ms_tenant_id', '=', trustedMicrosoftClaim.tenantId)
         .executeTakeFirst()
     : undefined
+  if (trustedMicrosoftClaim && !microsoftTenantWorkspace) {
+    stopReasons.push('microsoft_tenant_workspace_not_found')
+  }
+  const targetId =
+    microsoftTenantWorkspace?.id ??
+    claimRow?.workspace_id ??
+    options.proposedTargetWorkspaceId ??
+    nanoid()
+  const proposedTargetWorkspace =
+    rawInput.source === 'google_hd' && !claimRow && domain
+      ? { id: targetId, name: domain, plan: 'free', willCreate: true }
+      : undefined
+  const existingTargetWorkspace =
+    microsoftTenantWorkspace ??
+    (claimRow
+      ? await db
+          .selectFrom('workspaces')
+          .select(['id', 'name', 'plan'])
+          .where('id', '=', claimRow.workspace_id)
+          .executeTakeFirst()
+      : undefined)
   const resolvedTargetWorkspace = existingTargetWorkspace
     ? { ...existingTargetWorkspace, willCreate: false }
     : proposedTargetWorkspace
   if (claimRow && !resolvedTargetWorkspace)
     stopReasons.push('claim_workspace_not_found')
+  if (
+    rawInput.source === 'microsoft_verified_domain' &&
+    userRow &&
+    resolvedTargetWorkspace &&
+    userRow.workspace_id !== resolvedTargetWorkspace.id &&
+    claimRow?.workspace_id !== resolvedTargetWorkspace.id
+  ) {
+    stopReasons.push('microsoft_claim_user_not_in_tenant_workspace')
+  }
+  const microsoftClaimRepairCandidate = Boolean(
+    rawInput.source === 'microsoft_verified_domain' &&
+    userRow &&
+    resolvedTargetWorkspace &&
+    userRow.workspace_id === resolvedTargetWorkspace.id &&
+    claimRow?.workspace_id !== resolvedTargetWorkspace.id,
+  )
+  if (microsoftClaimRepairCandidate && claimRow) {
+    const disposableDuplicate = await db
+      .selectFrom('workspaces')
+      .select('id')
+      .where('id', '=', claimRow.workspace_id)
+      .where(
+        disposableEmptyWorkspaceCondition(
+          claimRow.workspace_id,
+          claimRow.domain,
+        ),
+      )
+      .executeTakeFirst()
+    if (!disposableDuplicate) {
+      stopReasons.push('duplicate_claim_workspace_not_empty')
+    }
+  }
 
-  const ownedShareableRows = userRow
-    ? await db
-        .selectFrom('shareables')
-        .select([
-          'id',
-          'slug',
-          'workspace_id',
-          'visibility',
-          'container_id',
-          'owner_user_id',
-        ])
-        .where('owner_user_id', '=', userRow.id)
-        .where('workspace_id', '=', userRow.workspace_id)
-        .orderBy('id')
-        .execute()
-    : []
-  const projectRows = userRow
-    ? await db
-        .selectFrom('artifact_containers')
-        .select([
-          'id',
-          'name',
-          'workspace_id',
-          'base_visibility',
-          'archived_at',
-          'kind',
-        ])
-        .where('kind', '=', 'project')
-        .where('workspace_id', '=', userRow.workspace_id)
-        .where((eb) =>
-          eb.or([
-            eb('owner_user_id', '=', userRow.id),
-            eb('created_by_id', '=', userRow.id),
-          ]),
-        )
-        .orderBy('id')
-        .execute()
-    : []
+  const ownedShareableRows =
+    userRow && !microsoftClaimRepairCandidate
+      ? await db
+          .selectFrom('shareables')
+          .select([
+            'id',
+            'slug',
+            'workspace_id',
+            'visibility',
+            'container_id',
+            'owner_user_id',
+          ])
+          .where('owner_user_id', '=', userRow.id)
+          .where('workspace_id', '=', userRow.workspace_id)
+          .orderBy('id')
+          .execute()
+      : []
+  const projectRows =
+    userRow && !microsoftClaimRepairCandidate
+      ? await db
+          .selectFrom('artifact_containers')
+          .select([
+            'id',
+            'name',
+            'workspace_id',
+            'base_visibility',
+            'archived_at',
+            'kind',
+          ])
+          .where('kind', '=', 'project')
+          .where('workspace_id', '=', userRow.workspace_id)
+          .where((eb) =>
+            eb.or([
+              eb('owner_user_id', '=', userRow.id),
+              eb('created_by_id', '=', userRow.id),
+            ]),
+          )
+          .orderBy('id')
+          .execute()
+      : []
   const projectIds = projectRows.map((row) => row.id)
   const projectShareableRows = projectIds.length
     ? await db
@@ -1001,15 +1301,28 @@ async function buildPlan(
         projectCount: 0,
         commentCount: 0,
         apiTokenCount: 0,
+        delegatedOAuthTokenCount: 0,
         adminMembershipCount: 0,
         sourceOrphanRiskCount: 0,
       }
-  if (blockingResources.commentCount > 0)
+  if (!microsoftClaimRepairCandidate && blockingResources.commentCount > 0)
     stopReasons.push('comment_data_present')
-  if (blockingResources.apiTokenCount > 0) stopReasons.push('api_token_present')
-  if (blockingResources.adminMembershipCount > 0)
+  if (!microsoftClaimRepairCandidate && blockingResources.apiTokenCount > 0)
+    stopReasons.push('api_token_present')
+  if (
+    !microsoftClaimRepairCandidate &&
+    blockingResources.delegatedOAuthTokenCount > 0
+  )
+    stopReasons.push('delegated_oauth_token_present')
+  if (
+    !microsoftClaimRepairCandidate &&
+    blockingResources.adminMembershipCount > 0
+  )
     stopReasons.push('admin_or_owner_membership_present')
-  if (blockingResources.sourceOrphanRiskCount > 0)
+  if (
+    !microsoftClaimRepairCandidate &&
+    blockingResources.sourceOrphanRiskCount > 0
+  )
     stopReasons.push('source_workspace_would_be_ownerless')
 
   const credentialCount = userRow
@@ -1024,10 +1337,19 @@ async function buildPlan(
   if (
     userRow &&
     resolvedTargetWorkspace &&
-    userRow.workspace_id === resolvedTargetWorkspace.id
+    userRow.workspace_id === resolvedTargetWorkspace.id &&
+    !(
+      rawInput.source === 'microsoft_verified_domain' &&
+      claimRow?.workspace_id !== resolvedTargetWorkspace.id
+    )
   )
     stopReasons.push('already_in_target_workspace')
-  if (claimRow && resolvedTargetWorkspace && userRow) {
+  if (
+    claimRow &&
+    resolvedTargetWorkspace &&
+    userRow &&
+    userRow.workspace_id !== resolvedTargetWorkspace.id
+  ) {
     const targetMembership = await db
       .selectFrom('workspace_members')
       .select(['role', 'status'])
@@ -1043,7 +1365,7 @@ async function buildPlan(
       stopReasons.push('target_membership_role_conflict')
   }
 
-  if (resolvedTargetWorkspace && userRow) {
+  if (resolvedTargetWorkspace && userRow && !microsoftClaimRepairCandidate) {
     const targetInbox = await db
       .selectFrom('artifact_containers')
       .select('id')
@@ -1081,21 +1403,22 @@ async function buildPlan(
   if (targetProjectNameConflict)
     stopReasons.push('target_project_name_conflict')
 
-  const targetShareableSlugs = await findTargetSlugConflicts(
-    db,
-    resolvedTargetWorkspace?.id,
-    shareables,
-  )
+  const targetShareableSlugs = microsoftClaimRepairCandidate
+    ? []
+    : await findTargetSlugConflicts(db, resolvedTargetWorkspace?.id, shareables)
   if (targetShareableSlugs.length > 0)
     stopReasons.push('target_shareable_slug_conflict')
 
   const requiredConfirmations = {
-    shareables: shareables.map((shareable) => ({
-      id: shareable.id,
-      before: shareable.before,
-      after: shareable.after,
-    })),
-    preserveCliRefreshCredentials: cliRefreshCredentialCount > 0,
+    shareables: microsoftClaimRepairCandidate
+      ? []
+      : shareables.map((shareable) => ({
+          id: shareable.id,
+          before: shareable.before,
+          after: shareable.after,
+        })),
+    preserveCliRefreshCredentials:
+      !microsoftClaimRepairCandidate && cliRefreshCredentialCount > 0,
     projects: [] as OAuthWorkspaceIntegrationProjectConfirmation[],
   }
   const loadTeamAdminAudience = (
@@ -1161,12 +1484,15 @@ async function buildPlan(
       afterTeamAdminAudience,
     })
   }
-  requiredConfirmations.projects = projects
+  requiredConfirmations.projects = microsoftClaimRepairCandidate ? [] : projects
 
   const claim = {
     domain: domain ?? input.domain,
     source: rawInput.source,
-    workspaceId: claimRow?.workspace_id ?? (domain ? targetId : null),
+    workspaceId: domain ? targetId : null,
+    previousWorkspaceId: claimRow?.workspace_id ?? null,
+    providerTenantId:
+      trustedMicrosoftClaim?.tenantId ?? claimRow?.provider_tenant_id ?? null,
     willCreate: Boolean(domain && !claimRow),
   }
   const snapshot: PlanSnapshot = {
@@ -1208,11 +1534,13 @@ async function countBlockingResources(
   userId: string,
   sourceWorkspaceId: string,
 ) {
+  const activeTokenCutoff = nowIso()
   const [
     projects,
     commentThreads,
     commentMessages,
     apiTokens,
+    delegatedOAuthTokens,
     admins,
     sourceOrphanRisk,
   ] = await Promise.all([
@@ -1242,6 +1570,20 @@ async function countBlockingResources(
       .select(({ fn }) => fn.countAll<number>().as('count'))
       .where('user_id', '=', userId)
       .executeTakeFirst(),
+    sql<{ count: number }>`
+      SELECT (
+        (SELECT count(*) FROM oauthAccessToken
+         WHERE userId = ${userId}
+           AND (expiresAt IS NULL OR expiresAt > ${activeTokenCutoff})) +
+        (SELECT count(*) FROM oauthRefreshToken
+         WHERE userId = ${userId}
+           AND revoked IS NULL
+           AND (expiresAt IS NULL OR expiresAt > ${activeTokenCutoff})) +
+        (SELECT count(*) FROM oauthConsent WHERE userId = ${userId})
+      ) AS count
+    `
+      .execute(db)
+      .then((result) => result.rows[0]),
     db
       .selectFrom('workspace_members')
       .select(({ fn }) => fn.countAll<number>().as('count'))
@@ -1274,6 +1616,7 @@ async function countBlockingResources(
     commentCount:
       Number(commentThreads?.count ?? 0) + Number(commentMessages?.count ?? 0),
     apiTokenCount: Number(apiTokens?.count ?? 0),
+    delegatedOAuthTokenCount: Number(delegatedOAuthTokens?.count ?? 0),
     adminMembershipCount: Number(admins?.count ?? 0),
     sourceOrphanRiskCount: Number(sourceOrphanRisk?.count ?? 0),
   }
@@ -1302,6 +1645,61 @@ function decodeStoredGoogleClaim(idToken: string | null | undefined): {
       domain:
         typeof parsed.hd === 'string' ? normalizeEmailDomain(parsed.hd) : null,
     }
+  } catch {
+    return null
+  }
+}
+
+function decodeStoredMicrosoftClaim(
+  idToken: string | null | undefined,
+  expectedEmail: string,
+  expectedDomain: string | null,
+): { tenantId: string } | null {
+  if (!idToken || !expectedDomain) return null
+  try {
+    const payload = idToken.split('.')[1]
+    if (!payload) return null
+    const parsed = JSON.parse(
+      UTF8_DECODER.decode(decodeBase64Url(payload)),
+    ) as {
+      tid?: unknown
+      email?: unknown
+      preferred_username?: unknown
+      verified_primary_email?: unknown
+      verified_secondary_email?: unknown
+      email_verified?: unknown
+      xms_edov?: unknown
+    }
+    const firstString = (...values: unknown[]) =>
+      values.find((value): value is string => typeof value === 'string') ?? null
+    const primary = Array.isArray(parsed.verified_primary_email)
+      ? parsed.verified_primary_email
+      : []
+    const secondary = Array.isArray(parsed.verified_secondary_email)
+      ? parsed.verified_secondary_email
+      : []
+    const email = firstString(
+      parsed.email,
+      primary[0],
+      parsed.preferred_username,
+    )?.toLowerCase()
+    const listedVerifiedEmail = [...primary, ...secondary].some(
+      (value) =>
+        typeof value === 'string' && value.toLowerCase() === expectedEmail,
+    )
+    const emailVerified =
+      parsed.email_verified === true ||
+      parsed.xms_edov === true ||
+      listedVerifiedEmail
+    if (
+      typeof parsed.tid !== 'string' ||
+      !emailVerified ||
+      email !== expectedEmail ||
+      normalizeEmailDomain(email) !== expectedDomain
+    ) {
+      return null
+    }
+    return { tenantId: parsed.tid }
   } catch {
     return null
   }

--- a/apps/web/app/services/workspace-domain-claims.server.test.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.test.ts
@@ -8,8 +8,11 @@ import {
   ensureDomainClaimWorkspace,
   ensureWorkspaceDomainClaim,
   findWorkspaceIdByDomainClaim,
+  findWorkspaceIdForMicrosoftTenantDomain,
+  findWorkspaceIdByProviderTenant,
   listWorkspaceMigrationCandidates,
   maybeMoveUserToClaimedWorkspace,
+  moveUserToWorkspaceForOAuth,
 } from './workspace-domain-claims.server'
 
 const sqliteRef = vi.hoisted(() => ({
@@ -57,7 +60,7 @@ describe('workspace domain claims', () => {
     )
   })
 
-  test('creates Microsoft verified domain claim without storing tenant id on workspace', async () => {
+  test('creates one Microsoft tenant workspace with its verified domain claim', async () => {
     const db = setup()
 
     const workspaceId = await ensureDomainClaimWorkspace(db, {
@@ -80,7 +83,7 @@ describe('workspace domain claims', () => {
 
     expect(workspace).toEqual({
       id: workspaceId,
-      ms_tenant_id: null,
+      ms_tenant_id: 'tenant-1',
       email_domain: 'example.com',
     })
     expect(claim).toEqual({
@@ -89,6 +92,425 @@ describe('workspace domain claims', () => {
       source: 'microsoft_verified_domain',
       provider_tenant_id: 'tenant-1',
     })
+  })
+
+  test('attaches a verified domain claim to an existing Microsoft tenant workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      hd: null,
+      emailDomain: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+
+    await expect(
+      ensureDomainClaimWorkspace(db, {
+        domain: 'corp.com',
+        source: 'microsoft_verified_domain',
+        providerTenantId: 'tenant-1',
+        now: '2026-06-26T00:00:00.000Z',
+      }),
+    ).resolves.toBe('ws-tenant')
+
+    await expect(
+      db.selectFrom('workspaces').select('id').execute(),
+    ).resolves.toEqual([{ id: 'ws-tenant' }])
+    await expect(
+      db
+        .selectFrom('workspace_domain_claims')
+        .select(['domain', 'workspace_id', 'provider_tenant_id'])
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({
+      domain: 'corp.com',
+      workspace_id: 'ws-tenant',
+      provider_tenant_id: 'tenant-1',
+    })
+  })
+
+  test('collapses concurrent verified domains onto one Microsoft tenant workspace', async () => {
+    const db = setup()
+    const [first, second] = await Promise.all([
+      ensureDomainClaimWorkspace(db, {
+        domain: 'a.corp.com',
+        source: 'microsoft_verified_domain',
+        providerTenantId: 'tenant-concurrent',
+        now: '2026-06-26T00:00:00.000Z',
+      }),
+      ensureDomainClaimWorkspace(db, {
+        domain: 'b.corp.com',
+        source: 'microsoft_verified_domain',
+        providerTenantId: 'tenant-concurrent',
+        now: '2026-06-26T00:00:00.000Z',
+      }),
+    ])
+
+    expect(first).toBe(second)
+    await expect(
+      db.selectFrom('workspaces').select('id').execute(),
+    ).resolves.toHaveLength(1)
+    await expect(
+      db.selectFrom('workspace_domain_claims').select('domain').execute(),
+    ).resolves.toHaveLength(2)
+  })
+
+  test('does not choose an arbitrary claim workspace by a non-unique provider tenant id', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-a', hd: null, emailDomain: 'a.test' })
+    await seedWorkspace(db, { id: 'ws-b', hd: null, emailDomain: 'b.test' })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'a.test',
+      workspaceId: 'ws-a',
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-legacy',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'b.test',
+      workspaceId: 'ws-b',
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-legacy',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+
+    await expect(
+      findWorkspaceIdByProviderTenant(db, 'tenant-legacy'),
+    ).resolves.toBeNull()
+  })
+
+  test('domain lookup prefers the canonical Microsoft tenant workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      hd: null,
+      emailDomain: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, {
+      id: 'ws-duplicate',
+      hd: null,
+      emailDomain: 'corp.com',
+    })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-duplicate',
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+
+    await expect(findWorkspaceIdByDomainClaim(db, 'corp.com')).resolves.toBe(
+      'ws-tenant',
+    )
+  })
+
+  test('domain and tenant lookup preserve a nonempty legacy Microsoft claim workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      hd: null,
+      emailDomain: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, {
+      id: 'ws-duplicate',
+      hd: null,
+      emailDomain: 'corp.com',
+    })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-duplicate',
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u-existing',
+      email: 'existing@corp.com',
+      workspaceId: 'ws-duplicate',
+    })
+
+    await expect(findWorkspaceIdByDomainClaim(db, 'corp.com')).resolves.toBe(
+      'ws-duplicate',
+    )
+    await expect(
+      findWorkspaceIdForMicrosoftTenantDomain(db, 'tenant-1', 'corp.com'),
+    ).resolves.toBe('ws-duplicate')
+  })
+
+  test('Microsoft tenant lookup honors a verified domain claim from a different tenant', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-resource-tenant',
+      hd: null,
+      microsoftTenantId: 'resource-tenant',
+    })
+    await seedWorkspace(db, {
+      id: 'ws-home-domain',
+      hd: null,
+      emailDomain: 'guest.example',
+    })
+    await seedWorkspace(db, {
+      id: 'ws-home-tenant',
+      hd: null,
+      emailDomain: 'guest.example',
+      microsoftTenantId: 'home-tenant',
+    })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'guest.example',
+      workspaceId: 'ws-home-domain',
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'home-tenant',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+
+    await expect(
+      findWorkspaceIdForMicrosoftTenantDomain(
+        db,
+        'resource-tenant',
+        'guest.example',
+      ),
+    ).resolves.toBe('ws-home-tenant')
+  })
+
+  test('moves a verified owner out of an empty viewer workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-viewer', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u-owner',
+      email: 'owner@corp.com',
+      workspaceId: 'ws-viewer',
+    })
+    await db
+      .insertInto('workspace_members')
+      .values({
+        workspace_id: 'ws-viewer',
+        user_id: 'u-owner',
+        role: 'owner',
+        status: 'active',
+        created_at: '2026-06-26T00:00:00.000Z',
+        updated_at: '2026-06-26T00:00:00.000Z',
+      })
+      .execute()
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u-owner',
+        email: 'owner@corp.com',
+        currentWorkspaceId: 'ws-viewer',
+      }),
+    ).resolves.toBe('ws-org')
+    await expect(
+      db
+        .selectFrom('workspace_members')
+        .select(['role', 'status'])
+        .where('workspace_id', '=', 'ws-org')
+        .where('user_id', '=', 'u-owner')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ role: 'owner', status: 'active' })
+  })
+
+  test('promotes an existing target admin before the newly moved member', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-viewer', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u-admin',
+      email: 'admin@example.com',
+      workspaceId: 'ws-org',
+    })
+    await seedUser(db, {
+      id: 'u-mover',
+      email: 'mover@corp.com',
+      workspaceId: 'ws-viewer',
+    })
+    await db
+      .insertInto('workspace_members')
+      .values([
+        {
+          workspace_id: 'ws-org',
+          user_id: 'u-admin',
+          role: 'admin',
+          status: 'active',
+          created_at: '2026-06-26T00:00:00.000Z',
+          updated_at: '2026-06-26T00:00:00.000Z',
+        },
+        {
+          workspace_id: 'ws-viewer',
+          user_id: 'u-mover',
+          role: 'owner',
+          status: 'active',
+          created_at: '2026-06-26T00:00:00.000Z',
+          updated_at: '2026-06-26T00:00:00.000Z',
+        },
+      ])
+      .execute()
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u-mover',
+        email: 'mover@corp.com',
+        currentWorkspaceId: 'ws-viewer',
+      }),
+    ).resolves.toBe('ws-org')
+    await expect(
+      db
+        .selectFrom('workspace_members')
+        .select(['user_id', 'role'])
+        .where('workspace_id', '=', 'ws-org')
+        .where('status', '=', 'active')
+        .orderBy('user_id')
+        .execute(),
+    ).resolves.toEqual([
+      { user_id: 'u-admin', role: 'owner' },
+      { user_id: 'u-mover', role: 'member' },
+    ])
+  })
+
+  test('repairs an ownerless claimed workspace when the user is already there', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u-member',
+      email: 'member@corp.com',
+      workspaceId: 'ws-org',
+    })
+    await db
+      .insertInto('workspace_members')
+      .values({
+        workspace_id: 'ws-org',
+        user_id: 'u-member',
+        role: 'member',
+        status: 'active',
+        created_at: '2026-06-26T00:00:00.000Z',
+        updated_at: '2026-06-26T00:00:00.000Z',
+      })
+      .execute()
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u-member',
+        email: 'member@corp.com',
+        currentWorkspaceId: 'ws-org',
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      db
+        .selectFrom('workspace_members')
+        .select('role')
+        .where('workspace_id', '=', 'ws-org')
+        .where('user_id', '=', 'u-member')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ role: 'owner' })
+  })
+
+  test('repairs an ownerless OAuth target when the user is already there', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null })
+    await seedUser(db, {
+      id: 'u-member',
+      email: 'member@example.com',
+      workspaceId: 'ws-org',
+    })
+    await db
+      .insertInto('workspace_members')
+      .values({
+        workspace_id: 'ws-org',
+        user_id: 'u-member',
+        role: 'member',
+        status: 'active',
+        created_at: '2026-06-26T00:00:00.000Z',
+        updated_at: '2026-06-26T00:00:00.000Z',
+      })
+      .execute()
+
+    await expect(
+      moveUserToWorkspaceForOAuth(db, {
+        userId: 'u-member',
+        email: 'member@example.com',
+        currentWorkspaceId: 'ws-org',
+        targetWorkspaceId: 'ws-org',
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      db
+        .selectFrom('workspace_members')
+        .select('role')
+        .where('workspace_id', '=', 'ws-org')
+        .where('user_id', '=', 'u-member')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ role: 'owner' })
+  })
+
+  test('does not move the owner out of a canonical Microsoft tenant workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      hd: null,
+      emailDomain: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, {
+      id: 'ws-claim',
+      hd: null,
+      emailDomain: 'corp.com',
+    })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-claim',
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u-owner',
+      email: 'owner@corp.com',
+      workspaceId: 'ws-tenant',
+    })
+    await db
+      .insertInto('workspace_members')
+      .values({
+        workspace_id: 'ws-tenant',
+        user_id: 'u-owner',
+        role: 'owner',
+        status: 'active',
+        created_at: '2026-06-26T00:00:00.000Z',
+        updated_at: '2026-06-26T00:00:00.000Z',
+      })
+      .execute()
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u-owner',
+        email: 'owner@corp.com',
+        currentWorkspaceId: 'ws-tenant',
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      db
+        .selectFrom('users')
+        .select('workspace_id')
+        .where('id', '=', 'u-owner')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-tenant' })
   })
 
   test('does not move a user with a removed membership at the target workspace', async () => {
@@ -178,6 +600,369 @@ describe('workspace domain claims', () => {
     ).resolves.toEqual({ workspace_id: 'ws-personal' })
   })
 
+  test('rolls back when agent data appears before the move batch', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u1',
+      email: 'alice@corp.com',
+      workspaceId: 'ws-personal',
+    })
+    await db
+      .insertInto('workspace_members')
+      .values({
+        workspace_id: 'ws-org',
+        user_id: 'u1',
+        role: 'member',
+        status: 'active',
+        created_at: '2026-06-26T00:00:00.000Z',
+        updated_at: '2026-06-26T00:00:00.000Z',
+      })
+      .execute()
+    sqliteRef.beforeNextBatch = () => {
+      sqliteRef.current
+        ?.prepare(
+          `INSERT INTO agent_profiles (id, user_id, workspace_id, created_at)
+           VALUES ('agent-race', 'u1', 'ws-personal', '2026-06-26T00:00:00.000Z')`,
+        )
+        .run()
+    }
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).rejects.toThrow()
+    await expect(
+      db
+        .selectFrom('users')
+        .select('workspace_id')
+        .where('id', '=', 'u1')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-personal' })
+    await expect(
+      db
+        .selectFrom('workspaces')
+        .select('id')
+        .where('id', '=', 'ws-personal')
+        .executeTakeFirst(),
+    ).resolves.toEqual({ id: 'ws-personal' })
+    await expect(
+      db
+        .selectFrom('agent_profiles')
+        .select(['id', 'workspace_id'])
+        .where('id', '=', 'agent-race')
+        .executeTakeFirst(),
+    ).resolves.toEqual({ id: 'agent-race', workspace_id: 'ws-personal' })
+  })
+
+  test('rolls back when an API token appears before the move batch', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u1',
+      email: 'alice@corp.com',
+      workspaceId: 'ws-personal',
+    })
+    sqliteRef.beforeNextBatch = () => {
+      sqliteRef.current
+        ?.prepare(
+          `INSERT INTO api_tokens (id, user_id, name, token_hash, created_at)
+           VALUES ('token-race', 'u1', 'CLI', 'hash-race',
+                   '2026-06-26T00:00:00.000Z')`,
+        )
+        .run()
+    }
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).rejects.toThrow()
+    await expect(
+      db
+        .selectFrom('users')
+        .select('workspace_id')
+        .where('id', '=', 'u1')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-personal' })
+    await expect(
+      db
+        .selectFrom('api_tokens')
+        .select('id')
+        .where('id', '=', 'token-race')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ id: 'token-race' })
+  })
+
+  test('keeps users with delegated OAuth tokens in their current workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u1',
+      email: 'alice@corp.com',
+      workspaceId: 'ws-personal',
+    })
+    sqliteRef.current?.exec(`
+      INSERT INTO oauthClient (id, clientId, redirectUris)
+      VALUES ('client-row', 'client-1', '[]');
+      INSERT INTO oauthAccessToken (
+        id, token, clientId, userId, scopes
+      ) VALUES (
+        'access-1', 'delegated-token', 'client-1', 'u1', 'openid'
+      );
+    `)
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      db
+        .selectFrom('users')
+        .select('workspace_id')
+        .where('id', '=', 'u1')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-personal' })
+
+    sqliteRef.current
+      ?.prepare(
+        `UPDATE oauthAccessToken SET expiresAt = '2020-01-01T00:00:00.000Z'
+         WHERE id = 'access-1'`,
+      )
+      .run()
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).resolves.toBe('ws-org')
+  })
+
+  test('rolls back when a delegated OAuth token appears before the move batch', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u1',
+      email: 'alice@corp.com',
+      workspaceId: 'ws-personal',
+    })
+    sqliteRef.current?.exec(`
+      INSERT INTO oauthClient (id, clientId, redirectUris)
+      VALUES ('client-row', 'client-1', '[]');
+    `)
+    sqliteRef.beforeNextBatch = () => {
+      sqliteRef.current?.exec(`
+        INSERT INTO oauthAccessToken (
+          id, token, clientId, userId, scopes
+        ) VALUES (
+          'access-race', 'delegated-race', 'client-1', 'u1', 'openid'
+        );
+      `)
+    }
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).rejects.toThrow()
+    await expect(
+      db
+        .selectFrom('users')
+        .select('workspace_id')
+        .where('id', '=', 'u1')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-personal' })
+  })
+
+  test('rolls back when a shareable appears in the source workspace before the move batch', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u1',
+      email: 'alice@corp.com',
+      workspaceId: 'ws-personal',
+    })
+    await db
+      .insertInto('artifact_containers')
+      .values({
+        id: 'target-inbox',
+        workspace_id: 'ws-org',
+        kind: 'inbox',
+        owner_user_id: 'u1',
+        created_by_id: 'u1',
+        name: 'Inbox',
+        description: null,
+        archived_at: null,
+        base_visibility: 'private',
+        created_at: '2026-06-26T00:00:00.000Z',
+        updated_at: '2026-06-26T00:00:00.000Z',
+      })
+      .execute()
+    sqliteRef.beforeNextBatch = () => {
+      sqliteRef.current
+        ?.prepare(
+          `INSERT INTO shareables (
+             id, workspace_id, owner_user_id, name, artifact_kind, visibility,
+             created_at, updated_at, container_id
+           ) VALUES (
+             'share-race', 'ws-personal', 'u1', 'Draft', 'markdown_page',
+             'private', '2026-06-26T00:00:00.000Z',
+             '2026-06-26T00:00:00.000Z', 'target-inbox'
+           )`,
+        )
+        .run()
+    }
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).rejects.toThrow()
+    await expect(
+      db
+        .selectFrom('users')
+        .select('workspace_id')
+        .where('id', '=', 'u1')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-personal' })
+    await expect(
+      db
+        .selectFrom('workspaces')
+        .select('id')
+        .where('id', '=', 'ws-personal')
+        .executeTakeFirst(),
+    ).resolves.toEqual({ id: 'ws-personal' })
+    await expect(
+      db
+        .selectFrom('shareables')
+        .select(['id', 'workspace_id'])
+        .where('id', '=', 'share-race')
+        .executeTakeFirst(),
+    ).resolves.toEqual({ id: 'share-race', workspace_id: 'ws-personal' })
+  })
+
+  test('keeps a personal workspace with customized sharing settings', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u1',
+      email: 'alice@corp.com',
+      workspaceId: 'ws-personal',
+    })
+    await db
+      .updateTable('workspaces')
+      .set({ link_sharing_enabled: 1 })
+      .where('id', '=', 'ws-personal')
+      .execute()
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      db
+        .selectFrom('users')
+        .select('workspace_id')
+        .where('id', '=', 'u1')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-personal' })
+  })
+
+  test('keeps a renamed personal workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u1',
+      email: 'alice@corp.com',
+      workspaceId: 'ws-personal',
+    })
+    await db
+      .updateTable('workspaces')
+      .set({ name: 'My renamed workspace' })
+      .where('id', '=', 'ws-personal')
+      .execute()
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      db
+        .selectFrom('users')
+        .select('workspace_id')
+        .where('id', '=', 'u1')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-personal' })
+  })
+
   test('moves an empty verified personal user into claimed workspace', async () => {
     const db = setup()
     await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
@@ -210,6 +995,70 @@ describe('workspace domain claims', () => {
     expect(user.workspace_id).toBe('ws-org')
   })
 
+  test('deletes the empty personal workspace using the live user email', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', hd: null })
+    await seedUser(db, {
+      id: 'u1',
+      email: 'current@corp.com',
+      workspaceId: 'ws-personal',
+    })
+
+    await expect(
+      moveUserToWorkspaceForOAuth(db, {
+        userId: 'u1',
+        email: 'stale@corp.com',
+        currentWorkspaceId: 'ws-personal',
+        targetWorkspaceId: 'ws-org',
+      }),
+    ).resolves.toBe('ws-org')
+    await expect(
+      db
+        .selectFrom('workspaces')
+        .select('id')
+        .where('id', '=', 'ws-personal')
+        .executeTakeFirst(),
+    ).resolves.toBeUndefined()
+  })
+
+  test('moves a default personal workspace created from a mixed-case email', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u1',
+      email: 'alice@corp.com',
+      workspaceId: 'ws-personal',
+    })
+    await db
+      .updateTable('workspaces')
+      .set({ name: "Alice@Corp.com's workspace" })
+      .where('id', '=', 'ws-personal')
+      .execute()
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).resolves.toBe('ws-org')
+    await expect(
+      db
+        .selectFrom('workspaces')
+        .select('id')
+        .where('id', '=', 'ws-personal')
+        .executeTakeFirst(),
+    ).resolves.toBeUndefined()
+  })
+
   test('keeps the source workspace when it has a Slack integration', async () => {
     const db = setup()
     await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
@@ -239,17 +1088,26 @@ describe('workspace domain claims', () => {
       })
       .execute()
 
-    await maybeMoveUserToClaimedWorkspace(db, {
-      userId: 'u1',
-      email: 'alice@corp.com',
-      currentWorkspaceId: 'ws-personal',
-    })
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).resolves.toBeNull()
 
     await expect(
       db
         .selectFrom('slack_workspaces')
         .select('workspace_id')
         .where('id', '=', 'slack-1')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-personal' })
+    await expect(
+      db
+        .selectFrom('users')
+        .select('workspace_id')
+        .where('id', '=', 'u1')
         .executeTakeFirstOrThrow(),
     ).resolves.toEqual({ workspace_id: 'ws-personal' })
   })
@@ -296,6 +1154,62 @@ describe('workspace domain claims', () => {
         userId: 'u1',
         email: 'alice@corp.com',
         apiTokensCount: 1,
+      },
+    ])
+
+    await db.deleteFrom('api_tokens').where('id', '=', 'tok1').execute()
+    sqliteRef.current?.exec(`
+      INSERT INTO oauthClient (id, clientId, redirectUris)
+      VALUES ('candidate-client-row', 'candidate-client', '[]');
+      INSERT INTO oauthAccessToken (
+        id, token, clientId, userId, scopes
+      ) VALUES (
+        'candidate-access', 'candidate-token', 'candidate-client', 'u1', 'openid'
+      );
+    `)
+    await expect(listWorkspaceMigrationCandidates(db)).resolves.toMatchObject([
+      {
+        userId: 'u1',
+        apiTokensCount: 0,
+        oauthAccessTokensCount: 1,
+        oauthRefreshTokensCount: 0,
+      },
+    ])
+  })
+
+  test('keeps users with stateless OAuth consent in their current workspace', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-personal', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u1',
+      email: 'alice@corp.com',
+      workspaceId: 'ws-personal',
+    })
+    sqliteRef.current?.exec(`
+      INSERT INTO oauthClient (id, clientId, redirectUris)
+      VALUES ('client-row', 'client-1', '[]');
+      INSERT INTO oauthConsent (id, clientId, userId, scopes)
+      VALUES ('consent-1', 'client-1', 'u1', 'openid');
+    `)
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u1',
+        email: 'alice@corp.com',
+        currentWorkspaceId: 'ws-personal',
+      }),
+    ).resolves.toBeNull()
+    await expect(listWorkspaceMigrationCandidates(db)).resolves.toMatchObject([
+      {
+        userId: 'u1',
+        oauthConsentsCount: 1,
       },
     ])
   })
@@ -386,5 +1300,13 @@ async function seedUser(
       updated_at: '2026-06-26T00:00:00.000Z',
       workspace_id: input.workspaceId,
     })
+    .execute()
+  await db
+    .updateTable('workspaces')
+    .set({ name: `${input.email}'s workspace` })
+    .where('id', '=', input.workspaceId)
+    .where('name', '=', input.workspaceId)
+    .where('hd', 'is', null)
+    .where('ms_tenant_id', 'is', null)
     .execute()
 }

--- a/apps/web/app/services/workspace-domain-claims.server.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.ts
@@ -7,6 +7,7 @@ import {
   normalizeEmailDomain,
 } from '~/lib/workspace-domains'
 import type { DB } from '~/types/db'
+import { ensureWorkspaceAdmin } from './team-management.server'
 
 export type WorkspaceDomainClaimSource =
   | 'google_hd'
@@ -59,10 +60,125 @@ export async function findWorkspaceIdByDomainClaim(
 
   const claim = await db
     .selectFrom('workspace_domain_claims')
-    .select('workspace_id')
+    .select(['workspace_id', 'source', 'provider_tenant_id'])
     .where('domain', '=', normalized)
     .executeTakeFirst()
+  if (
+    claim?.source === 'microsoft_verified_domain' &&
+    claim.provider_tenant_id
+  ) {
+    return await resolveMicrosoftClaimWorkspace(db, {
+      domain: normalized,
+      workspaceId: claim.workspace_id,
+      providerTenantId: claim.provider_tenant_id,
+    })
+  }
   return claim?.workspace_id ?? null
+}
+
+export async function findWorkspaceIdForMicrosoftTenantDomain(
+  db: Kysely<DB>,
+  providerTenantId: string,
+  domain: string | null,
+): Promise<string | null> {
+  const normalized = normalizeEmailDomain(domain)
+  if (normalized && !isPublicEmailDomain(normalized)) {
+    const claim = await db
+      .selectFrom('workspace_domain_claims')
+      .select(['workspace_id', 'source', 'provider_tenant_id'])
+      .where('domain', '=', normalized)
+      .executeTakeFirst()
+    if (
+      claim?.source === 'microsoft_verified_domain' &&
+      claim.provider_tenant_id
+    ) {
+      return await resolveMicrosoftClaimWorkspace(db, {
+        domain: normalized,
+        workspaceId: claim.workspace_id,
+        providerTenantId: claim.provider_tenant_id,
+      })
+    }
+    if (claim) return claim.workspace_id
+  }
+  return await findWorkspaceIdByProviderTenant(db, providerTenantId)
+}
+
+async function resolveMicrosoftClaimWorkspace(
+  db: Kysely<DB>,
+  input: {
+    domain: string
+    workspaceId: string
+    providerTenantId: string
+  },
+): Promise<string> {
+  const tenantWorkspaceId = await findWorkspaceIdByProviderTenant(
+    db,
+    input.providerTenantId,
+  )
+  if (!tenantWorkspaceId || tenantWorkspaceId === input.workspaceId) {
+    return input.workspaceId
+  }
+
+  const disposableDuplicate = await db
+    .selectFrom('workspaces')
+    .select('id')
+    .where('id', '=', input.workspaceId)
+    .where(
+      sql<boolean>`
+        hd IS NULL
+        AND ms_tenant_id IS NULL
+        AND plan = 'free'
+        AND storage_used_bytes = 0
+        AND stripe_customer_id IS NULL
+        AND stripe_subscription_id IS NULL
+        AND stripe_subscription_status = 'none'
+        AND link_sharing_enabled = 0
+        AND external_posting_enabled = 0
+        AND link_expiry_default_days = 30
+        AND link_expiry_max_days = 90
+        AND (
+          (self_upload_enabled = 1 AND storage_quota_bytes = 104857600)
+          OR (self_upload_enabled = 0 AND storage_quota_bytes = 0)
+        )
+        AND NOT EXISTS (SELECT 1 FROM users WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM workspace_members WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_domain_claims
+          WHERE workspace_id = ${input.workspaceId} AND domain != ${input.domain}
+        )
+        AND NOT EXISTS (SELECT 1 FROM workspace_storage_daily_usage WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM billing_overage_charges WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM artifact_containers WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM shareables WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM agent_profiles WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM cli_family_authorities WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM cli_session_authorities WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM bridge_authorities WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM slack_workspaces WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM artifact_keys WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM events WHERE workspace_id = ${input.workspaceId})
+      `,
+    )
+    .executeTakeFirst()
+  return disposableDuplicate ? tenantWorkspaceId : input.workspaceId
+}
+
+export async function findWorkspaceIdByProviderTenant(
+  db: Kysely<DB>,
+  providerTenantId: string | null | undefined,
+): Promise<string | null> {
+  if (!providerTenantId) return null
+
+  // The workspace column is the canonical Microsoft tenant identity. Prefer
+  // it over a claim row so legacy duplicate data cannot route a sign-in to an
+  // empty claim-only workspace.
+  const tenantWorkspace = await db
+    .selectFrom('workspaces')
+    .select('id')
+    .where('ms_tenant_id', '=', providerTenantId)
+    .executeTakeFirst()
+  return tenantWorkspace?.id ?? null
 }
 
 export async function ensureDomainClaimWorkspace(
@@ -84,21 +200,55 @@ export async function ensureDomainClaimWorkspace(
   const existingClaim = await findWorkspaceIdByDomainClaim(db, domain)
   if (existingClaim) return existingClaim
 
-  const workspaceId = nanoid()
-  const insertedWorkspace = await db
-    .insertInto('workspaces')
-    .values({
-      id: workspaceId,
-      hd: null,
-      ms_tenant_id: null,
-      name: domain,
-      created_at: input.now,
-      email_domain: domain,
-      ...input.creation,
+  const existingTenantWorkspace = await findWorkspaceIdByProviderTenant(
+    db,
+    input.providerTenantId,
+  )
+  if (existingTenantWorkspace) {
+    return await ensureWorkspaceDomainClaim(db, {
+      domain,
+      workspaceId: existingTenantWorkspace,
+      source: input.source,
+      providerTenantId: input.providerTenantId ?? null,
+      now: input.now,
     })
+  }
+
+  const workspaceId = nanoid()
+  let insertWorkspace = db.insertInto('workspaces').values({
+    id: workspaceId,
+    hd: null,
+    ms_tenant_id:
+      input.source === 'microsoft_verified_domain'
+        ? (input.providerTenantId ?? null)
+        : null,
+    name: domain,
+    created_at: input.now,
+    email_domain: domain,
+    ...input.creation,
+  })
+  if (input.source === 'microsoft_verified_domain' && input.providerTenantId) {
+    insertWorkspace = insertWorkspace.onConflict((oc) =>
+      oc.column('ms_tenant_id').doNothing(),
+    )
+  }
+  const insertedWorkspace = await insertWorkspace
     .returning('id')
     .executeTakeFirst()
-  if (!insertedWorkspace) return null
+  if (!insertedWorkspace) {
+    const concurrentTenantWorkspace = await findWorkspaceIdByProviderTenant(
+      db,
+      input.providerTenantId,
+    )
+    if (!concurrentTenantWorkspace) return null
+    return await ensureWorkspaceDomainClaim(db, {
+      domain,
+      workspaceId: concurrentTenantWorkspace,
+      source: input.source,
+      providerTenantId: input.providerTenantId ?? null,
+      now: input.now,
+    })
+  }
 
   const claimedWorkspaceId = await ensureWorkspaceDomainClaim(db, {
     domain,
@@ -108,12 +258,34 @@ export async function ensureDomainClaimWorkspace(
     now: input.now,
   })
   if (claimedWorkspaceId !== insertedWorkspace.id) {
-    await db
-      .deleteFrom('workspaces')
-      .where('id', '=', insertedWorkspace.id)
-      .execute()
+    await deleteWorkspaceIfUnreferenced(db, insertedWorkspace.id).execute()
   }
   return claimedWorkspaceId
+}
+
+function deleteWorkspaceIfUnreferenced(db: Kysely<DB>, workspaceId: string) {
+  return db
+    .deleteFrom('workspaces')
+    .where('id', '=', workspaceId)
+    .where(
+      sql<boolean>`
+        NOT EXISTS (SELECT 1 FROM users WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM workspace_members WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM workspace_domain_claims WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM workspace_storage_daily_usage WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM billing_overage_charges WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM artifact_containers WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM shareables WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM agent_profiles WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM cli_family_authorities WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM cli_session_authorities WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM bridge_authorities WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM slack_workspaces WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM artifact_keys WHERE workspace_id = ${workspaceId})
+        AND NOT EXISTS (SELECT 1 FROM events WHERE workspace_id = ${workspaceId})
+      `,
+    )
 }
 
 export async function maybeMoveUserToClaimedWorkspace(
@@ -130,14 +302,22 @@ export async function maybeMoveUserToClaimedWorkspace(
   if (mover?.kind !== 'human') return null
   const domain = normalizeEmailDomain(input.email)
   const targetWorkspaceId = await findWorkspaceIdByDomainClaim(db, domain)
-  if (!targetWorkspaceId || targetWorkspaceId === input.currentWorkspaceId) {
+  if (!targetWorkspaceId) return null
+  if (targetWorkspaceId === input.currentWorkspaceId) {
+    await ensureWorkspaceAdmin(db, targetWorkspaceId, nowIso())
     return null
   }
 
-  return await moveUserToWorkspaceIfSafe(db, {
-    ...input,
-    targetWorkspaceId,
-  })
+  return await moveUserToWorkspaceIfSafe(
+    db,
+    {
+      ...input,
+      targetWorkspaceId,
+    },
+    {
+      allowCurrentWorkspaceAdmin: input.currentWorkspaceId,
+    },
+  )
 }
 
 export async function moveUserToWorkspaceForOAuth(
@@ -149,7 +329,10 @@ export async function moveUserToWorkspaceForOAuth(
     targetWorkspaceId: string
   },
 ): Promise<string | null> {
-  if (input.targetWorkspaceId === input.currentWorkspaceId) return null
+  if (input.targetWorkspaceId === input.currentWorkspaceId) {
+    await ensureWorkspaceAdmin(db, input.targetWorkspaceId, nowIso())
+    return null
+  }
   return await moveUserToWorkspaceIfSafe(db, input, {
     allowCurrentWorkspaceAdmin: input.currentWorkspaceId,
   })
@@ -183,6 +366,90 @@ async function moveUserToWorkspaceIfSafe(
     .set({ workspace_id: input.targetWorkspaceId })
     .where('id', '=', input.userId)
     .where('workspace_id', '=', input.currentWorkspaceId)
+    .where(
+      sql<boolean>`
+        EXISTS (
+          SELECT 1
+          FROM workspaces AS source
+          WHERE source.id = ${input.currentWorkspaceId}
+            AND source.hd IS NULL
+            AND source.ms_tenant_id IS NULL
+            AND source.plan = 'free'
+            AND source.storage_used_bytes = 0
+            AND source.stripe_customer_id IS NULL
+            AND source.stripe_subscription_id IS NULL
+            AND source.stripe_subscription_status = 'none'
+            AND source.link_sharing_enabled = 0
+            AND source.external_posting_enabled = 0
+            AND source.link_expiry_default_days = 30
+            AND source.link_expiry_max_days = 90
+            AND lower(source.name) = lower((
+              SELECT email || '''s workspace'
+              FROM users
+              WHERE id = ${input.userId}
+                AND workspace_id = source.id
+            ))
+            AND (
+              (source.self_upload_enabled = 1 AND source.storage_quota_bytes = 104857600)
+              OR (source.self_upload_enabled = 0 AND source.storage_quota_bytes = 0)
+            )
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM users
+            WHERE workspace_id = ${input.currentWorkspaceId} AND id != ${input.userId}
+          UNION ALL SELECT 1 FROM workspace_members
+            WHERE workspace_id = ${input.currentWorkspaceId} AND user_id != ${input.userId}
+          UNION ALL SELECT 1 FROM workspace_domain_claims
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM workspace_storage_daily_usage
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM billing_overage_charges
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM artifact_containers
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM shareables
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM agent_profiles
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM cli_family_authorities
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM cli_session_authorities
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM bridge_authorities
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM slack_workspaces
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM mcp_artifact_posts
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM artifact_keys
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM events
+            WHERE workspace_id = ${input.currentWorkspaceId}
+          UNION ALL SELECT 1 FROM api_tokens
+            WHERE user_id = ${input.userId}
+          UNION ALL SELECT 1 FROM cli_refresh_credentials
+            WHERE user_id = ${input.userId}
+          UNION ALL SELECT 1 FROM oauthAccessToken
+            WHERE userId = ${input.userId}
+              AND (expiresAt IS NULL OR expiresAt > ${now})
+          UNION ALL SELECT 1 FROM oauthRefreshToken
+            WHERE userId = ${input.userId}
+              AND revoked IS NULL
+              AND (expiresAt IS NULL OR expiresAt > ${now})
+          UNION ALL SELECT 1 FROM oauthConsent
+            WHERE userId = ${input.userId}
+          UNION ALL SELECT 1 FROM comment_threads
+            WHERE created_by_id = ${input.userId}
+          UNION ALL SELECT 1 FROM comment_messages
+            WHERE created_by_id = ${input.userId}
+          UNION ALL SELECT 1 FROM workspace_members
+            WHERE user_id = ${input.userId}
+              AND workspace_id != ${input.currentWorkspaceId}
+              AND status = 'active'
+              AND role IN ('owner', 'admin')
+        )
+      `,
+    )
   const membershipUpsert = db
     .insertInto('workspace_members')
     .columns([
@@ -221,10 +488,13 @@ async function moveUserToWorkspaceIfSafe(
       ${now}
     WHERE NOT EXISTS (
       SELECT 1
-      FROM workspace_members
-      WHERE workspace_id = ${input.targetWorkspaceId}
-        AND user_id = ${input.userId}
-        AND status = 'active'
+      FROM users
+      INNER JOIN workspace_members
+        ON workspace_members.workspace_id = users.workspace_id
+        AND workspace_members.user_id = users.id
+      WHERE users.id = ${input.userId}
+        AND users.workspace_id = ${input.targetWorkspaceId}
+        AND workspace_members.status = 'active'
     )
   `
   const targetMembershipGuardQuery = {
@@ -256,6 +526,17 @@ async function moveUserToWorkspaceIfSafe(
     .where('stripe_customer_id', 'is', null)
     .where('stripe_subscription_id', 'is', null)
     .where('stripe_subscription_status', '=', 'none')
+    .where('link_sharing_enabled', '=', 0)
+    .where('external_posting_enabled', '=', 0)
+    .where('link_expiry_default_days', '=', 30)
+    .where('link_expiry_max_days', '=', 90)
+    .where(
+      sql<boolean>`lower(name) = lower((
+        SELECT email || '''s workspace'
+        FROM users
+        WHERE id = ${input.userId}
+      ))`,
+    )
     .where((eb) =>
       eb.or([
         eb.and([
@@ -290,6 +571,46 @@ async function moveUserToWorkspaceIfSafe(
           eb.exists(
             eb
               .selectFrom('artifact_containers')
+              .select('id')
+              .where('workspace_id', '=', input.currentWorkspaceId),
+          ),
+        ),
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom('shareables')
+              .select('id')
+              .where('workspace_id', '=', input.currentWorkspaceId),
+          ),
+        ),
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom('agent_profiles')
+              .select('id')
+              .where('workspace_id', '=', input.currentWorkspaceId),
+          ),
+        ),
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom('cli_family_authorities')
+              .select('family_id')
+              .where('workspace_id', '=', input.currentWorkspaceId),
+          ),
+        ),
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom('cli_session_authorities')
+              .select('session_id')
+              .where('workspace_id', '=', input.currentWorkspaceId),
+          ),
+        ),
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom('bridge_authorities')
               .select('id')
               .where('workspace_id', '=', input.currentWorkspaceId),
           ),
@@ -343,6 +664,14 @@ async function moveUserToWorkspaceIfSafe(
               .where('workspace_id', '=', input.currentWorkspaceId),
           ),
         ),
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom('events')
+              .select('id')
+              .where('workspace_id', '=', input.currentWorkspaceId),
+          ),
+        ),
       ]),
     )
   await runD1Batch(
@@ -353,6 +682,7 @@ async function moveUserToWorkspaceIfSafe(
     sourceMembershipDelete,
     emptySourceWorkspaceDelete,
   )
+  await ensureWorkspaceAdmin(db, input.targetWorkspaceId, now)
   return input.targetWorkspaceId
 }
 
@@ -364,17 +694,125 @@ export async function canAutoMoveUserWorkspace(
   if (options.allowCurrentWorkspaceAdmin) {
     const workspace = await db
       .selectFrom('workspaces')
+      .innerJoin('users as workspace_user', (join) =>
+        join
+          .onRef('workspace_user.workspace_id', '=', 'workspaces.id')
+          .on('workspace_user.id', '=', userId),
+      )
       .leftJoin(
         'workspace_domain_claims',
         'workspace_domain_claims.workspace_id',
         'workspaces.id',
       )
-      .select(['workspaces.hd', 'workspace_domain_claims.domain'])
+      .select([
+        'workspaces.hd',
+        'workspaces.name',
+        'workspaces.ms_tenant_id',
+        'workspaces.plan',
+        'workspaces.storage_used_bytes',
+        'workspaces.self_upload_enabled',
+        'workspaces.storage_quota_bytes',
+        'workspaces.stripe_customer_id',
+        'workspaces.stripe_subscription_id',
+        'workspaces.stripe_subscription_status',
+        'workspaces.link_sharing_enabled',
+        'workspaces.external_posting_enabled',
+        'workspaces.link_expiry_default_days',
+        'workspaces.link_expiry_max_days',
+        'workspace_user.email as user_email',
+        'workspace_domain_claims.domain',
+      ])
       .where('workspaces.id', '=', options.allowCurrentWorkspaceAdmin)
       .executeTakeFirst()
-    if (workspace?.hd || workspace?.domain) return false
+    const disposableProvisioning =
+      workspace &&
+      ((workspace.self_upload_enabled === 1 &&
+        workspace.storage_quota_bytes === 104857600) ||
+        (workspace.self_upload_enabled === 0 &&
+          workspace.storage_quota_bytes === 0))
+    if (
+      !workspace ||
+      workspace.hd ||
+      workspace.ms_tenant_id ||
+      workspace.domain ||
+      workspace.plan !== 'free' ||
+      workspace.storage_used_bytes !== 0 ||
+      workspace.stripe_customer_id ||
+      workspace.stripe_subscription_id ||
+      workspace.stripe_subscription_status !== 'none' ||
+      workspace.link_sharing_enabled !== 0 ||
+      workspace.external_posting_enabled !== 0 ||
+      workspace.link_expiry_default_days !== 30 ||
+      workspace.link_expiry_max_days !== 90 ||
+      workspace.name.toLowerCase() !==
+        `${workspace.user_email.toLowerCase()}'s workspace` ||
+      !disposableProvisioning
+    ) {
+      return false
+    }
+    const workspaceId = options.allowCurrentWorkspaceAdmin
+    const residual = await sql<{ has_data: number }>`
+      SELECT EXISTS (
+        SELECT 1 FROM users WHERE workspace_id = ${workspaceId} AND id != ${userId}
+        UNION ALL SELECT 1 FROM workspace_members WHERE workspace_id = ${workspaceId} AND user_id != ${userId}
+        UNION ALL SELECT 1 FROM workspace_storage_daily_usage WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM billing_overage_charges WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM artifact_containers WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM shareables WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM agent_profiles WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM cli_family_authorities WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM cli_session_authorities WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM bridge_authorities WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM slack_workspaces WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM artifact_keys WHERE workspace_id = ${workspaceId}
+        UNION ALL SELECT 1 FROM events WHERE workspace_id = ${workspaceId}
+      ) AS has_data
+    `.execute(db)
+    if (Number(residual.rows[0]?.has_data ?? 0) !== 0) return false
   }
 
+  return await hasSafeUserStateForWorkspaceChange(db, userId, options)
+}
+
+export async function canEnableOAuthWorkspaceSelfUpload(
+  db: Kysely<DB>,
+  userId: string,
+  workspaceId: string,
+): Promise<boolean> {
+  const workspace = await db
+    .selectFrom('workspaces')
+    .leftJoin(
+      'workspace_domain_claims',
+      'workspace_domain_claims.workspace_id',
+      'workspaces.id',
+    )
+    .select([
+      'workspaces.hd',
+      'workspaces.ms_tenant_id',
+      'workspace_domain_claims.domain',
+    ])
+    .where('workspaces.id', '=', workspaceId)
+    .executeTakeFirst()
+  if (
+    !workspace ||
+    workspace.hd ||
+    workspace.ms_tenant_id ||
+    workspace.domain
+  ) {
+    return false
+  }
+  return await hasSafeUserStateForWorkspaceChange(db, userId, {
+    allowCurrentWorkspaceAdmin: workspaceId,
+  })
+}
+
+async function hasSafeUserStateForWorkspaceChange(
+  db: Kysely<DB>,
+  userId: string,
+  options: { allowCurrentWorkspaceAdmin?: string },
+): Promise<boolean> {
+  const activeTokenCutoff = nowIso()
   const adminWorkspaceFilter = options.allowCurrentWorkspaceAdmin
     ? sql<boolean>`
         AND (
@@ -455,6 +893,21 @@ export async function canAutoMoveUserWorkspace(
             .where('cli_refresh_credentials.user_id', '=', userId),
         )
         .as('has_cli_refresh_credentials'),
+      sql<boolean>`EXISTS (
+        SELECT 1 FROM oauthAccessToken
+        WHERE userId = ${userId}
+          AND (expiresAt IS NULL OR expiresAt > ${activeTokenCutoff})
+      )`.as('has_oauth_access_tokens'),
+      sql<boolean>`EXISTS (
+        SELECT 1 FROM oauthRefreshToken
+        WHERE userId = ${userId}
+          AND revoked IS NULL
+          AND (expiresAt IS NULL OR expiresAt > ${activeTokenCutoff})
+      )`.as('has_oauth_refresh_tokens'),
+      sql<boolean>`EXISTS (
+        SELECT 1 FROM oauthConsent
+        WHERE userId = ${userId}
+      )`.as('has_oauth_consents'),
     ])
     .where('id', '=', userId)
     .executeTakeFirst()
@@ -467,7 +920,10 @@ export async function canAutoMoveUserWorkspace(
     !row.has_comment_messages &&
     !row.has_comment_threads &&
     !row.has_api_tokens &&
-    !row.has_cli_refresh_credentials,
+    !row.has_cli_refresh_credentials &&
+    !row.has_oauth_access_tokens &&
+    !row.has_oauth_refresh_tokens &&
+    !row.has_oauth_consents,
   )
 }
 
@@ -483,11 +939,15 @@ export interface WorkspaceMigrationCandidate {
   commentMessagesCount: number
   apiTokensCount: number
   cliRefreshCredentialsCount: number
+  oauthAccessTokensCount: number
+  oauthRefreshTokensCount: number
+  oauthConsentsCount: number
 }
 
 export async function listWorkspaceMigrationCandidates(
   db: Kysely<DB>,
 ): Promise<WorkspaceMigrationCandidate[]> {
+  const activeTokenCutoff = nowIso()
   const rows = await sql<WorkspaceMigrationCandidate>`
     SELECT
       claims.domain AS domain,
@@ -528,7 +988,25 @@ export async function listWorkspaceMigrationCandidates(
         SELECT count(*)
         FROM cli_refresh_credentials
         WHERE cli_refresh_credentials.user_id = users.id
-      ) AS cliRefreshCredentialsCount
+      ) AS cliRefreshCredentialsCount,
+      (
+        SELECT count(*)
+        FROM oauthAccessToken
+        WHERE oauthAccessToken.userId = users.id
+          AND (oauthAccessToken.expiresAt IS NULL OR oauthAccessToken.expiresAt > ${activeTokenCutoff})
+      ) AS oauthAccessTokensCount,
+      (
+        SELECT count(*)
+        FROM oauthRefreshToken
+        WHERE oauthRefreshToken.userId = users.id
+          AND oauthRefreshToken.revoked IS NULL
+          AND (oauthRefreshToken.expiresAt IS NULL OR oauthRefreshToken.expiresAt > ${activeTokenCutoff})
+      ) AS oauthRefreshTokensCount,
+      (
+        SELECT count(*)
+        FROM oauthConsent
+        WHERE oauthConsent.userId = users.id
+      ) AS oauthConsentsCount
     FROM workspace_domain_claims AS claims
     INNER JOIN users
       ON lower(substr(users.email, instr(users.email, '@') + 1)) = claims.domain
@@ -542,6 +1020,9 @@ export async function listWorkspaceMigrationCandidates(
         OR commentMessagesCount > 0
         OR apiTokensCount > 0
         OR cliRefreshCredentialsCount > 0
+        OR oauthAccessTokensCount > 0
+        OR oauthRefreshTokensCount > 0
+        OR oauthConsentsCount > 0
       )
     ORDER BY claims.domain, users.email
   `.execute(db)
@@ -554,5 +1035,8 @@ export async function listWorkspaceMigrationCandidates(
     commentMessagesCount: Number(row.commentMessagesCount),
     apiTokensCount: Number(row.apiTokensCount),
     cliRefreshCredentialsCount: Number(row.cliRefreshCredentialsCount),
+    oauthAccessTokensCount: Number(row.oauthAccessTokensCount),
+    oauthRefreshTokensCount: Number(row.oauthRefreshTokensCount),
+    oauthConsentsCount: Number(row.oauthConsentsCount),
   }))
 }


### PR DESCRIPTION
## 概要

- 検証済みドメインの claim と OAuth テナントの workspace 解決を一貫させました。
- 検証済みメールのユーザーが claim 済み workspace に安全に合流できるようにしました。
- 既存データを移す運用向けに、事前確認と競合検知を備えた plan/apply 処理を追加しました。

## 安全性

- データ、設定、権限、認証情報が残る workspace は自動移動・削除しません。
- Microsoft の domain claim 修復は、保存済みの tenant-domain 証跡と canonical tenant workspace が一致する場合だけ実行します。
- D1 の更新は単一バッチで適用し、適用中に状態が変わった場合は全体を失敗させます。

## 検証

- `pnpm validate:static`
  - Web unit: 3,220 passed / 1 skipped
  - QM bridge: 81 passed
  - React Doctor: 100
  - public repository scan: 0 findings
- Codex deep implementation review: no actionable correctness issues
- Claude deep implementation review: no correctness or safety blocker; one low-severity query-cost follow-up
- trusted `origin/main` checkout による public development guard: passed
