### PR TITLE
Treat zero-usage history as disposable during claim repair

### DIFF
--- a/apps/web/app/services/oauth-workspace-integration.server.test.ts
+++ b/apps/web/app/services/oauth-workspace-integration.server.test.ts
@@ -356,7 +356,7 @@ describe('OAuth workspace integration', () => {
     ).resolves.toMatchObject({ kind: 'applied' })
   })
 
-  test('blocks Microsoft claim repair when the duplicate workspace contains data', async () => {
+  test('repairs a Microsoft claim when the duplicate workspace has only zero-usage history', async () => {
     const db = setup()
     await seedWorkspace(db, {
       id: 'ws-tenant',
@@ -377,7 +377,58 @@ describe('OAuth workspace integration', () => {
         workspace_id: 'ws-duplicate',
         date: '2026-08-26',
         used_bytes: 0,
-        included_bytes: 0,
+        included_bytes: 104857600,
+        billable_overage_gb: 0,
+      })
+      .execute()
+
+    const plan = await planOAuthWorkspaceIntegration(db, {
+      domain: 'corp.com',
+      email: 'alice@corp.com',
+      source: 'microsoft_verified_domain',
+    })
+
+    expect(plan.executable).toBe(true)
+    const result = await applyOAuthWorkspaceIntegration(db, plan)
+    expect(result.kind).toBe('applied')
+    await expect(
+      db
+        .selectFrom('workspace_domain_claims')
+        .select('workspace_id')
+        .where('domain', '=', 'corp.com')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ workspace_id: 'ws-tenant' })
+    await expect(
+      db
+        .selectFrom('workspace_storage_daily_usage')
+        .select('workspace_id')
+        .where('workspace_id', '=', 'ws-duplicate')
+        .executeTakeFirst(),
+    ).resolves.toBeUndefined()
+  })
+
+  test('blocks Microsoft claim repair when duplicate usage is nonzero', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      name: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, { id: 'ws-duplicate', name: 'corp.com' })
+    await seedUser(db, 'u-ms', 'alice@corp.com', 'ws-tenant')
+    await db.deleteFrom('accounts').where('user_id', '=', 'u-ms').execute()
+    await seedMicrosoftAccount(db, 'u-ms', 'alice@corp.com', 'tenant-1')
+    await seedClaim(db, 'corp.com', 'ws-duplicate', {
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+    })
+    await db
+      .insertInto('workspace_storage_daily_usage')
+      .values({
+        workspace_id: 'ws-duplicate',
+        date: '2026-08-26',
+        used_bytes: 1,
+        included_bytes: 104857600,
         billable_overage_gb: 0,
       })
       .execute()
@@ -390,19 +441,11 @@ describe('OAuth workspace integration', () => {
 
     expect(plan.executable).toBe(false)
     expect(plan.stopReasons).toContain('duplicate_claim_workspace_not_empty')
-    const result = await applyOAuthWorkspaceIntegration(db, plan)
-    expect(result.kind).toBe('blocked')
     await expect(
       db
         .selectFrom('workspace_domain_claims')
         .select('workspace_id')
         .where('domain', '=', 'corp.com')
-        .executeTakeFirstOrThrow(),
-    ).resolves.toEqual({ workspace_id: 'ws-duplicate' })
-    await expect(
-      db
-        .selectFrom('workspace_storage_daily_usage')
-        .select('workspace_id')
         .executeTakeFirstOrThrow(),
     ).resolves.toEqual({ workspace_id: 'ws-duplicate' })
   })
@@ -471,7 +514,7 @@ describe('OAuth workspace integration', () => {
             .values({
               workspace_id: 'ws-racing',
               date: '2026-08-26',
-              used_bytes: 0,
+              used_bytes: 1,
               included_bytes: 0,
               billable_overage_gb: 0,
             })

--- a/apps/web/app/services/oauth-workspace-integration.server.ts
+++ b/apps/web/app/services/oauth-workspace-integration.server.ts
@@ -861,7 +861,11 @@ function disposableEmptyWorkspaceCondition(
         WHERE workspace_id = ${workspaceId} ${movingClaimExclusion}
       )
       AND NOT EXISTS (SELECT 1 FROM workspace_members WHERE workspace_id = ${workspaceId})
-      AND NOT EXISTS (SELECT 1 FROM workspace_storage_daily_usage WHERE workspace_id = ${workspaceId})
+      AND NOT EXISTS (
+        SELECT 1 FROM workspace_storage_daily_usage
+        WHERE workspace_id = ${workspaceId}
+          AND (used_bytes != 0 OR billable_overage_gb != 0)
+      )
       AND NOT EXISTS (SELECT 1 FROM billing_overage_charges WHERE workspace_id = ${workspaceId})
       AND NOT EXISTS (SELECT 1 FROM artifact_containers WHERE workspace_id = ${workspaceId})
       AND NOT EXISTS (SELECT 1 FROM shareables WHERE workspace_id = ${workspaceId})

--- a/apps/web/app/services/workspace-domain-claims.server.test.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.test.ts
@@ -197,6 +197,16 @@ describe('workspace domain claims', () => {
       providerTenantId: 'tenant-1',
       now: '2026-06-26T00:00:00.000Z',
     })
+    await db
+      .insertInto('workspace_storage_daily_usage')
+      .values({
+        workspace_id: 'ws-duplicate',
+        date: '2026-06-26',
+        used_bytes: 0,
+        included_bytes: 104857600,
+        billable_overage_gb: 0,
+      })
+      .execute()
 
     await expect(findWorkspaceIdByDomainClaim(db, 'corp.com')).resolves.toBe(
       'ws-tenant',
@@ -228,6 +238,45 @@ describe('workspace domain claims', () => {
       email: 'existing@corp.com',
       workspaceId: 'ws-duplicate',
     })
+
+    await expect(findWorkspaceIdByDomainClaim(db, 'corp.com')).resolves.toBe(
+      'ws-duplicate',
+    )
+    await expect(
+      findWorkspaceIdForMicrosoftTenantDomain(db, 'tenant-1', 'corp.com'),
+    ).resolves.toBe('ws-duplicate')
+  })
+
+  test('domain and tenant lookup preserve a Microsoft claim workspace with nonzero usage', async () => {
+    const db = setup()
+    await seedWorkspace(db, {
+      id: 'ws-tenant',
+      hd: null,
+      emailDomain: 'corp.com',
+      microsoftTenantId: 'tenant-1',
+    })
+    await seedWorkspace(db, {
+      id: 'ws-duplicate',
+      hd: null,
+      emailDomain: 'corp.com',
+    })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-duplicate',
+      source: 'microsoft_verified_domain',
+      providerTenantId: 'tenant-1',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await db
+      .insertInto('workspace_storage_daily_usage')
+      .values({
+        workspace_id: 'ws-duplicate',
+        date: '2026-06-26',
+        used_bytes: 1,
+        included_bytes: 104857600,
+        billable_overage_gb: 0,
+      })
+      .execute()
 
     await expect(findWorkspaceIdByDomainClaim(db, 'corp.com')).resolves.toBe(
       'ws-duplicate',

--- a/apps/web/app/services/workspace-domain-claims.server.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.ts
@@ -146,7 +146,11 @@ async function resolveMicrosoftClaimWorkspace(
           SELECT 1 FROM workspace_domain_claims
           WHERE workspace_id = ${input.workspaceId} AND domain != ${input.domain}
         )
-        AND NOT EXISTS (SELECT 1 FROM workspace_storage_daily_usage WHERE workspace_id = ${input.workspaceId})
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_storage_daily_usage
+          WHERE workspace_id = ${input.workspaceId}
+            AND (used_bytes != 0 OR billable_overage_gb != 0)
+        )
         AND NOT EXISTS (SELECT 1 FROM billing_overage_charges WHERE workspace_id = ${input.workspaceId})
         AND NOT EXISTS (SELECT 1 FROM artifact_containers WHERE workspace_id = ${input.workspaceId})
         AND NOT EXISTS (SELECT 1 FROM shareables WHERE workspace_id = ${input.workspaceId})


### PR DESCRIPTION
## Summary

- treat zero-byte daily storage snapshots as disposable history during Microsoft claim repair
- keep login-time tenant claim resolution aligned with repair eligibility
- continue blocking repair when recorded usage or billable overage is nonzero

## Validation

- `pnpm --filter @artifactshare/web exec vitest --config vitest.config.ts --run app/services/oauth-workspace-integration.server.test.ts app/services/workspace-domain-claims.server.test.ts`
- `pnpm --filter @artifactshare/web typecheck`
- `pnpm --filter @artifactshare/web lint`
- `pnpm --filter @artifactshare/web format`
- `pnpm validate:static`
- `pnpm public:scan .`
- trusted `origin/main` pull-request boundary guard
- Codex and Claude deep implementation review on `fb9600dab38a9a0f2db98fa4a058298cdf3fef4d` with no unresolved blockers

## Review disposition

- Follow-up: the equivalent disposable-workspace predicates remain duplicated across claim resolution and repair. Both paths are aligned and covered by regression tests in this change; consolidating them is not required for the current behavior fix.
