### PR TITLE
Detect blocked workspace migrations for operator review

### DIFF
--- a/apps/web/app/lib/d1-batch.server.ts
+++ b/apps/web/app/lib/d1-batch.server.ts
@@ -6,17 +6,30 @@ export async function runD1Batch(
   db: Kysely<DB>,
   ...queries: Compilable<unknown>[]
 ): Promise<void> {
+  await runD1BatchWithResults(db, ...queries)
+}
+
+export async function runD1BatchWithResults(
+  db: Kysely<DB>,
+  ...queries: Compilable<unknown>[]
+): Promise<unknown[]> {
   // Service tests use an in-process Kysely database without a Workers binding.
   // Production always takes the D1 batch path below.
   const database = d1DatabaseFor(db)
   if (!database) {
-    for (const query of queries)
-      await (query as unknown as { execute: () => Promise<unknown> }).execute()
-    return
+    const results: unknown[] = []
+    for (const query of queries) {
+      results.push(
+        await (
+          query as unknown as { execute: () => Promise<unknown> }
+        ).execute(),
+      )
+    }
+    return results
   }
   const stmts = queries.map((query) => {
     const compiled = query.compile()
     return database.prepare(compiled.sql).bind(...compiled.parameters)
   })
-  await database.batch(stmts)
+  return await database.batch(stmts)
 }

--- a/apps/web/app/services/reconcile.server.test.ts
+++ b/apps/web/app/services/reconcile.server.test.ts
@@ -711,13 +711,14 @@ describe('runReconciliation', () => {
       'reconcile_view_events_prune_done',
       'reconcile_quota_done',
       'reconcile_daily_usage_done',
+      'reconcile_workspace_migration_waits_done',
       'reconcile_billing_overage_skipped',
       'reconcile_error',
       'reconcile_r2_references_done',
       'reconcile_security_audit_cleanup_done',
       'reconcile_done',
     ])
-    const doneLog = JSON.parse(logSpy.mock.calls[8]?.[0] as string)
+    const doneLog = JSON.parse(logSpy.mock.calls[9]?.[0] as string)
     expect(doneLog.failed_jobs).toBe(1)
     logSpy.mockRestore()
   })
@@ -736,6 +737,7 @@ describe('runReconciliation', () => {
       'reconcile_view_events_prune_done',
       'reconcile_quota_done',
       'reconcile_daily_usage_done',
+      'reconcile_workspace_migration_waits_done',
       'reconcile_billing_overage_skipped',
       'reconcile_r2_done',
       'reconcile_r2_references_done',

--- a/apps/web/app/services/reconcile.server.ts
+++ b/apps/web/app/services/reconcile.server.ts
@@ -377,6 +377,7 @@ export async function runReconciliation(
         active: migrationWaits.active,
         newly_detected: migrationWaits.newlyDetected,
         resolved: migrationWaits.resolved,
+        skipped: migrationWaits.skipped,
       }),
     )
     for (const notification of migrationWaits.notifications) {

--- a/apps/web/app/services/reconcile.server.ts
+++ b/apps/web/app/services/reconcile.server.ts
@@ -11,6 +11,10 @@ import {
   cleanupExpiredSecurityAuditRecords,
   SECURITY_AUDIT_CLEANUP_BATCH_SIZE,
 } from './security-audit.server'
+import {
+  reconcileWorkspaceMigrationWaits,
+  WORKSPACE_MIGRATION_WAIT_LOG_MARKER,
+} from './workspace-migration-waits.server'
 
 export type ReconciliationOptions = {
   stripe?: Stripe
@@ -365,6 +369,24 @@ export async function runReconciliation(
     errors.push(err)
   }
 
+  try {
+    const migrationWaits = await reconcileWorkspaceMigrationWaits(db, now)
+    console.log(
+      JSON.stringify({
+        event: 'reconcile_workspace_migration_waits_done',
+        active: migrationWaits.active,
+        newly_detected: migrationWaits.newlyDetected,
+        resolved: migrationWaits.resolved,
+      }),
+    )
+    for (const notification of migrationWaits.notifications) {
+      console.warn(WORKSPACE_MIGRATION_WAIT_LOG_MARKER, notification)
+    }
+  } catch (err) {
+    console.log(JSON.stringify(formatError('workspace_migration_waits', err)))
+    errors.push(err)
+  }
+
   if (!options?.stripe || !options.overageProductId) {
     console.log(
       JSON.stringify({
@@ -467,7 +489,8 @@ function formatError(
     | 'billing_overage'
     | 'r2'
     | 'r2_references'
-    | 'view_events_prune',
+    | 'view_events_prune'
+    | 'workspace_migration_waits',
   err: unknown,
 ) {
   const e = err instanceof Error ? err : new Error(String(err))

--- a/apps/web/app/services/workspace-domain-claims.server.test.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.test.ts
@@ -365,6 +365,89 @@ describe('workspace domain claims', () => {
     ).resolves.toEqual({ role: 'owner', status: 'active' })
   })
 
+  test('moves a verified owner when the source has only zero-usage history', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-viewer', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u-owner',
+      email: 'owner@corp.com',
+      workspaceId: 'ws-viewer',
+    })
+    await db
+      .insertInto('workspace_storage_daily_usage')
+      .values({
+        workspace_id: 'ws-viewer',
+        date: '2026-06-26',
+        used_bytes: 0,
+        included_bytes: 104857600,
+        billable_overage_gb: 0,
+      })
+      .execute()
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u-owner',
+        email: 'owner@corp.com',
+        currentWorkspaceId: 'ws-viewer',
+      }),
+    ).resolves.toBe('ws-org')
+    await expect(
+      db
+        .selectFrom('workspace_storage_daily_usage')
+        .select('workspace_id')
+        .where('workspace_id', '=', 'ws-viewer')
+        .executeTakeFirst(),
+    ).resolves.toBeUndefined()
+  })
+
+  test('reports nonzero source usage as a migration wait reason', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-viewer', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u-owner',
+      email: 'owner@corp.com',
+      workspaceId: 'ws-viewer',
+    })
+    await db
+      .insertInto('workspace_storage_daily_usage')
+      .values({
+        workspace_id: 'ws-viewer',
+        date: '2026-06-26',
+        used_bytes: 1,
+        included_bytes: 104857600,
+        billable_overage_gb: 0,
+      })
+      .execute()
+
+    await expect(
+      maybeMoveUserToClaimedWorkspace(db, {
+        userId: 'u-owner',
+        email: 'owner@corp.com',
+        currentWorkspaceId: 'ws-viewer',
+      }),
+    ).resolves.toBeNull()
+    await expect(listWorkspaceMigrationCandidates(db)).resolves.toMatchObject([
+      {
+        userId: 'u-owner',
+        reasonCodes: ['source_workspace_has_usage'],
+      },
+    ])
+  })
+
   test('promotes an existing target admin before the newly moved member', async () => {
     const db = setup()
     await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })

--- a/apps/web/app/services/workspace-domain-claims.server.test.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.test.ts
@@ -448,6 +448,38 @@ describe('workspace domain claims', () => {
     ])
   })
 
+  test('reports nullable source expiry policy as configured', async () => {
+    const db = setup()
+    await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })
+    await seedWorkspace(db, { id: 'ws-viewer', hd: null })
+    await ensureWorkspaceDomainClaim(db, {
+      domain: 'corp.com',
+      workspaceId: 'ws-org',
+      source: 'google_hd',
+      now: '2026-06-26T00:00:00.000Z',
+    })
+    await seedUser(db, {
+      id: 'u-owner',
+      email: 'owner@corp.com',
+      workspaceId: 'ws-viewer',
+    })
+    await db
+      .updateTable('workspaces')
+      .set({
+        link_expiry_default_days: null,
+        link_expiry_max_days: null,
+      })
+      .where('id', '=', 'ws-viewer')
+      .execute()
+
+    await expect(listWorkspaceMigrationCandidates(db)).resolves.toMatchObject([
+      {
+        userId: 'u-owner',
+        reasonCodes: ['source_workspace_configured'],
+      },
+    ])
+  })
+
   test('promotes an existing target admin before the newly moved member', async () => {
     const db = setup()
     await seedWorkspace(db, { id: 'ws-org', hd: null, emailDomain: 'corp.com' })

--- a/apps/web/app/services/workspace-domain-claims.server.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.ts
@@ -1092,25 +1092,30 @@ export async function listWorkspaceMigrationCandidates(
         WHERE source_member.workspace_id = personal_ws.id
           AND source_member.user_id != users.id
       ) AS sourceWorkspaceHasOtherMembers,
-      EXISTS (
-        SELECT 1 FROM workspace_storage_daily_usage
-        WHERE workspace_id = personal_ws.id
-          AND (used_bytes != 0 OR billable_overage_gb != 0)
-        UNION ALL SELECT 1 FROM billing_overage_charges WHERE workspace_id = personal_ws.id
+      (
+        EXISTS (
+          SELECT 1 FROM workspace_storage_daily_usage
+          WHERE workspace_id = personal_ws.id
+            AND (used_bytes != 0 OR billable_overage_gb != 0)
+        )
+        OR EXISTS (
+          SELECT 1 FROM billing_overage_charges
+          WHERE workspace_id = personal_ws.id
+        )
       ) AS sourceWorkspaceHasUsage,
-      EXISTS (
-        SELECT 1 FROM artifact_containers WHERE workspace_id = personal_ws.id
-        UNION ALL SELECT 1 FROM shareables WHERE workspace_id = personal_ws.id
-        UNION ALL SELECT 1 FROM artifact_keys WHERE workspace_id = personal_ws.id
-        UNION ALL SELECT 1 FROM events WHERE workspace_id = personal_ws.id
+      (
+        EXISTS (SELECT 1 FROM artifact_containers WHERE workspace_id = personal_ws.id)
+        OR EXISTS (SELECT 1 FROM shareables WHERE workspace_id = personal_ws.id)
+        OR EXISTS (SELECT 1 FROM artifact_keys WHERE workspace_id = personal_ws.id)
+        OR EXISTS (SELECT 1 FROM events WHERE workspace_id = personal_ws.id)
       ) AS sourceWorkspaceHasContent,
-      EXISTS (
-        SELECT 1 FROM agent_profiles WHERE workspace_id = personal_ws.id
-        UNION ALL SELECT 1 FROM cli_family_authorities WHERE workspace_id = personal_ws.id
-        UNION ALL SELECT 1 FROM cli_session_authorities WHERE workspace_id = personal_ws.id
-        UNION ALL SELECT 1 FROM bridge_authorities WHERE workspace_id = personal_ws.id
-        UNION ALL SELECT 1 FROM slack_workspaces WHERE workspace_id = personal_ws.id
-        UNION ALL SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = personal_ws.id
+      (
+        EXISTS (SELECT 1 FROM agent_profiles WHERE workspace_id = personal_ws.id)
+        OR EXISTS (SELECT 1 FROM cli_family_authorities WHERE workspace_id = personal_ws.id)
+        OR EXISTS (SELECT 1 FROM cli_session_authorities WHERE workspace_id = personal_ws.id)
+        OR EXISTS (SELECT 1 FROM bridge_authorities WHERE workspace_id = personal_ws.id)
+        OR EXISTS (SELECT 1 FROM slack_workspaces WHERE workspace_id = personal_ws.id)
+        OR EXISTS (SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = personal_ws.id)
       ) AS sourceWorkspaceHasIntegrations,
       EXISTS (
         SELECT 1 FROM workspace_members AS admins

--- a/apps/web/app/services/workspace-domain-claims.server.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.ts
@@ -1027,17 +1027,106 @@ export interface WorkspaceMigrationCandidate {
   reasonCodes: WorkspaceMigrationBlockReason[]
 }
 
+interface WorkspaceMigrationCandidateRow extends Omit<
+  WorkspaceMigrationCandidate,
+  'reasonCodes'
+> {
+  emailVerified: number
+  targetMembershipRemoved: number
+  sourceWorkspaceConfigured: number
+  sourceWorkspaceHasOtherUsers: number
+  sourceWorkspaceHasOtherMembers: number
+  sourceWorkspaceHasUsage: number
+  sourceWorkspaceHasContent: number
+  sourceWorkspaceHasIntegrations: number
+  userAdministersAnotherWorkspace: number
+}
+
 export async function listWorkspaceMigrationCandidates(
   db: Kysely<DB>,
 ): Promise<WorkspaceMigrationCandidate[]> {
   const activeTokenCutoff = nowIso()
-  const rows = await sql<WorkspaceMigrationCandidate>`
+  const rows = await sql<WorkspaceMigrationCandidateRow>`
     SELECT
       claims.domain AS domain,
       claims.workspace_id AS claimWorkspaceId,
       personal_ws.id AS personalWorkspaceId,
       users.id AS userId,
       users.email AS email,
+      users.email_verified AS emailVerified,
+      EXISTS (
+        SELECT 1 FROM workspace_members
+        WHERE workspace_id = claims.workspace_id
+          AND user_id = users.id
+          AND status = 'removed'
+      ) AS targetMembershipRemoved,
+      NOT (
+        personal_ws.hd IS NULL
+        AND personal_ws.ms_tenant_id IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_domain_claims AS source_claim
+          WHERE source_claim.workspace_id = personal_ws.id
+        )
+        AND personal_ws.plan = 'free'
+        AND personal_ws.storage_used_bytes = 0
+        AND personal_ws.stripe_customer_id IS NULL
+        AND personal_ws.stripe_subscription_id IS NULL
+        AND personal_ws.stripe_subscription_status = 'none'
+        AND personal_ws.link_sharing_enabled = 0
+        AND personal_ws.external_posting_enabled = 0
+        AND personal_ws.link_expiry_default_days = 30
+        AND personal_ws.link_expiry_max_days = 90
+        AND lower(personal_ws.name) = lower(users.email || '''s workspace')
+        AND (
+          (personal_ws.self_upload_enabled = 1 AND personal_ws.storage_quota_bytes = 104857600)
+          OR (personal_ws.self_upload_enabled = 0 AND personal_ws.storage_quota_bytes = 0)
+        )
+      ) AS sourceWorkspaceConfigured,
+      EXISTS (
+        SELECT 1 FROM users AS source_user
+        WHERE source_user.workspace_id = personal_ws.id
+          AND source_user.id != users.id
+      ) AS sourceWorkspaceHasOtherUsers,
+      EXISTS (
+        SELECT 1 FROM workspace_members AS source_member
+        WHERE source_member.workspace_id = personal_ws.id
+          AND source_member.user_id != users.id
+      ) AS sourceWorkspaceHasOtherMembers,
+      EXISTS (
+        SELECT 1 FROM workspace_storage_daily_usage
+        WHERE workspace_id = personal_ws.id
+          AND (used_bytes != 0 OR billable_overage_gb != 0)
+        UNION ALL SELECT 1 FROM billing_overage_charges WHERE workspace_id = personal_ws.id
+      ) AS sourceWorkspaceHasUsage,
+      EXISTS (
+        SELECT 1 FROM artifact_containers WHERE workspace_id = personal_ws.id
+        UNION ALL SELECT 1 FROM shareables WHERE workspace_id = personal_ws.id
+        UNION ALL SELECT 1 FROM artifact_keys WHERE workspace_id = personal_ws.id
+        UNION ALL SELECT 1 FROM events WHERE workspace_id = personal_ws.id
+      ) AS sourceWorkspaceHasContent,
+      EXISTS (
+        SELECT 1 FROM agent_profiles WHERE workspace_id = personal_ws.id
+        UNION ALL SELECT 1 FROM cli_family_authorities WHERE workspace_id = personal_ws.id
+        UNION ALL SELECT 1 FROM cli_session_authorities WHERE workspace_id = personal_ws.id
+        UNION ALL SELECT 1 FROM bridge_authorities WHERE workspace_id = personal_ws.id
+        UNION ALL SELECT 1 FROM slack_workspaces WHERE workspace_id = personal_ws.id
+        UNION ALL SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = personal_ws.id
+      ) AS sourceWorkspaceHasIntegrations,
+      EXISTS (
+        SELECT 1 FROM workspace_members AS admins
+        WHERE admins.user_id = users.id
+          AND admins.role IN ('owner', 'admin')
+          AND admins.status = 'active'
+          AND (
+            admins.workspace_id != personal_ws.id
+            OR EXISTS (
+              SELECT 1 FROM workspace_members AS peers
+              WHERE peers.workspace_id = admins.workspace_id
+                AND peers.user_id != users.id
+                AND peers.status = 'active'
+            )
+          )
+      ) AS userAdministersAnotherWorkspace,
       (
         SELECT count(*)
         FROM shareables
@@ -1100,9 +1189,50 @@ export async function listWorkspaceMigrationCandidates(
     ORDER BY claims.domain, users.email
   `.execute(db)
 
-  const candidates = await Promise.all(
-    rows.rows.map(async (row) => ({
-      ...row,
+  const candidates = rows.rows.map((row) => {
+    const reasonCodes: WorkspaceMigrationBlockReason[] = []
+    if (Number(row.targetMembershipRemoved) !== 0)
+      reasonCodes.push('target_membership_removed')
+    if (Number(row.sourceWorkspaceConfigured) !== 0)
+      reasonCodes.push('source_workspace_configured')
+    if (Number(row.sourceWorkspaceHasOtherUsers) !== 0)
+      reasonCodes.push('source_workspace_has_other_users')
+    if (Number(row.sourceWorkspaceHasOtherMembers) !== 0)
+      reasonCodes.push('source_workspace_has_other_members')
+    if (Number(row.sourceWorkspaceHasUsage) !== 0)
+      reasonCodes.push('source_workspace_has_usage')
+    if (Number(row.sourceWorkspaceHasContent) !== 0)
+      reasonCodes.push('source_workspace_has_content')
+    if (Number(row.sourceWorkspaceHasIntegrations) !== 0)
+      reasonCodes.push('source_workspace_has_integrations')
+    if (Number(row.emailVerified) !== 1) reasonCodes.push('email_not_verified')
+    if (Number(row.userAdministersAnotherWorkspace) !== 0)
+      reasonCodes.push('user_administers_another_workspace')
+    if (Number(row.shareablesCount) !== 0)
+      reasonCodes.push('user_has_shareables')
+    if (Number(row.projectsCount) !== 0) reasonCodes.push('user_has_projects')
+    if (
+      Number(row.commentThreadsCount) !== 0 ||
+      Number(row.commentMessagesCount) !== 0
+    )
+      reasonCodes.push('user_has_comments')
+    if (Number(row.apiTokensCount) !== 0)
+      reasonCodes.push('user_has_api_tokens')
+    if (Number(row.cliRefreshCredentialsCount) !== 0)
+      reasonCodes.push('user_has_cli_credentials')
+    if (
+      Number(row.oauthAccessTokensCount) !== 0 ||
+      Number(row.oauthRefreshTokensCount) !== 0
+    )
+      reasonCodes.push('user_has_oauth_tokens')
+    if (Number(row.oauthConsentsCount) !== 0)
+      reasonCodes.push('user_has_oauth_consents')
+    return {
+      domain: row.domain,
+      claimWorkspaceId: row.claimWorkspaceId,
+      personalWorkspaceId: row.personalWorkspaceId,
+      userId: row.userId,
+      email: row.email,
       shareablesCount: Number(row.shareablesCount),
       projectsCount: Number(row.projectsCount),
       commentThreadsCount: Number(row.commentThreadsCount),
@@ -1112,11 +1242,8 @@ export async function listWorkspaceMigrationCandidates(
       oauthAccessTokensCount: Number(row.oauthAccessTokensCount),
       oauthRefreshTokensCount: Number(row.oauthRefreshTokensCount),
       oauthConsentsCount: Number(row.oauthConsentsCount),
-      reasonCodes: await workspaceMigrationBlockReasons(db, row.userId, {
-        allowCurrentWorkspaceAdmin: row.personalWorkspaceId,
-        targetWorkspaceId: row.claimWorkspaceId,
-      }),
-    })),
-  )
+      reasonCodes,
+    }
+  })
   return candidates.filter((candidate) => candidate.reasonCodes.length > 0)
 }

--- a/apps/web/app/services/workspace-domain-claims.server.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.ts
@@ -352,17 +352,11 @@ async function moveUserToWorkspaceIfSafe(
   },
   options: { allowCurrentWorkspaceAdmin?: string } = {},
 ): Promise<string | null> {
-  const removedMembership = await db
-    .selectFrom('workspace_members')
-    .select('status')
-    .where('workspace_id', '=', input.targetWorkspaceId)
-    .where('user_id', '=', input.userId)
-    .where('status', '=', 'removed')
-    .executeTakeFirst()
-  if (removedMembership) return null
-
-  const canMove = await canAutoMoveUserWorkspace(db, input.userId, options)
-  if (!canMove) return null
+  const reasons = await workspaceMigrationBlockReasons(db, input.userId, {
+    ...options,
+    targetWorkspaceId: input.targetWorkspaceId,
+  })
+  if (reasons.length > 0) return null
 
   const now = nowIso()
   const userUpdate = db
@@ -407,6 +401,7 @@ async function moveUserToWorkspaceIfSafe(
             WHERE workspace_id = ${input.currentWorkspaceId}
           UNION ALL SELECT 1 FROM workspace_storage_daily_usage
             WHERE workspace_id = ${input.currentWorkspaceId}
+              AND (used_bytes != 0 OR billable_overage_gb != 0)
           UNION ALL SELECT 1 FROM billing_overage_charges
             WHERE workspace_id = ${input.currentWorkspaceId}
           UNION ALL SELECT 1 FROM artifact_containers
@@ -633,7 +628,13 @@ async function moveUserToWorkspaceIfSafe(
             eb
               .selectFrom('workspace_storage_daily_usage')
               .select('date')
-              .where('workspace_id', '=', input.currentWorkspaceId),
+              .where('workspace_id', '=', input.currentWorkspaceId)
+              .where((usage) =>
+                usage.or([
+                  usage('used_bytes', '!=', 0),
+                  usage('billable_overage_gb', '!=', 0),
+                ]),
+              ),
           ),
         ),
         eb.not(
@@ -695,6 +696,49 @@ export async function canAutoMoveUserWorkspace(
   userId: string,
   options: { allowCurrentWorkspaceAdmin?: string } = {},
 ): Promise<boolean> {
+  return (
+    (await workspaceMigrationBlockReasons(db, userId, options)).length === 0
+  )
+}
+
+export type WorkspaceMigrationBlockReason =
+  | 'target_membership_removed'
+  | 'source_workspace_configured'
+  | 'source_workspace_has_other_users'
+  | 'source_workspace_has_other_members'
+  | 'source_workspace_has_usage'
+  | 'source_workspace_has_content'
+  | 'source_workspace_has_integrations'
+  | 'email_not_verified'
+  | 'user_administers_another_workspace'
+  | 'user_has_shareables'
+  | 'user_has_projects'
+  | 'user_has_comments'
+  | 'user_has_api_tokens'
+  | 'user_has_cli_credentials'
+  | 'user_has_oauth_tokens'
+  | 'user_has_oauth_consents'
+
+export async function workspaceMigrationBlockReasons(
+  db: Kysely<DB>,
+  userId: string,
+  options: {
+    allowCurrentWorkspaceAdmin?: string
+    targetWorkspaceId?: string
+  } = {},
+): Promise<WorkspaceMigrationBlockReason[]> {
+  const reasons: WorkspaceMigrationBlockReason[] = []
+  if (options.targetWorkspaceId) {
+    const removedMembership = await db
+      .selectFrom('workspace_members')
+      .select('status')
+      .where('workspace_id', '=', options.targetWorkspaceId)
+      .where('user_id', '=', userId)
+      .where('status', '=', 'removed')
+      .executeTakeFirst()
+    if (removedMembership) reasons.push('target_membership_removed')
+  }
+
   if (options.allowCurrentWorkspaceAdmin) {
     const workspace = await db
       .selectFrom('workspaces')
@@ -752,31 +796,55 @@ export async function canAutoMoveUserWorkspace(
         `${workspace.user_email.toLowerCase()}'s workspace` ||
       !disposableProvisioning
     ) {
-      return false
+      reasons.push('source_workspace_configured')
     }
     const workspaceId = options.allowCurrentWorkspaceAdmin
-    const residual = await sql<{ has_data: number }>`
-      SELECT EXISTS (
-        SELECT 1 FROM users WHERE workspace_id = ${workspaceId} AND id != ${userId}
-        UNION ALL SELECT 1 FROM workspace_members WHERE workspace_id = ${workspaceId} AND user_id != ${userId}
-        UNION ALL SELECT 1 FROM workspace_storage_daily_usage WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM billing_overage_charges WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM artifact_containers WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM shareables WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM agent_profiles WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM cli_family_authorities WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM cli_session_authorities WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM bridge_authorities WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM slack_workspaces WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM artifact_keys WHERE workspace_id = ${workspaceId}
-        UNION ALL SELECT 1 FROM events WHERE workspace_id = ${workspaceId}
-      ) AS has_data
+    const residual = await sql<{
+      has_other_users: number
+      has_other_members: number
+      has_usage: number
+      has_content: number
+      has_integrations: number
+    }>`
+      SELECT
+        EXISTS (SELECT 1 FROM users WHERE workspace_id = ${workspaceId} AND id != ${userId}) AS has_other_users,
+        EXISTS (SELECT 1 FROM workspace_members WHERE workspace_id = ${workspaceId} AND user_id != ${userId}) AS has_other_members,
+        EXISTS (
+          SELECT 1 FROM workspace_storage_daily_usage
+          WHERE workspace_id = ${workspaceId}
+            AND (used_bytes != 0 OR billable_overage_gb != 0)
+          UNION ALL SELECT 1 FROM billing_overage_charges WHERE workspace_id = ${workspaceId}
+        ) AS has_usage,
+        EXISTS (
+          SELECT 1 FROM artifact_containers WHERE workspace_id = ${workspaceId}
+          UNION ALL SELECT 1 FROM shareables WHERE workspace_id = ${workspaceId}
+          UNION ALL SELECT 1 FROM artifact_keys WHERE workspace_id = ${workspaceId}
+          UNION ALL SELECT 1 FROM events WHERE workspace_id = ${workspaceId}
+        ) AS has_content,
+        EXISTS (
+          SELECT 1 FROM agent_profiles WHERE workspace_id = ${workspaceId}
+          UNION ALL SELECT 1 FROM cli_family_authorities WHERE workspace_id = ${workspaceId}
+          UNION ALL SELECT 1 FROM cli_session_authorities WHERE workspace_id = ${workspaceId}
+          UNION ALL SELECT 1 FROM bridge_authorities WHERE workspace_id = ${workspaceId}
+          UNION ALL SELECT 1 FROM slack_workspaces WHERE workspace_id = ${workspaceId}
+          UNION ALL SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = ${workspaceId}
+        ) AS has_integrations
     `.execute(db)
-    if (Number(residual.rows[0]?.has_data ?? 0) !== 0) return false
+    const state = residual.rows[0]
+    if (Number(state?.has_other_users ?? 0) !== 0)
+      reasons.push('source_workspace_has_other_users')
+    if (Number(state?.has_other_members ?? 0) !== 0)
+      reasons.push('source_workspace_has_other_members')
+    if (Number(state?.has_usage ?? 0) !== 0)
+      reasons.push('source_workspace_has_usage')
+    if (Number(state?.has_content ?? 0) !== 0)
+      reasons.push('source_workspace_has_content')
+    if (Number(state?.has_integrations ?? 0) !== 0)
+      reasons.push('source_workspace_has_integrations')
   }
 
-  return await hasSafeUserStateForWorkspaceChange(db, userId, options)
+  reasons.push(...(await userWorkspaceChangeBlockReasons(db, userId, options)))
+  return [...new Set(reasons)]
 }
 
 export async function canEnableOAuthWorkspaceSelfUpload(
@@ -816,6 +884,16 @@ async function hasSafeUserStateForWorkspaceChange(
   userId: string,
   options: { allowCurrentWorkspaceAdmin?: string },
 ): Promise<boolean> {
+  return (
+    (await userWorkspaceChangeBlockReasons(db, userId, options)).length === 0
+  )
+}
+
+async function userWorkspaceChangeBlockReasons(
+  db: Kysely<DB>,
+  userId: string,
+  options: { allowCurrentWorkspaceAdmin?: string },
+): Promise<WorkspaceMigrationBlockReason[]> {
   const activeTokenCutoff = nowIso()
   const adminWorkspaceFilter = options.allowCurrentWorkspaceAdmin
     ? sql<boolean>`
@@ -916,19 +994,19 @@ async function hasSafeUserStateForWorkspaceChange(
     .where('id', '=', userId)
     .executeTakeFirst()
 
-  return Boolean(
-    row?.email_verified === 1 &&
-    !row.has_admin &&
-    !row.has_shareables &&
-    !row.has_projects &&
-    !row.has_comment_messages &&
-    !row.has_comment_threads &&
-    !row.has_api_tokens &&
-    !row.has_cli_refresh_credentials &&
-    !row.has_oauth_access_tokens &&
-    !row.has_oauth_refresh_tokens &&
-    !row.has_oauth_consents,
-  )
+  const reasons: WorkspaceMigrationBlockReason[] = []
+  if (row?.email_verified !== 1) reasons.push('email_not_verified')
+  if (row?.has_admin) reasons.push('user_administers_another_workspace')
+  if (row?.has_shareables) reasons.push('user_has_shareables')
+  if (row?.has_projects) reasons.push('user_has_projects')
+  if (row?.has_comment_messages || row?.has_comment_threads)
+    reasons.push('user_has_comments')
+  if (row?.has_api_tokens) reasons.push('user_has_api_tokens')
+  if (row?.has_cli_refresh_credentials) reasons.push('user_has_cli_credentials')
+  if (row?.has_oauth_access_tokens || row?.has_oauth_refresh_tokens)
+    reasons.push('user_has_oauth_tokens')
+  if (row?.has_oauth_consents) reasons.push('user_has_oauth_consents')
+  return reasons
 }
 
 export interface WorkspaceMigrationCandidate {
@@ -946,6 +1024,7 @@ export interface WorkspaceMigrationCandidate {
   oauthAccessTokensCount: number
   oauthRefreshTokensCount: number
   oauthConsentsCount: number
+  reasonCodes: WorkspaceMigrationBlockReason[]
 }
 
 export async function listWorkspaceMigrationCandidates(
@@ -1017,30 +1096,27 @@ export async function listWorkspaceMigrationCandidates(
     INNER JOIN workspaces AS personal_ws
       ON personal_ws.id = users.workspace_id
     WHERE users.workspace_id <> claims.workspace_id
-      AND (
-        shareablesCount > 0
-        OR projectsCount > 0
-        OR commentThreadsCount > 0
-        OR commentMessagesCount > 0
-        OR apiTokensCount > 0
-        OR cliRefreshCredentialsCount > 0
-        OR oauthAccessTokensCount > 0
-        OR oauthRefreshTokensCount > 0
-        OR oauthConsentsCount > 0
-      )
+      AND users.kind = 'human'
     ORDER BY claims.domain, users.email
   `.execute(db)
 
-  return rows.rows.map((row) => ({
-    ...row,
-    shareablesCount: Number(row.shareablesCount),
-    projectsCount: Number(row.projectsCount),
-    commentThreadsCount: Number(row.commentThreadsCount),
-    commentMessagesCount: Number(row.commentMessagesCount),
-    apiTokensCount: Number(row.apiTokensCount),
-    cliRefreshCredentialsCount: Number(row.cliRefreshCredentialsCount),
-    oauthAccessTokensCount: Number(row.oauthAccessTokensCount),
-    oauthRefreshTokensCount: Number(row.oauthRefreshTokensCount),
-    oauthConsentsCount: Number(row.oauthConsentsCount),
-  }))
+  const candidates = await Promise.all(
+    rows.rows.map(async (row) => ({
+      ...row,
+      shareablesCount: Number(row.shareablesCount),
+      projectsCount: Number(row.projectsCount),
+      commentThreadsCount: Number(row.commentThreadsCount),
+      commentMessagesCount: Number(row.commentMessagesCount),
+      apiTokensCount: Number(row.apiTokensCount),
+      cliRefreshCredentialsCount: Number(row.cliRefreshCredentialsCount),
+      oauthAccessTokensCount: Number(row.oauthAccessTokensCount),
+      oauthRefreshTokensCount: Number(row.oauthRefreshTokensCount),
+      oauthConsentsCount: Number(row.oauthConsentsCount),
+      reasonCodes: await workspaceMigrationBlockReasons(db, row.userId, {
+        allowCurrentWorkspaceAdmin: row.personalWorkspaceId,
+        targetWorkspaceId: row.claimWorkspaceId,
+      }),
+    })),
+  )
+  return candidates.filter((candidate) => candidate.reasonCodes.length > 0)
 }

--- a/apps/web/app/services/workspace-domain-claims.server.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.ts
@@ -1060,7 +1060,7 @@ export async function listWorkspaceMigrationCandidates(
           AND user_id = users.id
           AND status = 'removed'
       ) AS targetMembershipRemoved,
-      NOT (
+      COALESCE(NOT (
         personal_ws.hd IS NULL
         AND personal_ws.ms_tenant_id IS NULL
         AND NOT EXISTS (
@@ -1081,7 +1081,7 @@ export async function listWorkspaceMigrationCandidates(
           (personal_ws.self_upload_enabled = 1 AND personal_ws.storage_quota_bytes = 104857600)
           OR (personal_ws.self_upload_enabled = 0 AND personal_ws.storage_quota_bytes = 0)
         )
-      ) AS sourceWorkspaceConfigured,
+      ), 1) AS sourceWorkspaceConfigured,
       EXISTS (
         SELECT 1 FROM users AS source_user
         WHERE source_user.workspace_id = personal_ws.id

--- a/apps/web/app/services/workspace-migration-waits.server.test.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.test.ts
@@ -93,12 +93,12 @@ describe('workspace migration waits', () => {
       new Date('2026-08-27T01:00:00.000Z'),
     )
     expect(first).toMatchObject({ active: 1, newlyDetected: 1, resolved: 0 })
-    expect(first.notifications).toHaveLength(1)
-    expect(JSON.stringify(first.notifications)).not.toMatch(
-      /alice|corp\.com|ws-personal|ws-org/u,
-    )
-    const waitId = first.notifications[0]?.waitId
-    expect(waitId).toHaveLength(16)
+    expect(first.notifications).toEqual([{ revision: 1 }])
+    const waitId = await db
+      .selectFrom('workspace_migration_waits')
+      .select('id')
+      .executeTakeFirstOrThrow()
+      .then((row) => row.id)
 
     const repeated = await reconcileWorkspaceMigrationWaits(
       db,
@@ -108,7 +108,7 @@ describe('workspace migration waits', () => {
       active: 1,
       newlyDetected: 0,
       resolved: 0,
-      notifications: [{ waitId, generation: 1 }],
+      notifications: [{ revision: 1 }],
     })
 
     await db.deleteFrom('api_tokens').where('id', '=', 'token-1').execute()
@@ -141,7 +141,7 @@ describe('workspace migration waits', () => {
       active: 1,
       newlyDetected: 1,
       resolved: 0,
-      notifications: [{ waitId, generation: 2 }],
+      notifications: [{ revision: 2 }],
     })
 
     await expect(
@@ -234,7 +234,7 @@ describe('workspace migration waits', () => {
     )
 
     expect(result).toMatchObject({ active: 17, newlyDetected: 17 })
-    expect(batchStatementCount).toBe(3)
+    expect(batchStatementCount).toBe(4)
     expect(maximumParameters).toBeLessThanOrEqual(100)
   })
 })

--- a/apps/web/app/services/workspace-migration-waits.server.test.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.test.ts
@@ -88,12 +88,39 @@ describe('workspace migration waits', () => {
       })
       .execute()
 
-    const first = await reconcileWorkspaceMigrationWaits(
+    let releaseFirstBatch: (() => void) | undefined
+    const firstBatchEntered = new Promise<void>((resolveEntered) => {
+      sqliteRef.beforeNextBatch = async () => {
+        resolveEntered()
+        await new Promise<void>((resolveRelease) => {
+          releaseFirstBatch = resolveRelease
+        })
+      }
+    })
+    const firstPromise = reconcileWorkspaceMigrationWaits(
       db,
       new Date('2026-08-27T01:00:00.000Z'),
     )
+    await firstBatchEntered
+    const overlappingPromise = reconcileWorkspaceMigrationWaits(
+      db,
+      new Date('2026-08-27T01:00:01.000Z'),
+    )
+    const overlapping = await overlappingPromise
+    releaseFirstBatch?.()
+    const first = await firstPromise
     expect(first).toMatchObject({ active: 1, newlyDetected: 1, resolved: 0 })
-    expect(first.notifications).toEqual([{ revision: 1 }])
+    expect(overlapping).toMatchObject({
+      active: 1,
+      newlyDetected: 1,
+      resolved: 0,
+    })
+    expect(
+      new Set([
+        first.notifications[0]?.revision,
+        overlapping.notifications[0]?.revision,
+      ]),
+    ).toEqual(new Set([1, 2]))
     const waitId = await db
       .selectFrom('workspace_migration_waits')
       .select('id')
@@ -108,7 +135,7 @@ describe('workspace migration waits', () => {
       active: 1,
       newlyDetected: 0,
       resolved: 0,
-      notifications: [{ revision: 1 }],
+      notifications: [{ revision: 2 }],
     })
 
     await db.deleteFrom('api_tokens').where('id', '=', 'token-1').execute()
@@ -141,7 +168,7 @@ describe('workspace migration waits', () => {
       active: 1,
       newlyDetected: 1,
       resolved: 0,
-      notifications: [{ revision: 2 }],
+      notifications: [{ revision: 3 }],
     })
 
     await expect(

--- a/apps/web/app/services/workspace-migration-waits.server.test.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.test.ts
@@ -35,7 +35,7 @@ describe('workspace migration waits', () => {
     return fixture.db
   }
 
-  test('records once, resolves, and notifies again only after recurrence', async () => {
+  test('leases reconciliation, records once, resolves, and notifies on recurrence', async () => {
     const db = setup()
     await db
       .insertInto('workspaces')
@@ -111,16 +111,13 @@ describe('workspace migration waits', () => {
     const first = await firstPromise
     expect(first).toMatchObject({ active: 1, newlyDetected: 1, resolved: 0 })
     expect(overlapping).toMatchObject({
-      active: 1,
-      newlyDetected: 1,
+      active: 0,
+      newlyDetected: 0,
       resolved: 0,
+      skipped: true,
+      notifications: [],
     })
-    expect(
-      new Set([
-        first.notifications[0]?.revision,
-        overlapping.notifications[0]?.revision,
-      ]),
-    ).toEqual(new Set([1, 2]))
+    expect(first.notifications).toEqual([{ revision: 1 }])
     const waitId = await db
       .selectFrom('workspace_migration_waits')
       .select('id')
@@ -135,7 +132,8 @@ describe('workspace migration waits', () => {
       active: 1,
       newlyDetected: 0,
       resolved: 0,
-      notifications: [{ revision: 2 }],
+      skipped: false,
+      notifications: [{ revision: 1 }],
     })
 
     await db.deleteFrom('api_tokens').where('id', '=', 'token-1').execute()
@@ -147,6 +145,7 @@ describe('workspace migration waits', () => {
       active: 0,
       newlyDetected: 0,
       resolved: 1,
+      skipped: false,
       notifications: [],
     })
 
@@ -168,7 +167,8 @@ describe('workspace migration waits', () => {
       active: 1,
       newlyDetected: 1,
       resolved: 0,
-      notifications: [{ revision: 3 }],
+      skipped: false,
+      notifications: [{ revision: 2 }],
     })
 
     await expect(

--- a/apps/web/app/services/workspace-migration-waits.server.test.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.test.ts
@@ -163,7 +163,7 @@ describe('workspace migration waits', () => {
     )
   })
 
-  test('batches wait persistence within the D1 parameter budget', async () => {
+  test('persists many waits with a bounded D1 statement count', async () => {
     const db = setup()
     const createdAt = '2026-08-27T00:00:00.000Z'
     await db
@@ -234,7 +234,7 @@ describe('workspace migration waits', () => {
     )
 
     expect(result).toMatchObject({ active: 17, newlyDetected: 17 })
-    expect(batchStatementCount).toBe(4)
-    expect(maximumParameters).toBeLessThanOrEqual(100)
+    expect(batchStatementCount).toBe(2)
+    expect(maximumParameters).toBeLessThanOrEqual(3)
   })
 })

--- a/apps/web/app/services/workspace-migration-waits.server.test.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import type { DatabaseSync } from 'node:sqlite'
+import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
+import {
+  reconcileWorkspaceMigrationWaits,
+  WORKSPACE_MIGRATION_WAIT_LOG_MARKER,
+} from './workspace-migration-waits.server'
+
+const sqliteRef = vi.hoisted(() => ({
+  current: null as DatabaseSync | null,
+}))
+
+vi.mock('cloudflare:workers', () => ({
+  env: {
+    DB: createD1BatchDbMock({ sqlite: sqliteRef }),
+  },
+}))
+
+describe('workspace migration waits', () => {
+  let fixture: ReturnType<typeof createD1BatchFixture> | null = null
+
+  afterEach(async () => {
+    await fixture?.db.destroy()
+    fixture = null
+    sqliteRef.current = null
+  })
+
+  function setup() {
+    fixture = createD1BatchFixture({ sqlite: sqliteRef })
+    sqliteRef.current = fixture.sqlite
+    return fixture.db
+  }
+
+  test('records once, resolves, and notifies again only after recurrence', async () => {
+    const db = setup()
+    await db
+      .insertInto('workspaces')
+      .values([
+        {
+          id: 'ws-org',
+          name: 'corp.com',
+          email_domain: 'corp.com',
+          created_at: '2026-08-27T00:00:00.000Z',
+        },
+        {
+          id: 'ws-personal',
+          name: "alice@corp.com's workspace",
+          created_at: '2026-08-27T00:00:00.000Z',
+        },
+      ])
+      .execute()
+    await db
+      .insertInto('workspace_domain_claims')
+      .values({
+        domain: 'corp.com',
+        workspace_id: 'ws-org',
+        source: 'google_hd',
+        provider_tenant_id: null,
+        created_at: '2026-08-27T00:00:00.000Z',
+        updated_at: '2026-08-27T00:00:00.000Z',
+      })
+      .execute()
+    await db
+      .insertInto('users')
+      .values({
+        id: 'user-1',
+        email: 'alice@corp.com',
+        email_verified: 1,
+        name: 'Alice',
+        created_at: '2026-08-27T00:00:00.000Z',
+        updated_at: '2026-08-27T00:00:00.000Z',
+        workspace_id: 'ws-personal',
+        kind: 'human',
+      })
+      .execute()
+    await db
+      .insertInto('api_tokens')
+      .values({
+        id: 'token-1',
+        user_id: 'user-1',
+        name: 'CLI',
+        token_hash: 'hash',
+        created_at: '2026-08-27T00:00:00.000Z',
+      })
+      .execute()
+
+    const first = await reconcileWorkspaceMigrationWaits(
+      db,
+      new Date('2026-08-27T01:00:00.000Z'),
+    )
+    expect(first).toMatchObject({ active: 1, newlyDetected: 1, resolved: 0 })
+    expect(first.notifications).toHaveLength(1)
+    expect(JSON.stringify(first.notifications)).not.toMatch(
+      /alice|corp\.com|ws-personal|ws-org/u,
+    )
+    const waitId = first.notifications[0]?.waitId
+    expect(waitId).toHaveLength(16)
+
+    const repeated = await reconcileWorkspaceMigrationWaits(
+      db,
+      new Date('2026-08-27T02:00:00.000Z'),
+    )
+    expect(repeated).toEqual({
+      active: 1,
+      newlyDetected: 0,
+      resolved: 0,
+      notifications: [],
+    })
+
+    await db.deleteFrom('api_tokens').where('id', '=', 'token-1').execute()
+    const resolved = await reconcileWorkspaceMigrationWaits(
+      db,
+      new Date('2026-08-27T03:00:00.000Z'),
+    )
+    expect(resolved).toEqual({
+      active: 0,
+      newlyDetected: 0,
+      resolved: 1,
+      notifications: [],
+    })
+
+    await db
+      .insertInto('api_tokens')
+      .values({
+        id: 'token-2',
+        user_id: 'user-1',
+        name: 'CLI again',
+        token_hash: 'hash-2',
+        created_at: '2026-08-27T04:00:00.000Z',
+      })
+      .execute()
+    const recurring = await reconcileWorkspaceMigrationWaits(
+      db,
+      new Date('2026-08-27T04:00:00.000Z'),
+    )
+    expect(recurring).toMatchObject({
+      active: 1,
+      newlyDetected: 1,
+      resolved: 0,
+      notifications: [{ waitId, generation: 2 }],
+    })
+
+    await expect(
+      db
+        .selectFrom('workspace_migration_waits')
+        .select(['reason_codes', 'generation', 'resolved_at'])
+        .where('id', '=', waitId ?? '')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({
+      reason_codes: '["user_has_api_tokens"]',
+      generation: 2,
+      resolved_at: null,
+    })
+  })
+
+  test('uses a stable PII-free log marker', () => {
+    expect(WORKSPACE_MIGRATION_WAIT_LOG_MARKER).toBe(
+      'artifactshare_workspace_migration_wait',
+    )
+  })
+})

--- a/apps/web/app/services/workspace-migration-waits.server.test.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.test.ts
@@ -8,6 +8,9 @@ import {
 
 const sqliteRef = vi.hoisted(() => ({
   current: null as DatabaseSync | null,
+  beforeNextBatch: null as
+    | ((statements: { sql: string; params: unknown[] }[]) => void)
+    | null,
 }))
 
 vi.mock('cloudflare:workers', () => ({
@@ -23,6 +26,7 @@ describe('workspace migration waits', () => {
     await fixture?.db.destroy()
     fixture = null
     sqliteRef.current = null
+    sqliteRef.beforeNextBatch = null
   })
 
   function setup() {
@@ -157,5 +161,80 @@ describe('workspace migration waits', () => {
     expect(WORKSPACE_MIGRATION_WAIT_LOG_MARKER).toBe(
       'artifactshare_workspace_migration_wait',
     )
+  })
+
+  test('batches wait persistence within the D1 parameter budget', async () => {
+    const db = setup()
+    const createdAt = '2026-08-27T00:00:00.000Z'
+    await db
+      .insertInto('workspaces')
+      .values({ id: 'ws-org', name: 'corp.com', created_at: createdAt })
+      .execute()
+    await db
+      .insertInto('workspace_domain_claims')
+      .values({
+        domain: 'corp.com',
+        workspace_id: 'ws-org',
+        source: 'google_hd',
+        provider_tenant_id: null,
+        created_at: createdAt,
+        updated_at: createdAt,
+      })
+      .execute()
+    await db
+      .insertInto('workspaces')
+      .values(
+        Array.from({ length: 17 }, (_, index) => ({
+          id: `ws-personal-${index}`,
+          name: `user${index}@corp.com's workspace`,
+          created_at: createdAt,
+        })),
+      )
+      .execute()
+    await db
+      .insertInto('users')
+      .values(
+        Array.from({ length: 17 }, (_, index) => ({
+          id: `user-${index}`,
+          email: `user${index}@corp.com`,
+          email_verified: 1,
+          name: `User ${index}`,
+          created_at: createdAt,
+          updated_at: createdAt,
+          workspace_id: `ws-personal-${index}`,
+          kind: 'human' as const,
+        })),
+      )
+      .execute()
+    await db
+      .insertInto('api_tokens')
+      .values(
+        Array.from({ length: 17 }, (_, index) => ({
+          id: `token-${index}`,
+          user_id: `user-${index}`,
+          name: 'CLI',
+          token_hash: `hash-${index}`,
+          created_at: createdAt,
+        })),
+      )
+      .execute()
+
+    let batchStatementCount = 0
+    let maximumParameters = 0
+    sqliteRef.beforeNextBatch = (statements) => {
+      batchStatementCount = statements.length
+      maximumParameters = Math.max(
+        ...statements.map((statement) => statement.params.length),
+      )
+    }
+
+    const result = await reconcileWorkspaceMigrationWaits(
+      db,
+      new Date('2026-08-27T01:00:00.000Z'),
+    )
+
+    expect(result).toMatchObject({ active: 17, newlyDetected: 17 })
+    expect(batchStatementCount).toBe(3)
+    expect(maximumParameters).toBeLessThanOrEqual(100)
   })
 })

--- a/apps/web/app/services/workspace-migration-waits.server.test.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.test.ts
@@ -104,7 +104,7 @@ describe('workspace migration waits', () => {
       active: 1,
       newlyDetected: 0,
       resolved: 0,
-      notifications: [],
+      notifications: [{ waitId, generation: 1 }],
     })
 
     await db.deleteFrom('api_tokens').where('id', '=', 'token-1').execute()

--- a/apps/web/app/services/workspace-migration-waits.server.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.ts
@@ -157,15 +157,15 @@ export async function reconcileWorkspaceMigrationWaits(
     }
   }
 
-  const resolvedIds = existing
-    .filter(
-      (previous) =>
-        previous.resolved_at === null &&
-        !activeKeys.has(
-          waitKey(previous.user_id, previous.target_workspace_id),
-        ),
-    )
-    .map((previous) => previous.id)
+  const resolvedIds: string[] = []
+  for (const previous of existing) {
+    if (
+      previous.resolved_at === null &&
+      !activeKeys.has(waitKey(previous.user_id, previous.target_workspace_id))
+    ) {
+      resolvedIds.push(previous.id)
+    }
+  }
   for (let index = 0; index < resolvedIds.length; index += 5000) {
     const idsJson = JSON.stringify(resolvedIds.slice(index, index + 5000))
     queries.push(

--- a/apps/web/app/services/workspace-migration-waits.server.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.ts
@@ -111,13 +111,38 @@ export async function reconcileWorkspaceMigrationWaits(
   }
 
   if (upsertValues.length > 0) {
-    // Ten columns per row plus the conflict update stay below D1's 100 bound
-    // parameter limit when each statement contains at most eight rows.
-    for (let index = 0; index < upsertValues.length; index += 8) {
+    for (let index = 0; index < upsertValues.length; index += 500) {
+      const valuesJson = JSON.stringify(upsertValues.slice(index, index + 500))
       queries.push(
         db
           .insertInto('workspace_migration_waits')
-          .values(upsertValues.slice(index, index + 8))
+          .columns([
+            'id',
+            'user_id',
+            'source_workspace_id',
+            'target_workspace_id',
+            'reason_codes',
+            'generation',
+            'first_detected_at',
+            'last_detected_at',
+            'resolved_at',
+          ])
+          .expression(
+            () => sql`
+            SELECT
+              json_extract(value, '$.id'),
+              json_extract(value, '$.user_id'),
+              json_extract(value, '$.source_workspace_id'),
+              json_extract(value, '$.target_workspace_id'),
+              json_extract(value, '$.reason_codes'),
+              json_extract(value, '$.generation'),
+              json_extract(value, '$.first_detected_at'),
+              json_extract(value, '$.last_detected_at'),
+              NULL
+            FROM json_each(${valuesJson})
+            WHERE true
+          `,
+          )
           .onConflict((conflict) =>
             conflict.columns(['user_id', 'target_workspace_id']).doUpdateSet({
               source_workspace_id: (eb) =>
@@ -141,13 +166,18 @@ export async function reconcileWorkspaceMigrationWaits(
         ),
     )
     .map((previous) => previous.id)
-  for (let index = 0; index < resolvedIds.length; index += 90) {
+  for (let index = 0; index < resolvedIds.length; index += 5000) {
+    const idsJson = JSON.stringify(resolvedIds.slice(index, index + 5000))
     queries.push(
       db
         .updateTable('workspace_migration_waits')
         .set({ resolved_at: detectedAt })
-        .where('id', 'in', resolvedIds.slice(index, index + 90))
-        .where('resolved_at', 'is', null),
+        .where('resolved_at', 'is', null)
+        .where(
+          'id',
+          'in',
+          sql<string>`(SELECT value FROM json_each(${idsJson}))`,
+        ),
     )
   }
   const resolved = resolvedIds.length

--- a/apps/web/app/services/workspace-migration-waits.server.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid'
-import type { Compilable, Kysely } from 'kysely'
+import { sql, type Compilable, type Kysely, type Selectable } from 'kysely'
 import { runD1Batch } from '~/lib/d1-batch.server'
 import type { DB } from '~/types/db'
 import { listWorkspaceMigrationCandidates } from './workspace-domain-claims.server'
@@ -24,10 +24,24 @@ export async function reconcileWorkspaceMigrationWaits(
 ): Promise<WorkspaceMigrationWaitReconcileResult> {
   const detectedAt = now.toISOString()
   const candidates = await listWorkspaceMigrationCandidates(db)
-  const existing = await db
-    .selectFrom('workspace_migration_waits')
-    .selectAll()
-    .execute()
+  const existing = (
+    await sql<Selectable<DB['workspace_migration_waits']>>`
+      SELECT waits.*
+      FROM workspace_migration_waits AS waits
+      WHERE waits.resolved_at IS NULL
+      UNION ALL
+      SELECT waits.*
+      FROM workspace_domain_claims AS claims
+      INNER JOIN users
+        ON lower(substr(users.email, instr(users.email, '@') + 1)) = claims.domain
+      INNER JOIN workspace_migration_waits AS waits
+        ON waits.user_id = users.id
+        AND waits.target_workspace_id = claims.workspace_id
+      WHERE waits.resolved_at IS NOT NULL
+        AND users.workspace_id <> claims.workspace_id
+        AND users.kind = 'human'
+    `.execute(db)
+  ).rows
   const alertState = await db
     .selectFrom('workspace_migration_wait_alert_state')
     .select('revision')

--- a/apps/web/app/services/workspace-migration-waits.server.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.ts
@@ -1,0 +1,118 @@
+import { nanoid } from 'nanoid'
+import type { Compilable, Kysely } from 'kysely'
+import { runD1Batch } from '~/lib/d1-batch.server'
+import type { DB } from '~/types/db'
+import { listWorkspaceMigrationCandidates } from './workspace-domain-claims.server'
+
+export const WORKSPACE_MIGRATION_WAIT_LOG_MARKER =
+  'artifactshare_workspace_migration_wait'
+
+export interface WorkspaceMigrationWaitNotification {
+  waitId: string
+  generation: number
+}
+
+export interface WorkspaceMigrationWaitReconcileResult {
+  active: number
+  newlyDetected: number
+  resolved: number
+  notifications: WorkspaceMigrationWaitNotification[]
+}
+
+export async function reconcileWorkspaceMigrationWaits(
+  db: Kysely<DB>,
+  now: Date,
+): Promise<WorkspaceMigrationWaitReconcileResult> {
+  const detectedAt = now.toISOString()
+  const candidates = await listWorkspaceMigrationCandidates(db)
+  const existing = await db
+    .selectFrom('workspace_migration_waits')
+    .selectAll()
+    .execute()
+  const existingByKey = new Map(
+    existing.map((wait) => [
+      waitKey(wait.user_id, wait.target_workspace_id),
+      wait,
+    ]),
+  )
+  const activeKeys = new Set<string>()
+  const notifications: WorkspaceMigrationWaitNotification[] = []
+  const queries: Compilable<unknown>[] = []
+  let newlyDetected = 0
+
+  for (const candidate of candidates) {
+    const key = waitKey(candidate.userId, candidate.claimWorkspaceId)
+    activeKeys.add(key)
+    const previous = existingByKey.get(key)
+    const reasonCodes = JSON.stringify([...candidate.reasonCodes].sort())
+    if (!previous) {
+      const id = nanoid(16)
+      queries.push(
+        db.insertInto('workspace_migration_waits').values({
+          id,
+          user_id: candidate.userId,
+          source_workspace_id: candidate.personalWorkspaceId,
+          target_workspace_id: candidate.claimWorkspaceId,
+          reason_codes: reasonCodes,
+          generation: 1,
+          first_detected_at: detectedAt,
+          last_detected_at: detectedAt,
+          resolved_at: null,
+        }),
+      )
+      notifications.push({ waitId: id, generation: 1 })
+      newlyDetected++
+      continue
+    }
+
+    const reactivated = previous.resolved_at !== null
+    const generation = reactivated
+      ? Number(previous.generation) + 1
+      : Number(previous.generation)
+    queries.push(
+      db
+        .updateTable('workspace_migration_waits')
+        .set({
+          source_workspace_id: candidate.personalWorkspaceId,
+          reason_codes: reasonCodes,
+          generation,
+          last_detected_at: detectedAt,
+          resolved_at: null,
+        })
+        .where('id', '=', previous.id),
+    )
+    if (reactivated) {
+      notifications.push({ waitId: previous.id, generation })
+      newlyDetected++
+    }
+  }
+
+  let resolved = 0
+  for (const previous of existing) {
+    if (
+      previous.resolved_at === null &&
+      !activeKeys.has(waitKey(previous.user_id, previous.target_workspace_id))
+    ) {
+      queries.push(
+        db
+          .updateTable('workspace_migration_waits')
+          .set({ resolved_at: detectedAt })
+          .where('id', '=', previous.id)
+          .where('resolved_at', 'is', null),
+      )
+      resolved++
+    }
+  }
+
+  if (queries.length > 0) await runD1Batch(db, ...queries)
+  return {
+    active: candidates.length,
+    newlyDetected,
+    resolved,
+    notifications,
+  }
+}
+
+function waitKey(userId: string, targetWorkspaceId: string): string {
+  return `${userId}\u0000${targetWorkspaceId}`
+}

--- a/apps/web/app/services/workspace-migration-waits.server.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.ts
@@ -38,6 +38,17 @@ export async function reconcileWorkspaceMigrationWaits(
   const activeKeys = new Set<string>()
   const notifications: WorkspaceMigrationWaitNotification[] = []
   const queries: Compilable<unknown>[] = []
+  const upsertValues: Array<{
+    id: string
+    user_id: string
+    source_workspace_id: string
+    target_workspace_id: string
+    reason_codes: string
+    generation: number
+    first_detected_at: string
+    last_detected_at: string
+    resolved_at: null
+  }> = []
   let newlyDetected = 0
 
   for (const candidate of candidates) {
@@ -47,19 +58,17 @@ export async function reconcileWorkspaceMigrationWaits(
     const reasonCodes = JSON.stringify([...candidate.reasonCodes].sort())
     if (!previous) {
       const id = nanoid(16)
-      queries.push(
-        db.insertInto('workspace_migration_waits').values({
-          id,
-          user_id: candidate.userId,
-          source_workspace_id: candidate.personalWorkspaceId,
-          target_workspace_id: candidate.claimWorkspaceId,
-          reason_codes: reasonCodes,
-          generation: 1,
-          first_detected_at: detectedAt,
-          last_detected_at: detectedAt,
-          resolved_at: null,
-        }),
-      )
+      upsertValues.push({
+        id,
+        user_id: candidate.userId,
+        source_workspace_id: candidate.personalWorkspaceId,
+        target_workspace_id: candidate.claimWorkspaceId,
+        reason_codes: reasonCodes,
+        generation: 1,
+        first_detected_at: detectedAt,
+        last_detected_at: detectedAt,
+        resolved_at: null,
+      })
       notifications.push({ waitId: id, generation: 1 })
       newlyDetected++
       continue
@@ -69,40 +78,64 @@ export async function reconcileWorkspaceMigrationWaits(
     const generation = reactivated
       ? Number(previous.generation) + 1
       : Number(previous.generation)
-    queries.push(
-      db
-        .updateTable('workspace_migration_waits')
-        .set({
-          source_workspace_id: candidate.personalWorkspaceId,
-          reason_codes: reasonCodes,
-          generation,
-          last_detected_at: detectedAt,
-          resolved_at: null,
-        })
-        .where('id', '=', previous.id),
-    )
+    upsertValues.push({
+      id: previous.id,
+      user_id: candidate.userId,
+      source_workspace_id: candidate.personalWorkspaceId,
+      target_workspace_id: candidate.claimWorkspaceId,
+      reason_codes: reasonCodes,
+      generation,
+      first_detected_at: previous.first_detected_at,
+      last_detected_at: detectedAt,
+      resolved_at: null,
+    })
     if (reactivated) {
       newlyDetected++
     }
     notifications.push({ waitId: previous.id, generation })
   }
 
-  let resolved = 0
-  for (const previous of existing) {
-    if (
-      previous.resolved_at === null &&
-      !activeKeys.has(waitKey(previous.user_id, previous.target_workspace_id))
-    ) {
+  if (upsertValues.length > 0) {
+    // Ten columns per row plus the conflict update stay below D1's 100 bound
+    // parameter limit when each statement contains at most eight rows.
+    for (let index = 0; index < upsertValues.length; index += 8) {
       queries.push(
         db
-          .updateTable('workspace_migration_waits')
-          .set({ resolved_at: detectedAt })
-          .where('id', '=', previous.id)
-          .where('resolved_at', 'is', null),
+          .insertInto('workspace_migration_waits')
+          .values(upsertValues.slice(index, index + 8))
+          .onConflict((conflict) =>
+            conflict.columns(['user_id', 'target_workspace_id']).doUpdateSet({
+              source_workspace_id: (eb) =>
+                eb.ref('excluded.source_workspace_id'),
+              reason_codes: (eb) => eb.ref('excluded.reason_codes'),
+              generation: (eb) => eb.ref('excluded.generation'),
+              last_detected_at: (eb) => eb.ref('excluded.last_detected_at'),
+              resolved_at: null,
+            }),
+          ),
       )
-      resolved++
     }
   }
+
+  const resolvedIds = existing
+    .filter(
+      (previous) =>
+        previous.resolved_at === null &&
+        !activeKeys.has(
+          waitKey(previous.user_id, previous.target_workspace_id),
+        ),
+    )
+    .map((previous) => previous.id)
+  for (let index = 0; index < resolvedIds.length; index += 90) {
+    queries.push(
+      db
+        .updateTable('workspace_migration_waits')
+        .set({ resolved_at: detectedAt })
+        .where('id', 'in', resolvedIds.slice(index, index + 90))
+        .where('resolved_at', 'is', null),
+    )
+  }
+  const resolved = resolvedIds.length
 
   if (queries.length > 0) await runD1Batch(db, ...queries)
   return {

--- a/apps/web/app/services/workspace-migration-waits.server.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.ts
@@ -82,9 +82,9 @@ export async function reconcileWorkspaceMigrationWaits(
         .where('id', '=', previous.id),
     )
     if (reactivated) {
-      notifications.push({ waitId: previous.id, generation })
       newlyDetected++
     }
+    notifications.push({ waitId: previous.id, generation })
   }
 
   let resolved = 0

--- a/apps/web/app/services/workspace-migration-waits.server.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid'
 import { sql, type Compilable, type Kysely, type Selectable } from 'kysely'
-import { runD1Batch } from '~/lib/d1-batch.server'
+import { runD1BatchWithResults } from '~/lib/d1-batch.server'
 import type { DB } from '~/types/db'
 import { listWorkspaceMigrationCandidates } from './workspace-domain-claims.server'
 
@@ -149,7 +149,10 @@ export async function reconcileWorkspaceMigrationWaits(
                 eb.ref('excluded.source_workspace_id'),
               reason_codes: (eb) => eb.ref('excluded.reason_codes'),
               generation: (eb) => eb.ref('excluded.generation'),
-              last_detected_at: (eb) => eb.ref('excluded.last_detected_at'),
+              last_detected_at: sql<string>`max(
+                workspace_migration_waits.last_detected_at,
+                excluded.last_detected_at
+              )`,
               resolved_at: null,
             }),
           ),
@@ -181,18 +184,25 @@ export async function reconcileWorkspaceMigrationWaits(
     )
   }
   const resolved = resolvedIds.length
-  const notificationRevision =
-    Number(alertState.revision) + (newlyDetected > 0 ? 1 : 0)
   if (newlyDetected > 0) {
     queries.push(
       db
         .updateTable('workspace_migration_wait_alert_state')
-        .set({ revision: notificationRevision, updated_at: detectedAt })
-        .where('id', '=', 1),
+        .set({
+          revision: sql<number>`revision + 1`,
+          updated_at: detectedAt,
+        })
+        .where('id', '=', 1)
+        .returning('revision'),
     )
   }
 
-  if (queries.length > 0) await runD1Batch(db, ...queries)
+  const results =
+    queries.length > 0 ? await runD1BatchWithResults(db, ...queries) : []
+  const notificationRevision =
+    newlyDetected > 0
+      ? revisionFromBatchResult(results.at(-1))
+      : Number(alertState.revision)
   return {
     active: candidates.length,
     newlyDetected,
@@ -202,6 +212,23 @@ export async function reconcileWorkspaceMigrationWaits(
         ? [{ revision: notificationRevision }]
         : [],
   }
+}
+
+function revisionFromBatchResult(result: unknown): number {
+  const row = Array.isArray(result)
+    ? result[0]
+    : result && typeof result === 'object' && 'results' in result
+      ? (result as { results?: unknown[] }).results?.[0]
+      : null
+  const revision = Number(
+    row && typeof row === 'object' && 'revision' in row
+      ? (row as { revision: unknown }).revision
+      : Number.NaN,
+  )
+  if (!Number.isInteger(revision) || revision < 1) {
+    throw new Error('workspace migration wait alert revision was not returned')
+  }
+  return revision
 }
 
 function waitKey(userId: string, targetWorkspaceId: string): string {

--- a/apps/web/app/services/workspace-migration-waits.server.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.ts
@@ -8,8 +8,7 @@ export const WORKSPACE_MIGRATION_WAIT_LOG_MARKER =
   'artifactshare_workspace_migration_wait'
 
 export interface WorkspaceMigrationWaitNotification {
-  waitId: string
-  generation: number
+  revision: number
 }
 
 export interface WorkspaceMigrationWaitReconcileResult {
@@ -29,6 +28,11 @@ export async function reconcileWorkspaceMigrationWaits(
     .selectFrom('workspace_migration_waits')
     .selectAll()
     .execute()
+  const alertState = await db
+    .selectFrom('workspace_migration_wait_alert_state')
+    .select('revision')
+    .where('id', '=', 1)
+    .executeTakeFirstOrThrow()
   const existingByKey = new Map(
     existing.map((wait) => [
       waitKey(wait.user_id, wait.target_workspace_id),
@@ -36,7 +40,6 @@ export async function reconcileWorkspaceMigrationWaits(
     ]),
   )
   const activeKeys = new Set<string>()
-  const notifications: WorkspaceMigrationWaitNotification[] = []
   const queries: Compilable<unknown>[] = []
   const upsertValues: Array<{
     id: string
@@ -69,7 +72,6 @@ export async function reconcileWorkspaceMigrationWaits(
         last_detected_at: detectedAt,
         resolved_at: null,
       })
-      notifications.push({ waitId: id, generation: 1 })
       newlyDetected++
       continue
     }
@@ -92,7 +94,6 @@ export async function reconcileWorkspaceMigrationWaits(
     if (reactivated) {
       newlyDetected++
     }
-    notifications.push({ waitId: previous.id, generation })
   }
 
   if (upsertValues.length > 0) {
@@ -136,13 +137,26 @@ export async function reconcileWorkspaceMigrationWaits(
     )
   }
   const resolved = resolvedIds.length
+  const notificationRevision =
+    Number(alertState.revision) + (newlyDetected > 0 ? 1 : 0)
+  if (newlyDetected > 0) {
+    queries.push(
+      db
+        .updateTable('workspace_migration_wait_alert_state')
+        .set({ revision: notificationRevision, updated_at: detectedAt })
+        .where('id', '=', 1),
+    )
+  }
 
   if (queries.length > 0) await runD1Batch(db, ...queries)
   return {
     active: candidates.length,
     newlyDetected,
     resolved,
-    notifications,
+    notifications:
+      candidates.length > 0 && notificationRevision > 0
+        ? [{ revision: notificationRevision }]
+        : [],
   }
 }
 

--- a/apps/web/app/services/workspace-migration-waits.server.ts
+++ b/apps/web/app/services/workspace-migration-waits.server.ts
@@ -15,14 +15,59 @@ export interface WorkspaceMigrationWaitReconcileResult {
   active: number
   newlyDetected: number
   resolved: number
+  skipped: boolean
   notifications: WorkspaceMigrationWaitNotification[]
 }
+
+const RECONCILIATION_LEASE_MS = 15 * 60 * 1000
+const RELEASED_LEASE = '1970-01-01T00:00:00.000Z'
 
 export async function reconcileWorkspaceMigrationWaits(
   db: Kysely<DB>,
   now: Date,
 ): Promise<WorkspaceMigrationWaitReconcileResult> {
   const detectedAt = now.toISOString()
+  const leaseUntil = new Date(
+    now.getTime() + RECONCILIATION_LEASE_MS,
+  ).toISOString()
+  const lease = await db
+    .updateTable('workspace_migration_wait_alert_state')
+    .set({ lease_until: leaseUntil })
+    .where('id', '=', 1)
+    .where('lease_until', '<', detectedAt)
+    .returning('revision')
+    .executeTakeFirst()
+  if (!lease) {
+    return {
+      active: 0,
+      newlyDetected: 0,
+      resolved: 0,
+      skipped: true,
+      notifications: [],
+    }
+  }
+
+  try {
+    return await reconcileWorkspaceMigrationWaitsWithLease(
+      db,
+      detectedAt,
+      Number(lease.revision),
+    )
+  } finally {
+    await db
+      .updateTable('workspace_migration_wait_alert_state')
+      .set({ lease_until: RELEASED_LEASE })
+      .where('id', '=', 1)
+      .where('lease_until', '=', leaseUntil)
+      .execute()
+  }
+}
+
+async function reconcileWorkspaceMigrationWaitsWithLease(
+  db: Kysely<DB>,
+  detectedAt: string,
+  alertRevision: number,
+): Promise<WorkspaceMigrationWaitReconcileResult> {
   const candidates = await listWorkspaceMigrationCandidates(db)
   const existing = (
     await sql<Selectable<DB['workspace_migration_waits']>>`
@@ -42,11 +87,6 @@ export async function reconcileWorkspaceMigrationWaits(
         AND users.kind = 'human'
     `.execute(db)
   ).rows
-  const alertState = await db
-    .selectFrom('workspace_migration_wait_alert_state')
-    .select('revision')
-    .where('id', '=', 1)
-    .executeTakeFirstOrThrow()
   const existingByKey = new Map(
     existing.map((wait) => [
       waitKey(wait.user_id, wait.target_workspace_id),
@@ -200,13 +240,12 @@ export async function reconcileWorkspaceMigrationWaits(
   const results =
     queries.length > 0 ? await runD1BatchWithResults(db, ...queries) : []
   const notificationRevision =
-    newlyDetected > 0
-      ? revisionFromBatchResult(results.at(-1))
-      : Number(alertState.revision)
+    newlyDetected > 0 ? revisionFromBatchResult(results.at(-1)) : alertRevision
   return {
     active: candidates.length,
     newlyDetected,
     resolved,
+    skipped: false,
     notifications:
       candidates.length > 0 && notificationRevision > 0
         ? [{ revision: notificationRevision }]

--- a/apps/web/app/test/d1-batch-mock.ts
+++ b/apps/web/app/test/d1-batch-mock.ts
@@ -45,10 +45,15 @@ export function createD1BatchDbMock(options: D1BatchMockOptions) {
 
       sqlite.exec('BEGIN')
       try {
+        const results: Array<{ results: unknown[]; success: true }> = []
         for (const stmt of stmts) {
-          sqlite.prepare(stmt.sql).run(...(stmt.params as never[]))
+          results.push({
+            results: sqlite.prepare(stmt.sql).all(...(stmt.params as never[])),
+            success: true,
+          })
         }
         sqlite.exec('COMMIT')
+        return results
       } catch (err) {
         sqlite.exec('ROLLBACK')
         throw err

--- a/apps/web/app/types/db.ts
+++ b/apps/web/app/types/db.ts
@@ -13,6 +13,7 @@ export interface DB {
   workspaces: WorkspacesTable
   workspace_domain_claims: WorkspaceDomainClaimsTable
   workspace_members: WorkspaceMembersTable
+  workspace_migration_waits: WorkspaceMigrationWaitsTable
   audit_events: AuditEventsTable
   security_audit_records: SecurityAuditRecordsTable
   events: EventsTable
@@ -142,6 +143,18 @@ interface WorkspaceMembersTable {
   removed_by: string | null
   created_at: string
   updated_at: string
+}
+
+interface WorkspaceMigrationWaitsTable {
+  id: string
+  user_id: string
+  source_workspace_id: string
+  target_workspace_id: string
+  reason_codes: string
+  generation: Generated<number>
+  first_detected_at: string
+  last_detected_at: string
+  resolved_at: string | null
 }
 
 interface AuditEventsTable {

--- a/apps/web/app/types/db.ts
+++ b/apps/web/app/types/db.ts
@@ -162,6 +162,7 @@ interface WorkspaceMigrationWaitAlertStateTable {
   id: number
   revision: number
   updated_at: string
+  lease_until: string
 }
 
 interface AuditEventsTable {

--- a/apps/web/app/types/db.ts
+++ b/apps/web/app/types/db.ts
@@ -14,6 +14,7 @@ export interface DB {
   workspace_domain_claims: WorkspaceDomainClaimsTable
   workspace_members: WorkspaceMembersTable
   workspace_migration_waits: WorkspaceMigrationWaitsTable
+  workspace_migration_wait_alert_state: WorkspaceMigrationWaitAlertStateTable
   audit_events: AuditEventsTable
   security_audit_records: SecurityAuditRecordsTable
   events: EventsTable
@@ -155,6 +156,12 @@ interface WorkspaceMigrationWaitsTable {
   first_detected_at: string
   last_detected_at: string
   resolved_at: string | null
+}
+
+interface WorkspaceMigrationWaitAlertStateTable {
+  id: number
+  revision: number
+  updated_at: string
 }
 
 interface AuditEventsTable {

--- a/apps/web/db/migrations/0093_workspace_migration_waits.sql
+++ b/apps/web/db/migrations/0093_workspace_migration_waits.sql
@@ -13,3 +13,32 @@ CREATE TABLE workspace_migration_waits (
 );
 CREATE INDEX workspace_migration_waits_active
   ON workspace_migration_waits(resolved_at, last_detected_at DESC);
+
+CREATE TABLE workspace_migration_wait_alert_state (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  revision    INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
+  updated_at  TEXT NOT NULL
+);
+INSERT INTO workspace_migration_wait_alert_state (id, revision, updated_at)
+VALUES (1, 0, '1970-01-01T00:00:00.000Z');
+
+CREATE INDEX users_email_domain_kind_workspace
+  ON users(lower(substr(email, instr(email, '@') + 1)), kind, workspace_id);
+CREATE INDEX shareables_owner_user_id
+  ON shareables(owner_user_id);
+CREATE INDEX artifact_containers_owner_kind
+  ON artifact_containers(owner_user_id, kind);
+CREATE INDEX artifact_containers_created_by_kind
+  ON artifact_containers(created_by_id, kind);
+CREATE INDEX comment_threads_created_by_id
+  ON comment_threads(created_by_id);
+CREATE INDEX comment_messages_created_by_id
+  ON comment_messages(created_by_id);
+CREATE INDEX agent_profiles_workspace_id
+  ON agent_profiles(workspace_id);
+CREATE INDEX cli_family_authorities_workspace_id
+  ON cli_family_authorities(workspace_id);
+CREATE INDEX cli_session_authorities_workspace_id
+  ON cli_session_authorities(workspace_id);
+CREATE INDEX artifact_keys_workspace_id
+  ON artifact_keys(workspace_id);

--- a/apps/web/db/migrations/0093_workspace_migration_waits.sql
+++ b/apps/web/db/migrations/0093_workspace_migration_waits.sql
@@ -17,10 +17,11 @@ CREATE INDEX workspace_migration_waits_active
 CREATE TABLE workspace_migration_wait_alert_state (
   id          INTEGER PRIMARY KEY CHECK (id = 1),
   revision    INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
-  updated_at  TEXT NOT NULL
+  updated_at  TEXT NOT NULL,
+  lease_until TEXT NOT NULL
 );
-INSERT INTO workspace_migration_wait_alert_state (id, revision, updated_at)
-VALUES (1, 0, '1970-01-01T00:00:00.000Z');
+INSERT INTO workspace_migration_wait_alert_state (id, revision, updated_at, lease_until)
+VALUES (1, 0, '1970-01-01T00:00:00.000Z', '1970-01-01T00:00:00.000Z');
 
 CREATE INDEX users_email_domain_kind_workspace
   ON users(lower(substr(email, instr(email, '@') + 1)), kind, workspace_id);

--- a/apps/web/db/migrations/0093_workspace_migration_waits.sql
+++ b/apps/web/db/migrations/0093_workspace_migration_waits.sql
@@ -1,0 +1,15 @@
+CREATE TABLE workspace_migration_waits (
+  id                   TEXT PRIMARY KEY,
+  user_id              TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  source_workspace_id  TEXT NOT NULL,
+  target_workspace_id  TEXT NOT NULL,
+  reason_codes         TEXT NOT NULL
+                       CHECK (json_valid(reason_codes) AND json_type(reason_codes) = 'array'),
+  generation           INTEGER NOT NULL DEFAULT 1 CHECK (generation > 0),
+  first_detected_at    TEXT NOT NULL,
+  last_detected_at     TEXT NOT NULL,
+  resolved_at          TEXT,
+  UNIQUE (user_id, target_workspace_id)
+);
+CREATE INDEX workspace_migration_waits_active
+  ON workspace_migration_waits(resolved_at, last_detected_at DESC);

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -139,6 +139,22 @@ CREATE INDEX workspace_members_workspace_status ON workspace_members(workspace_i
 CREATE UNIQUE INDEX workspace_members_single_owner
   ON workspace_members(workspace_id) WHERE role = 'owner';
 
+CREATE TABLE workspace_migration_waits (
+  id                   TEXT PRIMARY KEY,
+  user_id              TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  source_workspace_id  TEXT NOT NULL,
+  target_workspace_id  TEXT NOT NULL,
+  reason_codes         TEXT NOT NULL
+                       CHECK (json_valid(reason_codes) AND json_type(reason_codes) = 'array'),
+  generation           INTEGER NOT NULL DEFAULT 1 CHECK (generation > 0),
+  first_detected_at    TEXT NOT NULL,
+  last_detected_at     TEXT NOT NULL,
+  resolved_at          TEXT,
+  UNIQUE (user_id, target_workspace_id)
+);
+CREATE INDEX workspace_migration_waits_active
+  ON workspace_migration_waits(resolved_at, last_detected_at DESC);
+
 -- ────────────────────────────────────────────────
 -- billing (Stripe)
 -- ────────────────────────────────────────────────

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -158,10 +158,11 @@ CREATE INDEX workspace_migration_waits_active
 CREATE TABLE workspace_migration_wait_alert_state (
   id          INTEGER PRIMARY KEY CHECK (id = 1),
   revision    INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
-  updated_at  TEXT NOT NULL
+  updated_at  TEXT NOT NULL,
+  lease_until TEXT NOT NULL
 );
-INSERT INTO workspace_migration_wait_alert_state (id, revision, updated_at)
-VALUES (1, 0, '1970-01-01T00:00:00.000Z');
+INSERT INTO workspace_migration_wait_alert_state (id, revision, updated_at, lease_until)
+VALUES (1, 0, '1970-01-01T00:00:00.000Z', '1970-01-01T00:00:00.000Z');
 
 -- ────────────────────────────────────────────────
 -- billing (Stripe)

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -155,6 +155,14 @@ CREATE TABLE workspace_migration_waits (
 CREATE INDEX workspace_migration_waits_active
   ON workspace_migration_waits(resolved_at, last_detected_at DESC);
 
+CREATE TABLE workspace_migration_wait_alert_state (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  revision    INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
+  updated_at  TEXT NOT NULL
+);
+INSERT INTO workspace_migration_wait_alert_state (id, revision, updated_at)
+VALUES (1, 0, '1970-01-01T00:00:00.000Z');
+
 -- ────────────────────────────────────────────────
 -- billing (Stripe)
 -- ────────────────────────────────────────────────
@@ -1073,3 +1081,20 @@ CREATE TABLE project_pins (
   PRIMARY KEY (container_id, shareable_id)
 );
 CREATE INDEX project_pins_shareable ON project_pins(shareable_id);
+
+-- Scheduled workspace migration wait reconciliation lookups.
+CREATE INDEX users_email_domain_kind_workspace
+  ON users(lower(substr(email, instr(email, '@') + 1)), kind, workspace_id);
+CREATE INDEX shareables_owner_user_id ON shareables(owner_user_id);
+CREATE INDEX artifact_containers_owner_kind
+  ON artifact_containers(owner_user_id, kind);
+CREATE INDEX artifact_containers_created_by_kind
+  ON artifact_containers(created_by_id, kind);
+CREATE INDEX comment_threads_created_by_id ON comment_threads(created_by_id);
+CREATE INDEX comment_messages_created_by_id ON comment_messages(created_by_id);
+CREATE INDEX agent_profiles_workspace_id ON agent_profiles(workspace_id);
+CREATE INDEX cli_family_authorities_workspace_id
+  ON cli_family_authorities(workspace_id);
+CREATE INDEX cli_session_authorities_workspace_id
+  ON cli_session_authorities(workspace_id);
+CREATE INDEX artifact_keys_workspace_id ON artifact_keys(workspace_id);

--- a/apps/web/workers/alerts.test.ts
+++ b/apps/web/workers/alerts.test.ts
@@ -279,6 +279,25 @@ describe('alerts tail worker', () => {
     expect(fetch).toHaveBeenCalledTimes(2)
   })
 
+  test('alerts for every migration wait marker in one trace', async () => {
+    const trace = workspaceMigrationWaitTrace({
+      waitId: 'abcdefghijklmnop',
+      generation: 1,
+    })
+    trace.logs.push({
+      message: [
+        'artifactshare_workspace_migration_wait',
+        { waitId: 'ponmlkjihgfedcba', generation: 1 },
+      ],
+      level: 'warn',
+      timestamp: Date.parse('2026-07-04T00:00:01Z'),
+    })
+
+    await alerts.tail?.([trace], testEnv())
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
   test('ignores malformed workspace migration wait markers', async () => {
     await alerts.tail?.(
       [

--- a/apps/web/workers/alerts.test.ts
+++ b/apps/web/workers/alerts.test.ts
@@ -16,6 +16,20 @@ class MemoryKv {
     }
     this.values.set(key, value)
   }
+
+  async list(options: { prefix?: string }): Promise<{
+    keys: { name: string }[]
+    list_complete: true
+    cacheStatus: null
+  }> {
+    return {
+      keys: [...this.values.keys()]
+        .filter((key) => key.startsWith(options.prefix ?? ''))
+        .map((name) => ({ name })),
+      list_complete: true,
+      cacheStatus: null,
+    }
+  }
 }
 
 type TestEnv = Parameters<NonNullable<typeof alerts.tail>>[1]
@@ -295,7 +309,11 @@ describe('alerts tail worker', () => {
 
     await alerts.tail?.([trace], testEnv())
 
-    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [, init] = vi.mocked(fetch).mock.calls[0]
+    expect(JSON.stringify(JSON.parse(String(init?.body)))).toContain(
+      'unnotified waits: 2',
+    )
   })
 
   test('ignores malformed workspace migration wait markers', async () => {

--- a/apps/web/workers/alerts.test.ts
+++ b/apps/web/workers/alerts.test.ts
@@ -118,6 +118,16 @@ function sandboxReportTrace(detail: unknown): TraceItem {
   return trace
 }
 
+function workspaceMigrationWaitTrace(detail: unknown): TraceItem {
+  const trace = scheduledTrace('ok')
+  trace.logs.push({
+    message: ['artifactshare_workspace_migration_wait', detail],
+    level: 'warn',
+    timestamp: Date.parse('2026-07-04T00:00:00Z'),
+  })
+  return trace
+}
+
 describe('alerts tail worker', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -227,6 +237,60 @@ describe('alerts tail worker', () => {
     expect(fetch).toHaveBeenCalledTimes(1)
     const [, init] = vi.mocked(fetch).mock.calls[0]
     expect(JSON.parse(String(init?.body)).text).toContain('cron failed')
+  })
+
+  test('sends a PII-free alert for a new workspace migration wait', async () => {
+    await alerts.tail?.(
+      [
+        workspaceMigrationWaitTrace({
+          waitId: 'abcdefghijklmnop',
+          generation: 1,
+        }),
+      ],
+      testEnv(),
+    )
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [, init] = vi.mocked(fetch).mock.calls[0]
+    const payload = JSON.stringify(JSON.parse(String(init?.body)))
+    expect(payload).toContain('workspace migration waiting')
+    expect(payload).not.toContain('abcdefghijklmnop')
+    expect(payload).not.toMatch(/@|domain|workspace_id|user_id/u)
+  })
+
+  test('deduplicates one unresolved wait but alerts on a new generation', async () => {
+    const env = testEnv()
+    const first = workspaceMigrationWaitTrace({
+      waitId: 'abcdefghijklmnop',
+      generation: 1,
+    })
+
+    await alerts.tail?.([first, first], env)
+    await alerts.tail?.(
+      [
+        workspaceMigrationWaitTrace({
+          waitId: 'abcdefghijklmnop',
+          generation: 2,
+        }),
+      ],
+      env,
+    )
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  test('ignores malformed workspace migration wait markers', async () => {
+    await alerts.tail?.(
+      [
+        workspaceMigrationWaitTrace({
+          waitId: 'customer@example.com',
+          generation: 1,
+        }),
+      ],
+      testEnv(),
+    )
+
+    expect(fetch).not.toHaveBeenCalled()
   })
 
   test.each(['forbidden', 'network-error', 'timeout'])(

--- a/apps/web/workers/alerts.test.ts
+++ b/apps/web/workers/alerts.test.ts
@@ -16,20 +16,6 @@ class MemoryKv {
     }
     this.values.set(key, value)
   }
-
-  async list(options: { prefix?: string }): Promise<{
-    keys: { name: string }[]
-    list_complete: true
-    cacheStatus: null
-  }> {
-    return {
-      keys: [...this.values.keys()]
-        .filter((key) => key.startsWith(options.prefix ?? ''))
-        .map((name) => ({ name })),
-      list_complete: true,
-      cacheStatus: null,
-    }
-  }
 }
 
 type TestEnv = Parameters<NonNullable<typeof alerts.tail>>[1]
@@ -257,8 +243,7 @@ describe('alerts tail worker', () => {
     await alerts.tail?.(
       [
         workspaceMigrationWaitTrace({
-          waitId: 'abcdefghijklmnop',
-          generation: 1,
+          revision: 1,
         }),
       ],
       testEnv(),
@@ -268,23 +253,20 @@ describe('alerts tail worker', () => {
     const [, init] = vi.mocked(fetch).mock.calls[0]
     const payload = JSON.stringify(JSON.parse(String(init?.body)))
     expect(payload).toContain('workspace migration waiting')
-    expect(payload).not.toContain('abcdefghijklmnop')
     expect(payload).not.toMatch(/@|domain|workspace_id|user_id/u)
   })
 
   test('deduplicates one unresolved wait but alerts on a new generation', async () => {
     const env = testEnv()
     const first = workspaceMigrationWaitTrace({
-      waitId: 'abcdefghijklmnop',
-      generation: 1,
+      revision: 1,
     })
 
     await alerts.tail?.([first, first], env)
     await alerts.tail?.(
       [
         workspaceMigrationWaitTrace({
-          waitId: 'abcdefghijklmnop',
-          generation: 2,
+          revision: 2,
         }),
       ],
       env,
@@ -293,35 +275,11 @@ describe('alerts tail worker', () => {
     expect(fetch).toHaveBeenCalledTimes(2)
   })
 
-  test('alerts for every migration wait marker in one trace', async () => {
-    const trace = workspaceMigrationWaitTrace({
-      waitId: 'abcdefghijklmnop',
-      generation: 1,
-    })
-    trace.logs.push({
-      message: [
-        'artifactshare_workspace_migration_wait',
-        { waitId: 'ponmlkjihgfedcba', generation: 1 },
-      ],
-      level: 'warn',
-      timestamp: Date.parse('2026-07-04T00:00:01Z'),
-    })
-
-    await alerts.tail?.([trace], testEnv())
-
-    expect(fetch).toHaveBeenCalledTimes(1)
-    const [, init] = vi.mocked(fetch).mock.calls[0]
-    expect(JSON.stringify(JSON.parse(String(init?.body)))).toContain(
-      'unnotified waits: 2',
-    )
-  })
-
   test('ignores malformed workspace migration wait markers', async () => {
     await alerts.tail?.(
       [
         workspaceMigrationWaitTrace({
-          waitId: 'customer@example.com',
-          generation: 1,
+          revision: 'customer@example.com',
         }),
       ],
       testEnv(),

--- a/apps/web/workers/alerts.ts
+++ b/apps/web/workers/alerts.ts
@@ -35,6 +35,7 @@ const fiveXxThreshold = 5
 const fiveXxCooldownSeconds = 900
 const immediateCooldownSeconds = 300
 const slackFailureBackoffSeconds = 60
+const migrationWaitAlertBatchSize = 900
 
 export default {
   async tail(events, env) {
@@ -54,25 +55,17 @@ export default {
           outcome: escapeSlackText(event.outcome),
         })
       }
-      for (const migrationWait of workspaceMigrationWaitsFromLogs(event)) {
-        try {
-          // react-doctor-disable-next-line react-doctor/async-await-in-loop
-          await sendAlertWithCooldown(
-            {
-              key: `workspace-migration-wait:${migrationWait.waitId}:${migrationWait.generation}`,
-              title: 'Artifact Share workspace migration waiting',
-              summary: 'A workspace migration requires operator review.',
-              fields: ['action: Review the protected operations dashboard.'],
-              cooldownSeconds: null,
-            },
-            env,
-          )
-        } catch {
-          console.error('slack_alert_event_failed', {
-            worker: safeScriptName(event),
-            outcome: escapeSlackText(event.outcome),
-          })
-        }
+      try {
+        // react-doctor-disable-next-line react-doctor/async-await-in-loop
+        await sendWorkspaceMigrationWaitAlert(
+          workspaceMigrationWaitsFromLogs(event),
+          env,
+        )
+      } catch {
+        console.error('slack_alert_event_failed', {
+          worker: safeScriptName(event),
+          outcome: escapeSlackText(event.outcome),
+        })
       }
     }
   },
@@ -180,6 +173,76 @@ async function alertFromTrace(
     ],
     cooldownSeconds: fiveXxCooldownSeconds,
   }
+}
+
+async function sendWorkspaceMigrationWaitAlert(
+  waits: { waitId: string; generation: number }[],
+  env: AlertEnv,
+): Promise<void> {
+  if (waits.length === 0) return
+  if (!env.SLACK_ALERT_WEBHOOK_URL) {
+    console.error('slack_alert_webhook_missing', {
+      alert: 'workspace-migration-wait',
+      appEnv: env.APP_ENV,
+    })
+    return
+  }
+
+  const cooldownPrefix = `${alertPrefix}/cooldown/workspace-migration-wait:`
+  const notified = new Set<string>()
+  let cursor: string | undefined
+  do {
+    const page = await env.ALERT_STATE.list({ prefix: cooldownPrefix, cursor })
+    for (const key of page.keys) notified.add(key.name)
+    cursor = page.list_complete ? undefined : page.cursor
+  } while (cursor)
+
+  const pending = waits
+    .map((wait) => ({
+      ...wait,
+      cooldownKey: `${cooldownPrefix}${wait.waitId}:${wait.generation}`,
+    }))
+    .filter((wait) => !notified.has(wait.cooldownKey))
+    .slice(0, migrationWaitAlertBatchSize)
+  if (pending.length === 0) return
+
+  const failureBackoffKey = `${alertPrefix}/slack-failure/workspace-migration-wait`
+  if (await env.ALERT_STATE.get(failureBackoffKey)) return
+  const alert: Alert = {
+    key: 'workspace-migration-wait',
+    title: 'Artifact Share workspace migration waiting',
+    summary: 'Workspace migrations require operator review.',
+    fields: [
+      `unnotified waits: ${pending.length}`,
+      'action: Review the protected operations dashboard.',
+    ],
+    cooldownSeconds: null,
+  }
+  try {
+    const response = await fetch(env.SLACK_ALERT_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(slackPayload(alert)),
+    })
+    if (response.ok) {
+      const notifiedAt = new Date().toISOString()
+      await Promise.all(
+        pending.map((wait) =>
+          env.ALERT_STATE.put(wait.cooldownKey, notifiedAt),
+        ),
+      )
+      return
+    }
+    console.error('slack_alert_webhook_failed', {
+      alert: alert.key,
+      status: response.status,
+    })
+  } catch {
+    console.error('slack_alert_webhook_failed', { alert: alert.key })
+  }
+  await env.ALERT_STATE.put(failureBackoffKey, new Date().toISOString(), {
+    expirationTtl: slackFailureBackoffSeconds,
+  })
 }
 
 async function sendAlertWithCooldown(

--- a/apps/web/workers/alerts.ts
+++ b/apps/web/workers/alerts.ts
@@ -44,14 +44,35 @@ export default {
       try {
         // react-doctor-disable-next-line react-doctor/async-await-in-loop
         const alert = await alertFromTrace(event, env)
-        if (!alert) continue
-        // react-doctor-disable-next-line react-doctor/async-await-in-loop
-        await sendAlertWithCooldown(alert, env)
+        if (alert) {
+          // react-doctor-disable-next-line react-doctor/async-await-in-loop
+          await sendAlertWithCooldown(alert, env)
+        }
       } catch {
         console.error('slack_alert_event_failed', {
           worker: safeScriptName(event),
           outcome: escapeSlackText(event.outcome),
         })
+      }
+      for (const migrationWait of workspaceMigrationWaitsFromLogs(event)) {
+        try {
+          // react-doctor-disable-next-line react-doctor/async-await-in-loop
+          await sendAlertWithCooldown(
+            {
+              key: `workspace-migration-wait:${migrationWait.waitId}:${migrationWait.generation}`,
+              title: 'Artifact Share workspace migration waiting',
+              summary: 'A workspace migration requires operator review.',
+              fields: ['action: Review the protected operations dashboard.'],
+              cooldownSeconds: 30 * 24 * 60 * 60,
+            },
+            env,
+          )
+        } catch {
+          console.error('slack_alert_event_failed', {
+            worker: safeScriptName(event),
+            outcome: escapeSlackText(event.outcome),
+          })
+        }
       }
     }
   },
@@ -93,17 +114,6 @@ async function alertFromTrace(
       summary: 'Worker invocation recorded an exception.',
       fields: exceptionFields,
       cooldownSeconds: immediateCooldownSeconds,
-    }
-  }
-
-  const migrationWait = workspaceMigrationWaitFromLogs(item)
-  if (migrationWait) {
-    return {
-      key: `workspace-migration-wait:${migrationWait.waitId}:${migrationWait.generation}`,
-      title: 'Artifact Share workspace migration waiting',
-      summary: 'A workspace migration requires operator review.',
-      fields: ['action: Review the protected operations dashboard.'],
-      cooldownSeconds: 30 * 24 * 60 * 60,
     }
   }
 
@@ -307,9 +317,10 @@ function sandboxBlockReportFromLogs(
   return null
 }
 
-function workspaceMigrationWaitFromLogs(
+function workspaceMigrationWaitsFromLogs(
   item: TraceItem,
-): { waitId: string; generation: number } | null {
+): { waitId: string; generation: number }[] {
+  const waits: { waitId: string; generation: number }[] = []
   for (const log of item.logs) {
     const [marker, detail] = log.message ?? []
     if (
@@ -328,9 +339,9 @@ function workspaceMigrationWaitFromLogs(
       raw.generation < 1
     )
       continue
-    return { waitId: raw.waitId, generation: raw.generation }
+    waits.push({ waitId: raw.waitId, generation: raw.generation })
   }
-  return null
+  return waits
 }
 
 function fetchEvent(item: TraceItem): TraceItemFetchEventInfo | null {

--- a/apps/web/workers/alerts.ts
+++ b/apps/web/workers/alerts.ts
@@ -35,7 +35,6 @@ const fiveXxThreshold = 5
 const fiveXxCooldownSeconds = 900
 const immediateCooldownSeconds = 300
 const slackFailureBackoffSeconds = 60
-const migrationWaitAlertBatchSize = 900
 
 export default {
   async tail(events, env) {
@@ -57,10 +56,19 @@ export default {
       }
       try {
         // react-doctor-disable-next-line react-doctor/async-await-in-loop
-        await sendWorkspaceMigrationWaitAlert(
-          workspaceMigrationWaitsFromLogs(event),
-          env,
-        )
+        const migrationWait = workspaceMigrationWaitFromLogs(event)
+        if (migrationWait) {
+          await sendAlertWithCooldown(
+            {
+              key: `workspace-migration-wait:${migrationWait.revision}`,
+              title: 'Artifact Share workspace migration waiting',
+              summary: 'Workspace migrations require operator review.',
+              fields: ['action: Review the protected operations dashboard.'],
+              cooldownSeconds: null,
+            },
+            env,
+          )
+        }
       } catch {
         console.error('slack_alert_event_failed', {
           worker: safeScriptName(event),
@@ -173,76 +181,6 @@ async function alertFromTrace(
     ],
     cooldownSeconds: fiveXxCooldownSeconds,
   }
-}
-
-async function sendWorkspaceMigrationWaitAlert(
-  waits: { waitId: string; generation: number }[],
-  env: AlertEnv,
-): Promise<void> {
-  if (waits.length === 0) return
-  if (!env.SLACK_ALERT_WEBHOOK_URL) {
-    console.error('slack_alert_webhook_missing', {
-      alert: 'workspace-migration-wait',
-      appEnv: env.APP_ENV,
-    })
-    return
-  }
-
-  const cooldownPrefix = `${alertPrefix}/cooldown/workspace-migration-wait:`
-  const notified = new Set<string>()
-  let cursor: string | undefined
-  do {
-    const page = await env.ALERT_STATE.list({ prefix: cooldownPrefix, cursor })
-    for (const key of page.keys) notified.add(key.name)
-    cursor = page.list_complete ? undefined : page.cursor
-  } while (cursor)
-
-  const pending = waits
-    .map((wait) => ({
-      ...wait,
-      cooldownKey: `${cooldownPrefix}${wait.waitId}:${wait.generation}`,
-    }))
-    .filter((wait) => !notified.has(wait.cooldownKey))
-    .slice(0, migrationWaitAlertBatchSize)
-  if (pending.length === 0) return
-
-  const failureBackoffKey = `${alertPrefix}/slack-failure/workspace-migration-wait`
-  if (await env.ALERT_STATE.get(failureBackoffKey)) return
-  const alert: Alert = {
-    key: 'workspace-migration-wait',
-    title: 'Artifact Share workspace migration waiting',
-    summary: 'Workspace migrations require operator review.',
-    fields: [
-      `unnotified waits: ${pending.length}`,
-      'action: Review the protected operations dashboard.',
-    ],
-    cooldownSeconds: null,
-  }
-  try {
-    const response = await fetch(env.SLACK_ALERT_WEBHOOK_URL, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(slackPayload(alert)),
-    })
-    if (response.ok) {
-      const notifiedAt = new Date().toISOString()
-      await Promise.all(
-        pending.map((wait) =>
-          env.ALERT_STATE.put(wait.cooldownKey, notifiedAt),
-        ),
-      )
-      return
-    }
-    console.error('slack_alert_webhook_failed', {
-      alert: alert.key,
-      status: response.status,
-    })
-  } catch {
-    console.error('slack_alert_webhook_failed', { alert: alert.key })
-  }
-  await env.ALERT_STATE.put(failureBackoffKey, new Date().toISOString(), {
-    expirationTtl: slackFailureBackoffSeconds,
-  })
 }
 
 async function sendAlertWithCooldown(
@@ -384,10 +322,9 @@ function sandboxBlockReportFromLogs(
   return null
 }
 
-function workspaceMigrationWaitsFromLogs(
+function workspaceMigrationWaitFromLogs(
   item: TraceItem,
-): { waitId: string; generation: number }[] {
-  const waits: { waitId: string; generation: number }[] = []
+): { revision: number } | null {
   for (const log of item.logs) {
     const [marker, detail] = log.message ?? []
     if (
@@ -397,18 +334,16 @@ function workspaceMigrationWaitsFromLogs(
     )
       continue
     const raw = detail as Record<string, unknown>
-    if (Object.keys(raw).sort().join(',') !== 'generation,waitId') continue
-    if (typeof raw.waitId !== 'string' || !/^[\w-]{16}$/u.test(raw.waitId))
-      continue
+    if (Object.keys(raw).join(',') !== 'revision') continue
     if (
-      typeof raw.generation !== 'number' ||
-      !Number.isInteger(raw.generation) ||
-      raw.generation < 1
+      typeof raw.revision !== 'number' ||
+      !Number.isInteger(raw.revision) ||
+      raw.revision < 1
     )
       continue
-    waits.push({ waitId: raw.waitId, generation: raw.generation })
+    return { revision: raw.revision }
   }
-  return waits
+  return null
 }
 
 function fetchEvent(item: TraceItem): TraceItemFetchEventInfo | null {

--- a/apps/web/workers/alerts.ts
+++ b/apps/web/workers/alerts.ts
@@ -17,7 +17,7 @@ type Alert = {
   title: string
   summary: string
   fields: string[]
-  cooldownSeconds: number
+  cooldownSeconds: number | null
 }
 import {
   isSandboxArtifactId,
@@ -63,7 +63,7 @@ export default {
               title: 'Artifact Share workspace migration waiting',
               summary: 'A workspace migration requires operator review.',
               fields: ['action: Review the protected operations dashboard.'],
-              cooldownSeconds: 30 * 24 * 60 * 60,
+              cooldownSeconds: null,
             },
             env,
           )
@@ -207,9 +207,13 @@ async function sendAlertWithCooldown(
       body: JSON.stringify(slackPayload(alert)),
     })
     if (response.ok) {
-      await env.ALERT_STATE.put(cooldownKey, new Date().toISOString(), {
-        expirationTtl: alert.cooldownSeconds,
-      })
+      await env.ALERT_STATE.put(
+        cooldownKey,
+        new Date().toISOString(),
+        alert.cooldownSeconds === null
+          ? undefined
+          : { expirationTtl: alert.cooldownSeconds },
+      )
       return
     }
     console.error('slack_alert_webhook_failed', {

--- a/apps/web/workers/alerts.ts
+++ b/apps/web/workers/alerts.ts
@@ -28,6 +28,7 @@ import {
 const alertPrefix = 'ops-alerts'
 const authHangLogMarker = 'artifactshare_auth_hang'
 const sandboxBlockReportMarker = 'artifactshare_sandbox_block_report'
+const workspaceMigrationWaitMarker = 'artifactshare_workspace_migration_wait'
 const fiveXxWindowSeconds = 300
 const fiveXxBucketSeconds = 30
 const fiveXxThreshold = 5
@@ -92,6 +93,17 @@ async function alertFromTrace(
       summary: 'Worker invocation recorded an exception.',
       fields: exceptionFields,
       cooldownSeconds: immediateCooldownSeconds,
+    }
+  }
+
+  const migrationWait = workspaceMigrationWaitFromLogs(item)
+  if (migrationWait) {
+    return {
+      key: `workspace-migration-wait:${migrationWait.waitId}:${migrationWait.generation}`,
+      title: 'Artifact Share workspace migration waiting',
+      summary: 'A workspace migration requires operator review.',
+      fields: ['action: Review the protected operations dashboard.'],
+      cooldownSeconds: 30 * 24 * 60 * 60,
     }
   }
 
@@ -291,6 +303,32 @@ function sandboxBlockReportFromLogs(
       failureType: raw.failureType,
       confirmedAt: raw.confirmedAt,
     }
+  }
+  return null
+}
+
+function workspaceMigrationWaitFromLogs(
+  item: TraceItem,
+): { waitId: string; generation: number } | null {
+  for (const log of item.logs) {
+    const [marker, detail] = log.message ?? []
+    if (
+      marker !== workspaceMigrationWaitMarker ||
+      !detail ||
+      typeof detail !== 'object'
+    )
+      continue
+    const raw = detail as Record<string, unknown>
+    if (Object.keys(raw).sort().join(',') !== 'generation,waitId') continue
+    if (typeof raw.waitId !== 'string' || !/^[\w-]{16}$/u.test(raw.waitId))
+      continue
+    if (
+      typeof raw.generation !== 'number' ||
+      !Number.isInteger(raw.generation) ||
+      raw.generation < 1
+    )
+      continue
+    return { waitId: raw.waitId, generation: raw.generation }
   }
   return null
 }


### PR DESCRIPTION
## Summary

- record domain-claim workspace migrations that cannot move automatically, including stable reason codes and resolved/reactivated state
- reconcile waits with bounded D1 work, a crash-recoverable lease, and a PII-free deduplicated operator alert
- allow zero-only daily usage history to move with an otherwise disposable personal workspace
- add indexes for the scheduled candidate scan and concurrency-safe alert revisions

## Validation

- `pnpm validate:static`
- focused workspace migration, domain claim, reconciliation, alert, and D1 batch tests: 78 passed
- production-runtime integration harness: 30 passed
- Codex and Claude implementation reviews on `acf5af7`: no unresolved blockers
- trusted `origin/main` public-development guard
