### PR TITLE
Avoid D1 compound limits in workspace moves

### DIFF
--- a/apps/web/app/services/workspace-domain-claims.server.test.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { DatabaseSync } from 'node:sqlite'
 import { createMigratedInMemoryDb } from '~/test/sqlite-fixture'
-import { createD1BatchDbMock, createD1BatchFixture } from '~/test/d1-batch-mock'
+import {
+  createD1BatchDbMock,
+  createD1BatchFixture,
+  type D1BatchStmt,
+} from '~/test/d1-batch-mock'
 import type { DB } from '~/types/db'
 import type { Kysely } from 'kysely'
 import {
@@ -17,7 +21,9 @@ import {
 
 const sqliteRef = vi.hoisted(() => ({
   current: null as DatabaseSync | null,
-  beforeNextBatch: null as (() => void | Promise<void>) | null,
+  beforeNextBatch: null as
+    | ((stmts: D1BatchStmt[]) => void | Promise<void>)
+    | null,
 }))
 
 vi.mock('cloudflare:workers', () => ({
@@ -1142,6 +1148,10 @@ describe('workspace domain claims', () => {
       email: 'alice@corp.com',
       workspaceId: 'ws-personal',
     })
+    let moveStatements: D1BatchStmt[] = []
+    sqliteRef.beforeNextBatch = (stmts) => {
+      moveStatements = stmts
+    }
 
     await expect(
       maybeMoveUserToClaimedWorkspace(db, {
@@ -1150,6 +1160,10 @@ describe('workspace domain claims', () => {
         currentWorkspaceId: 'ws-personal',
       }),
     ).resolves.toBe('ws-org')
+    expect(moveStatements).not.toHaveLength(0)
+    expect(
+      moveStatements.every((stmt) => !/\bunion\s+all\b/i.test(stmt.sql)),
+    ).toBe(true)
 
     const user = await db
       .selectFrom('users')

--- a/apps/web/app/services/workspace-domain-claims.server.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.ts
@@ -799,6 +799,9 @@ export async function workspaceMigrationBlockReasons(
       reasons.push('source_workspace_configured')
     }
     const workspaceId = options.allowCurrentWorkspaceAdmin
+    // Keep each category as independent EXISTS predicates. D1 applies a low
+    // compound-SELECT term limit, so extending a UNION ALL list as new
+    // workspace-owned tables are added can make this login-time check fail.
     const residual = await sql<{
       has_other_users: number
       has_other_members: number
@@ -809,25 +812,27 @@ export async function workspaceMigrationBlockReasons(
       SELECT
         EXISTS (SELECT 1 FROM users WHERE workspace_id = ${workspaceId} AND id != ${userId}) AS has_other_users,
         EXISTS (SELECT 1 FROM workspace_members WHERE workspace_id = ${workspaceId} AND user_id != ${userId}) AS has_other_members,
-        EXISTS (
-          SELECT 1 FROM workspace_storage_daily_usage
-          WHERE workspace_id = ${workspaceId}
-            AND (used_bytes != 0 OR billable_overage_gb != 0)
-          UNION ALL SELECT 1 FROM billing_overage_charges WHERE workspace_id = ${workspaceId}
+        (
+          EXISTS (
+            SELECT 1 FROM workspace_storage_daily_usage
+            WHERE workspace_id = ${workspaceId}
+              AND (used_bytes != 0 OR billable_overage_gb != 0)
+          )
+          OR EXISTS (SELECT 1 FROM billing_overage_charges WHERE workspace_id = ${workspaceId})
         ) AS has_usage,
-        EXISTS (
-          SELECT 1 FROM artifact_containers WHERE workspace_id = ${workspaceId}
-          UNION ALL SELECT 1 FROM shareables WHERE workspace_id = ${workspaceId}
-          UNION ALL SELECT 1 FROM artifact_keys WHERE workspace_id = ${workspaceId}
-          UNION ALL SELECT 1 FROM events WHERE workspace_id = ${workspaceId}
+        (
+          EXISTS (SELECT 1 FROM artifact_containers WHERE workspace_id = ${workspaceId})
+          OR EXISTS (SELECT 1 FROM shareables WHERE workspace_id = ${workspaceId})
+          OR EXISTS (SELECT 1 FROM artifact_keys WHERE workspace_id = ${workspaceId})
+          OR EXISTS (SELECT 1 FROM events WHERE workspace_id = ${workspaceId})
         ) AS has_content,
-        EXISTS (
-          SELECT 1 FROM agent_profiles WHERE workspace_id = ${workspaceId}
-          UNION ALL SELECT 1 FROM cli_family_authorities WHERE workspace_id = ${workspaceId}
-          UNION ALL SELECT 1 FROM cli_session_authorities WHERE workspace_id = ${workspaceId}
-          UNION ALL SELECT 1 FROM bridge_authorities WHERE workspace_id = ${workspaceId}
-          UNION ALL SELECT 1 FROM slack_workspaces WHERE workspace_id = ${workspaceId}
-          UNION ALL SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = ${workspaceId}
+        (
+          EXISTS (SELECT 1 FROM agent_profiles WHERE workspace_id = ${workspaceId})
+          OR EXISTS (SELECT 1 FROM cli_family_authorities WHERE workspace_id = ${workspaceId})
+          OR EXISTS (SELECT 1 FROM cli_session_authorities WHERE workspace_id = ${workspaceId})
+          OR EXISTS (SELECT 1 FROM bridge_authorities WHERE workspace_id = ${workspaceId})
+          OR EXISTS (SELECT 1 FROM slack_workspaces WHERE workspace_id = ${workspaceId})
+          OR EXISTS (SELECT 1 FROM mcp_artifact_posts WHERE workspace_id = ${workspaceId})
         ) AS has_integrations
     `.execute(db)
     const state = residual.rows[0]

--- a/apps/web/app/services/workspace-domain-claims.server.ts
+++ b/apps/web/app/services/workspace-domain-claims.server.ts
@@ -392,61 +392,59 @@ async function moveUserToWorkspaceIfSafe(
               OR (source.self_upload_enabled = 0 AND source.storage_quota_bytes = 0)
             )
         )
-        AND NOT EXISTS (
-          SELECT 1 FROM users
-            WHERE workspace_id = ${input.currentWorkspaceId} AND id != ${input.userId}
-          UNION ALL SELECT 1 FROM workspace_members
-            WHERE workspace_id = ${input.currentWorkspaceId} AND user_id != ${input.userId}
-          UNION ALL SELECT 1 FROM workspace_domain_claims
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM workspace_storage_daily_usage
-            WHERE workspace_id = ${input.currentWorkspaceId}
-              AND (used_bytes != 0 OR billable_overage_gb != 0)
-          UNION ALL SELECT 1 FROM billing_overage_charges
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM artifact_containers
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM shareables
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM agent_profiles
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM cli_family_authorities
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM cli_session_authorities
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM bridge_authorities
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM slack_workspaces
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM mcp_artifact_posts
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM artifact_keys
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM events
-            WHERE workspace_id = ${input.currentWorkspaceId}
-          UNION ALL SELECT 1 FROM api_tokens
-            WHERE user_id = ${input.userId}
-          UNION ALL SELECT 1 FROM cli_refresh_credentials
-            WHERE user_id = ${input.userId}
-          UNION ALL SELECT 1 FROM oauthAccessToken
-            WHERE userId = ${input.userId}
-              AND (expiresAt IS NULL OR expiresAt > ${now})
-          UNION ALL SELECT 1 FROM oauthRefreshToken
-            WHERE userId = ${input.userId}
-              AND revoked IS NULL
-              AND (expiresAt IS NULL OR expiresAt > ${now})
-          UNION ALL SELECT 1 FROM oauthConsent
-            WHERE userId = ${input.userId}
-          UNION ALL SELECT 1 FROM comment_threads
-            WHERE created_by_id = ${input.userId}
-          UNION ALL SELECT 1 FROM comment_messages
-            WHERE created_by_id = ${input.userId}
-          UNION ALL SELECT 1 FROM workspace_members
-            WHERE user_id = ${input.userId}
-              AND workspace_id != ${input.currentWorkspaceId}
-              AND status = 'active'
-              AND role IN ('owner', 'admin')
-        )
+        AND NOT EXISTS (SELECT 1 FROM users
+          WHERE workspace_id = ${input.currentWorkspaceId} AND id != ${input.userId})
+        AND NOT EXISTS (SELECT 1 FROM workspace_members
+          WHERE workspace_id = ${input.currentWorkspaceId} AND user_id != ${input.userId})
+        AND NOT EXISTS (SELECT 1 FROM workspace_domain_claims
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM workspace_storage_daily_usage
+          WHERE workspace_id = ${input.currentWorkspaceId}
+            AND (used_bytes != 0 OR billable_overage_gb != 0))
+        AND NOT EXISTS (SELECT 1 FROM billing_overage_charges
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM artifact_containers
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM shareables
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM agent_profiles
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM cli_family_authorities
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM cli_session_authorities
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM bridge_authorities
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM slack_workspaces
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM mcp_artifact_posts
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM artifact_keys
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM events
+          WHERE workspace_id = ${input.currentWorkspaceId})
+        AND NOT EXISTS (SELECT 1 FROM api_tokens
+          WHERE user_id = ${input.userId})
+        AND NOT EXISTS (SELECT 1 FROM cli_refresh_credentials
+          WHERE user_id = ${input.userId})
+        AND NOT EXISTS (SELECT 1 FROM oauthAccessToken
+          WHERE userId = ${input.userId}
+            AND (expiresAt IS NULL OR expiresAt > ${now}))
+        AND NOT EXISTS (SELECT 1 FROM oauthRefreshToken
+          WHERE userId = ${input.userId}
+            AND revoked IS NULL
+            AND (expiresAt IS NULL OR expiresAt > ${now}))
+        AND NOT EXISTS (SELECT 1 FROM oauthConsent
+          WHERE userId = ${input.userId})
+        AND NOT EXISTS (SELECT 1 FROM comment_threads
+          WHERE created_by_id = ${input.userId})
+        AND NOT EXISTS (SELECT 1 FROM comment_messages
+          WHERE created_by_id = ${input.userId})
+        AND NOT EXISTS (SELECT 1 FROM workspace_members
+          WHERE user_id = ${input.userId}
+            AND workspace_id != ${input.currentWorkspaceId}
+            AND status = 'active'
+            AND role IN ('owner', 'admin'))
       `,
     )
   const membershipUpsert = db


### PR DESCRIPTION
## Summary

- avoid D1 compound-SELECT limits during authenticated workspace migration checks
- preserve the existing preflight categories and atomic move guards with independent existence predicates
- add a regression assertion that the production move batch contains no `UNION ALL`

## User-visible effect

Eligible signed-in users can complete an automatic move into their claimed workspace instead of receiving a server error during session resolution.

## Validation

- `pnpm validate:static`
- targeted workspace-domain-claims tests: 33 passed
- web typecheck
- Codex implementation review: no findings
- Claude implementation review: no findings
- trusted-main public development guard
