### PR TITLE
Re-anchor preview comments by content

### DIFF
--- a/packages/cli/src/preview/contract.ts
+++ b/packages/cli/src/preview/contract.ts
@@ -23,6 +23,10 @@ export type PreviewAnchor =
       label: string
       /** Nearby text captured at creation time, used for re-resolution. */
       contextText: string
+      /** The element's own text and tag, which identify it after an edit far
+       * more reliably than its positional selector. */
+      ownText?: string
+      tagName?: string
     }
 
 export type PreviewAnnotationStatus =
@@ -179,8 +183,12 @@ export function isPreviewAnchor(value: unknown): value is PreviewAnchor {
   if (record.state !== 'attached' && record.state !== 'orphaned') {
     return false
   }
+  const optionalString = (name: string): boolean =>
+    record[name] === undefined || typeof record[name] === 'string'
   if (record.kind === 'element') {
     return (
+      optionalString('ownText') &&
+      optionalString('tagName') &&
       typeof record.selector === 'string' &&
       typeof record.label === 'string' &&
       typeof record.contextText === 'string'

--- a/packages/cli/src/preview/shell.ts
+++ b/packages/cli/src/preview/shell.ts
@@ -297,6 +297,7 @@ export function renderPreviewShell(options: PreviewShellOptions): string {
   let revision = null;
   let pendingReload = null;
   let orphanedThreads = new Set();
+  let verifyPending = false;
   let batchTimer = null;
   let batchStartedAt = null;
   let batchWorkingCount = 0;
@@ -365,7 +366,10 @@ export function renderPreviewShell(options: PreviewShellOptions): string {
       openPopover({
         kind: 'element', state: 'attached',
         selector: data.selector, label: data.label, contextText: data.contextText,
+        ownText: data.ownText, tagName: data.tagName,
       }, data.label, data.rect);
+    } else if (data.kind === 'anchor-verdicts') {
+      applyAnchorVerdicts(data.verdicts);
     } else if (data.kind === 'text-selection') {
       // The reporter keeps emitting selections so normal reading still works;
       // only annotation mode turns one into a comment.
@@ -572,26 +576,38 @@ export function renderPreviewShell(options: PreviewShellOptions): string {
   }
 
   function checkOrphans() {
-    // Same-origin iframe: verify element/text anchors directly against the
-    // reloaded DOM, then persist the verdict so the next agent batch can
-    // tell which anchors lost their target.
-    let doc = null;
-    try { doc = frame.contentWindow.document; } catch (error) { return; }
-    if (!doc) return;
+    // The frame captured these anchors, so it also decides whether they still
+    // resolve: re-implementing the rules here would let capture and
+    // verification drift apart. Resolved and dismissed threads are excluded —
+    // their target was supposed to change.
+    const pending = annotations.filter((annotation) => {
+      if (annotation.status === 'resolved' || annotation.status === 'dismissed') return false;
+      const anchor = annotation.anchor;
+      return Boolean(anchor) && anchor.kind !== 'artifact';
+    });
+    if (pending.length === 0) return;
+    const request = {
+      kind: 'verify-anchors',
+      anchors: pending.map((annotation) => Object.assign(
+        { thread: annotation.thread }, annotation.anchor)),
+    };
+    verifyPending = true;
+    postToFrame(request);
+    // The frame arms its listener during the ready handshake, which this can
+    // still race. One resend keeps a missed request from leaving every anchor
+    // on a stale verdict.
+    setTimeout(() => { if (verifyPending) postToFrame(request); }, 1200);
+  }
+
+  function applyAnchorVerdicts(verdicts) {
+    verifyPending = false;
+    const attached = new Map((verdicts || []).map((v) => [v.thread, v.attached === true]));
     const newlyOrphaned = [];
     const states = [];
     annotations.forEach((annotation) => {
-      if (annotation.status === 'resolved' || annotation.status === 'dismissed') return;
+      if (!attached.has(annotation.thread)) return;
       const anchor = annotation.anchor;
-      if (!anchor || anchor.kind === 'artifact') return;
-      let found = true;
-      if (anchor.kind === 'element') {
-        try { found = Boolean(doc.querySelector(anchor.selector)); }
-        catch (error) { found = false; }
-      } else if (anchor.kind === 'text') {
-        const text = (doc.body && doc.body.innerText) || '';
-        found = anchor.quotedText !== '' && text.indexOf(anchor.quotedText) !== -1;
-      }
+      const found = attached.get(annotation.thread);
       if (!found && !orphanedThreads.has(annotation.thread)) {
         newlyOrphaned.push(annotation.thread);
       }

--- a/packages/viewer-kit/src/csp-reporter.ts
+++ b/packages/viewer-kit/src/csp-reporter.ts
@@ -1442,6 +1442,76 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
     return parts.join(' ').trim();
   }
 
+  /** Re-resolve saved anchors against the reloaded document.
+   *
+   * The captured selector is positional, so it answers the wrong question
+   * twice over: inserting anything above the target breaks a path that still
+   * has its element, and deleting the first of two identical items leaves the
+   * path quietly matching the survivor. What identifies the target is its own
+   * content, so that is what is searched for; the captured surroundings only
+   * decide between several equal candidates. */
+  function verifyAnchors(anchors) {
+    var verdicts = [];
+    var bodyText = null;
+    for (var i = 0; i < (anchors || []).length; i++) {
+      var anchor = anchors[i] || {};
+      var attached = false;
+      if (anchor.kind === 'element') {
+        attached = findElement(anchor) !== null;
+      } else if (anchor.kind === 'text') {
+        if (bodyText === null) bodyText = anchorTextContent();
+        attached = anchor.quotedText !== '' && findQuoted(bodyText, anchor) !== -1;
+      }
+      verdicts.push({ thread: anchor.thread, attached: attached });
+    }
+    send({ kind: 'anchor-verdicts', verdicts: verdicts });
+  }
+
+  function findElement(anchor) {
+    if (!anchor.ownText) {
+      // Nothing to search for, so the selector is all there is.
+      try { return document.querySelector(anchor.selector); } catch (error) { return null; }
+    }
+    var peers = anchor.tagName
+      ? anchorRoot().getElementsByTagName(anchor.tagName)
+      : anchorRoot().getElementsByTagName('*');
+    var matches = [];
+    for (var i = 0; i < peers.length; i++) {
+      if (ownText(peers[i]) === anchor.ownText) matches.push(peers[i]);
+    }
+    if (matches.length === 0) return null;
+    if (matches.length === 1) return matches[0];
+    for (var j = 0; j < matches.length; j++) {
+      if (annotateContextText(matches[j]) === anchor.contextText) return matches[j];
+    }
+    // Several identical candidates and none in the captured surroundings:
+    // saying "attached" here would point the comment at content nobody wrote
+    // it about.
+    return null;
+  }
+
+  /** One occurrence is the target. Several means the captured prefix and
+   * suffix have to say which. */
+  function findQuoted(bodyText, anchor) {
+    var first = bodyText.indexOf(anchor.quotedText);
+    if (first === -1) return -1;
+    if (bodyText.indexOf(anchor.quotedText, first + 1) === -1) return first;
+    var from = 0;
+    while (true) {
+      var at = bodyText.indexOf(anchor.quotedText, from);
+      if (at === -1) return -1;
+      var end = at + anchor.quotedText.length;
+      var prefix = bodyText.slice(Math.max(0, at - 120), at).trim();
+      var suffix = bodyText.slice(end, Math.min(bodyText.length, end + 120)).trim();
+      if (prefix === anchor.prefixText && suffix === anchor.suffixText) return at;
+      from = at + 1;
+    }
+  }
+
+  function ownText(el) {
+    return (el.textContent || '').replace(/\\s+/g, ' ').trim();
+  }
+
   function setAnnotateMode(enabled) {
     annotateModeEnabled = enabled === true;
     if (annotateModeEnabled) {
@@ -1511,6 +1581,8 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
       selector: cssPath(target),
       label: elementLabel(target),
       contextText: annotateContextText(target),
+      ownText: ownText(target),
+      tagName: target.tagName,
       rect: {
         top: rect.top,
         left: rect.left,
@@ -1547,6 +1619,8 @@ export const VIOLATION_REPORTER_SCRIPT_BODY = `(function () {
       pingElement(data.selector);
     } else if (data.kind === 'element-flash') {
       flashElement(data.selector);
+    } else if (data.kind === 'verify-anchors') {
+      verifyAnchors(data.anchors);
     }
   });
 
@@ -1631,7 +1705,7 @@ export const VIOLATION_REPORTER_TAG = `<script>${VIOLATION_REPORTER_SCRIPT_BODY}
 // string. If the body changes, the drift test in csp-reporter.test.ts
 // fails and prints the new value to paste here.
 export const VIOLATION_REPORTER_SHA256 =
-  'kD88PhzWsEjASuLnyZQnHYtWlbSf25M0VMwN69PTZQw='
+  'L0iuV4vyZCqCuLVKh66WUbGqwgWl8JQ0LoLfcSbH2Ec='
 
 export interface CspViolationMessage {
   source: 'artifactshare'

--- a/scripts/public-development-guard.mjs
+++ b/scripts/public-development-guard.mjs
@@ -471,8 +471,14 @@ if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  let input = ''
-  for await (const chunk of process.stdin) input += chunk
+  // Only the pre-push hook feeds this on stdin. Draining it up front made
+  // every other mode wait for an EOF its caller never sends, so `--check`
+  // hung with no output whenever it ran with an open stdin.
+  const readStdin = async () => {
+    let input = ''
+    for await (const chunk of process.stdin) input += chunk
+    return input
+  }
   try {
     const args = process.argv.slice(2)
     const values = (option) =>
@@ -527,7 +533,7 @@ if (
       if (!remote || values('--remote').length !== 1)
         throw new Error('remote option requires a value')
       guardPush({
-        input,
+        input: await readStdin(),
         remoteName: remote,
         branch: execFileSync('git', ['branch', '--show-current'], {
           encoding: 'utf8',


### PR DESCRIPTION
## Change

Preview comments now find their target by what it says, not by where it sat.

An anchor captured a positional CSS path, and reconciliation after a file change asked only whether that path still matched. That answered the wrong question in both directions:

- Insert or delete anything above a commented element and its `:nth-of-type` index shifts, so the path stops matching an element that is still there. The comment was marked orphaned even though nothing about its target changed. This is the common case — an agent editing the file above a pending comment loses it.
- Delete the first of two identical elements and the path quietly matches the survivor. The comment stayed attached while pointing at content nobody wrote it about, and the agent could fix the wrong occurrence with no signal to anyone.

An element anchor now also records its own text and tag, and re-resolution searches for that content: one match is the target, several are decided by the surroundings captured with the comment, and none — or no candidate in those surroundings — is honestly orphaned. Text anchors follow the same rule, using the captured prefix and suffix only when the quote occurs more than once.

Verification moved into the artifact frame, which is where the anchors were captured. The shell asks and applies the verdicts, so the capture and re-resolution rules cannot drift apart, and the request is resent once in case it raced the frame's handshake.

Known limit: when duplicates are reduced to exactly one, the survivor is accepted. Its content is byte-identical to the captured target, so a fix aimed at either is the same fix.

Also fixes a workflow script: `public-development-guard.mjs` drained stdin at startup even in modes that never read it, so `--check` waited forever for an EOF its caller never sends. Any caller with an open stdin — a background shell, a supervisor — got no output and no exit. The read now happens only in the pre-push branch that uses it.

## Validation

- `pnpm validate:static` — pass (format, lint, typecheck, D1, generated-reference sync, glossary, React Doctor 100, boundary scan).
- `node --test scripts/public-development-guard.test.mjs` — 15 pass.
- `pnpm --filter @artifactshare/cli test` — 532 pass, 1 skipped. Three failures on the maintainer machine (`doctor`, `cli`, `artifacts-get`) come from a gitignored `.artifactshare/config.local.json` in the checkout leaking into their auth assertions, not from this change.
- Manual end-to-end on a list with duplicate items: commented an item, deleted an item above it, and confirmed the comment stayed attached where it previously went orphaned; commented one of two identical items, removed it, and confirmed the surroundings check reports the target as lost.
- Reproduced the guard hang against the previous script with an open stdin, then confirmed `--check` returns with the same stdin after the fix.

## Review

Follow-up to the preview feature, taken from a finding both reviewers raised and I had deferred. Reviewing it properly showed the deferred item was the smaller half of the problem: the positional selector was already losing comments on ordinary edits. Two earlier designs for this were discarded after testing showed each produced false orphans — comparing the full captured context, and gating that comparison on a capture-time ambiguity flag. The content-first rule replaces both and needs no flag.
