### PR TITLE
Pin the toolchain and move to pnpm 12

### DIFF
--- a/config/repository-boundary.json
+++ b/config/repository-boundary.json
@@ -33,6 +33,7 @@
     "docs/reference/screen-capture.md",
     "docs/reference/source-available-boundary.md",
     "docs/development-workflow.md",
+    "mise.toml",
     "pnpm-workspace.yaml",
     "scripts/check-analytics-dimensions.mjs",
     "scripts/check-analytics-dimensions.test.mjs",

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,7 @@
+# Pins the toolchain this repository is validated against. Without it a
+# developer's global versions decide what runs, and a mismatch is easy to miss:
+# a pnpm that cannot switch to the pinned version exits 0 having run nothing,
+# so validation reports success while doing no work.
+[tools]
+node = "24"
+pnpm = "12"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "engines": {
     "node": ">=24",
-    "pnpm": ">=11"
+    "pnpm": ">=12"
   },
-  "packageManager": "pnpm@11.22.0",
+  "packageManager": "pnpm@12.0.0",
   "scripts": {
     "check:public-development-guard": "node scripts/public-development-guard.mjs --check",
     "review:codex": "node scripts/codex-review.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0
+        version: 12.0.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    resolution: {integrity: sha512-sqeoPfVMIfQhbwzDrKraXY2ynyuWClFqzvfImzAS/yczEru1m5SGvQ9kgFPDvQzJZ9AetedgJeDZC6qYvH8/tQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    resolution: {integrity: sha512-Quc3J6c9cGTy+LDgz1cLVgCNOU9IERuyAlDoEj0DCilKqvo50Jx1GV8k74iwn4J9fFSKkm8JrwNvtTDj3uWnUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    resolution: {integrity: sha512-EVWd3OTmgsMFhXx69b5JxIzoabG9Ma7m4OeTaf0ZKBzMnfYi8u21NDQo92ToMrdYL5dYDDCHsyYIjXzk+d0HhA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    resolution: {integrity: sha512-cXHHW8M4rAPsYNkKZO9WVcpLLK55i9EaIsZPfIqUuY2eopd5LqnFyBge54HCh1GC0yCX8ySn0hYIi+4OyAEoDg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    resolution: {integrity: sha512-UcXwMdFjly0mpddkGigHKTxe27IMv2fUK4IWW/MHmJ3yMguxXmkwNlEI4aE+G1HO2TLo20uNEUWD4ymLe/DaCQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    resolution: {integrity: sha512-6Rsl+zEWMOmus7v7/9J3OE8EMvHyNAfxYmDfmhQG4J0985OuT3G3Ho9NSGHjkBn4aU4bgklWifRhe1HX8dUSyw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    resolution: {integrity: sha512-O5F76A4oVFrpDGdFxEszRIThOSBfjHdH5c006gR+7UTCfiXrukr1XfqPungUI1DXcSR5gb9jBsPQqQZOAoOOxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    resolution: {integrity: sha512-5dKFajIEWJ1ai+KHXFJvskY6vchbunmLwSUV2ywbLymcmJjfY5XJVpgzPCyIoVCMVG0zHorr66+hM8h8b3aRfQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0:
+    resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    optional: true
+
+  pnpm@12.0.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-save-exact: true
+saveExact: true
 
 packages:
   - 'apps/*'


### PR DESCRIPTION
## Change

Pins the toolchain in the repository and moves the workspace to pnpm 12.

`mise.toml` names the Node and pnpm versions this repository is validated against, so a checkout resolves the same tools CI uses instead of whatever the developer happens to have globally. That mismatch is worth closing because it fails quietly: a pnpm that cannot switch to the pinned version can exit 0 having run nothing, so `validate:static` reports success while doing no work at all.

`packageManager` moves to `pnpm@12.0.0` and `engines.pnpm` to `>=12`. pnpm 12 records its own executable in the lockfile as a `packageManagerDependencies` entry, which is the 101 added lines; `lockfileVersion` stays at `9.0`, so the file is still readable by pnpm 11.

`pnpm-workspace.yaml` had `save-exact`, which pnpm reported as ignored for not being camelCase. Renaming it to `saveExact` makes the setting take effect and clears the warning that appeared on every command.

No workflow change is needed: every `pnpm/action-setup` step here takes its version from `packageManager`.

## Validation

- `pnpm install --frozen-lockfile && pnpm validate:static` under pnpm 12 — pass (format, lint, typecheck, D1, generated-reference sync, glossary, React Doctor 100, boundary scan).
- `pnpm validate:cli && pnpm build` under pnpm 12 — pass, 535 tests, 1 skipped.
- Confirmed the pinned toolchain resolves from a fresh login shell: `mise ls --current` reports node 24 and pnpm 12 from this file, and pnpm reports 12.0.0.

## Review

Toolchain and lockfile change, validated end to end on the new version. It came out of a real incident on this machine: a globally resolved pnpm could not load its own worker module, so it exited 0 without running the scripts and several validation runs reported a false green before the cause was found.
