### PR TITLE
Run CLI tests outside the checkout

### DIFF
--- a/packages/cli/src/artifacts-get.test.ts
+++ b/packages/cli/src/artifacts-get.test.ts
@@ -74,7 +74,13 @@ test('artifacts get without --json keeps auth_required instead of starting login
     .spyOn(process.stderr, 'write')
     .mockImplementation(() => true)
 
+  // This runner is called in process, so it discovers project config by
+  // walking up from the test runner's own directory. Inside this checkout that
+  // finds a developer's `.artifactshare/config.local.json` and resolves a
+  // credential the test is asserting the absence of.
+  const previousCwd = process.cwd()
   try {
+    process.chdir(configHome)
     process.env.ARTIFACTSHARE_TOKEN = ''
     process.env.ARTIFACTSHARE_CONFIG_HOME = configHome
     process.exitCode = undefined
@@ -87,6 +93,7 @@ test('artifacts get without --json keeps auth_required instead of starting login
       { json: false },
     )
   } finally {
+    process.chdir(previousCwd)
     if (previousToken === undefined) delete process.env.ARTIFACTSHARE_TOKEN
     else process.env.ARTIFACTSHARE_TOKEN = previousToken
     if (previousConfigHome === undefined) {

--- a/packages/cli/src/preview.test.ts
+++ b/packages/cli/src/preview.test.ts
@@ -10,7 +10,7 @@ import {
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, test } from 'vitest'
-import { expectFailure, expectSuccess, run } from './test/helpers.js'
+import { expectFailure, expectSuccess, run, testCwd } from './test/helpers.js'
 import {
   PREVIEW_MUTATION_HEADER,
   PREVIEW_MUTATION_HEADER_VALUE,
@@ -67,6 +67,9 @@ async function startPreview(
     process.execPath,
     [cliPath, 'preview', filePath, '--no-open', '--json', ...extraArgs],
     {
+      // The credential context includes the working directory, so a reuse
+      // check only compares like with like when both start from the same one.
+      cwd: testCwd,
       env: { ...process.env, ...env },
       stdio: ['ignore', 'pipe', 'pipe'],
     },

--- a/packages/cli/src/test/helpers.ts
+++ b/packages/cli/src/test/helpers.ts
@@ -4,7 +4,7 @@ import {
   spawnSync,
   type SpawnSyncReturns,
 } from 'node:child_process'
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, mkdirSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -24,6 +24,12 @@ const defaultConfigHome = join(
   'artifactshare-cli-test-config-missing',
 )
 const defaultHome = join(tmpdir(), 'artifactshare-cli-test-home-missing')
+/** Project config is discovered by walking up from the working directory, so
+ * running from inside this checkout lets a developer's own
+ * `.artifactshare/config.local.json` answer tests that assume no credential.
+ * Every run starts outside the repository unless a test picks its own place. */
+export const testCwd = join(tmpdir(), 'artifactshare-cli-test-cwd')
+mkdirSync(testCwd, { recursive: true })
 
 export function recordCliSubprocessLaunch(): void {
   const path = process.env.ARTIFACTSHARE_TEST_SUBPROCESS_COUNT_FILE
@@ -73,7 +79,7 @@ export function run(
       CI: '',
       ...env,
     },
-    cwd: options.cwd,
+    cwd: options.cwd ?? testCwd,
     input: options.input,
     timeout: 10_000,
   })
@@ -95,7 +101,7 @@ export function runAsync(
         CI: '',
         ...env,
       },
-      cwd: options.cwd,
+      cwd: options.cwd ?? testCwd,
       stdio: ['pipe', 'pipe', 'pipe'],
     })
     let stdout = ''


### PR DESCRIPTION
## Change

CLI tests now run from outside the checkout, so a developer's own project config cannot answer them.

`resolveProjectConfig` finds `.artifactshare/config.local.json` by walking up from the working directory. The test helpers overrode `HOME` and `ARTIFACTSHARE_CONFIG_HOME` but left the working directory alone, so every spawned CLI started inside this repository and the upward walk reached the checkout's own file — the one `init --profile` writes and git-excludes. Tests asserting that no credential resolves then saw `credential_source: local_config` and failed.

The failure only appeared for someone who had run `init` here, and never in CI, where the checkout is clean. That made it easy to keep calling it environmental; it is a gap in test isolation.

`run` and `runAsync` now default the working directory to a directory outside the repository, alongside the `HOME` and config-home overrides they already applied. The one test that calls its runner in process instead of spawning cannot be covered that way, so it changes directory for its duration and restores it afterwards.

`preview.test.ts` spawns the CLI itself rather than through the helper, and inherited the runner's directory. The preview credential context includes the working directory, so a reuse check compared a session started in one directory against a request from another. It now starts from the same directory the helper uses.

## Validation

- `pnpm --filter @artifactshare/cli test` with `.artifactshare/config.local.json` present in the checkout — 535 pass, 1 skipped. The same command failed three tests before this change.
- `pnpm validate:static` — pass (format, lint, typecheck, D1, generated-reference sync, glossary, React Doctor 100, boundary scan).

## Review

Test-isolation fix, verified by reproducing the failure with the local config in place and confirming it is gone with the config still there. The cause was found while investigating three failures that had been dismissed as environmental for most of a working session.
