### PR TITLE
Verify the installed skill against its source

### DIFF
--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -10,6 +10,15 @@ import {
   run,
 } from './test/helpers.js'
 
+/** Install writes the bundled file through unchanged, so comparing against the
+ * source is what actually verifies the install. Asserting its wording here
+ * only restated the source and broke on every edit to the skill. */
+const bundled = (file: 'SKILL.md' | 'artifactshare.mdc') =>
+  readFile(
+    join(import.meta.dirname, '..', 'skills', 'artifactshare', file),
+    'utf8',
+  )
+
 let workDir: string
 let homeDir: string
 
@@ -67,12 +76,7 @@ test('skills install writes managed skill files for each tool', async () => {
     ],
   )
   const codexSkill = await readFile(codexSkillPath(), 'utf8')
-  assert.ok(codexSkill.includes('artifactshare-skill'))
-  assert.ok(codexSkill.includes('version: 36'))
-  assert.ok(codexSkill.includes('npx --yes @artifactshare/cli'))
-  assert.ok(codexSkill.includes('Share, publish, upload, host'))
-  assert.ok(codexSkill.includes('return a browser link'))
-  assert.ok(codexSkill.includes('update the same URL'))
+  assert.equal(codexSkill, await bundled('SKILL.md'))
   assert.ok(codexSkill.includes('as でアップして'))
   assert.ok(codexSkill.includes('as に上げて'))
   assert.ok(codexSkill.includes('bare English "as" alone is not'))
@@ -109,11 +113,7 @@ test('skills install writes managed skill files for each tool', async () => {
   assert.ok(!codexSkill.includes('@artifactshare/cli@'))
   assert.equal(await readFile(claudeSkillPath(), 'utf8'), codexSkill)
   const cursorRule = await readFile(cursorRulePath(), 'utf8')
-  assert.ok(cursorRule.includes('artifactshare-skill'))
-  assert.ok(cursorRule.includes('version: 36'))
-  assert.ok(cursorRule.includes('Share, publish, upload, host'))
-  assert.ok(cursorRule.includes('return a browser link'))
-  assert.ok(cursorRule.includes('update the same URL'))
+  assert.equal(cursorRule, await bundled('artifactshare.mdc'))
   assert.ok(cursorRule.includes('as でアップして'))
   assert.ok(cursorRule.includes('as に上げて'))
   assert.ok(cursorRule.includes('bare English "as" alone is not'))
@@ -167,9 +167,7 @@ test('skills install --tool cursor --scope project writes artifactshare.mdc and 
     [['cursor', 'project', 'installed']],
   )
   const rule = await readFile(cursorRulePath(), 'utf8')
-  assert.ok(rule.includes('artifactshare-skill'))
-  assert.ok(rule.includes('version: 36'))
-  assert.ok(rule.includes('alwaysApply'))
+  assert.equal(rule, await bundled('artifactshare.mdc'))
   assert.ok(!(await pathExists(userCursorSkillPath())))
 
   const removed = expectSuccess(
@@ -192,10 +190,7 @@ test('skills install --tool cursor --scope user writes SKILL.md under home', asy
     [['cursor', 'user', 'installed']],
   )
   const skill = await readFile(userCursorSkillPath(), 'utf8')
-  assert.ok(skill.includes('artifactshare-skill'))
-  assert.ok(skill.includes('version: 36'))
-  assert.ok(skill.includes('Do not use this skill just because'))
-  assert.ok(!skill.includes('alwaysApply'))
+  assert.equal(skill, await bundled('SKILL.md'))
   assert.ok(!(await pathExists(cursorRulePath())))
 })
 


### PR DESCRIPTION
## Change

`skills install` writes the bundled `SKILL.md` and `artifactshare.mdc` through unchanged — there is no templating or substitution. The tests nonetheless asserted a handful of substrings of those files, including the managed `version:` number:

```ts
assert.ok(codexSkill.includes('artifactshare-skill'))
assert.ok(codexSkill.includes('version: 36'))
assert.ok(codexSkill.includes('Share, publish, upload, host'))
assert.ok(codexSkill.includes('return a browser link'))
assert.ok(codexSkill.includes('update the same URL'))
```

Those assertions compared the copy against phrases taken from the same source, so they verified nothing about the install and could not fail unless the source's own wording changed. What they did do was break on every edit to the skill: changing the description to name the preview flow failed four tests in three files, and each release that bumps the version fails them again.

They are replaced by comparing the written file to the bundled source. That is the property install actually has, so it catches a truncated, empty, or wrong-file write — and stays quiet when the skill's text changes. Equality also proves which of the two files landed where, which the `alwaysApply` presence checks were partly standing in for; the assertions that state a policy rather than echo the source (no pinned `@artifactshare/cli@` version, the Cursor user/project split) are kept.

## Validation

- `pnpm validate:cli` — 535 pass, 1 skipped.
- `pnpm validate:static` — pass (React Doctor 100, boundary scan 0 findings).
- Bumped the bundled skill version to 37 locally and confirmed the suite still passes, then restored it to 36. Before this change the same bump failed four assertions.

## Review

Test-quality change with no product behavior. It came out of preparing the 0.12.0 release, where updating the skill description required editing test literals that were not testing anything.
