### PR TITLE
Stabilize viewer list responsive test

### DIFF
--- a/apps/web/app/routes/viewer-list.behavior.browser.test.tsx
+++ b/apps/web/app/routes/viewer-list.behavior.browser.test.tsx
@@ -40,7 +40,17 @@ vi.mock('./a.$id/+hooks/use-edit-title', () => ({
 }))
 
 vi.mock('~/components/app/avatar-menu', () => ({
-  AvatarMenu: () => <button type="button">Account</button>,
+  // Preserve the real viewer trigger's responsive footprint. A text button
+  // here steals width from the adjacent meta row only in this test harness.
+  AvatarMenu: () => (
+    <button
+      type="button"
+      className="max-phone:size-7.5 inline-flex size-6.5 shrink-0 items-center justify-center border-0 p-0"
+      aria-label="Account"
+    >
+      V
+    </button>
+  ),
 }))
 
 vi.mock('~/components/app/analytics-consent-provider', () => ({
@@ -210,6 +220,9 @@ describe('viewer list browser behavior', () => {
   it('keeps the meta segment unclipped at a 390px viewport', async () => {
     await page.viewport(390, 844)
     await renderHarness()
+    // Geometry must be measured against the production typeface, not whichever
+    // fallback happens to render while the webfont is still loading.
+    await document.fonts.ready
     const button = entryButton()
     expect(button.scrollWidth).toBeLessThanOrEqual(button.clientWidth)
     const rect = button.getBoundingClientRect()


### PR DESCRIPTION
## 現状

390px の viewer-list レイアウト検査が Linux CI で不定期に失敗していました。テスト用の AvatarMenu モックだけが電話幅でも横長のテキストボタンを表示し、実際の製品より meta 行を狭めていました。さらに webfont 読み込み前後の文字幅を計測する競合がありました。

## 変更

- AvatarMenu モックの電話幅フットプリントを実コンポーネントと一致させました。
- レイアウト幅の検査前に production typeface の読み込み完了を待つようにしました。
- 製品コードと実際のレスポンシブレイアウトは変更していません。

## 検証

- `pnpm test:behavior-browser` (56 tests)
- Linux/Chromium コンテナで対象テスト (3 tests)
- `pnpm validate:static`
- `pnpm public:scan .`
- trusted `origin/main` からの pull-request boundary guard
- Codex / Claude implementation review: blocker、follow-up なし
