### PR TITLE
Stabilize browser layout assertions

### DIFF
--- a/apps/web/app/lib/csp-reporter.behavior.browser.test.tsx
+++ b/apps/web/app/lib/csp-reporter.behavior.browser.test.tsx
@@ -114,6 +114,7 @@ describe('CSP reporter runtime behavior', () => {
     button.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
     button.click()
     await vi.waitFor(() => expect(copied).toBe('const answer = 42'))
+    await probeReporter()
 
     expect(copied).toBe('const answer = 42')
     expect(button.textContent).toBe('Copied')
@@ -291,6 +292,12 @@ describe('CSP reporter runtime behavior', () => {
     doc
       .querySelector<HTMLElement>('.ash-comment-highlight-badge')!
       .dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    await probeReporter()
+    expect(
+      messages.filter(
+        (message) => message.kind === 'comment-outside-pointer-down',
+      ),
+    ).toHaveLength(0)
 
     doc
       .querySelector('#content')!
@@ -369,6 +376,7 @@ describe('CSP reporter runtime behavior', () => {
     pointer('pointermove', rect.left + 84, rect.top + 44)
     pointer('pointerup', rect.left + 84, rect.top + 44)
     await vi.waitFor(() => expect(badge.style.left).not.toBe(before))
+    await probeReporter()
     expect(badge.style.left).not.toBe(before)
     expect(selected()).toBeUndefined()
   })

--- a/apps/web/app/lib/csp-reporter.behavior.browser.test.tsx
+++ b/apps/web/app/lib/csp-reporter.behavior.browser.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import { VIOLATION_REPORTER_SCRIPT_BODY } from './csp-reporter'
 import { renderMermaidSvg, sanitizeMermaidSvg } from './mermaid-render.client'
@@ -11,6 +11,41 @@ type ReporterMessage = { kind?: string; [key: string]: unknown }
 
 let frame: HTMLIFrameElement | undefined
 let messages: ReporterMessage[] = []
+let probeSequence = 0
+
+async function waitForMessage(
+  kind: string,
+  predicate: (message: ReporterMessage) => boolean = () => true,
+  fromIndex = 0,
+) {
+  return vi.waitFor(() => {
+    const message = messages
+      .slice(fromIndex)
+      .find((candidate) => candidate.kind === kind && predicate(candidate))
+    expect(message).toBeDefined()
+    return message!
+  })
+}
+
+async function probeReporter(challenge?: string) {
+  const probe = challenge ?? `browser-test-probe-${probeSequence++}`
+  const firstResponseIndex = messages.length
+  frame!.contentWindow!.postMessage(
+    {
+      source: 'artifactshare-parent',
+      kind: 'ready-check',
+      challenge: probe,
+      textAnchorsEnabled: true,
+    },
+    '*',
+  )
+  await waitForMessage(
+    'ready',
+    (message) =>
+      message.challenge === probe && typeof message.token === 'string',
+    firstResponseIndex,
+  )
+}
 
 async function fixture(
   body = '<a id="normal" href="?artifact-link=1">Normal link</a><a id="target" href="?artifact-link=1">Highlighted text</a>',
@@ -23,7 +58,7 @@ async function fixture(
   await new Promise<void>((resolve) =>
     frame?.addEventListener('load', () => resolve(), { once: true }),
   )
-  await new Promise((resolve) => setTimeout(resolve, 20))
+  await probeReporter()
   return frame.contentDocument!
 }
 
@@ -41,7 +76,12 @@ async function applyHighlights(highlights: unknown[]) {
     },
     '*',
   )
-  await new Promise((resolve) => setTimeout(resolve, 30))
+  await probeReporter()
+  await vi.waitFor(() =>
+    expect(
+      frame!.contentDocument!.querySelectorAll('.ash-comment-highlight'),
+    ).toHaveLength(highlights.length),
+  )
 }
 
 function selected() {
@@ -73,7 +113,7 @@ describe('CSP reporter runtime behavior', () => {
     const button = doc.querySelector<HTMLButtonElement>('[data-code-copy]')!
     button.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
     button.click()
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await vi.waitFor(() => expect(copied).toBe('const answer = 42'))
 
     expect(copied).toBe('const answer = 42')
     expect(button.textContent).toBe('Copied')
@@ -122,10 +162,7 @@ describe('CSP reporter runtime behavior', () => {
       },
       '*',
     )
-    await new Promise((resolve) => setTimeout(resolve, 20))
-    const request = messages.find(
-      (message) => message.kind === 'mermaid-render-request',
-    ) as
+    const request = (await waitForMessage('mermaid-render-request')) as
       | {
           renderToken?: string
           diagrams?: Array<{ id: string; source: string }>
@@ -146,7 +183,7 @@ describe('CSP reporter runtime behavior', () => {
       },
       '*',
     )
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await probeReporter(request!.renderToken)
     expect(doc.querySelector('.mermaid-diagram')).toBeNull()
 
     frame!.contentWindow!.postMessage(
@@ -158,7 +195,9 @@ describe('CSP reporter runtime behavior', () => {
       },
       '*',
     )
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await vi.waitFor(() =>
+      expect(doc.querySelector('.mermaid-diagram svg')).not.toBeNull(),
+    )
 
     expect(doc.querySelector('.mermaid-diagram svg')).not.toBeNull()
     expect(doc.querySelector('pre')?.hidden).toBe(true)
@@ -216,7 +255,10 @@ describe('CSP reporter runtime behavior', () => {
     expect(doc.activeElement).toBe(badge)
     messages = []
     await userEvent.keyboard('{Enter}')
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await waitForMessage(
+      'comment-thread-selected',
+      (message) => message.threadId === 'thread-1',
+    )
     expect(selected()?.threadId).toBe('thread-1')
   })
 
@@ -232,7 +274,7 @@ describe('CSP reporter runtime behavior', () => {
       messages.filter((message) => message.kind === 'link-clicked'),
     ).toHaveLength(0)
     await reporter.getByText('Normal link', { exact: true }).click()
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await waitForMessage('link-clicked')
     expect(
       messages.filter((message) => message.kind === 'link-clicked'),
     ).toHaveLength(1)
@@ -249,17 +291,11 @@ describe('CSP reporter runtime behavior', () => {
     doc
       .querySelector<HTMLElement>('.ash-comment-highlight-badge')!
       .dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
-    await new Promise((resolve) => setTimeout(resolve, 10))
-    expect(
-      messages.filter(
-        (message) => message.kind === 'comment-outside-pointer-down',
-      ),
-    ).toHaveLength(0)
 
     doc
       .querySelector('#content')!
       .dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await waitForMessage('comment-outside-pointer-down')
     expect(
       messages.filter(
         (message) => message.kind === 'comment-outside-pointer-down',
@@ -332,7 +368,7 @@ describe('CSP reporter runtime behavior', () => {
     pointer('pointerdown', rect.left + 4, rect.top + 4)
     pointer('pointermove', rect.left + 84, rect.top + 44)
     pointer('pointerup', rect.left + 84, rect.top + 44)
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await vi.waitFor(() => expect(badge.style.left).not.toBe(before))
     expect(badge.style.left).not.toBe(before)
     expect(selected()).toBeUndefined()
   })

--- a/apps/web/app/routes/_home/file-row-home-compact.behavior.browser.test.tsx
+++ b/apps/web/app/routes/_home/file-row-home-compact.behavior.browser.test.tsx
@@ -5,6 +5,7 @@ import { page } from 'vitest/browser'
 import { FileRow } from './+components/file-row'
 import type { FileRowData } from './+components/file-data'
 import { fileDateHeadingClassName } from './+components/file-list-styles'
+import { waitForBrowserLayout } from '~/test/browser-layout'
 import '~/app.css'
 
 vi.mock('~/hooks/use-t', () => ({
@@ -94,6 +95,7 @@ async function mount(
   await vi.waitFor(() =>
     expect(host.querySelector('a[aria-label]')).not.toBeNull(),
   )
+  await waitForBrowserLayout()
   return { host, row: host.firstElementChild as HTMLElement }
 }
 

--- a/apps/web/app/routes/_home/file-row-menu.behavior.browser.test.tsx
+++ b/apps/web/app/routes/_home/file-row-menu.behavior.browser.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { createRoot, type Root } from 'react-dom/client'
 import { FileRowMenu } from './+components/file-row-menu'
+import { waitForBrowserLayout } from '~/test/browser-layout'
 import '~/app.css'
 
 vi.mock('~/hooks/use-t', () => ({
@@ -53,6 +54,7 @@ describe('FileRowMenu browser structure', () => {
       expect(found).toHaveLength(5)
       return found
     })
+    await waitForBrowserLayout()
     expect(items.map((item) => item.textContent?.trim())).toEqual([
       'リンクをコピー',
       '名前を変更',

--- a/apps/web/app/routes/_home/files-recent-structure.behavior.browser.test.tsx
+++ b/apps/web/app/routes/_home/files-recent-structure.behavior.browser.test.tsx
@@ -13,6 +13,8 @@ import type { FileRowData } from './+components/file-data'
 import { fileDateHeadingClassName } from './+components/file-list-styles'
 import { RecentContent } from './+components/recent-content'
 import Files from './_protected/files'
+import { listMainClassName } from '~/components/app/page-shell-styles'
+import { waitForBrowserLayout } from '~/test/browser-layout'
 import '~/app.css'
 
 type FilesTestProps = {
@@ -77,8 +79,13 @@ async function mount(
   return mountRoute(<FileRow data={data} {...props} />)
 }
 
-async function mountRoute(element: ReactNode, parent?: ReactNode) {
+async function mountRoute(
+  element: ReactNode,
+  parent?: ReactNode,
+  productionShell = false,
+) {
   const host = document.createElement('div')
+  if (productionShell) host.className = listMainClassName
   document.body.appendChild(host)
   root = createRoot(host)
   const routes: RouteObject[] = parent
@@ -87,6 +94,7 @@ async function mountRoute(element: ReactNode, parent?: ReactNode) {
   router = createMemoryRouter(routes, { initialEntries: ['/'] })
   root.render(<RouterProvider router={router} />)
   await vi.waitFor(() => expect(host.firstElementChild).not.toBeNull())
+  await waitForBrowserLayout()
   return host
 }
 
@@ -132,6 +140,7 @@ test('rows keep short visibility vocabulary, owner/activity/location order, and 
   expect(getComputedStyle(heading).backgroundColor).toBe('rgba(0, 0, 0, 0)')
   expect(heading.className).not.toContain('border-')
   await page.viewport(390, 844)
+  await waitForBrowserLayout()
   expect(getComputedStyle(preview!).flexDirection).toBe('column')
   expect(preview?.getBoundingClientRect().right).toBeLessThanOrEqual(
     host.getBoundingClientRect().right,
@@ -201,7 +210,7 @@ test('files and recent use the current page chrome', async () => {
       loaderData={{ files: [data], total: 1, page: 1, query: '' }}
     />
   )
-  let host = await mountRoute(files, <Outlet context={layout} />)
+  let host = await mountRoute(files, <Outlet context={layout} />, true)
   const columnHeader = () =>
     [...host.querySelectorAll<HTMLElement>('[aria-hidden="true"]')].find(
       (node) =>
@@ -215,6 +224,8 @@ test('files and recent use the current page chrome', async () => {
   expect(columnHeader()).toBeUndefined()
   expect(host.textContent).toContain(longProject)
   await page.viewport(390, 844)
+  await waitForBrowserLayout()
+  expect(host.scrollWidth).toBeLessThanOrEqual(host.clientWidth)
   expect(
     [...host.querySelectorAll('span')].filter(
       (node) => node.textContent === 'Owner' && node.offsetParent !== null,
@@ -236,7 +247,7 @@ test('files and recent use the current page chrome', async () => {
     />
   )
   await page.viewport(1440, 900)
-  host = await mountRoute(recent)
+  host = await mountRoute(recent, undefined, true)
   expect(host.querySelector('input[type="search"]')).toBeNull()
   expect(host.textContent).not.toContain(
     'Review recently opened files with their project context.',

--- a/apps/web/app/routes/_home/index.layout.behavior.browser.test.tsx
+++ b/apps/web/app/routes/_home/index.layout.behavior.browser.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { page } from 'vitest/browser'
 import { listMainClassName } from '~/components/app/page-shell-styles'
+import { waitForBrowserLayout } from '~/test/browser-layout'
 import '~/app.css'
 import Home from './index'
 import Files from './_protected/files'
@@ -57,10 +58,6 @@ vi.mock('~/components/app/page-breadcrumb', () => ({
 vi.mock('~/components/app/app-more-link', () => ({
   AppMoreLink: ({ children, to }: { children: ReactNode; to: string }) =>
     createElement('a', { href: to }, children),
-}))
-
-vi.mock('./+components/home-rail', () => ({
-  HomeRail: () => createElement('aside', { 'data-testid': 'rail' }),
 }))
 
 vi.mock('./+components/file-row-dialogs', () => ({
@@ -122,6 +119,16 @@ const recentFile: FileRowData = {
   modifiedTime: '2026-01-01T00:00:00.000Z',
 }
 
+const railFile: FileRowData = {
+  ...recentFile,
+  id: 'rail-file',
+  fileName: 'rail-file.html',
+  derivedTitle:
+    'A deliberately long rail title that must remain inside the production column',
+  viewCount: 123,
+  commentCount: 45,
+}
+
 afterEach(() => {
   root?.unmount()
   root = undefined
@@ -138,6 +145,7 @@ async function mount(element: ReactNode) {
     createElement(MemoryRouter, { initialEntries: ['/'] }, element) as never,
   )
   await vi.waitFor(() => expect(host.querySelector('h1')).not.toBeNull())
+  await waitForBrowserLayout()
   return {
     heading: host.querySelector('h1')!.getBoundingClientRect(),
     shellPadding: getComputedStyle(host).padding,
@@ -149,8 +157,17 @@ function home(rows: FileRowData[] = []) {
     loaderData: {
       signedIn: true,
       rail: {
-        files: [],
-        projects: [],
+        files: [railFile],
+        projects: [
+          {
+            id: 'rail-project',
+            name: 'A deliberately long project name for the Home rail',
+            joined: true,
+            fileCount: 123,
+            newCount: 100,
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
         errors: { files: false, projects: false },
       },
       recent: {
@@ -186,20 +203,33 @@ describe('home page shell spacing', () => {
     expect(getComputedStyle(dateCell).display).not.toBe('none')
     expect(getComputedStyle(title).whiteSpace).toBe('nowrap')
     expect(getComputedStyle(row).gridTemplateColumns.split(' ')).toHaveLength(3)
+    const rail = document.querySelector<HTMLElement>('aside')!
+    const grid = rail.parentElement!
+    expect(rail.textContent).toContain('A deliberately long rail title')
+    expect(grid.scrollWidth).toBeLessThanOrEqual(grid.clientWidth)
+    expect(getComputedStyle(grid).gridTemplateColumns.split(' ')).toHaveLength(
+      1,
+    )
 
     await page.viewport(1440, 900)
+    await waitForBrowserLayout()
     await vi.waitFor(() =>
       expect(getComputedStyle(row).gridTemplateColumns.split(' ')).toHaveLength(
         5,
       ),
     )
     expect(dateCell.textContent).toContain('Thu, Jan 1')
+    expect(getComputedStyle(grid).gridTemplateColumns.split(' ')).toHaveLength(
+      2,
+    )
+    expect(rail.getBoundingClientRect().width).toBe(300)
+    expect(grid.scrollWidth).toBeLessThanOrEqual(grid.clientWidth)
   })
 
   test('renders an empty home without the retired feed', async () => {
     await mount(home())
 
-    const rail = document.querySelector('[data-testid="rail"]')
+    const rail = document.querySelector('aside')
     expect(rail).not.toBeNull()
     expect(document.querySelector('[data-testid="feed"]')).toBeNull()
     expect(rail?.parentElement?.classList.contains('grid')).toBe(true)
@@ -220,8 +250,7 @@ describe('home page shell spacing', () => {
     ).toBeNull()
     expect(document.querySelectorAll('h1')).toHaveLength(1)
 
-    const grid = document.querySelector('[data-testid="rail"]')
-      ?.parentElement as HTMLElement
+    const grid = document.querySelector('aside')?.parentElement as HTMLElement
 
     expect(grid.classList.contains('grid')).toBe(true)
     expect(getComputedStyle(grid).padding).toBe('0px')

--- a/apps/web/app/routes/_home/projects-structure.behavior.browser.test.tsx
+++ b/apps/web/app/routes/_home/projects-structure.behavior.browser.test.tsx
@@ -4,6 +4,8 @@ import type { ReactNode } from 'react'
 import { page } from 'vitest/browser'
 import { createMemoryRouter, RouterProvider } from 'react-router'
 import ProjectsIndex from './_protected/projects'
+import { listMainClassName } from '~/components/app/page-shell-styles'
+import { waitForBrowserLayout } from '~/test/browser-layout'
 import '~/app.css'
 
 const submitMock = vi.hoisted(() => vi.fn())
@@ -123,8 +125,14 @@ afterEach(() => {
   document.body.replaceChildren()
 })
 
-async function mount(loaderData: Record<string, unknown>, initialEntry = '/') {
+async function mount(
+  loaderData: Record<string, unknown>,
+  initialEntry = '/',
+  viewport: [number, number] = [1440, 900],
+) {
+  await page.viewport(...viewport)
   const host = document.createElement('div')
+  host.className = listMainClassName
   document.body.appendChild(host)
   root = createRoot(host)
   router = createMemoryRouter(
@@ -138,6 +146,7 @@ async function mount(loaderData: Record<string, unknown>, initialEntry = '/') {
   )
   root.render(<RouterProvider router={router} />)
   await vi.waitFor(() => expect(host.querySelector('nav')).not.toBeNull())
+  await waitForBrowserLayout()
   return host
 }
 
@@ -249,19 +258,23 @@ describe('projects structure', () => {
       'Long project name that wraps to three lines on mobile screens'
     const joinableName =
       'Joinable project with a deliberately long name for mobile wrapping'
-    const host = await mount({
-      sharedProjects: [],
-      rows: [
-        row({ id: 'long-joined', name: joinedName, newCount: 1 }),
-        row({
-          id: 'long-joinable',
-          name: joinableName,
-          description:
-            'A deliberately long joinable project description keeps the Join button beside a realistic multi-line row on narrow screens.',
-          joined: false,
-        }),
-      ],
-    })
+    const host = await mount(
+      {
+        sharedProjects: [],
+        rows: [
+          row({ id: 'long-joined', name: joinedName, newCount: 1 }),
+          row({
+            id: 'long-joinable',
+            name: joinableName,
+            description:
+              'A deliberately long joinable project description keeps the Join button beside a realistic multi-line row on narrow screens.',
+            joined: false,
+          }),
+        ],
+      },
+      '/',
+      [390, 844],
+    )
 
     for (const name of [joinedName, joinableName]) {
       const link = host.querySelector<HTMLElement>(`a[aria-label="${name}"]`)

--- a/apps/web/app/routes/_home/recent-content.behavior.browser.test.tsx
+++ b/apps/web/app/routes/_home/recent-content.behavior.browser.test.tsx
@@ -4,6 +4,7 @@ import { createMemoryRouter, RouterProvider } from 'react-router'
 import { page } from 'vitest/browser'
 import { FileRow } from './+components/file-row'
 import type { FileRowData } from './+components/file-data'
+import { waitForBrowserLayout } from '~/test/browser-layout'
 import '~/app.css'
 
 const file = (overrides: Partial<FileRowData> = {}): FileRowData => ({
@@ -90,6 +91,7 @@ describe('FileRow unread browser structure', () => {
     expect(getComputedStyle(mobileMeta).display).toBe('none')
 
     await page.viewport(390, 844)
+    await waitForBrowserLayout()
     expect(getComputedStyle(desktopMotion).display).toBe('none')
     expect(getComputedStyle(mobileMeta).display).toBe('grid')
     expect(getComputedStyle(mobileMotion).display).not.toBe('none')

--- a/apps/web/app/routes/_home/topbar.behavior.browser.test.tsx
+++ b/apps/web/app/routes/_home/topbar.behavior.browser.test.tsx
@@ -3,6 +3,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter, useLocation } from 'react-router'
 import { page, userEvent } from 'vitest/browser'
 import { ProjectsDropdown } from './+components/projects-dropdown'
+import { waitForBrowserLayout } from '~/test/browser-layout'
 import '~/app.css'
 
 vi.mock('~/hooks/use-t', () => ({
@@ -195,6 +196,7 @@ describe('Topbar project dropdown behavior', () => {
     await page.viewport(640, 800)
     const host = await mount()
     await openWithClick()
+    await waitForBrowserLayout()
 
     for (const project of projects) {
       const link = document.querySelector<HTMLAnchorElement>(

--- a/apps/web/app/routes/viewer-list.behavior.browser.test.tsx
+++ b/apps/web/app/routes/viewer-list.behavior.browser.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 import '~/app.css'
 import { TooltipProvider } from '~/components/ui/tooltip'
+import { waitForBrowserLayout } from '~/test/browser-layout'
 import { ViewerChrome } from './a.$id/+components/viewer-chrome'
 import { ViewerListPanel } from './a.$id/+components/viewer-list-panel'
 import {
@@ -220,9 +221,7 @@ describe('viewer list browser behavior', () => {
   it('keeps the meta segment unclipped at a 390px viewport', async () => {
     await page.viewport(390, 844)
     await renderHarness()
-    // Geometry must be measured against the production typeface, not whichever
-    // fallback happens to render while the webfont is still loading.
-    await document.fonts.ready
+    await waitForBrowserLayout()
     const button = entryButton()
     expect(button.scrollWidth).toBeLessThanOrEqual(button.clientWidth)
     const rect = button.getBoundingClientRect()
@@ -233,6 +232,7 @@ describe('viewer list browser behavior', () => {
   it('never leaves the owner separator as an orphan at a 390px viewport', async () => {
     await page.viewport(390, 844)
     await renderHarness()
+    await waitForBrowserLayout()
     const segment = container.querySelector<HTMLElement>(
       '[data-viewer-owner-segment]',
     )

--- a/apps/web/app/test/browser-layout.ts
+++ b/apps/web/app/test/browser-layout.ts
@@ -1,0 +1,4 @@
+export async function waitForBrowserLayout() {
+  await document.fonts.ready
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+}


### PR DESCRIPTION
## Summary

- wait for web fonts and the next animation frame before browser geometry assertions
- run responsive route tests at explicit viewport sizes inside the production list shell
- replace fixed CSP reporter sleeps with observable message and DOM conditions
- exercise the real Home rail with representative content at desktop and mobile widths

## Validation

- `pnpm test:behavior-browser` (56 passed)
- `pnpm validate:static`
- Codex and Claude implementation reviews (no unresolved findings)
- trusted `origin/main` public development guard
