### PR TITLE
Allow external media in artifact viewers

### DIFF
--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -863,9 +863,12 @@ describe('handleArtifactSandboxRequest', () => {
     expect(response.headers.get('Content-Security-Policy')).toContain(
       "font-src 'self' data: https://fonts.gstatic.com",
     )
-    expect(response.headers.get('Content-Security-Policy')).toContain(
-      "media-src 'self'",
-    )
+    expect(
+      cspDirective(
+        response.headers.get('Content-Security-Policy') ?? '',
+        'media-src',
+      ),
+    ).toBe("media-src 'self' https: data: blob:")
     expect(storageMock.getArtifact).toHaveBeenCalledWith(
       {},
       'ws-a/abc123def4/v-bundle/index.html',
@@ -1714,6 +1717,9 @@ describe('handleArtifactSandboxRequest', () => {
     )
     expect(cspDirective(csp, 'script-src')).toBe(
       `script-src 'unsafe-inline' 'unsafe-eval' ${externalCspSources}`,
+    )
+    expect(cspDirective(csp, 'media-src')).toBe(
+      "media-src 'self' https: data: blob:",
     )
     expect(cspDirective(csp, 'connect-src')?.slice('connect-src '.length)).toBe(
       cspDirective(csp, 'script-src')?.slice(

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -49,6 +49,7 @@ const EXTERNAL_SCRIPT_CSP_SOURCES =
   'https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com https://esm.sh https://cdn.tailwindcss.com'
 const YOUTUBE_FRAME_CSP_SOURCES =
   'https://www.youtube-nocookie.com https://www.youtube.com'
+const MEDIA_CSP_SOURCES = "'self' https: data: blob:"
 const ENCODER = new TextEncoder()
 const DECODER = new TextDecoder()
 
@@ -665,6 +666,7 @@ function artifactCsp(renderType: ArtifactType, embed = false): string {
             "style-src 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com https://fonts.googleapis.com",
             "img-src 'self' data: https: blob:",
             "font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net",
+            `media-src ${MEDIA_CSP_SOURCES}`,
             `connect-src ${EXTERNAL_SCRIPT_CSP_SOURCES}`,
             `frame-src ${YOUTUBE_FRAME_CSP_SOURCES}`,
           ]
@@ -676,7 +678,7 @@ function artifactCsp(renderType: ArtifactType, embed = false): string {
             "style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com",
             "img-src 'self' data: blob:",
             "font-src 'self' data: https://fonts.gstatic.com",
-            "media-src 'self'",
+            `media-src ${MEDIA_CSP_SOURCES}`,
             `connect-src 'self' ${EXTERNAL_SCRIPT_CSP_SOURCES}`,
             `frame-src ${YOUTUBE_FRAME_CSP_SOURCES}`,
           ]


### PR DESCRIPTION
## Summary

- allow HTML and static-site artifacts to load media from the same supported sources
- support same-origin, HTTPS, data, and blob audio, video, and text-track resources
- keep Markdown's existing iframe-only media behavior unchanged

## Validation

- `pnpm --filter @artifactshare/web exec vitest --config vitest.config.ts --run workers/bundle-sandbox.test.ts`
- `pnpm --filter @artifactshare/web typecheck`
- `pnpm public:scan .`
- `pnpm validate:static`
- trusted-main public development guard
- Codex implementation review: no findings
- Claude implementation review: no findings
