### PR TITLE
Release CLI 0.13.0

### DIFF
--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "package_version": "0.12.0",
+  "package_version": "0.13.0",
   "commands": [
     {
       "path": "",
@@ -788,5 +788,5 @@
       ]
     }
   ],
-  "generated_date": "2026-08-29"
+  "generated_date": "2026-08-30"
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ For user-facing announcements, see https://artifactshare.com/updates?product=cli
 
 ## Unreleased
 
+## 0.13.0 - 2026-08-30
+
 - Continue local preview work in a managed Cursor ACP conversation, restoring
   its session after a bridge restart and preserving batches while it is busy
   or unavailable. The attended launcher asks before granting Cursor tool

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artifactshare/cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Upload and share HTML, Markdown, folders, and static sites from terminals, AI agents, automation, and CI.",
   "homepage": "https://artifactshare.com/connect",
   "repository": {


### PR DESCRIPTION
## What changed

- Bump `@artifactshare/cli` from 0.12.0 to 0.13.0.
- Move the preview agent-continuation changes into the 0.13.0 changelog section.
- Regenerate the published CLI reference metadata for 0.13.0.

## Validation

- `pnpm check:cli-release`
- `pnpm --filter @artifactshare/cli typecheck`
- `pnpm --filter @artifactshare/cli test` (574 passed, 1 skipped)
- `pnpm check:cli-reference`
- `pnpm validate:static`
- Packed CLI reports `artifactshare v0.13.0`
- npm confirms 0.13.0 is unpublished
- Codex and Claude implementation reviews: no findings
- Public development boundary guard
