### PR TITLE
Restore direct npx CLI invocation

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,10 @@ For user-facing announcements, see https://artifactshare.com/updates?product=cli
 
 ## Unreleased
 
+- Restore direct `npx @artifactshare/cli ...` invocation after adding the
+  Cursor preview executable by exposing `cli` as an alias of the main
+  `artifactshare` entrypoint.
+
 ## 0.13.0 - 2026-08-30
 
 - Continue local preview work in a managed Cursor ACP conversation, restoring

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
   "type": "module",
   "sideEffects": false,
   "bin": {
+    "cli": "./dist/index.js",
     "artifactshare": "./dist/index.js",
     "artifactshare-preview-cursor": "./dist/cursor-acp-entry.js"
   },

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -25,6 +25,21 @@ test('--version prints package.json version', async () => {
   assert.ok(result.stdout.includes(pkg.version))
 })
 
+test('package exposes an npm-inferable cli bin alongside named entrypoints', async () => {
+  const pkg = JSON.parse(
+    await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+  ) as {
+    bin: Record<string, string>
+  }
+
+  assert.equal(pkg.bin.cli, './dist/index.js')
+  assert.equal(pkg.bin.artifactshare, pkg.bin.cli)
+  assert.equal(
+    pkg.bin['artifactshare-preview-cursor'],
+    './dist/cursor-acp-entry.js',
+  )
+})
+
 test('--version works when launched via symlink (bin entrypoint)', async () => {
   const pkg = JSON.parse(
     await readFile(new URL('../package.json', import.meta.url), 'utf8'),


### PR DESCRIPTION
## Summary

- restore direct `npx @artifactshare/cli ...` invocation after the CLI gained a second executable
- expose `cli` as an alias of the existing main `artifactshare` entrypoint so npm can infer the scoped package's executable
- preserve the named `artifactshare` and `artifactshare-preview-cursor` entrypoints

## Validation

- `pnpm --filter @artifactshare/cli test` (575 passed, 1 skipped)
- packed the CLI, installed the tarball in an empty consumer project, and ran `npx --no-install @artifactshare/cli --version`
- `pnpm --filter @artifactshare/cli typecheck`
- `pnpm check:cli-changelog`
- `pnpm public:scan .`
- `pnpm validate:static`
- Codex and Claude implementation reviews: no blockers or follow-ups
