### PR TITLE
Prepare CLI 0.13.1

### DIFF
--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "package_version": "0.13.0",
+  "package_version": "0.13.1",
   "commands": [
     {
       "path": "",
@@ -81,7 +81,11 @@
     {
       "path": "changelog",
       "usage": "artifactshare changelog <OPTIONS>",
-      "options": ["--help", "--version", "--json"]
+      "options": [
+        "--help",
+        "--version",
+        "--json"
+      ]
     },
     {
       "path": "comments",

--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -81,11 +81,7 @@
     {
       "path": "changelog",
       "usage": "artifactshare changelog <OPTIONS>",
-      "options": [
-        "--help",
-        "--version",
-        "--json"
-      ]
+      "options": ["--help", "--version", "--json"]
     },
     {
       "path": "comments",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ For user-facing announcements, see https://artifactshare.com/updates?product=cli
 
 ## Unreleased
 
+## 0.13.1 - 2026-08-30
+
 - Restore direct `npx @artifactshare/cli ...` invocation after adding the
   Cursor preview executable by exposing `cli` as an alias of the main
   `artifactshare` entrypoint.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artifactshare/cli",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Upload and share HTML, Markdown, folders, and static sites from terminals, AI agents, automation, and CI.",
   "homepage": "https://artifactshare.com/connect",
   "repository": {


### PR DESCRIPTION
## Summary

- prepare `@artifactshare/cli` 0.13.1 with the direct `npx @artifactshare/cli ...` invocation fix already merged to `main`
- align the package version, changelog section, and generated CLI reference surface

## Validation

- `pnpm --filter @artifactshare/cli test` (575 passed, 1 skipped)
- packed the CLI, installed the tarball in an empty consumer project, and ran `npx --no-install @artifactshare/cli --version`
- `pnpm --filter @artifactshare/cli typecheck`
- `pnpm check:cli-release`
- `pnpm check:cli-reference`
- `pnpm public:scan .`
- `pnpm validate:static`
- Codex and Claude implementation reviews: no blockers or follow-ups
