### PR TITLE
Stop viewer recovery from looping indefinitely

### DIFF
--- a/apps/web/app/i18n/en.json
+++ b/apps/web/app/i18n/en.json
@@ -1256,7 +1256,7 @@
   "vw.sandboxBlocked.company": "Using a company network?",
   "vw.sandboxBlocked.admin": "Ask your IT administrator to allow HTTPS connections to artifactshare.com and *.sandbox.artifactshare.com. The second domain securely isolates and displays file content.",
   "vw.sandboxPaused.title": "Display paused",
-  "vw.sandboxPaused.body": "For your security, we paused the display after a period of inactivity.",
+  "vw.sandboxPaused.body": "The display did not finish loading, so we paused it.",
   "vw.sandboxPaused.reassurance": "The file and share link are unaffected",
   "vw.sandboxPaused.resume": "Continue viewing",
   "vw.sandboxPaused.next": "You can resume right away.",

--- a/apps/web/app/i18n/en.json
+++ b/apps/web/app/i18n/en.json
@@ -1260,6 +1260,7 @@
   "vw.sandboxPaused.reassurance": "The file and share link are unaffected",
   "vw.sandboxPaused.resume": "Continue viewing",
   "vw.sandboxPaused.next": "You can resume right away.",
+  "vw.sandboxPaused.retryFailed": "The last attempt did not finish. Try again or reload the page.",
   "vw.sandboxResuming": "Resuming display…",
   "project.pinMenu": "Pin menu",
   "project.fileMenu": "File menu",

--- a/apps/web/app/i18n/ja.json
+++ b/apps/web/app/i18n/ja.json
@@ -1256,7 +1256,7 @@
   "vw.sandboxBlocked.company": "社内ネットワークで利用する場合",
   "vw.sandboxBlocked.admin": "IT 管理者へ、artifactshare.com と *.sandbox.artifactshare.com への HTTPS 通信の許可を依頼してください。後者はファイルの内容を隔離して表示するための配信用ドメインです。",
   "vw.sandboxPaused.title": "表示を一時停止しています",
-  "vw.sandboxPaused.body": "しばらく操作がなかったため、安全のために表示を止めました。",
+  "vw.sandboxPaused.body": "読み込みを完了できなかったため、表示を一時停止しました。",
   "vw.sandboxPaused.reassurance": "ファイルと共有リンクに問題はありません",
   "vw.sandboxPaused.resume": "続きを表示",
   "vw.sandboxPaused.next": "すぐに表示を再開できます。",

--- a/apps/web/app/i18n/ja.json
+++ b/apps/web/app/i18n/ja.json
@@ -1260,6 +1260,7 @@
   "vw.sandboxPaused.reassurance": "ファイルと共有リンクに問題はありません",
   "vw.sandboxPaused.resume": "続きを表示",
   "vw.sandboxPaused.next": "すぐに表示を再開できます。",
+  "vw.sandboxPaused.retryFailed": "直前の再開処理を完了できませんでした。もう一度試すか、ページを再読み込みしてください。",
   "vw.sandboxResuming": "表示を再開しています…",
   "project.pinMenu": "ピン留めメニュー",
   "project.fileMenu": "ファイルメニュー",

--- a/apps/web/app/lib/sandbox-frame-state.test.ts
+++ b/apps/web/app/lib/sandbox-frame-state.test.ts
@@ -26,6 +26,7 @@ describe('sandbox frame transitions', () => {
         'The file and share link are unaffected',
         'Continue viewing',
         'You can resume right away.',
+        'The last attempt did not finish. Try again or reload the page.',
         'Resuming display…',
       ],
       ja: [
@@ -41,6 +42,7 @@ describe('sandbox frame transitions', () => {
         'ファイルと共有リンクに問題はありません',
         '続きを表示',
         'すぐに表示を再開できます。',
+        '直前の再開処理を完了できませんでした。もう一度試すか、ページを再読み込みしてください。',
         '表示を再開しています…',
       ],
     }
@@ -57,11 +59,12 @@ describe('sandbox frame transitions', () => {
       'reassurance',
       'resume',
       'next',
+      'retryFailed',
       'resuming',
     ]
     const lookup = (catalog: typeof en) =>
       keys.map((key, index) =>
-        index === 12
+        index === 13
           ? catalog['vw.sandboxResuming']
           : catalog[
               `vw.sandbox${index < 7 ? 'Blocked' : 'Paused'}.${key}` as keyof typeof catalog

--- a/apps/web/app/lib/sandbox-frame-state.test.ts
+++ b/apps/web/app/lib/sandbox-frame-state.test.ts
@@ -5,6 +5,7 @@ import {
   classifySandboxProbeResponse,
   shouldAcceptNavigationResult,
   shouldReportBlock,
+  shouldAttemptAutomaticRecovery,
   shouldStartLivenessCheck,
   shouldStartLivenessProbe,
 } from './sandbox-frame-state'
@@ -21,7 +22,7 @@ describe('sandbox frame transitions', () => {
         'Using a company network?',
         'Ask your IT administrator to allow HTTPS connections to artifactshare.com and *.sandbox.artifactshare.com. The second domain securely isolates and displays file content.',
         'Display paused',
-        'For your security, we paused the display after a period of inactivity.',
+        'The display did not finish loading, so we paused it.',
         'The file and share link are unaffected',
         'Continue viewing',
         'You can resume right away.',
@@ -36,7 +37,7 @@ describe('sandbox frame transitions', () => {
         '社内ネットワークで利用する場合',
         'IT 管理者へ、artifactshare.com と *.sandbox.artifactshare.com への HTTPS 通信の許可を依頼してください。後者はファイルの内容を隔離して表示するための配信用ドメインです。',
         '表示を一時停止しています',
-        'しばらく操作がなかったため、安全のために表示を止めました。',
+        '読み込みを完了できなかったため、表示を一時停止しました。',
         'ファイルと共有リンクに問題はありません',
         '続きを表示',
         'すぐに表示を再開できます。',
@@ -95,9 +96,15 @@ describe('sandbox frame transitions', () => {
       'forbidden',
     )
   })
-  test('hidden visibility does nothing; pageshow always checks', () => {
+  test('checks visible resumes and persisted pageshow only', () => {
     expect(shouldStartLivenessCheck('visibilitychange', 'hidden')).toBe(false)
     expect(shouldStartLivenessCheck('visibilitychange', 'visible')).toBe(true)
-    expect(shouldStartLivenessCheck('pageshow', 'hidden')).toBe(true)
+    expect(shouldStartLivenessCheck('pageshow', 'hidden', true)).toBe(false)
+    expect(shouldStartLivenessCheck('pageshow', 'visible', false)).toBe(false)
+    expect(shouldStartLivenessCheck('pageshow', 'visible', true)).toBe(true)
+  })
+  test('bounds automatic recovery attempts', () => {
+    expect(shouldAttemptAutomaticRecovery(0, 1)).toBe(true)
+    expect(shouldAttemptAutomaticRecovery(1, 1)).toBe(false)
   })
 })

--- a/apps/web/app/lib/sandbox-frame-state.ts
+++ b/apps/web/app/lib/sandbox-frame-state.ts
@@ -1,8 +1,17 @@
 export function shouldStartLivenessCheck(
   event: 'visibilitychange' | 'pageshow',
   visibilityState: DocumentVisibilityState,
+  pageShowPersisted = false,
 ): boolean {
-  return event === 'pageshow' || visibilityState === 'visible'
+  if (visibilityState !== 'visible') return false
+  return event === 'visibilitychange' || pageShowPersisted
+}
+
+export function shouldAttemptAutomaticRecovery(
+  completedAttempts: number,
+  attemptLimit: number,
+): boolean {
+  return completedAttempts < attemptLimit
 }
 
 export function shouldStartLivenessProbe(

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -244,10 +244,11 @@ function SandboxState({
                 size="sm"
                 ref={controller.primaryActionRef}
                 onClick={controller.retry}
+                aria-describedby="sandbox-paused-guidance"
               >
                 {t('vw.sandboxPaused.resume')}
               </Button>
-              <p>
+              <p id="sandbox-paused-guidance">
                 {t(
                   controller.retryFailed
                     ? 'vw.sandboxPaused.retryFailed'
@@ -791,6 +792,7 @@ function useSandboxFrameController({
           return
         frameNavigationIdRef.current += 1
         automaticRecoveryAttemptsRef.current = 0
+        setRetryFailed(false)
         setLoadState('loading')
         restartProbeCycle()
       }, 500)

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -247,7 +247,13 @@ function SandboxState({
               >
                 {t('vw.sandboxPaused.resume')}
               </Button>
-              <p>{t('vw.sandboxPaused.next')}</p>
+              <p>
+                {t(
+                  controller.retryFailed
+                    ? 'vw.sandboxPaused.retryFailed'
+                    : 'vw.sandboxPaused.next',
+                )}
+              </p>
             </>
           }
         />
@@ -298,6 +304,7 @@ function useSandboxFrameController({
   const [loadState, setLoadState] = useState<
     'loading' | 'ready' | 'resuming' | 'blocked' | 'paused'
   >('loading')
+  const [retryFailed, setRetryFailed] = useState(false)
   const [frameUrl, setFrameUrl] = useReducer(
     (_current: string, next: string) => next,
     url,
@@ -439,6 +446,7 @@ function useSandboxFrameController({
               AUTOMATIC_RECOVERY_ATTEMPT_LIMIT,
             )
           ) {
+            if (focusRetryFailureRef.current) setRetryFailed(true)
             setLoadState('paused')
             return
           }
@@ -461,6 +469,7 @@ function useSandboxFrameController({
             restartFrameInstance()
             setLoadState('loading')
           } else {
+            if (focusRetryFailureRef.current) setRetryFailed(true)
             setLoadState('paused')
           }
         } else if (outcome === 'forbidden') {
@@ -500,6 +509,7 @@ function useSandboxFrameController({
     const generation = frameNavigationIdRef.current + 1
     frameNavigationIdRef.current = generation
     automaticRecoveryAttemptsRef.current = 0
+    setRetryFailed(false)
     setLoadState('ready')
     if (focusRetryFailureRef.current) {
       focusRetryFailureRef.current = false
@@ -810,6 +820,7 @@ function useSandboxFrameController({
   return {
     violations,
     loadState,
+    retryFailed,
     frameUrl,
     frameInstance,
     isTransitioning,
@@ -820,11 +831,13 @@ function useSandboxFrameController({
       const generation = frameNavigationIdRef.current + 1
       frameNavigationIdRef.current = generation
       automaticRecoveryAttemptsRef.current = 0
+      setRetryFailed(false)
       setLoadState('resuming')
       void refreshSandboxFrameUrl(shareableId, versionId, frameUrl).then(
         (nextFrameUrl) => {
           if (generation !== frameNavigationIdRef.current) return
           if (!nextFrameUrl) {
+            setRetryFailed(true)
             setLoadState('paused')
             return
           }
@@ -834,6 +847,7 @@ function useSandboxFrameController({
         },
         () => {
           if (generation !== frameNavigationIdRef.current) return
+          setRetryFailed(true)
           setLoadState('paused')
         },
       )

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -50,6 +50,7 @@ import { type PendingTextAnchor } from './viewer-comment-types'
 import { normalizeStaticSiteFramePath } from './export-actions'
 import {
   classifySandboxProbeResponse,
+  shouldAttemptAutomaticRecovery,
   shouldAcceptNavigationResult,
   shouldReportBlock,
   shouldStartLivenessCheck,
@@ -117,6 +118,7 @@ type SandboxFrameProps = {
 }
 
 const SANDBOX_FRAME_BASE_CLASS_NAME = 'block h-full w-full border-0'
+const AUTOMATIC_RECOVERY_ATTEMPT_LIMIT = 1
 
 export function sandboxFrameSurfaceClassName(followsAppTheme: boolean) {
   return followsAppTheme
@@ -146,6 +148,7 @@ export function SandboxFrame(props: SandboxFrameProps) {
           </div>
         ) : null}
         <iframe
+          key={controller.frameInstance}
           ref={controller.frameRef}
           title={name}
           src={controller.frameUrl}
@@ -303,12 +306,17 @@ function useSandboxFrameController({
     (current: number) => current + 1,
     0,
   )
+  const [frameInstance, restartFrameInstance] = useReducer(
+    (current: number) => current + 1,
+    0,
+  )
   const isTransitioning = useViewTransitionState(`/a/${shareableId}`)
   const frameRef = useRef<HTMLIFrameElement | null>(null)
   const wasTransitioningRef = useRef(false)
   const readyFallbackTimeoutRef = useRef<number | null>(null)
   const [staticSiteAuthRef] = useState(() => ({ current: Date.now() }))
   const frameNavigationIdRef = useRef(0)
+  const automaticRecoveryAttemptsRef = useRef(0)
   const reportedGenerationRef = useRef<number | null>(null)
   const reportTimerRef = useRef<number | null>(null)
   const primaryActionRef = useRef<HTMLButtonElement>(null)
@@ -425,6 +433,16 @@ function useSandboxFrameController({
           SANDBOX_PROBE_MARKER,
         )
         if (outcome === 'reachable') {
+          if (
+            !shouldAttemptAutomaticRecovery(
+              automaticRecoveryAttemptsRef.current,
+              AUTOMATIC_RECOVERY_ATTEMPT_LIMIT,
+            )
+          ) {
+            setLoadState('paused')
+            return
+          }
+          automaticRecoveryAttemptsRef.current += 1
           setLoadState('resuming')
           const next = await refreshSandboxFrameUrl(
             shareableId,
@@ -440,6 +458,7 @@ function useSandboxFrameController({
             return
           if (next) {
             setFrameUrl(next)
+            restartFrameInstance()
             setLoadState('loading')
           } else {
             setLoadState('paused')
@@ -480,6 +499,7 @@ function useSandboxFrameController({
     }
     const generation = frameNavigationIdRef.current + 1
     frameNavigationIdRef.current = generation
+    automaticRecoveryAttemptsRef.current = 0
     setLoadState('ready')
     if (focusRetryFailureRef.current) {
       focusRetryFailureRef.current = false
@@ -741,8 +761,18 @@ function useSandboxFrameController({
   }, [loadState, probeCycle, requestFrameReady, probe])
 
   useEffect(() => {
-    const resume = (event: 'visibilitychange' | 'pageshow') => {
-      if (!shouldStartLivenessCheck(event, document.visibilityState)) return
+    const resume = (
+      event: 'visibilitychange' | 'pageshow',
+      pageShowPersisted = false,
+    ) => {
+      if (
+        !shouldStartLivenessCheck(
+          event,
+          document.visibilityState,
+          pageShowPersisted,
+        )
+      )
+        return
       const generation = frameNavigationIdRef.current
       requestFrameReady()
       window.setTimeout(() => {
@@ -754,7 +784,8 @@ function useSandboxFrameController({
       }, 500)
     }
     const onVisibilityChange = () => resume('visibilitychange')
-    const onPageShow = () => resume('pageshow')
+    const onPageShow = (event: PageTransitionEvent) =>
+      resume('pageshow', event.persisted)
     document.addEventListener('visibilitychange', onVisibilityChange)
     window.addEventListener('pageshow', onPageShow)
     return () => {
@@ -778,12 +809,15 @@ function useSandboxFrameController({
     violations,
     loadState,
     frameUrl,
+    frameInstance,
     isTransitioning,
     frameRef,
     handleFrameLoad,
     retry: () => {
       focusRetryFailureRef.current = true
       frameNavigationIdRef.current += 1
+      automaticRecoveryAttemptsRef.current = 0
+      restartFrameInstance()
       setLoadState('loading')
     },
     primaryActionRef,
@@ -805,6 +839,7 @@ async function refreshSandboxFrameUrl(
       renderType?: unknown
     }>(
       `/api/shareables/${encodeURIComponent(shareableId)}/sandbox-token?version=${encodeURIComponent(versionId)}`,
+      { cache: 'no-store' },
     )
   } catch (error) {
     logViewerNetworkEvent({

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -554,6 +554,7 @@ function useSandboxFrameController({
         )
         const navigationId = frameNavigationIdRef.current + 1
         frameNavigationIdRef.current = navigationId
+        automaticRecoveryAttemptsRef.current = 0
         const lastStaticSiteAuthAt = staticSiteAuthRef.current ?? Date.now()
         const needsRefresh = Date.now() - lastStaticSiteAuthAt > 9 * 60 * 1000
         if (!needsRefresh) {
@@ -779,6 +780,7 @@ function useSandboxFrameController({
         if (!shouldStartLivenessProbe(generation, frameNavigationIdRef.current))
           return
         frameNavigationIdRef.current += 1
+        automaticRecoveryAttemptsRef.current = 0
         setLoadState('loading')
         restartProbeCycle()
       }, 500)
@@ -815,10 +817,22 @@ function useSandboxFrameController({
     handleFrameLoad,
     retry: () => {
       focusRetryFailureRef.current = true
-      frameNavigationIdRef.current += 1
+      const generation = frameNavigationIdRef.current + 1
+      frameNavigationIdRef.current = generation
       automaticRecoveryAttemptsRef.current = 0
-      restartFrameInstance()
-      setLoadState('loading')
+      setLoadState('resuming')
+      void refreshSandboxFrameUrl(shareableId, versionId, frameUrl).then(
+        (nextFrameUrl) => {
+          if (generation !== frameNavigationIdRef.current) return
+          if (!nextFrameUrl) {
+            setLoadState('paused')
+            return
+          }
+          setFrameUrl(nextFrameUrl)
+          restartFrameInstance()
+          setLoadState('loading')
+        },
+      )
     },
     primaryActionRef,
   }

--- a/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
+++ b/apps/web/app/routes/a.$id/+components/sandbox-frame.tsx
@@ -832,6 +832,10 @@ function useSandboxFrameController({
           restartFrameInstance()
           setLoadState('loading')
         },
+        () => {
+          if (generation !== frameNavigationIdRef.current) return
+          setLoadState('paused')
+        },
       )
     },
     primaryActionRef,

--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.test.ts
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.test.ts
@@ -105,6 +105,7 @@ describe('/api/shareables/:id/sandbox-token', () => {
     const response = await loader(loaderArgs('abc123def4'))
 
     expect(response.status).toBe(200)
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
     const body = (await response.json()) as { sandboxUrl: string }
     expect(body.sandboxUrl).toMatch(
       /^https:\/\/abc123def4--v-7631\.sandbox\.artifactshare\.com\/\?t=/,
@@ -220,6 +221,7 @@ describe('/api/shareables/:id/sandbox-token', () => {
     const response = await loader(loaderArgs('abc123def4'))
 
     expect(response.status).toBe(404)
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
   })
 })
 

--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
@@ -11,6 +11,8 @@ import {
 import { createDb } from '~/services/db.server'
 import type { Route } from './+types/api.shareables.$id.sandbox-token'
 
+const NO_STORE_HEADERS = { 'Cache-Control': 'private, no-store' } as const
+
 export async function loader({ context, params, request }: Route.LoaderArgs) {
   const user = context.get(userContext)
   const db = createDb()
@@ -49,11 +51,17 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
           ? renderTypeFromKind(artifactKind)
           : null
   if (!shareable?.r2_key || !shareable.current_version_id || !renderType) {
-    return Response.json({ error: 'not-found' }, { status: 404 })
+    return Response.json(
+      { error: 'not-found' },
+      { status: 404, headers: NO_STORE_HEADERS },
+    )
   }
 
   if (!user && shareable.visibility !== 'link') {
-    return Response.json({ error: 'not-found' }, { status: 401 })
+    return Response.json(
+      { error: 'not-found' },
+      { status: 401, headers: NO_STORE_HEADERS },
+    )
   }
 
   const snapshot: ArtifactSnapshot = {
@@ -81,7 +89,10 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     },
   )
   if (check.kind !== 'access-granted') {
-    return Response.json({ error: 'not-found' }, { status: 404 })
+    return Response.json(
+      { error: 'not-found' },
+      { status: 404, headers: NO_STORE_HEADERS },
+    )
   }
 
   const requestedVersionId = new URL(request.url).searchParams
@@ -92,7 +103,10 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     requestedVersionId &&
     requestedVersionId !== shareable.current_version_id
   ) {
-    return Response.json({ error: 'not-found' }, { status: 404 })
+    return Response.json(
+      { error: 'not-found' },
+      { status: 404, headers: NO_STORE_HEADERS },
+    )
   }
   const version = requestedVersionId
     ? await db
@@ -117,7 +131,10 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
         ? renderTypeFromKind(version.artifact_kind)
         : null
   if (!version || !versionRenderType) {
-    return Response.json({ error: 'not-found' }, { status: 404 })
+    return Response.json(
+      { error: 'not-found' },
+      { status: 404, headers: NO_STORE_HEADERS },
+    )
   }
 
   const token = await signSandboxToken(
@@ -143,5 +160,8 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
       ? (version.entrypoint_path ?? undefined)
       : undefined,
   )
-  return Response.json({ sandboxUrl, renderType: versionRenderType })
+  return Response.json(
+    { sandboxUrl, renderType: versionRenderType },
+    { headers: NO_STORE_HEADERS },
+  )
 }

--- a/apps/web/app/routes/sandbox-frame-recovery.behavior.browser.test.tsx
+++ b/apps/web/app/routes/sandbox-frame-recovery.behavior.browser.test.tsx
@@ -210,6 +210,44 @@ describe('SandboxFrame recovery', () => {
     expect(tokenRequests).toHaveLength(2)
     expect(stateOf(host)).toBe('resuming')
   })
+
+  test('returns to the manual retry state when a refreshed URL is invalid', async () => {
+    vi.useFakeTimers()
+    const tokenRequests: Array<Deferred<Response>> = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        if (String(input).includes('/__artifactshare_probe')) {
+          return Promise.resolve(new Response('', { status: 403 }))
+        }
+        const request = deferred<Response>()
+        tokenRequests.push(request)
+        return request.promise
+      }),
+    )
+
+    const host = await renderFrame()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+      await Promise.resolve()
+    })
+    expect(stateOf(host)).toBe('blocked')
+
+    await act(async () =>
+      host.querySelector<HTMLButtonElement>('button')?.click(),
+    )
+    expect(stateOf(host)).toBe('resuming')
+    expect(tokenRequests).toHaveLength(1)
+
+    await act(async () => {
+      tokenRequests[0].resolve(
+        Response.json({ sandboxUrl: 'not a URL', renderType: 'html' }),
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(stateOf(host)).toBe('paused')
+  })
 })
 
 async function renderFrame() {

--- a/apps/web/app/routes/sandbox-frame-recovery.behavior.browser.test.tsx
+++ b/apps/web/app/routes/sandbox-frame-recovery.behavior.browser.test.tsx
@@ -250,6 +250,13 @@ describe('SandboxFrame recovery', () => {
     expect(host.textContent).toContain(
       'The last attempt did not finish. Try again or reload the page.',
     )
+    const retryButton = host.querySelector<HTMLButtonElement>('button')
+    expect(retryButton?.getAttribute('aria-describedby')).toBe(
+      'sandbox-paused-guidance',
+    )
+    expect(host.querySelector('#sandbox-paused-guidance')?.textContent).toBe(
+      'The last attempt did not finish. Try again or reload the page.',
+    )
   })
 })
 

--- a/apps/web/app/routes/sandbox-frame-recovery.behavior.browser.test.tsx
+++ b/apps/web/app/routes/sandbox-frame-recovery.behavior.browser.test.tsx
@@ -1,0 +1,180 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { SandboxFrame } from './a.$id/+components/sandbox-frame'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+vi.mock('~/hooks/use-t', async () => {
+  const { bindI18n } = await import('~/lib/i18n')
+  return { useT: () => bindI18n('en') }
+})
+
+vi.mock('react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router')>()),
+  useViewTransitionState: () => false,
+}))
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+let root: Root | undefined
+
+afterEach(async () => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  if (root) await act(async () => root?.unmount())
+  root = undefined
+  document.body.replaceChildren()
+})
+
+describe('SandboxFrame recovery', () => {
+  test('remounts once, then stops automatic recovery at the manual retry state', async () => {
+    vi.useFakeTimers()
+    const tokenRequests: Array<Deferred<Response>> = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url.includes('/__artifactshare_probe')) {
+          return Promise.resolve(
+            new Response('artifactshare-sandbox-probe-v1', {
+              status: 200,
+              headers: {
+                'X-ArtifactShare-Sandbox-Probe':
+                  'artifactshare-sandbox-probe-v1',
+              },
+            }),
+          )
+        }
+        expect(init?.cache).toBe('no-store')
+        const request = deferred<Response>()
+        tokenRequests.push(request)
+        return request.promise
+      }),
+    )
+
+    const host = await renderFrame()
+    const initialFrame = host.querySelector('iframe')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+      await Promise.resolve()
+    })
+    expect(tokenRequests).toHaveLength(1)
+
+    await act(async () => {
+      tokenRequests[0].resolve(
+        Response.json({
+          sandboxUrl:
+            'https://abc123def4--v-7631.sandbox.artifactshare.com/?t=fresh',
+          renderType: 'html',
+        }),
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(stateOf(host)).toBe('loading')
+    const recoveredFrame = host.querySelector('iframe')
+    expect(recoveredFrame).not.toBe(initialFrame)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(tokenRequests).toHaveLength(1)
+    expect(stateOf(host)).toBe('paused')
+
+    const retry = host.querySelector<HTMLButtonElement>('button')
+    expect(retry?.textContent).toBe('Continue viewing')
+    await act(async () => retry?.click())
+    expect(stateOf(host)).toBe('loading')
+    expect(host.querySelector('iframe')).not.toBe(recoveredFrame)
+  })
+
+  test('ignores initial pageshow but checks a visible persisted restore', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => {})),
+    )
+    const host = await renderFrame()
+    const frame = host.querySelector('iframe')
+    expect(frame?.contentWindow).not.toBeNull()
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: 'https://abc123def4--v-7631.sandbox.artifactshare.com',
+          source: frame?.contentWindow,
+          data: { source: 'artifactshare', kind: 'ready' },
+        }),
+      )
+    })
+    expect(stateOf(host)).toBe('ready')
+
+    await act(async () => {
+      window.dispatchEvent(
+        new PageTransitionEvent('pageshow', { persisted: false }),
+      )
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(stateOf(host)).toBe('ready')
+
+    await act(async () => {
+      window.dispatchEvent(
+        new PageTransitionEvent('pageshow', { persisted: true }),
+      )
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(stateOf(host)).toBe('loading')
+  })
+})
+
+async function renderFrame() {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(
+      <SandboxFrame
+        shareableId="abc123def4"
+        versionId="v1"
+        url="https://abc123def4--v-7631.sandbox.artifactshare.com/?t=old"
+        name="Recovery test"
+        mermaidEnabled={false}
+        textAnchorsEnabled={false}
+        linkNavigationMode="document"
+        bundlePaths={[]}
+        fallbackToIndex={false}
+        commentThreads={[]}
+        targetThreadId={null}
+        highlightThreadId={null}
+        followsAppTheme={false}
+        onTextSelection={() => {}}
+        onTextSelectionClear={() => {}}
+        onThreadSelect={() => {}}
+        onOutsidePointerDown={() => {}}
+        sandboxPermissions="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-downloads"
+      />,
+    )
+  })
+  return host
+}
+
+function stateOf(host: HTMLElement) {
+  return host
+    .querySelector('[data-sandbox-state]')
+    ?.getAttribute('data-sandbox-state')
+}

--- a/apps/web/app/routes/sandbox-frame-recovery.behavior.browser.test.tsx
+++ b/apps/web/app/routes/sandbox-frame-recovery.behavior.browser.test.tsx
@@ -247,6 +247,9 @@ describe('SandboxFrame recovery', () => {
       await Promise.resolve()
     })
     expect(stateOf(host)).toBe('paused')
+    expect(host.textContent).toContain(
+      'The last attempt did not finish. Try again or reload the page.',
+    )
   })
 })
 

--- a/apps/web/app/routes/sandbox-frame-recovery.behavior.browser.test.tsx
+++ b/apps/web/app/routes/sandbox-frame-recovery.behavior.browser.test.tsx
@@ -76,8 +76,7 @@ describe('SandboxFrame recovery', () => {
     await act(async () => {
       tokenRequests[0].resolve(
         Response.json({
-          sandboxUrl:
-            'https://abc123def4--v-7631.sandbox.artifactshare.com/?t=fresh',
+          sandboxUrl: `${window.location.origin}/sandbox-frame-test?t=fresh`,
           renderType: 'html',
         }),
       )
@@ -99,6 +98,20 @@ describe('SandboxFrame recovery', () => {
     const retry = host.querySelector<HTMLButtonElement>('button')
     expect(retry?.textContent).toBe('Continue viewing')
     await act(async () => retry?.click())
+    expect(stateOf(host)).toBe('resuming')
+    expect(host.querySelector('iframe')).toBe(recoveredFrame)
+    expect(tokenRequests).toHaveLength(2)
+
+    await act(async () => {
+      tokenRequests[1].resolve(
+        Response.json({
+          sandboxUrl: `${window.location.origin}/sandbox-frame-test?t=retry`,
+          renderType: 'html',
+        }),
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
     expect(stateOf(host)).toBe('loading')
     expect(host.querySelector('iframe')).not.toBe(recoveredFrame)
   })
@@ -116,7 +129,7 @@ describe('SandboxFrame recovery', () => {
     await act(async () => {
       window.dispatchEvent(
         new MessageEvent('message', {
-          origin: 'https://abc123def4--v-7631.sandbox.artifactshare.com',
+          origin: window.location.origin,
           source: frame?.contentWindow,
           data: { source: 'artifactshare', kind: 'ready' },
         }),
@@ -140,6 +153,63 @@ describe('SandboxFrame recovery', () => {
     })
     expect(stateOf(host)).toBe('loading')
   })
+
+  test('gives a restored navigation its own automatic recovery attempt', async () => {
+    vi.useFakeTimers()
+    const tokenRequests: Array<Deferred<Response>> = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        if (String(input).includes('/__artifactshare_probe')) {
+          return Promise.resolve(
+            new Response('artifactshare-sandbox-probe-v1', {
+              status: 200,
+              headers: {
+                'X-ArtifactShare-Sandbox-Probe':
+                  'artifactshare-sandbox-probe-v1',
+              },
+            }),
+          )
+        }
+        const request = deferred<Response>()
+        tokenRequests.push(request)
+        return request.promise
+      }),
+    )
+
+    const host = await renderFrame()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+      await Promise.resolve()
+    })
+    expect(tokenRequests).toHaveLength(1)
+    expect(stateOf(host)).toBe('resuming')
+
+    await act(async () => {
+      window.dispatchEvent(
+        new PageTransitionEvent('pageshow', { persisted: true }),
+      )
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(stateOf(host)).toBe('loading')
+
+    await act(async () => {
+      tokenRequests[0].resolve(
+        Response.json({
+          sandboxUrl: `${window.location.origin}/sandbox-frame-test?t=stale`,
+          renderType: 'html',
+        }),
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(3000)
+      await Promise.resolve()
+    })
+
+    expect(tokenRequests).toHaveLength(2)
+    expect(stateOf(host)).toBe('resuming')
+  })
 })
 
 async function renderFrame() {
@@ -151,7 +221,7 @@ async function renderFrame() {
       <SandboxFrame
         shareableId="abc123def4"
         versionId="v1"
-        url="https://abc123def4--v-7631.sandbox.artifactshare.com/?t=old"
+        url={`${window.location.origin}/sandbox-frame-test?t=old`}
         name="Recovery test"
         mermaidEnabled={false}
         textAnchorsEnabled={false}


### PR DESCRIPTION
## 現状

Viewer の iframe が ready にならない場合、到達確認とトークン更新を繰り返し、読み込み表示から抜けられないことがありました。長時間開いていたタブの復帰や、別アプリから Viewer を開いた場合にも同じ状態が起こり得ます。

## 変更

- ready が返らない場合の自動回復を1回に制限し、失敗後は操作可能な一時停止画面へ移します。
- 自動回復と手動再試行では、キャッシュを使わず新しい sandbox token を取得して iframe を再生成します。
- visible への復帰と persisted な pageshow で liveness を再確認し、表示世代ごとに回復回数を管理します。
- sandbox token API の全レスポンスへ `private, no-store` を設定します。
- 手動再試行が失敗した場合は再試行またはページ再読み込みを案内し、再フォーカスされる操作へ説明を関連付けます。
- Chromium のコンポーネントテストで、回復上限、手動再試行、ページ復帰競合、異常URL、失敗案内を検証します。

## 検証

- `pnpm validate:static`（React Doctor 100、public scan 0 findings）
- `pnpm --filter @artifactshare/web test:behavior-browser`（60 tests）
- `pnpm visual:compose`（94 tests）
- desktop / mobile の task walkthrough と paused / resuming / retry-failed / blocked の状態キャプチャ
- Codex / Claude implementation review（`a6bb6ebf5ebd`、未解決 blocker なし）
- trusted `origin/main` による pull-request boundary check

## Follow-up

- 静的サイト内リンクの認証更新が異常URLを受けた場合の通知を改善する。
- sandbox token の異常URLレスポンスを診断ログへ残す。
- 再試行失敗時の主ボタン文言を、状態に合わせてさらに明確にする。
- モバイルの「最近見た」最終ページで、ページ送りが固定タブバーに重ならないよう余白を調整する。
