### PR TITLE
Keep empty access requests sheet open

### DIFF
--- a/apps/web/app/components/app/avatar-menu.behavior.browser.test.tsx
+++ b/apps/web/app/components/app/avatar-menu.behavior.browser.test.tsx
@@ -1,0 +1,93 @@
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { AvatarMenu } from './avatar-menu'
+import { TooltipProvider } from '~/components/ui/tooltip'
+import '~/app.css'
+
+const submitMock = vi.hoisted(() => vi.fn())
+
+vi.mock('react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router')>()),
+  useFetcher: () => ({ formData: null, submit: submitMock }),
+  useNavigate: () => vi.fn(),
+  useRouteLoaderData: () => ({
+    appTheme: 'system',
+    accessRequestNotice: { count: 0 },
+  }),
+}))
+
+vi.mock('~/components/app/analytics-consent-provider', () => ({
+  useAnalyticsConsent: () => ({ openBanner: vi.fn() }),
+}))
+
+vi.mock('~/hooks/use-t', async () => {
+  const { bindI18n } = await import('~/lib/i18n')
+  return { useT: () => bindI18n('ja') }
+})
+
+let root: Root | undefined
+
+afterEach(() => {
+  root?.unmount()
+  root = undefined
+  document.body.replaceChildren()
+  vi.unstubAllGlobals()
+})
+
+describe('AvatarMenu access requests', () => {
+  test('keeps the sheet open after selecting it when there are no requests', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url === '/api/access-requests/count') {
+          return Promise.resolve(Response.json({ count: 0 }))
+        }
+        if (url === '/api/access-requests') {
+          return Promise.resolve(
+            Response.json({
+              received: [],
+              sent: [],
+              receivedPendingCount: 0,
+            }),
+          )
+        }
+        return Promise.resolve(new Response(null))
+      }),
+    )
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+    root.render(
+      <TooltipProvider>
+        <AvatarMenu
+          variant="viewer"
+          user={{
+            id: 'user-1',
+            email: 'user@example.com',
+            name: 'User',
+            image: null,
+            initial: 'U',
+          }}
+        />
+      </TooltipProvider>,
+    )
+
+    await page.getByRole('button', { name: 'user@example.com' }).click()
+    await page.getByRole('menuitem', { name: '閲覧リクエスト' }).click()
+
+    await vi.waitFor(() =>
+      expect(document.body.textContent).toContain(
+        '未対応のリクエストはありません。',
+      ),
+    )
+    await new Promise((resolve) => window.setTimeout(resolve, 250))
+
+    expect(document.querySelector('[data-slot="sheet-content"]')).not.toBeNull()
+    expect(document.body.textContent).toContain(
+      '未対応のリクエストはありません。',
+    )
+  })
+})

--- a/apps/web/app/components/app/avatar-menu.tsx
+++ b/apps/web/app/components/app/avatar-menu.tsx
@@ -81,6 +81,7 @@ export function AvatarMenu({
   const [showDot, setShowDot] = useState(rootData?.updatesNotice?.dot ?? false)
   const [showNew, setShowNew] = useState(rootData?.updatesNotice?.new ?? false)
   const noticeRequest = useRef<Promise<void> | null>(null)
+  const accessRequestsOpenFrame = useRef<number | null>(null)
 
   useEffect(() => {
     setShowDot(rootData?.updatesNotice?.dot ?? false)
@@ -95,6 +96,15 @@ export function AvatarMenu({
   useEffect(() => {
     setAccessRequestCount(rootData?.accessRequestNotice?.count ?? 0)
   }, [rootData?.accessRequestNotice?.count])
+
+  useEffect(
+    () => () => {
+      if (accessRequestsOpenFrame.current !== null) {
+        window.cancelAnimationFrame(accessRequestsOpenFrame.current)
+      }
+    },
+    [],
+  )
 
   const refreshAccessRequestCount = () => {
     void fetch('/api/access-requests/count')
@@ -136,6 +146,17 @@ export function AvatarMenu({
     if (!isAppTheme(next) || next === appTheme) return
     document.documentElement.dataset.theme = next
     fetcher.submit({ theme: next }, { method: 'POST', action: '/set-theme' })
+  }
+
+  const handleAccessRequestsOpen = () => {
+    setMenuOpen(false)
+    if (accessRequestsOpenFrame.current !== null) {
+      window.cancelAnimationFrame(accessRequestsOpenFrame.current)
+    }
+    accessRequestsOpenFrame.current = window.requestAnimationFrame(() => {
+      accessRequestsOpenFrame.current = null
+      setAccessRequestsOpen(true)
+    })
   }
 
   return (
@@ -208,7 +229,12 @@ export function AvatarMenu({
             </div>
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setAccessRequestsOpen(true)}>
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault()
+              handleAccessRequestsOpen()
+            }}
+          >
             {t('accessRequests.title')}
             {accessRequestCount > 0 && (
               <Badge variant="info" className="ml-auto">


### PR DESCRIPTION
## Why

Opening Access requests from the avatar menu could make the sheet appear briefly and immediately close when there were no pending requests. The dropdown's focus restoration raced with the non-modal sheet opening, so the interaction looked broken instead of showing the existing empty state.

## What

- Close the avatar dropdown before opening the Access requests sheet on the next animation frame.
- Cancel a pending frame if the action repeats or the menu unmounts.
- Add a browser regression test that loads zero received and sent requests and verifies the sheet remains open with the empty-state message.

## Validation

- `pnpm --filter @artifactshare/web exec vitest --config vitest.behavior.browser.config.ts --run app/components/app/avatar-menu.behavior.browser.test.tsx`
- `pnpm --filter @artifactshare/web test:unit`
- `pnpm --filter @artifactshare/web format`
- `pnpm --filter @artifactshare/web lint`
- `pnpm --filter @artifactshare/web typecheck`
- `pnpm review:implementation` — Codex and Claude reported no findings
- `pnpm visual:compose` — 98 passed
- `pnpm screens:capture -- --screen access-requests --label access-request-empty-fix` — desktop/mobile, light/dark: 4 succeeded
- `pnpm validate:static`
- trusted-main pull-request boundary guard

## UI critique

No visual styling or content changed. Desktop and mobile captures confirm the existing sheet layout remains intact; the targeted browser test covers the affected zero-request state and verifies that its empty-state message remains visible after the menu transition completes.

No deferred findings.
