### PR TITLE
Assign one handler per access request

### DIFF
--- a/apps/web/app/routes/api.shareables.$id.access-request.tsx
+++ b/apps/web/app/routes/api.shareables.$id.access-request.tsx
@@ -63,6 +63,12 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         'Verify your email before requesting access.',
         403,
       )
+    case 'not-available':
+      return errorResponse(
+        'access-request-unavailable',
+        'No one can review this access request.',
+        409,
+      )
     case 'not-found':
       return errorResponse('not-found', 'Not found.', 404)
     case 'not-denied':

--- a/apps/web/app/services/access-request-slack.server.test.ts
+++ b/apps/web/app/services/access-request-slack.server.test.ts
@@ -57,6 +57,9 @@ describe('access request Slack notifications', () => {
     )
     const payload = postMessage.mock.calls[0]?.[1]
     expect(JSON.stringify(payload)).toContain(
+      'Requester (requester@example.com)',
+    )
+    expect(JSON.stringify(payload)).toContain(
       'https://artifactshare.test/access-requests?request=request-1',
     )
   })

--- a/apps/web/app/services/access-request-slack.server.ts
+++ b/apps/web/app/services/access-request-slack.server.ts
@@ -110,7 +110,10 @@ async function sendAccessRequestSlackNotificationsBestEffort(
         accessRequestSlackPayload({
           channel: recipient.slackUserId,
           locale,
-          requester: input.requesterName?.trim() || input.requesterEmail,
+          requester: requesterIdentity(
+            input.requesterName,
+            input.requesterEmail,
+          ),
           shareableTitle: input.shareableTitle,
           requestUrl: accessRequestUrl(input.origin, input.requestId),
         }),
@@ -130,6 +133,11 @@ async function sendAccessRequestSlackNotificationsBestEffort(
       }),
     )
   })
+}
+
+function requesterIdentity(name: string | null, email: string): string {
+  const trimmedName = name?.trim()
+  return trimmedName ? `${trimmedName} (${email})` : email
 }
 
 export function accessRequestSlackPayload(input: {

--- a/apps/web/app/services/access-requests.server.test.ts
+++ b/apps/web/app/services/access-requests.server.test.ts
@@ -41,6 +41,18 @@ const REQUESTER: SessionUser = {
   name: 'Requester',
   workspaceId: 'requester-workspace',
 }
+const ADMIN: SessionUser = {
+  ...OWNER,
+  id: 'admin',
+  email: 'admin@example.com',
+  name: 'Admin',
+}
+const PROJECT_CREATOR: SessionUser = {
+  ...OWNER,
+  id: 'project-creator',
+  email: 'project-creator@example.com',
+  name: 'Project creator',
+}
 
 describe('access request service', () => {
   let db: Kysely<DB>
@@ -129,7 +141,32 @@ describe('access request service', () => {
     sqliteRef.beforeNextBatch = null
   })
 
-  test('creates one pending request and exposes it only to an approver', async () => {
+  test('assigns a human-owned request only to the artifact owner', async () => {
+    await db
+      .insertInto('users')
+      .values({
+        id: ADMIN.id,
+        email: ADMIN.email,
+        email_verified: 1,
+        name: ADMIN.name,
+        image: null,
+        workspace_id: ADMIN.workspaceId,
+        created_at: '2026-09-01T00:00:00.000Z',
+        updated_at: '2026-09-01T00:00:00.000Z',
+      })
+      .execute()
+    await db
+      .insertInto('workspace_members')
+      .values({
+        workspace_id: OWNER.workspaceId,
+        user_id: ADMIN.id,
+        role: 'admin',
+        status: 'active',
+        created_at: '2026-09-01T00:00:00.000Z',
+        updated_at: '2026-09-01T00:00:00.000Z',
+      })
+      .execute()
+
     const created = await createAccessRequest(db, 'artifact', REQUESTER)
     expect(created).toMatchObject({
       kind: 'created',
@@ -141,7 +178,193 @@ describe('access request service', () => {
       kind: 'pending',
     })
     await expect(countReceivedAccessRequests(db, OWNER)).resolves.toBe(1)
+    await expect(countReceivedAccessRequests(db, ADMIN)).resolves.toBe(0)
     await expect(countReceivedAccessRequests(db, REQUESTER)).resolves.toBe(0)
+    if (created.kind !== 'created') throw new Error('request setup failed')
+    await expect(
+      processAccessRequest(db, created.requestId, ADMIN, { kind: 'reject' }),
+    ).resolves.toEqual({ kind: 'forbidden' })
+    await expect(
+      db
+        .selectFrom('access_requests')
+        .select('handler_user_id')
+        .where('id', '=', created.requestId)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ handler_user_id: OWNER.id })
+  })
+
+  test('assigns a bot-owned project request to its active creator, not workspace admins', async () => {
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'team' })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    await db
+      .insertInto('users')
+      .values([
+        {
+          id: ADMIN.id,
+          email: ADMIN.email,
+          email_verified: 1,
+          name: ADMIN.name,
+          image: null,
+          workspace_id: ADMIN.workspaceId,
+          kind: 'human',
+          created_at: '2026-09-01T00:00:00.000Z',
+          updated_at: '2026-09-01T00:00:00.000Z',
+        },
+        {
+          id: PROJECT_CREATOR.id,
+          email: PROJECT_CREATOR.email,
+          email_verified: 1,
+          name: PROJECT_CREATOR.name,
+          image: null,
+          workspace_id: PROJECT_CREATOR.workspaceId,
+          kind: 'human',
+          created_at: '2026-09-01T00:00:00.000Z',
+          updated_at: '2026-09-01T00:00:00.000Z',
+        },
+        {
+          id: 'project-bot',
+          email: 'project-bot@example.com',
+          email_verified: 1,
+          name: 'Project bot',
+          image: null,
+          workspace_id: OWNER.workspaceId,
+          kind: 'bot',
+          created_at: '2026-09-01T00:00:00.000Z',
+          updated_at: '2026-09-01T00:00:00.000Z',
+        },
+      ])
+      .execute()
+    await db
+      .insertInto('workspace_members')
+      .values([
+        {
+          workspace_id: OWNER.workspaceId,
+          user_id: OWNER.id,
+          role: 'owner',
+          status: 'active',
+          created_at: '2026-09-01T00:00:00.000Z',
+          updated_at: '2026-09-01T00:00:00.000Z',
+        },
+        {
+          workspace_id: OWNER.workspaceId,
+          user_id: ADMIN.id,
+          role: 'admin',
+          status: 'active',
+          created_at: '2026-09-01T00:01:00.000Z',
+          updated_at: '2026-09-01T00:01:00.000Z',
+        },
+        {
+          workspace_id: OWNER.workspaceId,
+          user_id: PROJECT_CREATOR.id,
+          role: 'member',
+          status: 'active',
+          created_at: '2026-09-01T00:02:00.000Z',
+          updated_at: '2026-09-01T00:02:00.000Z',
+        },
+      ])
+      .execute()
+    await db
+      .insertInto('artifact_containers')
+      .values({
+        id: 'bot-project',
+        workspace_id: OWNER.workspaceId,
+        kind: 'project',
+        owner_user_id: null,
+        created_by_id: PROJECT_CREATOR.id,
+        name: 'Bot project',
+        description: null,
+        archived_at: null,
+        created_at: '2026-09-01T00:00:00.000Z',
+        updated_at: '2026-09-01T00:00:00.000Z',
+      })
+      .execute()
+    await db
+      .updateTable('shareables')
+      .set({
+        owner_user_id: 'project-bot',
+        container_id: 'bot-project',
+        visibility: 'project',
+      })
+      .where('id', '=', 'artifact')
+      .execute()
+
+    const created = await createAccessRequest(db, 'artifact', REQUESTER)
+    expect(created).toMatchObject({
+      kind: 'created',
+      approverEmails: [PROJECT_CREATOR.email],
+    })
+    await expect(
+      countReceivedAccessRequests(db, PROJECT_CREATOR),
+    ).resolves.toBe(1)
+    await expect(countReceivedAccessRequests(db, OWNER)).resolves.toBe(0)
+    await expect(countReceivedAccessRequests(db, ADMIN)).resolves.toBe(0)
+  })
+
+  test('falls back from a bot-owned inbox to the workspace owner only', async () => {
+    await db
+      .insertInto('users')
+      .values([
+        {
+          id: ADMIN.id,
+          email: ADMIN.email,
+          email_verified: 1,
+          name: ADMIN.name,
+          image: null,
+          workspace_id: ADMIN.workspaceId,
+          kind: 'human',
+          created_at: '2026-09-01T00:00:00.000Z',
+          updated_at: '2026-09-01T00:00:00.000Z',
+        },
+        {
+          id: 'inbox-bot',
+          email: 'inbox-bot@example.com',
+          email_verified: 1,
+          name: 'Inbox bot',
+          image: null,
+          workspace_id: OWNER.workspaceId,
+          kind: 'bot',
+          created_at: '2026-09-01T00:00:00.000Z',
+          updated_at: '2026-09-01T00:00:00.000Z',
+        },
+      ])
+      .execute()
+    await db
+      .insertInto('workspace_members')
+      .values([
+        {
+          workspace_id: OWNER.workspaceId,
+          user_id: OWNER.id,
+          role: 'owner',
+          status: 'active',
+          created_at: '2026-09-01T00:00:00.000Z',
+          updated_at: '2026-09-01T00:00:00.000Z',
+        },
+        {
+          workspace_id: OWNER.workspaceId,
+          user_id: ADMIN.id,
+          role: 'admin',
+          status: 'active',
+          created_at: '2026-09-01T00:01:00.000Z',
+          updated_at: '2026-09-01T00:01:00.000Z',
+        },
+      ])
+      .execute()
+    await db
+      .updateTable('shareables')
+      .set({ owner_user_id: 'inbox-bot' })
+      .where('id', '=', 'artifact')
+      .execute()
+
+    const created = await createAccessRequest(db, 'artifact', REQUESTER)
+    expect(created).toMatchObject({
+      kind: 'created',
+      approverEmails: [OWNER.email],
+    })
+    await expect(countReceivedAccessRequests(db, OWNER)).resolves.toBe(1)
+    await expect(countReceivedAccessRequests(db, ADMIN)).resolves.toBe(0)
   })
 
   test('requires a verified requester email at submission time', async () => {
@@ -388,6 +611,11 @@ describe('access request service', () => {
       .updateTable('shareables')
       .set({ owner_user_id: newOwner.id })
       .where('id', '=', 'artifact')
+      .execute()
+    await db
+      .updateTable('access_requests')
+      .set({ handler_user_id: newOwner.id })
+      .where('id', '=', created.requestId)
       .execute()
 
     await expect(

--- a/apps/web/app/services/access-requests.server.test.ts
+++ b/apps/web/app/services/access-requests.server.test.ts
@@ -193,12 +193,12 @@ describe('access request service', () => {
     ).resolves.toEqual({ handler_user_id: OWNER.id })
   })
 
-  test('falls back to a Team admin when a project artifact owner is unverified', async () => {
+  test('uses a Plus project creator who is also an admin when its human owner is unverified', async () => {
     await addHuman(db, ADMIN)
     await addWorkspaceMember(db, ADMIN.id, 'admin')
     await db
       .updateTable('workspaces')
-      .set({ plan: 'team' })
+      .set({ plan: 'plus' })
       .where('id', '=', OWNER.workspaceId)
       .execute()
     await db
@@ -213,7 +213,7 @@ describe('access request service', () => {
         workspace_id: OWNER.workspaceId,
         kind: 'project',
         owner_user_id: null,
-        created_by_id: null,
+        created_by_id: ADMIN.id,
         name: 'Admin project',
         description: null,
         archived_at: null,
@@ -233,6 +233,14 @@ describe('access request service', () => {
       approverEmails: [ADMIN.email],
     })
     await expect(countReceivedAccessRequests(db, ADMIN)).resolves.toBe(1)
+    if (created.kind !== 'created') throw new Error('request setup failed')
+    await expect(
+      processAccessRequest(db, created.requestId, ADMIN, {
+        kind: 'approve',
+        scope: 'project',
+        expectedProjectId: 'admin-project',
+      }),
+    ).resolves.toEqual({ kind: 'processed', status: 'approved' })
   })
 
   test('assigns a bot-owned project request to its active creator, not workspace admins', async () => {
@@ -407,6 +415,13 @@ describe('access request service', () => {
     })
     await expect(countReceivedAccessRequests(db, OWNER)).resolves.toBe(1)
     await expect(countReceivedAccessRequests(db, ADMIN)).resolves.toBe(0)
+    if (created.kind !== 'created') throw new Error('request setup failed')
+    await expect(
+      processAccessRequest(db, created.requestId, OWNER, { kind: 'reject' }),
+    ).resolves.toEqual({ kind: 'processed', status: 'rejected' })
+    await expect(
+      processAccessRequest(db, created.requestId, ADMIN, { kind: 'reject' }),
+    ).resolves.toEqual({ kind: 'already-processed', status: 'rejected' })
   })
 
   test('reassigns a pending bot inbox request when the original handler is removed', async () => {
@@ -734,6 +749,11 @@ describe('access request service', () => {
       .updateTable('shareables')
       .set({ owner_user_id: newOwner.id })
       .where('id', '=', 'artifact')
+      .execute()
+    await db
+      .updateTable('access_requests')
+      .set({ handler_user_id: null })
+      .where('id', '=', created.requestId)
       .execute()
 
     await expect(

--- a/apps/web/app/services/access-requests.server.test.ts
+++ b/apps/web/app/services/access-requests.server.test.ts
@@ -193,6 +193,48 @@ describe('access request service', () => {
     ).resolves.toEqual({ handler_user_id: OWNER.id })
   })
 
+  test('falls back to a Team admin when a project artifact owner is unverified', async () => {
+    await addHuman(db, ADMIN)
+    await addWorkspaceMember(db, ADMIN.id, 'admin')
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'team' })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    await db
+      .updateTable('users')
+      .set({ email_verified: 0 })
+      .where('id', '=', OWNER.id)
+      .execute()
+    await db
+      .insertInto('artifact_containers')
+      .values({
+        id: 'admin-project',
+        workspace_id: OWNER.workspaceId,
+        kind: 'project',
+        owner_user_id: null,
+        created_by_id: null,
+        name: 'Admin project',
+        description: null,
+        archived_at: null,
+        created_at: '2026-09-01T00:00:00.000Z',
+        updated_at: '2026-09-01T00:00:00.000Z',
+      })
+      .execute()
+    await db
+      .updateTable('shareables')
+      .set({ container_id: 'admin-project', visibility: 'project' })
+      .where('id', '=', 'artifact')
+      .execute()
+
+    const created = await createAccessRequest(db, 'artifact', REQUESTER)
+    expect(created).toMatchObject({
+      kind: 'created',
+      approverEmails: [ADMIN.email],
+    })
+    await expect(countReceivedAccessRequests(db, ADMIN)).resolves.toBe(1)
+  })
+
   test('assigns a bot-owned project request to its active creator, not workspace admins', async () => {
     await db
       .updateTable('workspaces')
@@ -467,6 +509,73 @@ describe('access request service', () => {
     ).resolves.toEqual({ kind: 'processed', status: 'approved' })
   })
 
+  test('rejects a stale handler when project priority changes during approval', async () => {
+    const creatorA = {
+      ...PROJECT_CREATOR,
+      id: 'race-creator-a',
+      email: 'race-a@example.com',
+    }
+    const creatorB = {
+      ...PROJECT_CREATOR,
+      id: 'race-creator-b',
+      email: 'race-b@example.com',
+    }
+    await addHuman(db, creatorA)
+    await addHuman(db, creatorB)
+    await addBot(db, 'race-project-bot')
+    await addWorkspaceMember(db, creatorA.id, 'admin')
+    await addWorkspaceMember(db, creatorB.id, 'member')
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'team' })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    await db
+      .insertInto('artifact_containers')
+      .values({
+        id: 'race-project',
+        workspace_id: OWNER.workspaceId,
+        kind: 'project',
+        owner_user_id: null,
+        created_by_id: creatorA.id,
+        name: 'Race project',
+        description: null,
+        archived_at: null,
+        created_at: '2026-09-01T00:00:00.000Z',
+        updated_at: '2026-09-01T00:00:00.000Z',
+      })
+      .execute()
+    await db
+      .updateTable('shareables')
+      .set({
+        owner_user_id: 'race-project-bot',
+        container_id: 'race-project',
+        visibility: 'project',
+      })
+      .where('id', '=', 'artifact')
+      .execute()
+    const created = await createAccessRequest(db, 'artifact', REQUESTER)
+    if (created.kind !== 'created') throw new Error('request setup failed')
+
+    sqliteRef.beforeNextBatch = () => {
+      sqliteRef.current
+        ?.prepare(
+          'UPDATE artifact_containers SET created_by_id = ? WHERE id = ?',
+        )
+        .run(creatorB.id, 'race-project')
+    }
+    await expect(
+      processAccessRequest(db, created.requestId, creatorA, {
+        kind: 'approve',
+        scope: 'project',
+        expectedProjectId: 'race-project',
+      }),
+    ).resolves.toEqual({ kind: 'forbidden' })
+    await expect(
+      getRequesterAccessRequestStatus(db, 'artifact', REQUESTER.id),
+    ).resolves.toBe('pending')
+  })
+
   test('uses an external project manager when no workspace handler can approve', async () => {
     const manager: SessionUser = {
       ...PROJECT_CREATOR,
@@ -609,6 +718,27 @@ describe('access request service', () => {
     ).resolves.toMatchObject({
       kind: 'created',
     })
+  })
+
+  test('keeps a processed request idempotent after its ownership changes', async () => {
+    const created = await createAccessRequest(db, 'artifact', REQUESTER)
+    if (created.kind !== 'created') throw new Error('request setup failed')
+    await processAccessRequest(db, created.requestId, OWNER, { kind: 'reject' })
+    const newOwner: SessionUser = {
+      ...OWNER,
+      id: 'resolved-new-owner',
+      email: 'resolved-new-owner@example.com',
+    }
+    await addHuman(db, newOwner)
+    await db
+      .updateTable('shareables')
+      .set({ owner_user_id: newOwner.id })
+      .where('id', '=', 'artifact')
+      .execute()
+
+    await expect(
+      processAccessRequest(db, created.requestId, OWNER, { kind: 'reject' }),
+    ).resolves.toEqual({ kind: 'already-processed', status: 'rejected' })
   })
 
   test('offers project scope to its creator and binds approval to that project', async () => {

--- a/apps/web/app/services/access-requests.server.test.ts
+++ b/apps/web/app/services/access-requests.server.test.ts
@@ -367,6 +367,174 @@ describe('access request service', () => {
     await expect(countReceivedAccessRequests(db, ADMIN)).resolves.toBe(0)
   })
 
+  test('reassigns a pending bot inbox request when the original handler is removed', async () => {
+    await addHuman(db, ADMIN)
+    await addBot(db, 'inbox-bot')
+    await addWorkspaceMember(db, OWNER.id, 'owner')
+    await addWorkspaceMember(db, ADMIN.id, 'admin')
+    await db
+      .updateTable('shareables')
+      .set({ owner_user_id: 'inbox-bot' })
+      .where('id', '=', 'artifact')
+      .execute()
+
+    const created = await createAccessRequest(db, 'artifact', REQUESTER)
+    expect(created).toMatchObject({
+      kind: 'created',
+      approverEmails: [OWNER.email],
+    })
+    await db
+      .updateTable('workspace_members')
+      .set({ status: 'removed', removed_at: '2026-09-01T01:00:00.000Z' })
+      .where('workspace_id', '=', OWNER.workspaceId)
+      .where('user_id', '=', OWNER.id)
+      .execute()
+
+    await expect(countReceivedAccessRequests(db, OWNER)).resolves.toBe(0)
+    await expect(countReceivedAccessRequests(db, ADMIN)).resolves.toBe(1)
+    if (created.kind !== 'created') throw new Error('request setup failed')
+    await expect(
+      processAccessRequest(db, created.requestId, ADMIN, {
+        kind: 'approve',
+        scope: 'artifact',
+        expectedProjectId: null,
+      }),
+    ).resolves.toEqual({ kind: 'processed', status: 'approved' })
+  })
+
+  test('moves a pending bot project request to the new project creator', async () => {
+    const creatorA = { ...PROJECT_CREATOR, id: 'creator-a' }
+    const creatorB = {
+      ...PROJECT_CREATOR,
+      id: 'creator-b',
+      email: 'creator-b@example.com',
+    }
+    await addHuman(db, creatorA)
+    await addHuman(db, creatorB)
+    await addBot(db, 'project-bot')
+    await addWorkspaceMember(db, creatorA.id, 'member')
+    await addWorkspaceMember(db, creatorB.id, 'member')
+    for (const [id, creator] of [
+      ['project-a', creatorA.id],
+      ['project-b', creatorB.id],
+    ] as const) {
+      await db
+        .insertInto('artifact_containers')
+        .values({
+          id,
+          workspace_id: OWNER.workspaceId,
+          kind: 'project',
+          owner_user_id: null,
+          created_by_id: creator,
+          name: id,
+          description: null,
+          archived_at: null,
+          created_at: '2026-09-01T00:00:00.000Z',
+          updated_at: '2026-09-01T00:00:00.000Z',
+        })
+        .execute()
+    }
+    await db
+      .updateTable('shareables')
+      .set({
+        owner_user_id: 'project-bot',
+        container_id: 'project-a',
+        visibility: 'project',
+      })
+      .where('id', '=', 'artifact')
+      .execute()
+
+    const created = await createAccessRequest(db, 'artifact', REQUESTER)
+    expect(created).toMatchObject({
+      kind: 'created',
+      approverEmails: [creatorA.email],
+    })
+    await db
+      .updateTable('shareables')
+      .set({ container_id: 'project-b' })
+      .where('id', '=', 'artifact')
+      .execute()
+
+    await expect(countReceivedAccessRequests(db, creatorA)).resolves.toBe(0)
+    await expect(countReceivedAccessRequests(db, creatorB)).resolves.toBe(1)
+    if (created.kind !== 'created') throw new Error('request setup failed')
+    await expect(
+      processAccessRequest(db, created.requestId, creatorB, {
+        kind: 'approve',
+        scope: 'project',
+        expectedProjectId: 'project-b',
+      }),
+    ).resolves.toEqual({ kind: 'processed', status: 'approved' })
+  })
+
+  test('uses an external project manager when no workspace handler can approve', async () => {
+    const manager: SessionUser = {
+      ...PROJECT_CREATOR,
+      id: 'external-manager',
+      email: 'external-manager@example.org',
+      workspaceId: REQUESTER.workspaceId,
+    }
+    await addHuman(db, manager)
+    await addBot(db, 'project-bot')
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'plus', external_posting_enabled: 1 })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    await db
+      .insertInto('artifact_containers')
+      .values({
+        id: 'managed-project',
+        workspace_id: OWNER.workspaceId,
+        kind: 'project',
+        owner_user_id: null,
+        created_by_id: null,
+        name: 'Managed project',
+        description: null,
+        archived_at: null,
+        created_at: '2026-09-01T00:00:00.000Z',
+        updated_at: '2026-09-01T00:00:00.000Z',
+      })
+      .execute()
+    await db
+      .insertInto('project_share_defaults')
+      .values({
+        id: 'manager-grant',
+        project_container_id: 'managed-project',
+        email: manager.email,
+        role: 'manager',
+        display_name: manager.name,
+        created_by_id: null,
+        created_at: '2026-09-01T00:00:00.000Z',
+        updated_at: '2026-09-01T00:00:00.000Z',
+      })
+      .execute()
+    await db
+      .updateTable('shareables')
+      .set({
+        owner_user_id: 'project-bot',
+        container_id: 'managed-project',
+        visibility: 'project',
+      })
+      .where('id', '=', 'artifact')
+      .execute()
+
+    const created = await createAccessRequest(db, 'artifact', REQUESTER)
+    expect(created).toMatchObject({
+      kind: 'created',
+      approverEmails: [manager.email],
+    })
+    await expect(countReceivedAccessRequests(db, manager)).resolves.toBe(1)
+    if (created.kind !== 'created') throw new Error('request setup failed')
+    await expect(
+      processAccessRequest(db, created.requestId, manager, {
+        kind: 'approve',
+        scope: 'project',
+        expectedProjectId: 'managed-project',
+      }),
+    ).resolves.toEqual({ kind: 'processed', status: 'approved' })
+  })
+
   test('requires a verified requester email at submission time', async () => {
     await expect(
       createAccessRequest(db, 'artifact', {
@@ -656,3 +824,55 @@ describe('access request service', () => {
     ).resolves.toBe('pending')
   })
 })
+
+async function addHuman(db: Kysely<DB>, user: SessionUser) {
+  await db
+    .insertInto('users')
+    .values({
+      id: user.id,
+      email: user.email,
+      email_verified: 1,
+      name: user.name,
+      image: user.image,
+      workspace_id: user.workspaceId,
+      kind: 'human',
+      created_at: '2026-09-01T00:00:00.000Z',
+      updated_at: '2026-09-01T00:00:00.000Z',
+    })
+    .execute()
+}
+
+async function addBot(db: Kysely<DB>, id: string) {
+  await db
+    .insertInto('users')
+    .values({
+      id,
+      email: `${id}@example.com`,
+      email_verified: 1,
+      name: id,
+      image: null,
+      workspace_id: OWNER.workspaceId,
+      kind: 'bot',
+      created_at: '2026-09-01T00:00:00.000Z',
+      updated_at: '2026-09-01T00:00:00.000Z',
+    })
+    .execute()
+}
+
+async function addWorkspaceMember(
+  db: Kysely<DB>,
+  userId: string,
+  role: 'owner' | 'admin' | 'member',
+) {
+  await db
+    .insertInto('workspace_members')
+    .values({
+      workspace_id: OWNER.workspaceId,
+      user_id: userId,
+      role,
+      status: 'active',
+      created_at: '2026-09-01T00:00:00.000Z',
+      updated_at: '2026-09-01T00:00:00.000Z',
+    })
+    .execute()
+}

--- a/apps/web/app/services/access-requests.server.ts
+++ b/apps/web/app/services/access-requests.server.ts
@@ -51,6 +51,7 @@ interface RequestContext {
   ownerKind: 'human' | 'bot'
   containerId: string | null
   containerKind: 'inbox' | 'project' | null
+  projectCreatorUserId: string | null
   containerArchivedAt: string | null
   projectName: string | null
   shareableTitle: string
@@ -149,6 +150,7 @@ export async function createAccessRequest(
     ownerKind: target.owner_kind,
     containerId: target.container_id,
     containerKind: target.container_kind,
+    projectCreatorUserId: target.container_created_by_id,
     containerArchivedAt: target.container_archived_at,
     projectName: target.container_name,
     shareableTitle:
@@ -159,11 +161,7 @@ export async function createAccessRequest(
     requesterEmailVerified: user.emailVerified,
     createdAt: now,
   }
-  const handler = await resolveAccessRequestHandler(
-    db,
-    requestContext,
-    target.container_created_by_id,
-  )
+  let handler = await resolveAccessRequestHandler(db, requestContext)
   if (!handler) return { kind: 'not-available' }
 
   try {
@@ -186,6 +184,28 @@ export async function createAccessRequest(
     const raced = await pendingRequestFor(db, shareableId, user.id)
     if (raced) return { kind: 'pending', requestId: raced.id }
     throw error
+  }
+
+  const currentContext = await loadRequestContext(db, id)
+  const currentHandler = currentContext
+    ? await resolveAccessRequestHandler(db, currentContext)
+    : null
+  if (!currentHandler) {
+    await db
+      .deleteFrom('access_requests')
+      .where('id', '=', id)
+      .where('status', '=', 'pending')
+      .execute()
+    return { kind: 'not-available' }
+  }
+  if (currentHandler.userId !== handler.userId) {
+    await db
+      .updateTable('access_requests')
+      .set({ handler_user_id: currentHandler.userId, updated_at: nowIso() })
+      .where('id', '=', id)
+      .where('status', '=', 'pending')
+      .execute()
+    handler = currentHandler
   }
 
   return {
@@ -307,7 +327,8 @@ export async function processAccessRequest(
 > {
   const context = await loadRequestContext(db, requestId)
   if (!context) return { kind: 'forbidden' }
-  if (context.handlerUserId !== user.id) return { kind: 'forbidden' }
+  const handler = await resolveAccessRequestHandler(db, context)
+  if (handler?.userId !== user.id) return { kind: 'forbidden' }
   const capabilities = await capabilitiesForContext(db, context, user)
   if (!capabilities.canGrantArtifact && !capabilities.canGrantProject) {
     return { kind: 'forbidden' }
@@ -357,10 +378,101 @@ function receivedBaseQuery(db: Kysely<DB>, user: SessionUser) {
   return db
     .selectFrom('access_requests as ar')
     .innerJoin('shareables as s', 's.id', 'ar.shareable_id')
+    .innerJoin('users as owner', 'owner.id', 's.owner_user_id')
     .innerJoin('users as requester', 'requester.id', 'ar.requester_user_id')
     .leftJoin('artifact_containers as c', 'c.id', 's.container_id')
+    .innerJoin('workspaces as w', 'w.id', 's.workspace_id')
     .where('ar.status', '=', 'pending')
-    .where('ar.handler_user_id', '=', user.id)
+    .where(currentAccessRequestHandlerPredicate(user.id))
+}
+
+function currentAccessRequestHandlerPredicate(userId: string) {
+  const verifiedHuman = (alias: string) =>
+    sql<boolean>`${sql.ref(`${alias}.kind`)} = 'human' AND ${sql.ref(`${alias}.email_verified`)} = 1`
+  return sql<boolean>`
+    CASE
+      WHEN owner.kind = 'human' AND owner.email_verified = 1
+        THEN s.owner_user_id
+      WHEN owner.kind = 'bot'
+        AND s.visibility = 'project'
+        AND c.kind = 'project'
+        AND c.archived_at IS NULL
+        THEN coalesce(
+          (
+            SELECT creator.id
+            FROM users creator
+            JOIN workspace_members creator_member
+              ON creator_member.workspace_id = s.workspace_id
+             AND creator_member.user_id = creator.id
+            WHERE creator.id = c.created_by_id
+              AND creator_member.status = 'active'
+              AND ${verifiedHuman('creator')}
+            LIMIT 1
+          ),
+          (
+            SELECT workspace_owner.user_id
+            FROM workspace_members workspace_owner
+            JOIN users owner_user ON owner_user.id = workspace_owner.user_id
+            WHERE workspace_owner.workspace_id = s.workspace_id
+              AND workspace_owner.role = 'owner'
+              AND workspace_owner.status = 'active'
+              AND w.plan = 'team'
+              AND ${verifiedHuman('owner_user')}
+            LIMIT 1
+          ),
+          (
+            SELECT workspace_admin.user_id
+            FROM workspace_members workspace_admin
+            JOIN users admin_user ON admin_user.id = workspace_admin.user_id
+            WHERE workspace_admin.workspace_id = s.workspace_id
+              AND workspace_admin.role = 'admin'
+              AND workspace_admin.status = 'active'
+              AND w.plan = 'team'
+              AND ${verifiedHuman('admin_user')}
+            ORDER BY workspace_admin.created_at, workspace_admin.user_id
+            LIMIT 1
+          ),
+          (
+            SELECT manager_user.id
+            FROM project_share_defaults manager_grant
+            JOIN users manager_user
+              ON ${lowerEmail('manager_user.email')} = ${lowerEmail('manager_grant.email')}
+            WHERE manager_grant.project_container_id = c.id
+              AND manager_grant.role = 'manager'
+              AND w.plan <> 'free'
+              AND w.external_posting_enabled = 1
+              AND ${verifiedHuman('manager_user')}
+            ORDER BY manager_grant.created_at, manager_grant.id
+            LIMIT 1
+          )
+        )
+      WHEN owner.kind = 'bot' AND c.kind = 'inbox'
+        THEN coalesce(
+          (
+            SELECT workspace_owner.user_id
+            FROM workspace_members workspace_owner
+            JOIN users owner_user ON owner_user.id = workspace_owner.user_id
+            WHERE workspace_owner.workspace_id = s.workspace_id
+              AND workspace_owner.role = 'owner'
+              AND workspace_owner.status = 'active'
+              AND ${verifiedHuman('owner_user')}
+            LIMIT 1
+          ),
+          (
+            SELECT workspace_admin.user_id
+            FROM workspace_members workspace_admin
+            JOIN users admin_user ON admin_user.id = workspace_admin.user_id
+            WHERE workspace_admin.workspace_id = s.workspace_id
+              AND workspace_admin.role = 'admin'
+              AND workspace_admin.status = 'active'
+              AND ${verifiedHuman('admin_user')}
+            ORDER BY workspace_admin.created_at, workspace_admin.user_id
+            LIMIT 1
+          )
+        )
+      ELSE NULL
+    END = ${userId}
+  `
 }
 
 async function loadRequestContext(
@@ -389,6 +501,7 @@ async function loadRequestContext(
       'owner.kind as owner_kind',
       'c.id as container_id',
       'c.kind as container_kind',
+      'c.created_by_id as project_creator_user_id',
       'c.base_visibility as container_base_visibility',
       'c.archived_at as container_archived_at',
       'c.name as project_name',
@@ -412,6 +525,7 @@ async function loadRequestContext(
     ownerKind: row.owner_kind,
     containerId: row.container_id,
     containerKind: row.container_kind,
+    projectCreatorUserId: row.project_creator_user_id,
     containerArchivedAt: row.container_archived_at,
     projectName: row.project_name,
     shareableTitle:
@@ -488,7 +602,6 @@ async function isActiveWorkspaceAdmin(
 async function resolveAccessRequestHandler(
   db: Kysely<DB>,
   context: RequestContext,
-  projectCreatorUserId: string | null,
 ): Promise<AccessRequestApprover | null> {
   const candidates: NonNullable<Awaited<ReturnType<typeof userById>>>[] = []
   const candidateIds = new Set<string>()
@@ -509,13 +622,13 @@ async function resolveAccessRequestHandler(
   if (
     context.ownerKind === 'bot' &&
     context.containerKind === 'project' &&
-    projectCreatorUserId
+    context.projectCreatorUserId
   ) {
     addCandidate(
       await activeWorkspaceUserById(
         db,
         context.workspaceId,
-        projectCreatorUserId,
+        context.projectCreatorUserId,
       ),
     )
   }
@@ -526,6 +639,14 @@ async function resolveAccessRequestHandler(
       role,
     )
     for (const candidate of roleCandidates) addCandidate(candidate)
+  }
+  if (
+    context.ownerKind === 'bot' &&
+    context.containerId &&
+    context.containerKind === 'project'
+  ) {
+    const managers = await activeProjectManagerUsers(db, context.containerId)
+    for (const manager of managers) addCandidate(manager)
   }
 
   for (const candidate of candidates) {
@@ -612,6 +733,32 @@ async function activeWorkspaceUsersByRole(
     .execute()
 }
 
+async function activeProjectManagerUsers(
+  db: Kysely<DB>,
+  projectContainerId: string,
+) {
+  return await db
+    .selectFrom('project_share_defaults as manager')
+    .innerJoin('users as candidate', (join) =>
+      join.on(lowerEmail('candidate.email'), '=', lowerEmail('manager.email')),
+    )
+    .select([
+      'candidate.id',
+      'candidate.email',
+      'candidate.workspace_id',
+      'candidate.name',
+      'candidate.image',
+      'candidate.locale',
+    ])
+    .where('manager.project_container_id', '=', projectContainerId)
+    .where('manager.role', '=', 'manager')
+    .where('candidate.kind', '=', 'human')
+    .where('candidate.email_verified', '=', 1)
+    .orderBy('manager.created_at', 'asc')
+    .orderBy('manager.id', 'asc')
+    .execute()
+}
+
 async function commitRejected(
   db: Kysely<DB>,
   context: RequestContext,
@@ -622,6 +769,7 @@ async function commitRejected(
     .updateTable('access_requests')
     .set({
       status: 'rejected',
+      handler_user_id: user.id,
       resolved_by_user_id: user.id,
       resolution_scope: null,
       resolved_at: now,
@@ -629,7 +777,6 @@ async function commitRejected(
     })
     .where('id', '=', context.requestId)
     .where('status', '=', 'pending')
-    .where('handler_user_id', '=', user.id)
     .where(processingCapabilityPredicate(context, user))
   try {
     await runD1Batch(
@@ -655,6 +802,7 @@ async function commitApproved(
     .updateTable('access_requests')
     .set({
       status: 'approved',
+      handler_user_id: user.id,
       resolved_by_user_id: user.id,
       resolution_scope: scope,
       resolved_at: now,
@@ -662,7 +810,6 @@ async function commitApproved(
     })
     .where('id', '=', context.requestId)
     .where('status', '=', 'pending')
-    .where('handler_user_id', '=', user.id)
     .where(scopeCapabilityPredicate(context, user, scope))
     .where(grantCapacityPredicate(context, scope, email))
     .where((eb) =>
@@ -748,7 +895,7 @@ function terminalGuard(
           sql<string>`${context.requestId}`.as('id'),
           sql<string>`${context.shareableId}`.as('shareable_id'),
           sql<string>`${context.requesterUserId}`.as('requester_user_id'),
-          sql<string | null>`${context.handlerUserId}`.as('handler_user_id'),
+          sql<string | null>`${actorId}`.as('handler_user_id'),
           sql<AccessRequestStatus>`'pending'`.as('status'),
           sql<string | null>`NULL`.as('resolved_by_user_id'),
           sql<AccessRequestScope | null>`NULL`.as('resolution_scope'),
@@ -811,7 +958,7 @@ function grantGuard(
           sql<string>`${context.requestId}`.as('id'),
           sql<string>`${context.shareableId}`.as('shareable_id'),
           sql<string>`${context.requesterUserId}`.as('requester_user_id'),
-          sql<string | null>`${context.handlerUserId}`.as('handler_user_id'),
+          sql<string | null>`${actorId}`.as('handler_user_id'),
           sql<AccessRequestStatus>`'pending'`.as('status'),
           sql<string | null>`NULL`.as('resolved_by_user_id'),
           sql<AccessRequestScope | null>`NULL`.as('resolution_scope'),

--- a/apps/web/app/services/access-requests.server.ts
+++ b/apps/web/app/services/access-requests.server.ts
@@ -43,6 +43,7 @@ interface RequestContext {
   requestId: string
   status: AccessRequestStatus
   handlerUserId: string | null
+  resolvedByUserId: string | null
   shareableId: string
   workspaceId: string
   visibility: string
@@ -142,6 +143,7 @@ export async function createAccessRequest(
     requestId: id,
     status: 'pending',
     handlerUserId: null,
+    resolvedByUserId: null,
     shareableId: target.id,
     workspaceId: target.workspace_id,
     visibility: target.visibility,
@@ -328,7 +330,11 @@ export async function processAccessRequest(
   const context = await loadRequestContext(db, requestId)
   if (!context) return { kind: 'forbidden' }
   if (context.status !== 'pending') {
-    return context.handlerUserId === user.id
+    if (context.resolvedByUserId === user.id) {
+      return { kind: 'already-processed', status: context.status }
+    }
+    const capabilities = await capabilitiesForContext(db, context, user)
+    return capabilities.canGrantArtifact || capabilities.canGrantProject
       ? { kind: 'already-processed', status: context.status }
       : { kind: 'forbidden' }
   }
@@ -398,7 +404,6 @@ function currentAccessRequestHandlerPredicate(userId: string) {
         AND s.visibility = 'project'
         AND c.kind = 'project'
         AND c.archived_at IS NULL
-        AND w.plan = 'team'
         THEN coalesce(
           (
             SELECT workspace_owner.user_id
@@ -407,6 +412,10 @@ function currentAccessRequestHandlerPredicate(userId: string) {
             WHERE workspace_owner.workspace_id = s.workspace_id
               AND workspace_owner.role = 'owner'
               AND workspace_owner.status = 'active'
+              AND (
+                w.plan = 'team'
+                OR workspace_owner.user_id = c.created_by_id
+              )
               AND ${verifiedHuman('owner_user')}
             LIMIT 1
           ),
@@ -417,6 +426,10 @@ function currentAccessRequestHandlerPredicate(userId: string) {
             WHERE workspace_admin.workspace_id = s.workspace_id
               AND workspace_admin.role = 'admin'
               AND workspace_admin.status = 'active'
+              AND (
+                w.plan = 'team'
+                OR workspace_admin.user_id = c.created_by_id
+              )
               AND ${verifiedHuman('admin_user')}
             ORDER BY workspace_admin.created_at, workspace_admin.user_id
             LIMIT 1
@@ -518,6 +531,7 @@ async function loadRequestContext(
       'ar.id as request_id',
       'ar.status',
       'ar.handler_user_id',
+      'ar.resolved_by_user_id',
       'ar.created_at',
       's.id as shareable_id',
       's.workspace_id',
@@ -546,6 +560,7 @@ async function loadRequestContext(
     requestId: row.request_id,
     status: row.status,
     handlerUserId: row.handler_user_id,
+    resolvedByUserId: row.resolved_by_user_id,
     shareableId: row.shareable_id,
     workspaceId: row.workspace_id,
     visibility: row.visibility,

--- a/apps/web/app/services/access-requests.server.ts
+++ b/apps/web/app/services/access-requests.server.ts
@@ -42,6 +42,7 @@ export interface AccessRequestApprover {
 interface RequestContext {
   requestId: string
   status: AccessRequestStatus
+  handlerUserId: string | null
   shareableId: string
   workspaceId: string
   visibility: string
@@ -75,6 +76,7 @@ export async function createAccessRequest(
     }
   | { kind: 'pending'; requestId: string }
   | { kind: 'email-unverified' }
+  | { kind: 'not-available' }
   | { kind: 'not-found' }
   | { kind: 'not-denied' }
 > {
@@ -95,7 +97,11 @@ export async function createAccessRequest(
       'c.id as container_id',
       'c.kind as container_kind',
       'c.base_visibility as container_base_visibility',
+      'c.created_by_id as container_created_by_id',
+      'c.archived_at as container_archived_at',
+      'c.name as container_name',
       'owner.email as owner_email',
+      'owner.kind as owner_kind',
     ])
     .where('s.id', '=', shareableId)
     .executeTakeFirst()
@@ -131,6 +137,35 @@ export async function createAccessRequest(
 
   const id = nanoid()
   const now = nowIso()
+  const requestContext: RequestContext = {
+    requestId: id,
+    status: 'pending',
+    handlerUserId: null,
+    shareableId: target.id,
+    workspaceId: target.workspace_id,
+    visibility: target.visibility,
+    ownerUserId: target.owner_user_id,
+    ownerEmail: target.owner_email,
+    ownerKind: target.owner_kind,
+    containerId: target.container_id,
+    containerKind: target.container_kind,
+    containerArchivedAt: target.container_archived_at,
+    projectName: target.container_name,
+    shareableTitle:
+      target.title_override ?? target.derived_title ?? target.name,
+    requesterUserId: user.id,
+    requesterName: user.name,
+    requesterEmail: user.email,
+    requesterEmailVerified: user.emailVerified,
+    createdAt: now,
+  }
+  const handler = await resolveAccessRequestHandler(
+    db,
+    requestContext,
+    target.container_created_by_id,
+  )
+  if (!handler) return { kind: 'not-available' }
+
   try {
     await db
       .insertInto('access_requests')
@@ -138,6 +173,7 @@ export async function createAccessRequest(
         id,
         shareable_id: shareableId,
         requester_user_id: user.id,
+        handler_user_id: handler.userId,
         status: 'pending',
         resolved_by_user_id: null,
         resolution_scope: null,
@@ -152,14 +188,12 @@ export async function createAccessRequest(
     throw error
   }
 
-  const approvers = await listApprovers(db, id)
   return {
     kind: 'created',
     requestId: id,
-    approverEmails: approvers.map((approver) => approver.email),
-    approvers,
-    shareableTitle:
-      target.title_override ?? target.derived_title ?? target.name,
+    approverEmails: [handler.email],
+    approvers: [handler],
+    shareableTitle: requestContext.shareableTitle,
     workspaceId: target.workspace_id,
   }
 }
@@ -273,6 +307,7 @@ export async function processAccessRequest(
 > {
   const context = await loadRequestContext(db, requestId)
   if (!context) return { kind: 'forbidden' }
+  if (context.handlerUserId !== user.id) return { kind: 'forbidden' }
   const capabilities = await capabilitiesForContext(db, context, user)
   if (!capabilities.canGrantArtifact && !capabilities.canGrantProject) {
     return { kind: 'forbidden' }
@@ -319,58 +354,13 @@ async function pendingRequestFor(
 }
 
 function receivedBaseQuery(db: Kysely<DB>, user: SessionUser) {
-  const normalizedEmail = user.emailVerified
-    ? normalizeGrantEmail(user.email)
-    : null
   return db
     .selectFrom('access_requests as ar')
     .innerJoin('shareables as s', 's.id', 'ar.shareable_id')
-    .innerJoin('users as owner', 'owner.id', 's.owner_user_id')
     .innerJoin('users as requester', 'requester.id', 'ar.requester_user_id')
     .leftJoin('artifact_containers as c', 'c.id', 's.container_id')
-    .innerJoin('workspaces as w', 'w.id', 's.workspace_id')
     .where('ar.status', '=', 'pending')
-    .where(
-      sql<boolean>`(
-        (s.owner_user_id = ${user.id} AND owner.kind = 'human')
-        OR (
-          owner.kind = 'bot' AND c.kind = 'inbox'
-          AND EXISTS (
-            SELECT 1 FROM workspace_members admin_member
-            WHERE admin_member.workspace_id = s.workspace_id
-              AND admin_member.user_id = ${user.id}
-              AND admin_member.role IN ('owner', 'admin')
-              AND admin_member.status = 'active'
-          )
-        )
-        OR (
-          s.visibility = 'project'
-          AND c.kind = 'project' AND c.archived_at IS NULL
-          AND (
-            c.created_by_id = ${user.id}
-            OR EXISTS (
-              SELECT 1 FROM workspace_members project_admin
-              WHERE project_admin.workspace_id = c.workspace_id
-                AND project_admin.user_id = ${user.id}
-                AND project_admin.role IN ('owner', 'admin')
-                AND project_admin.status = 'active'
-                AND w.plan = 'team'
-            )
-            OR (
-              w.plan <> 'free'
-              AND w.external_posting_enabled = 1
-              AND ${normalizedEmail} IS NOT NULL
-              AND EXISTS (
-                SELECT 1 FROM project_share_defaults manager_grant
-                WHERE manager_grant.project_container_id = c.id
-                  AND manager_grant.role = 'manager'
-                  AND ${lowerEmail('manager_grant.email')} = ${normalizedEmail}
-              )
-            )
-          )
-        )
-      )`,
-    )
+    .where('ar.handler_user_id', '=', user.id)
 }
 
 async function loadRequestContext(
@@ -386,6 +376,7 @@ async function loadRequestContext(
     .select([
       'ar.id as request_id',
       'ar.status',
+      'ar.handler_user_id',
       'ar.created_at',
       's.id as shareable_id',
       's.workspace_id',
@@ -412,6 +403,7 @@ async function loadRequestContext(
   return {
     requestId: row.request_id,
     status: row.status,
+    handlerUserId: row.handler_user_id,
     shareableId: row.shareable_id,
     workspaceId: row.workspace_id,
     visibility: row.visibility,
@@ -493,101 +485,71 @@ async function isActiveWorkspaceAdmin(
   return Boolean(row)
 }
 
-async function listApprovers(
+async function resolveAccessRequestHandler(
   db: Kysely<DB>,
-  requestId: string,
-): Promise<AccessRequestApprover[]> {
-  const context = await loadRequestContext(db, requestId)
-  if (!context) return []
+  context: RequestContext,
+  projectCreatorUserId: string | null,
+): Promise<AccessRequestApprover | null> {
+  const candidates: NonNullable<Awaited<ReturnType<typeof userById>>>[] = []
   const candidateIds = new Set<string>()
-  if (context.ownerKind === 'human') candidateIds.add(context.ownerUserId)
-
-  if (context.containerKind === 'inbox' && context.ownerKind === 'bot') {
-    const admins = await db
-      .selectFrom('workspace_members')
-      .select('user_id')
-      .where('workspace_id', '=', context.workspaceId)
-      .where('role', 'in', ['owner', 'admin'])
-      .where('status', '=', 'active')
-      .execute()
-    for (const admin of admins) candidateIds.add(admin.user_id)
+  const addCandidate = (
+    candidate:
+      | NonNullable<Awaited<ReturnType<typeof userById>>>
+      | null
+      | undefined,
+  ) => {
+    if (!candidate || candidateIds.has(candidate.id)) return
+    candidateIds.add(candidate.id)
+    candidates.push(candidate)
   }
 
-  const managerEmails = new Set<string>()
+  if (context.ownerKind === 'human') {
+    addCandidate(await userById(db, context.ownerUserId))
+  }
   if (
-    context.containerId &&
+    context.ownerKind === 'bot' &&
     context.containerKind === 'project' &&
-    context.visibility === 'project'
+    projectCreatorUserId
   ) {
-    const project = await db
-      .selectFrom('artifact_containers')
-      .select('created_by_id')
-      .where('id', '=', context.containerId)
-      .executeTakeFirst()
-    if (project?.created_by_id) candidateIds.add(project.created_by_id)
+    addCandidate(
+      await activeWorkspaceUserById(
+        db,
+        context.workspaceId,
+        projectCreatorUserId,
+      ),
+    )
+  }
+  for (const role of ['owner', 'admin'] as const) {
+    const roleCandidates = await activeWorkspaceUsersByRole(
+      db,
+      context.workspaceId,
+      role,
+    )
+    for (const candidate of roleCandidates) addCandidate(candidate)
+  }
 
-    const admins = await db
-      .selectFrom('workspace_members')
-      .select('user_id')
-      .where('workspace_id', '=', context.workspaceId)
-      .where('role', 'in', ['owner', 'admin'])
-      .where('status', '=', 'active')
-      .execute()
-    for (const admin of admins) candidateIds.add(admin.user_id)
-
-    if (await isExternalPostingEnabledForWorkspace(db, context.workspaceId)) {
-      const managers = await db
-        .selectFrom('project_share_defaults')
-        .select('email')
-        .where('project_container_id', '=', context.containerId)
-        .where('role', '=', 'manager')
-        .execute()
-      for (const manager of managers) {
-        managerEmails.add(normalizeGrantEmail(manager.email))
+  for (const candidate of candidates) {
+    const capabilities = await capabilitiesForContext(db, context, {
+      id: candidate.id,
+      email: candidate.email,
+      emailVerified: true,
+      name: candidate.name,
+      image: candidate.image,
+      workspaceId: candidate.workspace_id,
+      hd: null,
+      msTenantId: null,
+      locale: null,
+      kind: 'human',
+    })
+    if (capabilities.canGrantArtifact || capabilities.canGrantProject) {
+      return {
+        userId: candidate.id,
+        email: normalizeGrantEmail(candidate.email),
+        locale: candidate.locale,
       }
     }
   }
-
-  const candidateUsers = new Map<
-    string,
-    NonNullable<Awaited<ReturnType<typeof userById>>>
-  >()
-  const foundCandidates = await Promise.all([
-    ...[...candidateIds].map((id) => userById(db, id)),
-    ...[...managerEmails].map((email) => userByVerifiedEmail(db, email)),
-  ])
-  for (const candidate of foundCandidates) {
-    if (candidate) candidateUsers.set(candidate.id, candidate)
-  }
-  const candidates = [...candidateUsers.values()]
-  const capableApprovers = await Promise.all(
-    candidates.map(async (candidate) => {
-      const capabilities = await capabilitiesForContext(db, context, {
-        id: candidate.id,
-        email: candidate.email,
-        emailVerified: true,
-        name: candidate.name,
-        image: candidate.image,
-        workspaceId: candidate.workspace_id,
-        hd: null,
-        msTenantId: null,
-        locale: null,
-        kind: 'human',
-      })
-      return capabilities.canGrantArtifact || capabilities.canGrantProject
-        ? {
-            userId: candidate.id,
-            email: normalizeGrantEmail(candidate.email),
-            locale: candidate.locale,
-          }
-        : null
-    }),
-  )
-  const unique = new Map<string, AccessRequestApprover>()
-  for (const approver of capableApprovers) {
-    if (approver) unique.set(approver.userId, approver)
-  }
-  return [...unique.values()]
+  return null
 }
 
 async function userById(db: Kysely<DB>, id: string) {
@@ -600,14 +562,54 @@ async function userById(db: Kysely<DB>, id: string) {
     .executeTakeFirst()
 }
 
-async function userByVerifiedEmail(db: Kysely<DB>, email: string) {
+async function activeWorkspaceUserById(
+  db: Kysely<DB>,
+  workspaceId: string,
+  userId: string,
+) {
   return await db
-    .selectFrom('users')
-    .select(['id', 'email', 'workspace_id', 'name', 'image', 'locale'])
-    .where(lowerEmail('email'), '=', email)
-    .where('kind', '=', 'human')
-    .where('email_verified', '=', 1)
+    .selectFrom('workspace_members as member')
+    .innerJoin('users as candidate', 'candidate.id', 'member.user_id')
+    .select([
+      'candidate.id',
+      'candidate.email',
+      'candidate.workspace_id',
+      'candidate.name',
+      'candidate.image',
+      'candidate.locale',
+    ])
+    .where('member.workspace_id', '=', workspaceId)
+    .where('member.user_id', '=', userId)
+    .where('member.status', '=', 'active')
+    .where('candidate.kind', '=', 'human')
+    .where('candidate.email_verified', '=', 1)
     .executeTakeFirst()
+}
+
+async function activeWorkspaceUsersByRole(
+  db: Kysely<DB>,
+  workspaceId: string,
+  role: 'owner' | 'admin',
+) {
+  return await db
+    .selectFrom('workspace_members as member')
+    .innerJoin('users as candidate', 'candidate.id', 'member.user_id')
+    .select([
+      'candidate.id',
+      'candidate.email',
+      'candidate.workspace_id',
+      'candidate.name',
+      'candidate.image',
+      'candidate.locale',
+    ])
+    .where('member.workspace_id', '=', workspaceId)
+    .where('member.role', '=', role)
+    .where('member.status', '=', 'active')
+    .where('candidate.kind', '=', 'human')
+    .where('candidate.email_verified', '=', 1)
+    .orderBy('member.created_at', 'asc')
+    .orderBy('member.user_id', 'asc')
+    .execute()
 }
 
 async function commitRejected(
@@ -627,6 +629,7 @@ async function commitRejected(
     })
     .where('id', '=', context.requestId)
     .where('status', '=', 'pending')
+    .where('handler_user_id', '=', user.id)
     .where(processingCapabilityPredicate(context, user))
   try {
     await runD1Batch(
@@ -659,6 +662,7 @@ async function commitApproved(
     })
     .where('id', '=', context.requestId)
     .where('status', '=', 'pending')
+    .where('handler_user_id', '=', user.id)
     .where(scopeCapabilityPredicate(context, user, scope))
     .where(grantCapacityPredicate(context, scope, email))
     .where((eb) =>
@@ -730,6 +734,7 @@ function terminalGuard(
       'id',
       'shareable_id',
       'requester_user_id',
+      'handler_user_id',
       'status',
       'resolved_by_user_id',
       'resolution_scope',
@@ -743,6 +748,7 @@ function terminalGuard(
           sql<string>`${context.requestId}`.as('id'),
           sql<string>`${context.shareableId}`.as('shareable_id'),
           sql<string>`${context.requesterUserId}`.as('requester_user_id'),
+          sql<string | null>`${context.handlerUserId}`.as('handler_user_id'),
           sql<AccessRequestStatus>`'pending'`.as('status'),
           sql<string | null>`NULL`.as('resolved_by_user_id'),
           sql<AccessRequestScope | null>`NULL`.as('resolution_scope'),
@@ -791,6 +797,7 @@ function grantGuard(
       'id',
       'shareable_id',
       'requester_user_id',
+      'handler_user_id',
       'status',
       'resolved_by_user_id',
       'resolution_scope',
@@ -804,6 +811,7 @@ function grantGuard(
           sql<string>`${context.requestId}`.as('id'),
           sql<string>`${context.shareableId}`.as('shareable_id'),
           sql<string>`${context.requesterUserId}`.as('requester_user_id'),
+          sql<string | null>`${context.handlerUserId}`.as('handler_user_id'),
           sql<AccessRequestStatus>`'pending'`.as('status'),
           sql<string | null>`NULL`.as('resolved_by_user_id'),
           sql<AccessRequestScope | null>`NULL`.as('resolution_scope'),

--- a/apps/web/app/services/access-requests.server.ts
+++ b/apps/web/app/services/access-requests.server.ts
@@ -327,16 +327,17 @@ export async function processAccessRequest(
 > {
   const context = await loadRequestContext(db, requestId)
   if (!context) return { kind: 'forbidden' }
+  if (context.status !== 'pending') {
+    return context.handlerUserId === user.id
+      ? { kind: 'already-processed', status: context.status }
+      : { kind: 'forbidden' }
+  }
   const handler = await resolveAccessRequestHandler(db, context)
   if (handler?.userId !== user.id) return { kind: 'forbidden' }
   const capabilities = await capabilitiesForContext(db, context, user)
   if (!capabilities.canGrantArtifact && !capabilities.canGrantProject) {
     return { kind: 'forbidden' }
   }
-  if (context.status !== 'pending') {
-    return { kind: 'already-processed', status: context.status }
-  }
-
   if (decision.kind === 'reject') {
     return await commitRejected(db, context, user)
   }
@@ -393,6 +394,34 @@ function currentAccessRequestHandlerPredicate(userId: string) {
     CASE
       WHEN owner.kind = 'human' AND owner.email_verified = 1
         THEN s.owner_user_id
+      WHEN owner.kind = 'human'
+        AND s.visibility = 'project'
+        AND c.kind = 'project'
+        AND c.archived_at IS NULL
+        AND w.plan = 'team'
+        THEN coalesce(
+          (
+            SELECT workspace_owner.user_id
+            FROM workspace_members workspace_owner
+            JOIN users owner_user ON owner_user.id = workspace_owner.user_id
+            WHERE workspace_owner.workspace_id = s.workspace_id
+              AND workspace_owner.role = 'owner'
+              AND workspace_owner.status = 'active'
+              AND ${verifiedHuman('owner_user')}
+            LIMIT 1
+          ),
+          (
+            SELECT workspace_admin.user_id
+            FROM workspace_members workspace_admin
+            JOIN users admin_user ON admin_user.id = workspace_admin.user_id
+            WHERE workspace_admin.workspace_id = s.workspace_id
+              AND workspace_admin.role = 'admin'
+              AND workspace_admin.status = 'active'
+              AND ${verifiedHuman('admin_user')}
+            ORDER BY workspace_admin.created_at, workspace_admin.user_id
+            LIMIT 1
+          )
+        )
       WHEN owner.kind = 'bot'
         AND s.visibility = 'project'
         AND c.kind = 'project'
@@ -777,6 +806,9 @@ async function commitRejected(
     })
     .where('id', '=', context.requestId)
     .where('status', '=', 'pending')
+    .where(({ exists }) =>
+      exists(currentHandlerQuery(db, context.shareableId, user.id)),
+    )
     .where(processingCapabilityPredicate(context, user))
   try {
     await runD1Batch(
@@ -810,6 +842,9 @@ async function commitApproved(
     })
     .where('id', '=', context.requestId)
     .where('status', '=', 'pending')
+    .where(({ exists }) =>
+      exists(currentHandlerQuery(db, context.shareableId, user.id)),
+    )
     .where(scopeCapabilityPredicate(context, user, scope))
     .where(grantCapacityPredicate(context, scope, email))
     .where((eb) =>
@@ -993,6 +1028,21 @@ function processingCapabilityPredicate(
   )`
 }
 
+function currentHandlerQuery(
+  db: Kysely<DB>,
+  shareableId: string,
+  userId: string,
+) {
+  return db
+    .selectFrom('shareables as s')
+    .innerJoin('users as owner', 'owner.id', 's.owner_user_id')
+    .leftJoin('artifact_containers as c', 'c.id', 's.container_id')
+    .innerJoin('workspaces as w', 'w.id', 's.workspace_id')
+    .select('s.id')
+    .where('s.id', '=', shareableId)
+    .where(currentAccessRequestHandlerPredicate(userId))
+}
+
 function scopeCapabilityPredicate(
   context: RequestContext,
   user: SessionUser,
@@ -1118,6 +1168,8 @@ async function settledAfterRace(
   if (current.status === 'approved' || current.status === 'rejected') {
     return { kind: 'already-processed' as const, status: current.status }
   }
+  const handler = await resolveAccessRequestHandler(db, current)
+  if (handler?.userId !== user.id) return { kind: 'forbidden' as const }
   const capabilities = await capabilitiesForContext(db, current, user)
   if (decision.kind === 'reject') {
     if (!capabilities.canGrantArtifact && !capabilities.canGrantProject) {

--- a/apps/web/app/services/dev-screen-state.server.ts
+++ b/apps/web/app/services/dev-screen-state.server.ts
@@ -1702,6 +1702,7 @@ export async function seedDevScreenState(
         id: 'dev-screen-access-request',
         shareable_id: shareableId,
         requester_user_id: requesterId,
+        handler_user_id: userId,
         status: 'pending',
         resolved_by_user_id: null,
         resolution_scope: null,

--- a/apps/web/app/services/team-management.server.test.ts
+++ b/apps/web/app/services/team-management.server.test.ts
@@ -1296,6 +1296,7 @@ describe('team-management service', () => {
     seedWorkspace(sqlite, 'team')
     seedUser(sqlite, 'u1')
     seedUser(sqlite, 'u2')
+    seedUser(sqlite, 'u3')
     seedAdmin(sqlite, 'u1')
     markRemoved(sqlite, 'u2')
     seedContainer(sqlite, 'inbox-u2', 'inbox', 'u2')
@@ -1304,6 +1305,20 @@ describe('team-management service', () => {
     seedArtifact(sqlite, 'a-project', 'u2', 'project-1')
     seedArtifactKey(sqlite, 'key-1', 'u2', 'inbox-u2', 'a-inbox')
     seedArtifactAuthorship(sqlite, 'a-inbox', 'u2')
+    sqlite
+      .prepare(
+        `INSERT INTO access_requests
+          (id, shareable_id, requester_user_id, handler_user_id, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'pending', ?, ?)`,
+      )
+      .run(
+        'request-1',
+        'a-inbox',
+        'u3',
+        'u2',
+        '2026-09-01T00:00:00.000Z',
+        '2026-09-01T00:00:00.000Z',
+      )
 
     await expect(
       transferRemovedMemberAssets(db, user('u1'), 'u2', 'u1'),
@@ -1328,6 +1343,13 @@ describe('team-management service', () => {
     ])
     expect(artifacts[0]!.container_id).not.toBe('inbox-u2')
     expect(readCount(sqlite, 'artifact_keys')).toBe(0)
+    expect(
+      sqlite
+        .prepare(
+          `SELECT handler_user_id FROM access_requests WHERE id = 'request-1'`,
+        )
+        .get(),
+    ).toEqual({ handler_user_id: 'u1' })
     const audits = readAuditEvents(sqlite, 'ws1')
     expect(audits).toHaveLength(1)
     expect(audits[0]!.action).toBe('assets.transfer')

--- a/apps/web/app/services/team-management.server.ts
+++ b/apps/web/app/services/team-management.server.ts
@@ -824,6 +824,24 @@ export async function transferRemovedMemberAssets(
         exists(eligibleAssetRecipient(db, actor.workspaceId, recipientUserId)),
       ),
     db
+      .updateTable('access_requests')
+      .set({ handler_user_id: recipientUserId, updated_at: now })
+      .where('status', '=', 'pending')
+      .where('handler_user_id', '=', targetUserId)
+      .where(
+        'shareable_id',
+        'in',
+        db
+          .selectFrom('shareables')
+          .select('id')
+          .where('workspace_id', '=', actor.workspaceId)
+          .where('owner_user_id', '=', targetUserId),
+      )
+      .where(({ exists }) => exists(commonGuard()))
+      .where(({ exists }) =>
+        exists(eligibleAssetRecipient(db, actor.workspaceId, recipientUserId)),
+      ),
+    db
       .updateTable('shareables')
       .set({ owner_user_id: recipientUserId, updated_at: now })
       .where('workspace_id', '=', actor.workspaceId)

--- a/apps/web/app/types/db.ts
+++ b/apps/web/app/types/db.ts
@@ -471,6 +471,7 @@ interface AccessRequestsTable {
   id: string
   shareable_id: string
   requester_user_id: string
+  handler_user_id: string | null
   status: 'pending' | 'approved' | 'rejected'
   resolved_by_user_id: string | null
   resolution_scope: 'artifact' | 'project' | null

--- a/apps/web/db/migrations/0097_access_request_handler.sql
+++ b/apps/web/db/migrations/0097_access_request_handler.sql
@@ -2,7 +2,8 @@ ALTER TABLE access_requests
   ADD COLUMN handler_user_id TEXT REFERENCES users(id) ON DELETE SET NULL;
 
 -- Preserve the existing priority for requests already waiting at deployment:
--- human artifact owner, project creator, workspace owner, then one admin.
+-- human artifact owner, project creator, workspace owner, one admin, then a
+-- project manager when workspace roles cannot approve.
 UPDATE access_requests
 SET handler_user_id = (
   SELECT s.owner_user_id
@@ -102,6 +103,30 @@ WHERE status = 'pending'
         )
       )
   );
+
+UPDATE access_requests
+SET handler_user_id = (
+  SELECT manager_user.id
+  FROM shareables s
+  JOIN artifact_containers c ON c.id = s.container_id
+  JOIN workspaces w ON w.id = s.workspace_id
+  JOIN project_share_defaults manager_grant
+    ON manager_grant.project_container_id = c.id
+   AND manager_grant.role = 'manager'
+  JOIN users manager_user ON lower(manager_user.email) = lower(manager_grant.email)
+  WHERE s.id = access_requests.shareable_id
+    AND s.visibility = 'project'
+    AND c.kind = 'project'
+    AND c.archived_at IS NULL
+    AND w.plan <> 'free'
+    AND w.external_posting_enabled = 1
+    AND manager_user.kind = 'human'
+    AND manager_user.email_verified = 1
+  ORDER BY manager_grant.created_at, manager_grant.id
+  LIMIT 1
+)
+WHERE status = 'pending'
+  AND handler_user_id IS NULL;
 
 CREATE INDEX access_requests_handler_pending
   ON access_requests(handler_user_id, status, created_at, id);

--- a/apps/web/db/migrations/0097_access_request_handler.sql
+++ b/apps/web/db/migrations/0097_access_request_handler.sql
@@ -1,6 +1,11 @@
 ALTER TABLE access_requests
   ADD COLUMN handler_user_id TEXT REFERENCES users(id) ON DELETE SET NULL;
 
+UPDATE access_requests
+SET handler_user_id = resolved_by_user_id
+WHERE status IN ('approved', 'rejected')
+  AND resolved_by_user_id IS NOT NULL;
+
 -- Preserve the existing priority for requests already waiting at deployment:
 -- human artifact owner, project creator, workspace owner, one admin, then a
 -- project manager when workspace roles cannot approve.

--- a/apps/web/db/migrations/0097_access_request_handler.sql
+++ b/apps/web/db/migrations/0097_access_request_handler.sql
@@ -1,0 +1,107 @@
+ALTER TABLE access_requests
+  ADD COLUMN handler_user_id TEXT REFERENCES users(id) ON DELETE SET NULL;
+
+-- Preserve the existing priority for requests already waiting at deployment:
+-- human artifact owner, project creator, workspace owner, then one admin.
+UPDATE access_requests
+SET handler_user_id = (
+  SELECT s.owner_user_id
+  FROM shareables s
+  JOIN users owner ON owner.id = s.owner_user_id
+  WHERE s.id = access_requests.shareable_id
+    AND owner.kind = 'human'
+    AND owner.email_verified = 1
+)
+WHERE status = 'pending';
+
+UPDATE access_requests
+SET handler_user_id = (
+  SELECT c.created_by_id
+  FROM shareables s
+  JOIN artifact_containers c ON c.id = s.container_id
+  JOIN users creator ON creator.id = c.created_by_id
+  JOIN workspace_members member
+    ON member.workspace_id = s.workspace_id
+   AND member.user_id = c.created_by_id
+  WHERE s.id = access_requests.shareable_id
+    AND s.visibility = 'project'
+    AND c.kind = 'project'
+    AND c.archived_at IS NULL
+    AND creator.kind = 'human'
+    AND creator.email_verified = 1
+    AND member.status = 'active'
+)
+WHERE status = 'pending'
+  AND handler_user_id IS NULL;
+
+UPDATE access_requests
+SET handler_user_id = (
+  SELECT member.user_id
+  FROM shareables s
+  JOIN workspace_members member ON member.workspace_id = s.workspace_id
+  JOIN users candidate ON candidate.id = member.user_id
+  WHERE s.id = access_requests.shareable_id
+    AND member.role = 'owner'
+    AND member.status = 'active'
+    AND candidate.kind = 'human'
+    AND candidate.email_verified = 1
+  LIMIT 1
+)
+WHERE status = 'pending'
+  AND handler_user_id IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM shareables s
+    JOIN users owner ON owner.id = s.owner_user_id
+    LEFT JOIN artifact_containers c ON c.id = s.container_id
+    JOIN workspaces w ON w.id = s.workspace_id
+    WHERE s.id = access_requests.shareable_id
+      AND owner.kind = 'bot'
+      AND (
+        c.kind = 'inbox'
+        OR (
+          s.visibility = 'project'
+          AND c.kind = 'project'
+          AND c.archived_at IS NULL
+          AND w.plan = 'team'
+        )
+      )
+  );
+
+UPDATE access_requests
+SET handler_user_id = (
+  SELECT member.user_id
+  FROM shareables s
+  JOIN workspace_members member ON member.workspace_id = s.workspace_id
+  JOIN users candidate ON candidate.id = member.user_id
+  WHERE s.id = access_requests.shareable_id
+    AND member.role = 'admin'
+    AND member.status = 'active'
+    AND candidate.kind = 'human'
+    AND candidate.email_verified = 1
+  ORDER BY member.created_at, member.user_id
+  LIMIT 1
+)
+WHERE status = 'pending'
+  AND handler_user_id IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM shareables s
+    JOIN users owner ON owner.id = s.owner_user_id
+    LEFT JOIN artifact_containers c ON c.id = s.container_id
+    JOIN workspaces w ON w.id = s.workspace_id
+    WHERE s.id = access_requests.shareable_id
+      AND owner.kind = 'bot'
+      AND (
+        c.kind = 'inbox'
+        OR (
+          s.visibility = 'project'
+          AND c.kind = 'project'
+          AND c.archived_at IS NULL
+          AND w.plan = 'team'
+        )
+      )
+  );
+
+CREATE INDEX access_requests_handler_pending
+  ON access_requests(handler_user_id, status, created_at, id);

--- a/apps/web/db/migrations/0097_access_request_handler.sql
+++ b/apps/web/db/migrations/0097_access_request_handler.sql
@@ -57,11 +57,14 @@ WHERE status = 'pending'
     LEFT JOIN artifact_containers c ON c.id = s.container_id
     JOIN workspaces w ON w.id = s.workspace_id
     WHERE s.id = access_requests.shareable_id
-      AND owner.kind = 'bot'
       AND (
-        c.kind = 'inbox'
+        (
+          owner.kind = 'bot'
+          AND c.kind = 'inbox'
+        )
         OR (
-          s.visibility = 'project'
+          owner.kind IN ('human', 'bot')
+          AND s.visibility = 'project'
           AND c.kind = 'project'
           AND c.archived_at IS NULL
           AND w.plan = 'team'
@@ -92,11 +95,14 @@ WHERE status = 'pending'
     LEFT JOIN artifact_containers c ON c.id = s.container_id
     JOIN workspaces w ON w.id = s.workspace_id
     WHERE s.id = access_requests.shareable_id
-      AND owner.kind = 'bot'
       AND (
-        c.kind = 'inbox'
+        (
+          owner.kind = 'bot'
+          AND c.kind = 'inbox'
+        )
         OR (
-          s.visibility = 'project'
+          owner.kind IN ('human', 'bot')
+          AND s.visibility = 'project'
           AND c.kind = 'project'
           AND c.archived_at IS NULL
           AND w.plan = 'team'

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -613,6 +613,7 @@ CREATE TABLE access_requests (
   id                    TEXT PRIMARY KEY,
   shareable_id          TEXT NOT NULL REFERENCES shareables(id) ON DELETE CASCADE,
   requester_user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  handler_user_id       TEXT REFERENCES users(id) ON DELETE SET NULL,
   status                TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'rejected')),
   resolved_by_user_id   TEXT REFERENCES users(id) ON DELETE SET NULL,
   resolution_scope      TEXT CHECK (resolution_scope IS NULL OR resolution_scope IN ('artifact', 'project')),
@@ -635,6 +636,8 @@ CREATE INDEX access_requests_requester_created
   ON access_requests(requester_user_id, created_at DESC, id DESC);
 CREATE INDEX access_requests_shareable_pending
   ON access_requests(shareable_id, status, created_at, id);
+CREATE INDEX access_requests_handler_pending
+  ON access_requests(handler_user_id, status, created_at, id);
 
 CREATE TABLE versions (
   id                        TEXT PRIMARY KEY,                                         -- migration-generated hex or app-side nanoid


### PR DESCRIPTION
## Why

An access request could notify every workspace administrator even though only one person needed to act. That created duplicate interruptions and made it unclear who owned the response. Slack notifications also showed only a display name, which can be ambiguous in larger workspaces.

## What

- Assign exactly one current handler to each pending access request, preferring the artifact owner, project creator, workspace owner, one administrator, then an eligible external project manager.
- Re-evaluate the handler when ownership, project placement, membership, or plan capabilities change, and enforce that choice atomically during approval or rejection.
- Preserve idempotent responses for the person who resolved a request and for users who remain authorized to review the result.
- Send proactive email and Slack notifications only to the selected handler.
- Show the requester's email address alongside their display name in Slack so the requester can be identified reliably.
- Backfill existing pending and resolved requests during migration.

## Validation

- `pnpm validate:static`
- Access request service tests: 17 passed
- Web unit tests: 3311 passed, 1 skipped
- D1 tests: 12 passed
- QM bridge tests: 81 passed
- React Doctor: 100
- Public repository scan: 0 findings
- Public development boundary guard: passed against trusted `origin/main`
- Codex implementation review: no actionable findings
- Claude implementation review: no findings

## Review notes

- This changes notification routing and authorization behavior, but does not change product UI structure.
- Request history and workspace-wide audit access are intentionally outside this change.
