### PR TITLE
Viewerから閲覧リクエストシートを安定して開けるようにする

### DIFF
--- a/apps/web/app/components/app/avatar-menu.behavior.browser.test.tsx
+++ b/apps/web/app/components/app/avatar-menu.behavior.browser.test.tsx
@@ -87,10 +87,9 @@ describe('AvatarMenu access requests', () => {
     )
     await new Promise((resolve) => window.setTimeout(resolve, 600))
 
-    expect(document.querySelector('[data-slot="sheet-content"]')).not.toBeNull()
-    expect(document.activeElement).not.toBe(
-      document.querySelector('button[aria-label="user@example.com"]'),
-    )
+    const sheet = document.querySelector('[data-slot="sheet-content"]')
+    expect(sheet).not.toBeNull()
+    expect(sheet?.contains(document.activeElement)).toBe(true)
     expect(document.body.textContent).toContain(
       '未対応のリクエストはありません。',
     )
@@ -151,9 +150,9 @@ describe('AvatarMenu access requests', () => {
       )
       await new Promise((resolve) => window.setTimeout(resolve, 600))
 
-      expect(
-        document.querySelector('[data-slot="sheet-content"]'),
-      ).not.toBeNull()
+      const sheet = document.querySelector('[data-slot="sheet-content"]')
+      expect(sheet).not.toBeNull()
+      expect(sheet?.contains(document.activeElement)).toBe(true)
       expect(document.body.textContent).toContain(
         '未対応のリクエストはありません。',
       )

--- a/apps/web/app/components/app/avatar-menu.behavior.browser.test.tsx
+++ b/apps/web/app/components/app/avatar-menu.behavior.browser.test.tsx
@@ -1,8 +1,10 @@
 import { createRoot, type Root } from 'react-dom/client'
+import { createMemoryRouter, RouterProvider } from 'react-router'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { page } from 'vitest/browser'
 import { AvatarMenu } from './avatar-menu'
 import { TooltipProvider } from '~/components/ui/tooltip'
+import { ViewerFixture } from '~/routes/dev.scenarios.$scenario/+components/viewer-fixture'
 import '~/app.css'
 
 const submitMock = vi.hoisted(() => vi.fn())
@@ -83,11 +85,78 @@ describe('AvatarMenu access requests', () => {
         '未対応のリクエストはありません。',
       ),
     )
-    await new Promise((resolve) => window.setTimeout(resolve, 250))
+    await new Promise((resolve) => window.setTimeout(resolve, 600))
 
     expect(document.querySelector('[data-slot="sheet-content"]')).not.toBeNull()
+    expect(document.activeElement).not.toBe(
+      document.querySelector('button[aria-label="user@example.com"]'),
+    )
     expect(document.body.textContent).toContain(
       '未対応のリクエストはありません。',
     )
   })
+
+  test.each([
+    { viewport: 'desktop', width: 1440, height: 900 },
+    { viewport: 'mobile', width: 390, height: 844 },
+  ])(
+    'keeps the sheet open from the actual Viewer chrome on $viewport',
+    async ({ width, height }) => {
+      await page.viewport(width, height)
+      vi.stubGlobal(
+        'fetch',
+        vi.fn((input: RequestInfo | URL) => {
+          const url = String(input)
+          if (url === '/api/access-requests/count') {
+            return Promise.resolve(Response.json({ count: 0 }))
+          }
+          if (url === '/api/access-requests') {
+            return Promise.resolve(
+              Response.json({
+                received: [],
+                sent: [],
+                receivedPendingCount: 0,
+              }),
+            )
+          }
+          return Promise.resolve(new Response(null))
+        }),
+      )
+
+      const host = document.createElement('div')
+      document.body.appendChild(host)
+      root = createRoot(host)
+      const router = createMemoryRouter(
+        [
+          {
+            path: '*',
+            element: (
+              <TooltipProvider>
+                <ViewerFixture tooltipOpen />
+              </TooltipProvider>
+            ),
+          },
+        ],
+        { initialEntries: ['/a/fixture-viewer'] },
+      )
+      root.render(<RouterProvider router={router} />)
+
+      await page.getByRole('button', { name: 'viewer@example.test' }).click()
+      await page.getByRole('menuitem', { name: '閲覧リクエスト' }).click()
+
+      await vi.waitFor(() =>
+        expect(document.body.textContent).toContain(
+          '未対応のリクエストはありません。',
+        ),
+      )
+      await new Promise((resolve) => window.setTimeout(resolve, 600))
+
+      expect(
+        document.querySelector('[data-slot="sheet-content"]'),
+      ).not.toBeNull()
+      expect(document.body.textContent).toContain(
+        '未対応のリクエストはありません。',
+      )
+    },
+  )
 })

--- a/apps/web/app/components/app/avatar-menu.tsx
+++ b/apps/web/app/components/app/avatar-menu.tsx
@@ -81,7 +81,7 @@ export function AvatarMenu({
   const [showDot, setShowDot] = useState(rootData?.updatesNotice?.dot ?? false)
   const [showNew, setShowNew] = useState(rootData?.updatesNotice?.new ?? false)
   const noticeRequest = useRef<Promise<void> | null>(null)
-  const accessRequestsOpenFrame = useRef<number | null>(null)
+  const openingAccessRequests = useRef(false)
 
   useEffect(() => {
     setShowDot(rootData?.updatesNotice?.dot ?? false)
@@ -96,15 +96,6 @@ export function AvatarMenu({
   useEffect(() => {
     setAccessRequestCount(rootData?.accessRequestNotice?.count ?? 0)
   }, [rootData?.accessRequestNotice?.count])
-
-  useEffect(
-    () => () => {
-      if (accessRequestsOpenFrame.current !== null) {
-        window.cancelAnimationFrame(accessRequestsOpenFrame.current)
-      }
-    },
-    [],
-  )
 
   const refreshAccessRequestCount = () => {
     void fetch('/api/access-requests/count')
@@ -149,14 +140,8 @@ export function AvatarMenu({
   }
 
   const handleAccessRequestsOpen = () => {
-    setMenuOpen(false)
-    if (accessRequestsOpenFrame.current !== null) {
-      window.cancelAnimationFrame(accessRequestsOpenFrame.current)
-    }
-    accessRequestsOpenFrame.current = window.requestAnimationFrame(() => {
-      accessRequestsOpenFrame.current = null
-      setAccessRequestsOpen(true)
-    })
+    openingAccessRequests.current = true
+    setAccessRequestsOpen(true)
   }
 
   return (
@@ -219,7 +204,15 @@ export function AvatarMenu({
             {user.email}
           </TooltipContent>
         </Tooltip>
-        <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuContent
+          align="end"
+          className="w-56"
+          onCloseAutoFocus={(event) => {
+            if (!openingAccessRequests.current) return
+            openingAccessRequests.current = false
+            event.preventDefault()
+          }}
+        >
           <DropdownMenuLabel className="font-normal">
             <div className="flex flex-col gap-0.5">
               {user.name && <span className="font-medium">{user.name}</span>}
@@ -229,12 +222,7 @@ export function AvatarMenu({
             </div>
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={(event) => {
-              event.preventDefault()
-              handleAccessRequestsOpen()
-            }}
-          >
+          <DropdownMenuItem onSelect={handleAccessRequestsOpen}>
             {t('accessRequests.title')}
             {accessRequestCount > 0 && (
               <Badge variant="info" className="ml-auto">


### PR DESCRIPTION
## 現状

Viewerのアバターメニューから閲覧リクエストを開くと、ドロップダウンメニューの終了時にアバターボタンへフォーカスが戻り、直後に開いた非モーダルシートがフォーカス外への移動として閉じることがありました。

## 変更

- 閲覧リクエストを選んだ場合だけ、ドロップダウンメニューによるトリガーへのフォーカス復帰を抑止しました
- 遅延してシートを開く処理をやめ、メニュー選択時に直接開くようにしました
- 実際のViewer chromeを使い、Desktop / Mobileで空状態のシートが開いたままになり、フォーカスがシート内へ移ることを検証するブラウザ回帰テストを追加しました

## 検証

- `pnpm --filter @artifactshare/web test:behavior-browser -- avatar-menu.behavior.browser.test.tsx`
- `pnpm visual:compose`
- `pnpm check:scenario-routes`
- `pnpm validate:static`
- `pnpm check:doctor`（score 100）
- trusted `origin/main` からのPR境界ガード
- Codex / Claude implementation review（blockerなし）
