### PR TITLE
閲覧リクエストを対象ファイルのViewerで確認できるようにする

### DIFF
--- a/apps/web/app/components/app/access-requests-sheet.tsx
+++ b/apps/web/app/components/app/access-requests-sheet.tsx
@@ -22,7 +22,13 @@ interface AccessRequestsResponse {
   receivedPendingCount: number
 }
 
-type AccessRequestError = 'load' | 'changed' | 'limit' | 'action' | null
+type AccessRequestError =
+  | 'load'
+  | 'changed'
+  | 'unavailable'
+  | 'limit'
+  | 'action'
+  | null
 
 function AccessRequestDetail({
   request,
@@ -194,22 +200,28 @@ function AccessRequestLists({
         <TabsTrigger value="sent">{t('accessRequests.sent')}</TabsTrigger>
       </TabsList>
       <TabsContent value="received" className="overflow-y-auto p-3">
-        {(error === 'changed' || error === 'load') && (
+        {(error === 'changed' ||
+          error === 'unavailable' ||
+          error === 'load') && (
           <div className="space-y-3 p-4 text-center">
             <p className="text-destructive text-sm">
               {error === 'changed'
                 ? t('accessRequests.changedError')
-                : t('accessRequests.loadError')}
+                : error === 'unavailable'
+                  ? t('accessRequests.unavailableError')
+                  : t('accessRequests.loadError')}
             </p>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={loading}
-              onClick={onRetry}
-            >
-              {t('accessRequests.retry')}
-            </Button>
+            {error !== 'unavailable' && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={loading}
+                onClick={onRetry}
+              >
+                {t('accessRequests.retry')}
+              </Button>
+            )}
           </div>
         )}
         {data?.received.map((item) => (
@@ -231,6 +243,7 @@ function AccessRequestLists({
         {data &&
           data.received.length === 0 &&
           error !== 'changed' &&
+          error !== 'unavailable' &&
           error !== 'load' && (
             <p className="text-muted-foreground p-4 text-center text-sm">
               {t('accessRequests.receivedEmpty')}
@@ -300,7 +313,11 @@ export function AccessRequestsSheet({
     const errorVersion = errorVersionRef.current
     setActiveLoadId(requestId)
     try {
-      const response = await fetch('/api/access-requests')
+      const requestedId = unverifiedInitialIdRef.current
+      const requestUrl = requestedId
+        ? `/api/access-requests?request=${encodeURIComponent(requestedId)}`
+        : '/api/access-requests'
+      const response = await fetch(requestUrl)
       if (!response.ok) throw new Error('load-failed')
       const next = (await response.json()) as AccessRequestsResponse
       if (requestId !== loadRequestIdRef.current) return
@@ -314,7 +331,7 @@ export function AccessRequestsSheet({
         setSelectedId(null)
         if (unverifiedInitialIdRef.current === activeId) {
           unverifiedInitialIdRef.current = null
-          if (errorVersion === errorVersionRef.current) setError(null)
+          replaceError('unavailable')
         } else {
           replaceError('changed')
         }

--- a/apps/web/app/components/app/avatar-menu.behavior.browser.test.tsx
+++ b/apps/web/app/components/app/avatar-menu.behavior.browser.test.tsx
@@ -8,11 +8,12 @@ import { ViewerFixture } from '~/routes/dev.scenarios.$scenario/+components/view
 import '~/app.css'
 
 const submitMock = vi.hoisted(() => vi.fn())
+const navigateMock = vi.hoisted(() => vi.fn())
 
 vi.mock('react-router', async (importOriginal) => ({
   ...(await importOriginal<typeof import('react-router')>()),
   useFetcher: () => ({ formData: null, submit: submitMock }),
-  useNavigate: () => vi.fn(),
+  useNavigate: () => navigateMock,
   useRouteLoaderData: () => ({
     appTheme: 'system',
     accessRequestNotice: { count: 0 },
@@ -35,6 +36,7 @@ afterEach(() => {
   root = undefined
   document.body.replaceChildren()
   vi.unstubAllGlobals()
+  navigateMock.mockReset()
 })
 
 describe('AvatarMenu access requests', () => {
@@ -158,4 +160,128 @@ describe('AvatarMenu access requests', () => {
       )
     },
   )
+
+  test.each([
+    { viewport: 'desktop', width: 1440, height: 900 },
+    { viewport: 'mobile', width: 390, height: 844 },
+  ])(
+    'opens a linked request over the actual Viewer on $viewport',
+    async ({ width, height }) => {
+      await page.viewport(width, height)
+      vi.stubGlobal(
+        'fetch',
+        vi.fn((input: RequestInfo | URL) => {
+          const url = String(input)
+          if (url === '/api/access-requests?request=request-1') {
+            return Promise.resolve(
+              Response.json({
+                received: [
+                  {
+                    id: 'request-1',
+                    requesterName: 'Requester',
+                    requesterEmail: 'requester@example.com',
+                    shareableId: 'fixture-viewer',
+                    shareableTitle: 'Review notes',
+                    projectId: 'fixture-project',
+                    projectName: 'Fixture project',
+                    canGrantArtifact: true,
+                    canGrantProject: true,
+                    createdAt: '2026-09-01T00:00:00.000Z',
+                  },
+                ],
+                sent: [],
+                receivedPendingCount: 1,
+              }),
+            )
+          }
+          return Promise.resolve(new Response(null))
+        }),
+      )
+
+      const host = document.createElement('div')
+      document.body.appendChild(host)
+      root = createRoot(host)
+      const router = createMemoryRouter(
+        [
+          {
+            path: '*',
+            element: (
+              <TooltipProvider>
+                <ViewerFixture tooltipOpen />
+              </TooltipProvider>
+            ),
+          },
+        ],
+        {
+          initialEntries: ['/a/fixture-viewer?access-request=request-1'],
+        },
+      )
+      root.render(<RouterProvider router={router} />)
+
+      await vi.waitFor(() =>
+        expect(document.body.textContent).toContain(
+          'Requester (requester@example.com)',
+        ),
+      )
+
+      expect(
+        document.querySelector('[data-slot="sheet-content"]'),
+      ).not.toBeNull()
+      expect(document.body.textContent).toContain('Review notes')
+      expect(document.querySelector('iframe')).not.toBeNull()
+
+      await page.getByRole('button', { name: '閉じる' }).click()
+      expect(navigateMock).toHaveBeenCalledWith(
+        { pathname: '/a/fixture-viewer', search: '' },
+        { replace: true },
+      )
+    },
+  )
+
+  test('shows a safe state when a linked request is no longer reviewable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        if (String(input) === '/api/access-requests?request=processed') {
+          return Promise.resolve(
+            Response.json({
+              received: [],
+              sent: [],
+              receivedPendingCount: 0,
+            }),
+          )
+        }
+        return Promise.resolve(new Response(null))
+      }),
+    )
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+    const router = createMemoryRouter(
+      [
+        {
+          path: '*',
+          element: (
+            <TooltipProvider>
+              <ViewerFixture tooltipOpen />
+            </TooltipProvider>
+          ),
+        },
+      ],
+      { initialEntries: ['/a/fixture-viewer?access-request=processed'] },
+    )
+    root.render(<RouterProvider router={router} />)
+
+    await vi.waitFor(() =>
+      expect(document.body.textContent).toContain(
+        'このリクエストは処理済みか、現在は確認できません。',
+      ),
+    )
+
+    expect(document.querySelector('iframe')).not.toBeNull()
+    expect(document.body.textContent).not.toContain(
+      '未対応のリクエストはありません。',
+    )
+  })
 })

--- a/apps/web/app/components/app/avatar-menu.tsx
+++ b/apps/web/app/components/app/avatar-menu.tsx
@@ -39,6 +39,8 @@ interface AvatarMenuProps {
   user: UserInfo
   variant?: 'default' | 'viewer'
   className?: string
+  initialAccessRequestId?: string | null
+  onAccessRequestDismiss?: () => void
 }
 
 const triggerClassName = cn(
@@ -56,6 +58,8 @@ export function AvatarMenu({
   user,
   variant = 'default',
   className,
+  initialAccessRequestId = null,
+  onAccessRequestDismiss,
 }: AvatarMenuProps) {
   const { t, locale } = useT()
   const { openBanner } = useAnalyticsConsent()
@@ -74,7 +78,9 @@ export function AvatarMenu({
     ? submittedAppTheme
     : resolvedAppTheme
   const [menuOpen, setMenuOpen] = useState(false)
-  const [accessRequestsOpen, setAccessRequestsOpen] = useState(false)
+  const [accessRequestsOpen, setAccessRequestsOpen] = useState(
+    initialAccessRequestId !== null,
+  )
   const [accessRequestCount, setAccessRequestCount] = useState(
     rootData?.accessRequestNotice?.count ?? 0,
   )
@@ -304,8 +310,13 @@ export function AvatarMenu({
         </DropdownMenuContent>
       </DropdownMenu>
       <AccessRequestsSheet
+        key={initialAccessRequestId ?? 'list'}
         open={accessRequestsOpen}
-        onOpenChange={setAccessRequestsOpen}
+        initialRequestId={initialAccessRequestId}
+        onOpenChange={(open) => {
+          setAccessRequestsOpen(open)
+          if (!open && initialAccessRequestId) onAccessRequestDismiss?.()
+        }}
         onCountChange={setAccessRequestCount}
       />
     </>

--- a/apps/web/app/i18n/en.json
+++ b/apps/web/app/i18n/en.json
@@ -860,6 +860,7 @@
   "accessRequests.loadError": "Could not load requests. Try again.",
   "accessRequests.actionError": "Could not process this request. Check your access and try again.",
   "accessRequests.changedError": "The file location or requester state changed. Reload and try again.",
+  "accessRequests.unavailableError": "This request has been processed or is no longer available to review.",
   "accessRequests.permissionChangedError": "The request status or your access changed. Reload to check the latest state.",
   "accessRequests.limitError": "The sharing audience is full. Review the sharing settings and try again.",
   "accessRequests.back": "Back to requests",

--- a/apps/web/app/i18n/ja.json
+++ b/apps/web/app/i18n/ja.json
@@ -860,6 +860,7 @@
   "accessRequests.loadError": "リクエストを読み込めませんでした。もう一度お試しください。",
   "accessRequests.actionError": "処理できませんでした。権限を確認してもう一度お試しください。",
   "accessRequests.changedError": "ファイルの所属プロジェクトまたは依頼者の状態が変わりました。再読み込みしてください。",
+  "accessRequests.unavailableError": "このリクエストは処理済みか、現在は確認できません。",
   "accessRequests.permissionChangedError": "リクエストの状態またはあなたの権限が変わりました。再読み込みして最新の状態を確認してください。",
   "accessRequests.limitError": "共有相手の上限に達しています。共有設定を見直してからもう一度お試しください。",
   "accessRequests.back": "一覧に戻る",

--- a/apps/web/app/routes/_protected/access-requests.tsx
+++ b/apps/web/app/routes/_protected/access-requests.tsx
@@ -1,5 +1,29 @@
-import { useNavigate, useSearchParams } from 'react-router'
+import { redirect, useNavigate, useSearchParams } from 'react-router'
 import { AccessRequestsSheet } from '~/components/app/access-requests-sheet'
+import { requireUser } from '~/middleware/context'
+import { createDb } from '~/services/db.server'
+import { getReceivedAccessRequestTarget } from '~/services/access-requests.server'
+import type { Route } from './+types/access-requests'
+
+export async function loader({ url, context }: Route.LoaderArgs) {
+  const requestId = url.searchParams.get('request')
+  if (!requestId) return null
+
+  const user = requireUser(context)
+  const target = await getReceivedAccessRequestTarget(
+    createDb(),
+    requestId,
+    user,
+  )
+  if (!target?.canView) return null
+
+  const destination = new URL(
+    `/a/${encodeURIComponent(target.shareableId)}`,
+    url,
+  )
+  destination.searchParams.set('access-request', requestId)
+  return redirect(`${destination.pathname}${destination.search}`)
+}
 
 export default function AccessRequestsPage() {
   const navigate = useNavigate()

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
@@ -75,7 +75,12 @@ vi.mock('react-router', () => ({
       {children}
     </a>
   ),
-  useLocation: () => ({ state: mockLocationState }),
+  useLocation: () => ({
+    pathname: '/a/artifact',
+    search: '',
+    state: mockLocationState,
+  }),
+  useNavigate: () => vi.fn(),
   useRevalidator: () => ({ revalidate: vi.fn() }),
 }))
 

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
@@ -9,7 +9,7 @@ import {
   IconStack2 as Layers,
 } from '@tabler/icons-react'
 import { type RefObject, useLayoutEffect, useRef, useState } from 'react'
-import { Link, useLocation } from 'react-router'
+import { Link, useLocation, useNavigate } from 'react-router'
 import { Popover as PopoverPrimitive } from 'radix-ui'
 import { toast } from 'sonner'
 import { useT } from '~/hooks/use-t'
@@ -167,6 +167,23 @@ interface ViewerChromeProps {
   onCollapsedChange?: (collapsed: boolean) => void
 }
 
+function useViewerAccessRequest(location: ReturnType<typeof useLocation>) {
+  const navigate = useNavigate()
+  const requestId = new URLSearchParams(location.search).get('access-request')
+  const dismiss = () => {
+    const params = new URLSearchParams(location.search)
+    params.delete('access-request')
+    void navigate(
+      {
+        pathname: location.pathname,
+        search: params.size > 0 ? `?${params.toString()}` : '',
+      },
+      { replace: true },
+    )
+  }
+  return { requestId, dismiss }
+}
+
 export function ViewerChrome({
   artifact,
   user,
@@ -193,6 +210,8 @@ export function ViewerChrome({
   const [moveOpen, setMoveOpen] = useState(false)
   const location = useLocation()
   const returnTo = viewerReturnTo(location.state, artifact.defaultReturnTo)
+  const { requestId: accessRequestId, dismiss: dismissAccessRequest } =
+    useViewerAccessRequest(location)
 
   const currentVisibility = isVisibility(artifact.visibility)
     ? artifact.visibility
@@ -344,6 +363,7 @@ export function ViewerChrome({
         <BridgeAttribution {...bridgeAttributionProps} variant="phone" />
         <div className="max-viewer:hidden flex-1" />
         <ViewerActions
+          accessRequestId={accessRequestId}
           artifactCanViewHistory={artifact.canViewHistory}
           canChangeVisibility={canChangeVisibility}
           commentCount={commentCount}
@@ -365,6 +385,7 @@ export function ViewerChrome({
           onDownloadHtml={onDownloadHtml}
           onDownloadMarkdown={onDownloadMarkdown}
           onDownloadPdf={onDownloadPdf}
+          onAccessRequestDismiss={dismissAccessRequest}
           translator={translator}
           user={user}
         />
@@ -880,6 +901,7 @@ function ViewerVisibilityDialog({
 }
 
 interface ViewerActionsProps {
+  accessRequestId: string | null
   artifactCanViewHistory: boolean | undefined
   canChangeVisibility: boolean
   canMove: boolean
@@ -906,12 +928,14 @@ interface ViewerActionsProps {
   onDownloadHtml?: () => void
   onDownloadMarkdown?: () => void
   onDownloadPdf?: () => void
+  onAccessRequestDismiss: () => void
   presence: ReadonlyArray<ViewerPresence>
   translator: ReturnType<typeof useT>
   user: UserInfo | null
 }
 
 function ViewerActions({
+  accessRequestId,
   artifactCanViewHistory,
   canChangeVisibility,
   canMove,
@@ -932,6 +956,7 @@ function ViewerActions({
   onDownloadHtml,
   onDownloadMarkdown,
   onDownloadPdf,
+  onAccessRequestDismiss,
   presence,
   translator,
   user,
@@ -1031,7 +1056,11 @@ function ViewerActions({
               compactActionClassName,
             )}
             aria-label={t('vw.copyUrl')}
-            onClick={() => copyShareUrl(window.location.href, translator)}
+            onClick={() => {
+              const url = new URL(window.location.href)
+              url.searchParams.delete('access-request')
+              void copyShareUrl(url.toString(), translator)
+            }}
           >
             <IconCopy size={14} strokeWidth={2} aria-hidden="true" />
             <span>{t('vw.copyUrl')}</span>
@@ -1128,7 +1157,13 @@ function ViewerActions({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <AvatarMenu user={user} variant="viewer" />
+          <AvatarMenu
+            key={accessRequestId ?? 'account'}
+            user={user}
+            variant="viewer"
+            initialAccessRequestId={accessRequestId}
+            onAccessRequestDismiss={onAccessRequestDismiss}
+          />
         </>
       ) : (
         <>

--- a/apps/web/app/routes/api.access-requests.tsx
+++ b/apps/web/app/routes/api.access-requests.tsx
@@ -10,11 +10,12 @@ import type { Route } from './+types/api.access-requests'
 
 export const middleware = [requireUserApiMiddleware]
 
-export async function loader({ context }: Route.LoaderArgs) {
+export async function loader({ context, url }: Route.LoaderArgs) {
   const user = requireUser(context)
   const db = createDb()
+  const requestedId = url.searchParams.get('request')
   const [received, sent, receivedPendingCount] = await Promise.all([
-    listReceivedAccessRequests(db, user),
+    listReceivedAccessRequests(db, user, requestedId),
     listSentAccessRequests(db, user.id),
     countReceivedAccessRequests(db, user),
   ])

--- a/apps/web/app/services/access-request-email.server.test.ts
+++ b/apps/web/app/services/access-request-email.server.test.ts
@@ -66,6 +66,9 @@ describe('access request email notifications', () => {
     expect(mail.send).toHaveBeenCalledWith(
       expect.objectContaining({ to: 'handler@example.com' }),
     )
+    expect(mail.send.mock.calls[0]?.[0]?.text).toContain(
+      'https://artifactshare.test/access-requests?request=request-1',
+    )
     await expect(emailAudit(db)).resolves.toMatchObject({
       action: 'access_request.email.succeeded',
     })

--- a/apps/web/app/services/access-requests.server.test.ts
+++ b/apps/web/app/services/access-requests.server.test.ts
@@ -17,6 +17,7 @@ vi.mock('cloudflare:workers', () => ({
 import {
   countReceivedAccessRequests,
   createAccessRequest,
+  getReceivedAccessRequestTarget,
   getRequesterAccessRequestStatus,
   listReceivedAccessRequests,
   processAccessRequest,
@@ -133,6 +134,27 @@ describe('access request service', () => {
         updated_at: '2026-09-01T00:00:00.000Z',
       })
       .execute()
+    await db
+      .insertInto('versions')
+      .values({
+        id: 'artifact-v1',
+        shareable_id: 'artifact',
+        artifact_kind: 'html_page',
+        status: 'published',
+        entrypoint_path: '/index.html',
+        r2_key: 'owner-workspace/artifact/v1/index.html',
+        size_bytes: 1,
+        sha256: 'artifact-v1-sha',
+        created_by_id: OWNER.id,
+        created_at: '2026-09-01T00:00:00.000Z',
+        published_at: '2026-09-01T00:00:00.000Z',
+      })
+      .execute()
+    await db
+      .updateTable('shareables')
+      .set({ current_version_id: 'artifact-v1' })
+      .where('id', '=', 'artifact')
+      .execute()
   })
 
   afterEach(async () => {
@@ -172,15 +194,21 @@ describe('access request service', () => {
       kind: 'created',
       approverEmails: [OWNER.email],
     })
+    if (created.kind !== 'created') throw new Error('request setup failed')
     await expect(
       createAccessRequest(db, 'artifact', REQUESTER),
     ).resolves.toMatchObject({
       kind: 'pending',
     })
     await expect(countReceivedAccessRequests(db, OWNER)).resolves.toBe(1)
+    await expect(
+      getReceivedAccessRequestTarget(db, created.requestId, OWNER),
+    ).resolves.toEqual({ shareableId: 'artifact', canView: true })
+    await expect(
+      getReceivedAccessRequestTarget(db, created.requestId, ADMIN),
+    ).resolves.toBeNull()
     await expect(countReceivedAccessRequests(db, ADMIN)).resolves.toBe(0)
     await expect(countReceivedAccessRequests(db, REQUESTER)).resolves.toBe(0)
-    if (created.kind !== 'created') throw new Error('request setup failed')
     await expect(
       processAccessRequest(db, created.requestId, ADMIN, { kind: 'reject' }),
     ).resolves.toEqual({ kind: 'forbidden' })
@@ -191,6 +219,68 @@ describe('access request service', () => {
         .where('id', '=', created.requestId)
         .executeTakeFirstOrThrow(),
     ).resolves.toEqual({ handler_user_id: OWNER.id })
+    await db
+      .updateTable('shareables')
+      .set({ current_version_id: null })
+      .where('id', '=', 'artifact')
+      .execute()
+    await expect(
+      getReceivedAccessRequestTarget(db, created.requestId, OWNER),
+    ).resolves.toEqual({ shareableId: 'artifact', canView: false })
+  })
+
+  test('includes a linked pending request beyond the first page', async () => {
+    const now = '2026-09-01T00:00:00.000Z'
+    const indexes = Array.from({ length: 51 }, (_, index) => index)
+    for (let offset = 0; offset < indexes.length; offset += 10) {
+      const chunk = indexes.slice(offset, offset + 10)
+      await db
+        .insertInto('users')
+        .values(
+          chunk.map((index) => ({
+            id: `bulk-requester-${index.toString().padStart(2, '0')}`,
+            email: `bulk-${index}@example.org`,
+            email_verified: 1,
+            name: `Bulk ${index}`,
+            image: null,
+            workspace_id: REQUESTER.workspaceId,
+            created_at: now,
+            updated_at: now,
+          })),
+        )
+        .execute()
+      await db
+        .insertInto('access_requests')
+        .values(
+          chunk.map((index) => ({
+            id: `bulk-request-${index.toString().padStart(2, '0')}`,
+            shareable_id: 'artifact',
+            requester_user_id: `bulk-requester-${index.toString().padStart(2, '0')}`,
+            handler_user_id: OWNER.id,
+            status: 'pending' as const,
+            resolved_by_user_id: null,
+            resolution_scope: null,
+            created_at: now,
+            updated_at: now,
+            resolved_at: null,
+          })),
+        )
+        .execute()
+    }
+
+    const defaultPage = await listReceivedAccessRequests(db, OWNER)
+    expect(defaultPage).toHaveLength(50)
+    expect(defaultPage.some((item) => item.id === 'bulk-request-50')).toBe(
+      false,
+    )
+
+    const linkedPage = await listReceivedAccessRequests(
+      db,
+      OWNER,
+      'bulk-request-50',
+    )
+    expect(linkedPage).toHaveLength(50)
+    expect(linkedPage[0]?.id).toBe('bulk-request-50')
   })
 
   test('records creation and approval snapshots with the request state changes', async () => {
@@ -473,6 +563,9 @@ describe('access request service', () => {
     await expect(countReceivedAccessRequests(db, OWNER)).resolves.toBe(1)
     await expect(countReceivedAccessRequests(db, ADMIN)).resolves.toBe(0)
     if (created.kind !== 'created') throw new Error('request setup failed')
+    await expect(
+      getReceivedAccessRequestTarget(db, created.requestId, OWNER),
+    ).resolves.toEqual({ shareableId: 'artifact', canView: false })
     await expect(
       processAccessRequest(db, created.requestId, OWNER, { kind: 'reject' }),
     ).resolves.toEqual({ kind: 'processed', status: 'rejected' })

--- a/apps/web/app/services/access-requests.server.ts
+++ b/apps/web/app/services/access-requests.server.ts
@@ -274,23 +274,82 @@ export async function countReceivedAccessRequests(
   return Number(row?.count ?? 0)
 }
 
+export async function getReceivedAccessRequestTarget(
+  db: Kysely<DB>,
+  requestId: string,
+  user: SessionUser,
+): Promise<{ shareableId: string; canView: boolean } | null> {
+  const row = await receivedBaseQuery(db, user)
+    .select([
+      's.id as shareableId',
+      's.name',
+      's.visibility',
+      's.owner_user_id as ownerUserId',
+      's.workspace_id as artifactWorkspaceId',
+      'owner.email as ownerEmail',
+      'c.id as containerId',
+      'c.kind as containerKind',
+      'c.base_visibility as containerBaseVisibility',
+      'current_version.r2_key as r2Key',
+    ])
+    .where('ar.id', '=', requestId)
+    .executeTakeFirst()
+  if (!row) return null
+
+  const access = await viewerDisplayCheck(
+    db,
+    row.visibility,
+    user.id,
+    row.r2Key
+      ? {
+          id: row.r2Key,
+          name: row.name,
+          mimeType: 'text/html',
+          modifiedTime: null,
+          ownerEmail: row.ownerEmail,
+        }
+      : null,
+    {
+      shareableId: row.shareableId,
+      ownerUserId: row.ownerUserId,
+      artifactWorkspaceId: row.artifactWorkspaceId,
+      viewerWorkspaceId: user.workspaceId,
+      viewerEmail: user.email,
+      viewerEmailVerified: user.emailVerified,
+      containerId: row.containerId,
+      containerKind: row.containerKind,
+      containerBaseVisibility: row.containerBaseVisibility,
+    },
+  )
+  return {
+    shareableId: row.shareableId,
+    canView: access.kind === 'access-granted',
+  }
+}
+
 export async function listReceivedAccessRequests(
   db: Kysely<DB>,
   user: SessionUser,
+  requestedId?: string | null,
 ): Promise<ReceivedAccessRequest[]> {
-  const rows = await receivedBaseQuery(db, user)
-    .select([
-      'ar.id',
-      'ar.created_at',
-      'requester.name as requester_name',
-      'requester.email as requester_email',
-      's.id as shareable_id',
-      's.name as shareable_name',
-      's.derived_title',
-      's.title_override',
-      'c.id as project_id',
-      'c.name as project_name',
-    ])
+  const query = receivedBaseQuery(db, user).select([
+    'ar.id',
+    'ar.created_at',
+    'requester.name as requester_name',
+    'requester.email as requester_email',
+    's.id as shareable_id',
+    's.name as shareable_name',
+    's.derived_title',
+    's.title_override',
+    'c.id as project_id',
+    'c.name as project_name',
+  ])
+  const prioritized = requestedId
+    ? query.orderBy(
+        sql<number>`CASE WHEN ar.id = ${requestedId} THEN 0 ELSE 1 END`,
+      )
+    : query
+  const rows = await prioritized
     .orderBy('ar.created_at', 'asc')
     .orderBy('ar.id', 'asc')
     .limit(50)
@@ -396,6 +455,11 @@ function receivedBaseQuery(db: Kysely<DB>, user: SessionUser) {
     .innerJoin('users as owner', 'owner.id', 's.owner_user_id')
     .innerJoin('users as requester', 'requester.id', 'ar.requester_user_id')
     .leftJoin('artifact_containers as c', 'c.id', 's.container_id')
+    .leftJoin(
+      'versions as current_version',
+      'current_version.id',
+      's.current_version_id',
+    )
     .innerJoin('workspaces as w', 'w.id', 's.workspace_id')
     .where('ar.status', '=', 'pending')
     .where(currentAccessRequestHandlerPredicate(user.id))


### PR DESCRIPTION
## 現状

閲覧リクエストの通知から確認画面を開いても、対象ファイルが表示されないため、タイトルだけでは何を確認すべきか判断しづらい状態でした。また、Viewer内の深いリンクから対象申請が一覧上限を超えている場合や、すでに処理済みの場合の表示が安定していませんでした。

## 変更

- 通知のレビュー入口から、担当者が対象ファイルを表示できる場合はViewer上で閲覧リクエストシートを開くようにしました
- Bot所有の非公開ファイルや実体欠損など、Viewerで表示できない場合は既存の権限申請画面へ安全にフォールバックします
- 深いリンクの対象申請を50件の一覧上限内へ優先的に含めます
- 処理済み・閲覧不能な申請では専用メッセージを表示し、空状態との二重表示をなくしました
- Viewerの共有リンクをコピーするときは内部用の申請IDを除外します

## 検証

- `pnpm validate:static`
- `pnpm test:behavior-browser`（13 files / 66 tests）
- `pnpm visual:compose`（4 files / 98 tests）
- `pnpm check:scenario-routes`
- `pnpm review:implementation`（Codex / Claudeともに最終指摘なし）
- trusted mainを使った公開境界ガード
