### PR TITLE
Send sanitized GA4 page_views so landing attribution works

### DIFF
--- a/apps/web/app/components/app/analytics-gtag.test.tsx
+++ b/apps/web/app/components/app/analytics-gtag.test.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter, useNavigate } from 'react-router'
 import { trackEvent } from '~/lib/analytics/track.client'
 
 import { AnalyticsGtag } from './analytics-gtag'
@@ -11,6 +12,7 @@ describe('AnalyticsGtag', () => {
   let root: Root
 
   beforeEach(() => {
+    window.history.replaceState({}, '', '/')
     document.head.innerHTML = ''
     document.cookie = '_ga=; Path=/; Max-Age=0'
     document.cookie = '_ga_TEST=; Path=/; Max-Age=0'
@@ -31,11 +33,13 @@ describe('AnalyticsGtag', () => {
   it('does not load when consent is false', async () => {
     await React.act(async () => {
       root.render(
-        <AnalyticsGtag
-          shouldLoadAnalytics={false}
-          measurementId="G-TEST"
-          userId={null}
-        />,
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics={false}
+            measurementId="G-TEST"
+            userId={null}
+          />
+        </MemoryRouter>,
       )
     })
     expect(document.getElementById('as-gtag-js')).toBeNull()
@@ -46,20 +50,24 @@ describe('AnalyticsGtag', () => {
     ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
     await React.act(async () => {
       root.render(
-        <AnalyticsGtag
-          shouldLoadAnalytics
-          measurementId="G-TEST"
-          userId="u-hash"
-        />,
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics
+            measurementId="G-TEST"
+            userId="u-hash"
+          />
+        </MemoryRouter>,
       )
     })
     await React.act(async () => {
       root.render(
-        <AnalyticsGtag
-          shouldLoadAnalytics
-          measurementId="G-TEST"
-          userId="u-hash"
-        />,
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics
+            measurementId="G-TEST"
+            userId="u-hash"
+          />
+        </MemoryRouter>,
       )
     })
     expect(document.querySelectorAll('#as-gtag-js')).toHaveLength(1)
@@ -70,27 +78,43 @@ describe('AnalyticsGtag', () => {
       send_page_view: false,
       cookie_domain: 'none',
     })
+    expect(
+      gtag.mock.calls.filter(([command]) => command === 'config'),
+    ).toHaveLength(1)
     expect(gtag).toHaveBeenCalledWith('set', { user_id: 'u-hash' })
+    // page_view is explicit (send_page_view is false) and sent once per route.
+    expect(
+      gtag.mock.calls.filter(
+        ([command, name]) => command === 'event' && name === 'page_view',
+      ),
+    ).toHaveLength(1)
   })
 
-  it('queues consent, js, config, and user_id in order', async () => {
+  it('queues consent, js, user_id, config, page fields, and page_view in order', async () => {
     const gtag = vi.fn()
     ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
     await React.act(async () => {
       root.render(
-        <AnalyticsGtag
-          shouldLoadAnalytics
-          measurementId="G-TEST"
-          userId="u-hash"
-        />,
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics
+            measurementId="G-TEST"
+            userId="u-hash"
+          />
+        </MemoryRouter>,
       )
     })
     expect(gtag.mock.calls.map(([command]) => command)).toEqual([
       'consent',
       'js',
+      'set',
       'config',
       'set',
+      'event',
     ])
+    expect(gtag).toHaveBeenLastCalledWith('event', 'page_view', {
+      page_location: expect.stringContaining('http'),
+    })
   })
 
   it('initializes before a preceding sibling passive event', async () => {
@@ -104,24 +128,26 @@ describe('AnalyticsGtag', () => {
     }
     await React.act(async () => {
       root.render(
-        <>
+        <MemoryRouter>
           <DirectLandingEvent />
           <AnalyticsGtag
             shouldLoadAnalytics
             measurementId="G-TEST"
             userId={null}
           />
-        </>,
+        </MemoryRouter>,
       )
     })
     expect(gtag.mock.calls.map(([command]) => command)).toEqual([
       'consent',
       'js',
+      'set',
       'config',
       'set',
       'event',
+      'event',
     ])
-    expect(gtag).toHaveBeenLastCalledWith('event', 'artifact_view', {
+    expect(gtag).toHaveBeenCalledWith('event', 'artifact_view', {
       artifact_id: 'direct',
     })
   })
@@ -136,14 +162,14 @@ describe('AnalyticsGtag', () => {
       return null
     }
     const render = (shouldLoad: boolean) => (
-      <>
+      <MemoryRouter>
         <ConsentAwareEvent shouldLoad={shouldLoad} />
         <AnalyticsGtag
           shouldLoadAnalytics={shouldLoad}
           measurementId="G-TEST"
           userId={null}
         />
-      </>
+      </MemoryRouter>
     )
     await React.act(async () => root.render(render(false)))
     expect(gtag).not.toHaveBeenCalledWith(
@@ -156,11 +182,13 @@ describe('AnalyticsGtag', () => {
     expect(gtag.mock.calls.map(([command]) => command)).toEqual([
       'consent',
       'js',
+      'set',
       'config',
       'set',
       'event',
+      'event',
     ])
-    expect(gtag).toHaveBeenLastCalledWith('event', 'artifact_view', {
+    expect(gtag).toHaveBeenCalledWith('event', 'artifact_view', {
       artifact_id: 'after-consent',
     })
   })
@@ -172,20 +200,24 @@ describe('AnalyticsGtag', () => {
     document.cookie = '_ga_TEST=y; Path=/'
     await React.act(async () => {
       root.render(
-        <AnalyticsGtag
-          shouldLoadAnalytics
-          measurementId="G-TEST"
-          userId="u-hash"
-        />,
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics
+            measurementId="G-TEST"
+            userId="u-hash"
+          />
+        </MemoryRouter>,
       )
     })
     await React.act(async () => {
       root.render(
-        <AnalyticsGtag
-          shouldLoadAnalytics={false}
-          measurementId="G-TEST"
-          userId={null}
-        />,
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics={false}
+            measurementId="G-TEST"
+            userId={null}
+          />
+        </MemoryRouter>,
       )
     })
     // gtag.js was loaded, so withdrawal must tell GA consent is denied — not
@@ -206,11 +238,13 @@ describe('AnalyticsGtag', () => {
     ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
     await React.act(async () => {
       root.render(
-        <AnalyticsGtag
-          shouldLoadAnalytics
-          measurementId="G-TEST"
-          userId={null}
-        />,
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics
+            measurementId="G-TEST"
+            userId={null}
+          />
+        </MemoryRouter>,
       )
     })
     expect(gtag).toHaveBeenCalledWith('set', { user_id: null })
@@ -221,30 +255,36 @@ describe('AnalyticsGtag', () => {
     ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
     await React.act(async () => {
       root.render(
-        <AnalyticsGtag
-          shouldLoadAnalytics
-          measurementId="G-TEST"
-          userId="u-hash"
-        />,
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics
+            measurementId="G-TEST"
+            userId="u-hash"
+          />
+        </MemoryRouter>,
       )
     })
     await React.act(async () => {
       root.render(
-        <AnalyticsGtag
-          shouldLoadAnalytics={false}
-          measurementId="G-TEST"
-          userId={null}
-        />,
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics={false}
+            measurementId="G-TEST"
+            userId={null}
+          />
+        </MemoryRouter>,
       )
     })
     gtag.mockClear()
     await React.act(async () => {
       root.render(
-        <AnalyticsGtag
-          shouldLoadAnalytics
-          measurementId="G-TEST"
-          userId="u-hash"
-        />,
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics
+            measurementId="G-TEST"
+            userId="u-hash"
+          />
+        </MemoryRouter>,
       )
     })
     // gtag.js is already loaded, so a re-grant must restore granted (not
@@ -256,5 +296,124 @@ describe('AnalyticsGtag', () => {
       ad_personalization: 'denied',
     })
     expect(document.querySelectorAll('#as-gtag-js')).toHaveLength(1)
+  })
+
+  it('strips non-allowlisted query parameters from page_view', async () => {
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    window.history.replaceState(
+      {},
+      '',
+      '/device?user_code=SECRET&utm_source=x&utm_campaign=exp001#frag',
+    )
+    await React.act(async () => {
+      root.render(
+        <MemoryRouter>
+          <AnalyticsGtag
+            shouldLoadAnalytics
+            measurementId="G-TEST"
+            userId={null}
+          />
+        </MemoryRouter>,
+      )
+    })
+    const pageView = gtag.mock.calls.find(
+      ([command, name]) => command === 'event' && name === 'page_view',
+    )
+    if (!pageView) throw new Error('page_view not sent')
+    const { page_location } = pageView[2] as { page_location: string }
+    expect(page_location).toContain('utm_source=x')
+    expect(page_location).toContain('utm_campaign=exp001')
+    expect(page_location).not.toContain('user_code')
+    expect(page_location).not.toContain('SECRET')
+    expect(page_location).not.toContain('#')
+    window.history.replaceState({}, '', '/')
+  })
+
+  it('sends one page_view per route and dedupes replace-only query changes', async () => {
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    function Navigator({
+      to,
+      replace = false,
+    }: {
+      to: string | null
+      replace?: boolean
+    }) {
+      const navigate = useNavigate()
+      const doneRef = React.useRef<string | null>(null)
+      useEffect(() => {
+        if (to && doneRef.current !== to) {
+          doneRef.current = to
+          if (replace) window.history.replaceState({}, '', to)
+          else window.history.pushState({}, '', to)
+          navigate(to, { replace })
+        }
+      }, [to, replace, navigate])
+      return null
+    }
+    const render = (to: string | null, replace = false) => (
+      <MemoryRouter>
+        <Navigator to={to} replace={replace} />
+        <AnalyticsGtag
+          shouldLoadAnalytics
+          measurementId="G-TEST"
+          userId={null}
+        />
+      </MemoryRouter>
+    )
+    const pageViews = () =>
+      gtag.mock.calls.filter(
+        ([command, name]) => command === 'event' && name === 'page_view',
+      )
+    await React.act(async () => root.render(render(null)))
+    expect(pageViews()).toHaveLength(1)
+
+    await React.act(async () =>
+      root.render(render('/pricing?utm_source=x&session_token=SECRET')),
+    )
+    expect(pageViews()).toHaveLength(2)
+    const { page_location } = pageViews()[1][2] as { page_location: string }
+    expect(page_location).toContain('/pricing?utm_source=x')
+    expect(page_location).not.toContain('SECRET')
+
+    // A replace navigation that only strips a non-allowlisted query parameter
+    // changes location.key but not the sanitized page — no extra page_view.
+    await React.act(async () =>
+      root.render(render('/pricing?utm_source=x', true)),
+    )
+    expect(pageViews()).toHaveLength(2)
+
+    // A push navigation still counts even when only non-allowlisted query
+    // state changes (e.g. pagination): the user did move to a new view.
+    await React.act(async () =>
+      root.render(render('/pricing?utm_source=x&page=2')),
+    )
+    expect(pageViews()).toHaveLength(3)
+  })
+
+  it('sends the landing page_view again after withdrawal and re-grant', async () => {
+    const gtag = vi.fn()
+    ;(window as unknown as { gtag: typeof gtag }).gtag = gtag
+    const render = (shouldLoad: boolean) => (
+      <MemoryRouter>
+        <AnalyticsGtag
+          shouldLoadAnalytics={shouldLoad}
+          measurementId="G-TEST"
+          userId={null}
+        />
+      </MemoryRouter>
+    )
+    const pageViews = () =>
+      gtag.mock.calls.filter(
+        ([command, name]) => command === 'event' && name === 'page_view',
+      )
+    await React.act(async () => root.render(render(true)))
+    expect(pageViews()).toHaveLength(1)
+    // Withdrawal wipes GA cookies; the next granted session must get its
+    // landing page_view or its landing page becomes "(not set)".
+    await React.act(async () => root.render(render(false)))
+    await React.act(async () => root.render(render(true)))
+    expect(pageViews()).toHaveLength(2)
   })
 })

--- a/apps/web/app/components/app/analytics-gtag.tsx
+++ b/apps/web/app/components/app/analytics-gtag.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useLayoutEffect } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
+import { useLocation, useNavigationType } from 'react-router'
 
-import { setAnalyticsRuntimeState } from '~/lib/analytics/track.client'
+import { ANALYTICS_EVENTS } from '~/lib/analytics/events'
+import {
+  setAnalyticsRuntimeState,
+  trackEvent,
+} from '~/lib/analytics/track.client'
 import { clearFirstTouch } from '~/lib/analytics/first-touch.client'
 import { clearAllAuthAttempts } from '~/lib/analytics/auth-attempt.client'
 
@@ -19,7 +24,7 @@ function removeAnalyticsCookies(measurementId: string | null): void {
   }
 }
 
-function loadGtag(measurementId: string): void {
+function loadGtag(measurementId: string, userId: string | null): void {
   const w0 = window as unknown as { gtag?: (...args: unknown[]) => void }
   if (document.getElementById('as-gtag-js')) {
     // Already loaded (e.g. consent re-granted after a withdrawal that set
@@ -30,6 +35,7 @@ function loadGtag(measurementId: string): void {
       ad_user_data: 'denied',
       ad_personalization: 'denied',
     })
+    w0.gtag?.('set', { user_id: userId })
     return
   }
   const script = document.createElement('script')
@@ -47,7 +53,13 @@ function loadGtag(measurementId: string): void {
     ad_personalization: 'denied',
   })
   w.gtag?.('js', new Date())
+  // Apply user_id before config so every page_view carries it.
+  w.gtag?.('set', { user_id: userId })
   // cookie_domain 'none' keeps GA cookies host-only so withdrawal cleanup works.
+  // send_page_view stays off: page_view is sent explicitly with a sanitized
+  // page_location (see AnalyticsGtag), because some routes carry authorization
+  // material in the query string (e.g. /device?user_code=...) that must not
+  // reach a third-party analytics store.
   w.gtag?.('config', measurementId, {
     send_page_view: false,
     cookie_domain: 'none',
@@ -87,12 +99,10 @@ function syncGtagWithConsent(
   }
 
   if (measurementId) {
-    loadGtag(measurementId)
-    // Apply user_id after config and before enabling the event sender. Since
-    // send_page_view is false, the first hit is still the later custom event.
-    // null clears a prior user (logout); re-grant also reapplies the current id.
-    const w = window as unknown as { gtag?: (...args: unknown[]) => void }
-    w.gtag?.('set', { user_id: userId })
+    // loadGtag applies user_id before config so every hit, including the
+    // initial page_view, carries it. null clears a prior user (logout);
+    // re-grant also reapplies the current id.
+    loadGtag(measurementId, userId)
     setAnalyticsRuntimeState({ shouldLoadAnalytics: true, measurementId })
     return
   }
@@ -107,6 +117,60 @@ function syncGtagWithConsent(
   }
 }
 
+// Query parameters allowed on the page_location sent to GA. Everything else is
+// stripped: routes like /device?user_code=... and the signed OAuth sign-in URL
+// carry authorization material that must never reach Google.
+const PAGE_VIEW_ALLOWED_PARAMS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'utm_id',
+  'utm_source_platform',
+  // Google auto-tagging / cross-domain linker parameters: stripping these
+  // would break paid attribution, and they carry no authorization material.
+  'gclid',
+  'dclid',
+  'gbraid',
+  'wbraid',
+  'srsltid',
+  '_gl',
+]
+
+function sanitizeUrl(href: string): string {
+  const url = new URL(href)
+  const kept = new URLSearchParams()
+  for (const name of PAGE_VIEW_ALLOWED_PARAMS) {
+    const value = url.searchParams.get(name)
+    if (value !== null) kept.set(name, value)
+  }
+  url.search = kept.toString()
+  url.hash = ''
+  return url.toString()
+}
+
+function sanitizedPageLocation(): string {
+  return sanitizeUrl(window.location.href)
+}
+
+// A same-origin referrer (e.g. /device?user_code=... into a full-page
+// sign-in navigation) can carry the same authorization material, so it gets
+// the same allowlist. Cross-origin referrers keep their value — that is the
+// acquisition signal — and an unparsable one is dropped.
+function sanitizedPageReferrer(): string | null {
+  const referrer = document.referrer
+  if (!referrer) return null
+  try {
+    const url = new URL(referrer)
+    return url.origin === window.location.origin
+      ? sanitizeUrl(referrer)
+      : referrer
+  } catch {
+    return null
+  }
+}
+
 export function AnalyticsGtag({
   shouldLoadAnalytics,
   measurementId,
@@ -116,11 +180,78 @@ export function AnalyticsGtag({
   measurementId: string | null
   userId: string | null
 }): null {
+  const location = useLocation()
+  const navigationType = useNavigationType()
+  // Sanitized location/referrer pinned for the current route (all hits), and
+  // the last page_view actually sent (for dedupe across replace cleanups).
+  const pinnedPage = useRef<{
+    location: string
+    referrer: string | null
+  } | null>(null)
+  const sentPageView = useRef<{ key: string; location: string } | null>(null)
   // All passive event effects run after this layout effect, including a direct
   // landing's ArtifactViewTracker even though it appears earlier in the tree.
   useClientLayoutEffect(() => {
     syncGtagWithConsent(shouldLoadAnalytics, measurementId, userId)
   }, [shouldLoadAnalytics, measurementId, userId])
+
+  // Pin the sanitized page fields globally before any passive event effect
+  // runs, so every hit — custom events included — carries the sanitized
+  // page_location/page_referrer instead of gtag's raw document.location.
+  // For SPA navigations the referrer is the previous in-app page (already
+  // sanitized); document.referrer only seeds the initial load.
+  useClientLayoutEffect(() => {
+    if (!shouldLoadAnalytics || !measurementId) {
+      // Forget the pinned page on withdrawal so a later re-grant derives
+      // page_referrer from the actual previous page, not a pre-withdrawal one.
+      pinnedPage.current = null
+      return
+    }
+    const pageLocation = sanitizedPageLocation()
+    const previous = pinnedPage.current
+    const referrer =
+      previous === null
+        ? sanitizedPageReferrer()
+        : previous.location === pageLocation
+          ? previous.referrer
+          : previous.location
+    pinnedPage.current = { location: pageLocation, referrer }
+    const w = window as unknown as { gtag?: (...args: unknown[]) => void }
+    w.gtag?.('set', { page_location: pageLocation, page_referrer: referrer })
+  }, [location.key, shouldLoadAnalytics, measurementId])
+
+  // Explicit page_view per route (landing included), so acquisition
+  // attribution (UTM, referrer) works. Enhanced Measurement's history-change
+  // page_view must stay OFF on the GA4 stream: it would send raw URLs and
+  // double-count. A replace navigation whose sanitized location is unchanged
+  // (query-parameter cleanup) adopts the new location.key without re-sending;
+  // push/pop navigations always count, even when only non-allowlisted query
+  // state changed. Consent withdrawal clears the sent marker so a re-grant
+  // session gets its landing page_view again.
+  useEffect(() => {
+    if (!shouldLoadAnalytics || !measurementId) {
+      sentPageView.current = null
+      return
+    }
+    const pageLocation = sanitizedPageLocation()
+    const previous = sentPageView.current
+    if (previous?.key === location.key) return
+    if (
+      previous !== null &&
+      navigationType === 'REPLACE' &&
+      previous.location === pageLocation
+    ) {
+      sentPageView.current = { key: location.key, location: pageLocation }
+      return
+    }
+    // trackEvent reports whether the hit was actually pushed; only then is
+    // this location marked as counted, so a missing gtag runtime retries.
+    if (
+      trackEvent(ANALYTICS_EVENTS.pageView, { page_location: pageLocation })
+    ) {
+      sentPageView.current = { key: location.key, location: pageLocation }
+    }
+  }, [location.key, navigationType, shouldLoadAnalytics, measurementId])
 
   return null
 }

--- a/apps/web/app/lib/analytics/events.test.ts
+++ b/apps/web/app/lib/analytics/events.test.ts
@@ -8,6 +8,7 @@ import {
 describe('analytics definitions', () => {
   test('defines the analytics events', () => {
     expect(Object.values(ANALYTICS_EVENTS)).toEqual([
+      'page_view',
       'artifact_view',
       'copy_link_succeeded',
       'copy_link_failed',

--- a/apps/web/app/lib/analytics/events.ts
+++ b/apps/web/app/lib/analytics/events.ts
@@ -1,6 +1,7 @@
 // client と Node Admin スクリプトの両方が import する純粋モジュール。window/server を参照しない
 
 export const ANALYTICS_EVENTS = {
+  pageView: 'page_view',
   artifactView: 'artifact_view',
   copyLinkSucceeded: 'copy_link_succeeded',
   copyLinkFailed: 'copy_link_failed',


### PR DESCRIPTION
## Implementation

GA4 previously received no `page_view` at all (`send_page_view: false`, and no explicit sends), so landing pages were "(not set)" and UTM/referrer acquisition attribution never worked. This change sends an explicit `page_view` per route through the registered analytics sender (`trackEvent`, with `page_view` added to `ANALYTICS_EVENTS`), and pins sanitized `page_location`/`page_referrer` globally so every hit — custom events included — carries them.

Sanitization keeps an allowlist of campaign parameters (`utm_*`, Google auto-tagging/linker params) and strips everything else, because some routes carry authorization material in the query string (e.g. `/device?user_code=...`, the signed OAuth sign-in URL); the same allowlist applies to a same-origin referrer. This also fixes a pre-existing leak where custom events carried gtag's raw `document.location`.

Details: `user_id` now applies before `config` so every hit carries it; a REPLACE navigation whose sanitized location is unchanged (query cleanup) does not re-send `page_view`, while push/pop navigations always count; consent withdrawal clears the sent/pinned state so a re-granted session gets a fresh landing `page_view` and referrer. Enhanced Measurement's history-change page_view must stay OFF on the GA4 stream (it would send raw URLs and double-count); it is off.

## Visible effect

Landing pages, session source/medium/campaign (UTM), and referrer attribution appear in GA4 for consented sessions; sign-ups become attributable to ad campaigns. Sensitive query parameters never reach Google.

## Validation

- `pnpm validate:static` pass (react-doctor 100, scan 0 findings)
- New/updated unit tests: 11 in `analytics-gtag.test.tsx` (ordering, sanitization incl. `user_code` stripping, REPLACE dedupe vs push counting, withdrawal→re-grant resend), analytics contract tests updated (14 total pass)
- Final gate: Codex and Claude deep reviews in parallel on c2d813e — no blockers. Follow-ups noted: same-sanitized-URL push navigations reuse the prior referrer (accuracy nit); `utm_marketing_tactic`/`utm_creative_format`/`gad_source` not yet allowlisted; query-only push navigations (e.g. /recent filters) intentionally count as page_views with identical sanitized location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
