### PR TITLE
Enable collaborative artifact updates

### DIFF
--- a/apps/web/app/lib/cli-capability-matrix.json
+++ b/apps/web/app/lib/cli-capability-matrix.json
@@ -2389,8 +2389,7 @@
           "--token",
           "--profile",
           "--allow-plaintext-token-store",
-          "--insecure-localhost",
-          "--expected-version"
+          "--insecure-localhost"
         ]
       }
     },
@@ -2586,7 +2585,8 @@
           "--token",
           "--profile",
           "--allow-plaintext-token-store",
-          "--insecure-localhost"
+          "--insecure-localhost",
+          "--expected-version"
         ]
       }
     },

--- a/apps/web/app/lib/cli-capability-matrix.json
+++ b/apps/web/app/lib/cli-capability-matrix.json
@@ -2222,7 +2222,8 @@
           "--no-link-expiry",
           "--no-slack-notify",
           "--grant-email",
-          "--key"
+          "--key",
+          "--expected-version"
         ]
       }
     },
@@ -2388,7 +2389,8 @@
           "--token",
           "--profile",
           "--allow-plaintext-token-store",
-          "--insecure-localhost"
+          "--insecure-localhost",
+          "--expected-version"
         ]
       }
     },

--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -788,5 +788,5 @@
       ]
     }
   ],
-  "generated_date": "2026-08-30"
+  "generated_date": "2026-09-02"
 }

--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -658,7 +658,8 @@
         "--no-link-expiry",
         "--no-slack-notify",
         "--grant-email",
-        "--key"
+        "--key",
+        "--expected-version"
       ]
     },
     {
@@ -770,7 +771,8 @@
         "--token",
         "--profile",
         "--allow-plaintext-token-store",
-        "--insecure-localhost"
+        "--insecure-localhost",
+        "--expected-version"
       ]
     },
     {

--- a/apps/web/app/lib/create-version-response.server.ts
+++ b/apps/web/app/lib/create-version-response.server.ts
@@ -12,6 +12,13 @@ export function createVersionFailureResponse(
   switch (result.kind) {
     case 'not-found':
       return errorResponse('not-found', 'Shareable not found.', 404)
+    case 'version-conflict':
+      return errorResponse(
+        'version_conflict',
+        'The artifact changed before the update was committed.',
+        409,
+        { details: { current_version_id: result.currentVersionId } },
+      )
     case 'copy-forbidden':
       return copyForbidden()
     case 'unsupported-type':

--- a/apps/web/app/lib/static-site-upload-response.server.ts
+++ b/apps/web/app/lib/static-site-upload-response.server.ts
@@ -119,6 +119,17 @@ export function staticSiteBundleResponse(
       )
     case 'quota-exceeded':
       return errorResponse('quota-exceeded', 'Storage quota exceeded.', 413)
+    case 'version-conflict':
+      return Response.json(
+        {
+          error: {
+            code: 'version_conflict',
+            message: 'The artifact changed before the update was committed.',
+            details: { current_version_id: result.currentVersionId },
+          },
+        },
+        { status: 409 },
+      )
     case 'workspace-access-revoked':
       return workspaceAccessRevokedResponse()
     case 'contributor-limit-exceeded':

--- a/apps/web/app/lib/static-site-upload-response.server.ts
+++ b/apps/web/app/lib/static-site-upload-response.server.ts
@@ -130,6 +130,8 @@ export function staticSiteBundleResponse(
         },
         { status: 409 },
       )
+    case 'not-found':
+      return errorResponse('not-found', 'Artifact not found.', 404)
     case 'workspace-access-revoked':
       return workspaceAccessRevokedResponse()
     case 'contributor-limit-exceeded':

--- a/apps/web/app/lib/static-site-version-upload.server.ts
+++ b/apps/web/app/lib/static-site-version-upload.server.ts
@@ -2,6 +2,7 @@ import { parseFormData } from '@remix-run/form-data-parser'
 import type { Kysely } from 'kysely'
 import type { Visibility } from '~/lib/shareable-types'
 import type { DB } from '~/types/db'
+import type { CliAuthority } from '~/services/cli-authority.server'
 import {
   beginStaticSiteBundleVersionUploadSession,
   type StaticSiteBundleVersionUploadSessionResult,
@@ -42,6 +43,9 @@ export async function runStaticSiteVersionUpload(
       created?: boolean
     }
     waitUntil?: (promise: Promise<unknown>) => void
+    authority?: CliAuthority | null
+    expectedCurrentVersionId?: string
+    agentProfileId?: string | null
   } = {},
 ): Promise<Response> {
   const begun = await beginStaticSiteBundleVersionUploadSession(
@@ -49,7 +53,16 @@ export async function runStaticSiteVersionUpload(
     user,
     shareableId,
     options.touchArtifactKeyId ?? null,
-    { waitUntil: options.waitUntil },
+    {
+      ...(options.waitUntil ? { waitUntil: options.waitUntil } : {}),
+      ...(options.authority ? { authority: options.authority } : {}),
+      ...(options.expectedCurrentVersionId
+        ? { expectedCurrentVersionId: options.expectedCurrentVersionId }
+        : {}),
+      ...(options.agentProfileId
+        ? { agentProfileId: options.agentProfileId }
+        : {}),
+    },
   )
   if (begun.kind !== 'ok') return staticSiteSessionBeginResponse(begun)
   const { session } = begun

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -534,6 +534,7 @@ export async function loader({
       shareable.id,
       shareable.current_version_id,
       displayedVersion.id,
+      shareable.workspace_id === user.workspaceId,
     )
   ).map((version) => ({
     ...version,
@@ -1314,6 +1315,7 @@ async function loadHistoryVersions(
   shareableId: string,
   currentVersionId: string | null,
   displayedVersionId: string,
+  mayShowCreatorEmail: boolean,
 ): Promise<ReadonlyArray<VersionRow>> {
   const [countRow, rows] = await Promise.all([
     db
@@ -1332,6 +1334,7 @@ async function loadHistoryVersions(
         'versions.size_bytes as sizeBytes',
         'users.email as createdByEmail',
         'users.name as createdByName',
+        'versions.created_by_agent_profile_id as createdByAgentProfileId',
       ])
       .where('versions.shareable_id', '=', shareableId)
       .where('versions.status', '=', 'published')
@@ -1349,7 +1352,11 @@ async function loadHistoryVersions(
     createdAt: row.createdAt,
     sizeBytes: row.sizeBytes,
     isCurrent: row.id === currentVersionId,
-    createdByLabel: row.createdByName ?? row.createdByEmail,
+    createdByLabel: row.createdByAgentProfileId
+      ? 'Agent'
+      : (row.createdByName ??
+        (mayShowCreatorEmail ? row.createdByEmail : null) ??
+        'User'),
   }))
   if (versions.some((version) => version.id === displayedVersionId)) {
     return versions
@@ -1364,6 +1371,7 @@ async function loadHistoryVersions(
       'versions.size_bytes as sizeBytes',
       'users.email as createdByEmail',
       'users.name as createdByName',
+      'versions.created_by_agent_profile_id as createdByAgentProfileId',
       eb
         .selectFrom('versions as older')
         .select((sub) => sub.fn.count<number>('older.id').as('count'))
@@ -1395,7 +1403,11 @@ async function loadHistoryVersions(
       createdAt: displayedRow.createdAt,
       sizeBytes: displayedRow.sizeBytes,
       isCurrent: displayedRow.id === currentVersionId,
-      createdByLabel: displayedRow.createdByName ?? displayedRow.createdByEmail,
+      createdByLabel: displayedRow.createdByAgentProfileId
+        ? 'Agent'
+        : (displayedRow.createdByName ??
+          (mayShowCreatorEmail ? displayedRow.createdByEmail : null) ??
+          'User'),
     },
   ]
 }

--- a/apps/web/app/routes/api.cli.artifacts.$id.test.ts
+++ b/apps/web/app/routes/api.cli.artifacts.$id.test.ts
@@ -134,6 +134,7 @@ describe('/api/cli/artifacts/:id', () => {
         baseUrl: 'https://artifactshare.test',
         offset: 200000,
         include: ['versions', 'comments'],
+        includeSharedVersions: true,
       },
     )
   })

--- a/apps/web/app/routes/api.cli.artifacts.$id.tsx
+++ b/apps/web/app/routes/api.cli.artifacts.$id.tsx
@@ -54,6 +54,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
       baseUrl: url.origin,
       offset,
       include,
+      includeSharedVersions: true,
     })
     if (result.kind === 'ok') return Response.json(result.data)
     return cliArtifactErrorResponse(

--- a/apps/web/app/routes/api.cli.shareables.$id.edit.test.ts
+++ b/apps/web/app/routes/api.cli.shareables.$id.edit.test.ts
@@ -9,6 +9,7 @@ vi.mock('~/middleware/auth', () => ({
   requireUserApiWithBearerMiddleware: requireUserApiWithBearerMiddlewareMock,
 }))
 vi.mock('~/middleware/context', () => ({
+  getCliAuthority: () => null,
   requireUser: requireUserMock,
 }))
 vi.mock('~/services/db.server', () => ({
@@ -83,6 +84,7 @@ describe('/api/cli/shareables/:id/edit', () => {
         removeEmails: ['old@example.com'],
         destination: { type: 'project', projectId: 'prj1' },
       },
+      null,
     )
     expect(body).toEqual({
       artifact: {

--- a/apps/web/app/routes/api.cli.shareables.$id.edit.tsx
+++ b/apps/web/app/routes/api.cli.shareables.$id.edit.tsx
@@ -5,7 +5,7 @@ import {
   parseCliEditPayload,
 } from '~/lib/shareable-settings-adapter.server'
 import { requireUserApiWithBearerMiddleware } from '~/middleware/auth'
-import { requireUser } from '~/middleware/context'
+import { getCliAuthority, requireUser } from '~/middleware/context'
 import { withDb } from '~/services/db.server'
 import { editShareableSettings } from '~/services/shareables.server'
 import type { Route } from './+types/api.cli.shareables.$id.edit'
@@ -25,7 +25,14 @@ export async function action({ request, params, context }: Route.ActionArgs) {
   }
 
   const result = await withDb(
-    async (db) => await editShareableSettings(db, user, params.id, parsed),
+    async (db) =>
+      await editShareableSettings(
+        db,
+        user,
+        params.id,
+        parsed,
+        getCliAuthority(context),
+      ),
   )
   switch (result.kind) {
     case 'ok':

--- a/apps/web/app/routes/api.cli.shareables.$id.move.test.ts
+++ b/apps/web/app/routes/api.cli.shareables.$id.move.test.ts
@@ -9,6 +9,7 @@ vi.mock('~/middleware/auth', () => ({
   requireUserApiWithBearerMiddleware: requireUserApiWithBearerMiddlewareMock,
 }))
 vi.mock('~/middleware/context', () => ({
+  getCliAuthority: () => null,
   requireUser: requireUserMock,
 }))
 vi.mock('~/services/db.server', () => ({
@@ -66,6 +67,7 @@ describe('/api/cli/shareables/:id/move', () => {
       expect.objectContaining({ id: 'u1', workspaceId: 'ws1' }),
       'abc123def4',
       { type: 'project', projectId: 'prj1' },
+      null,
     )
     expect(body.destination).toEqual({ type: 'project', project_id: 'prj1' })
     expect(body.share).toEqual({
@@ -102,6 +104,7 @@ describe('/api/cli/shareables/:id/move', () => {
       expect.anything(),
       'abc123def4',
       { type: 'inbox' },
+      null,
     )
     expect(body.destination).toEqual({ type: 'home', project_id: null })
     expect(body.share.visibility).toBe('private')

--- a/apps/web/app/routes/api.cli.shareables.$id.move.tsx
+++ b/apps/web/app/routes/api.cli.shareables.$id.move.tsx
@@ -5,7 +5,7 @@ import {
   parseCliDestination,
 } from '~/lib/shareable-settings-adapter.server'
 import { requireUserApiWithBearerMiddleware } from '~/middleware/auth'
-import { requireUser } from '~/middleware/context'
+import { getCliAuthority, requireUser } from '~/middleware/context'
 import { withDb } from '~/services/db.server'
 import { moveShareableContainer } from '~/services/shareables.server'
 import type { Route } from './+types/api.cli.shareables.$id.move'
@@ -27,7 +27,13 @@ export async function action({ request, params, context }: Route.ActionArgs) {
 
   const result = await withDb(
     async (db) =>
-      await moveShareableContainer(db, user, params.id, destination),
+      await moveShareableContainer(
+        db,
+        user,
+        params.id,
+        destination,
+        getCliAuthority(context),
+      ),
   )
   if (result.kind !== 'ok') {
     return cliMoveErrorResponse(result)

--- a/apps/web/app/routes/api.shareables.$id.versions.tsx
+++ b/apps/web/app/routes/api.shareables.$id.versions.tsx
@@ -86,9 +86,10 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   const user = requireUser(context)
   const db = createDb()
   const authority = getCliAuthority(context)
-  const expectedCurrentVersionId = new URL(request.url).searchParams.get(
+  const expectedVersionParam = new URL(request.url).searchParams.get(
     'expected_version',
   )
+  const expectedCurrentVersionId = expectedVersionParam?.trim() || null
   if (authority?.kind === 'agent' && !expectedCurrentVersionId)
     return errorResponse(
       'expected-version-required',

--- a/apps/web/app/routes/api.shareables.$id.versions.tsx
+++ b/apps/web/app/routes/api.shareables.$id.versions.tsx
@@ -5,7 +5,6 @@ import { uploadPermissionFailureResponse } from '~/lib/upload-permission-respons
 import { checkUploadAccess } from '~/services/upload-access.server'
 import { requireUserApiWithBearerMiddleware } from '~/middleware/auth'
 import { ctxContext, getCliAuthority, requireUser } from '~/middleware/context'
-import { isAgentOwnedArtifact } from '~/services/agent-scope.server'
 import {
   viewerDisplayCheck,
   type ArtifactSnapshot,
@@ -87,16 +86,15 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   const user = requireUser(context)
   const db = createDb()
   const authority = getCliAuthority(context)
-  if (
-    authority?.kind === 'agent' &&
-    !(await isAgentOwnedArtifact(db, user, authority, params.id))
-  ) {
+  const expectedCurrentVersionId = new URL(request.url).searchParams.get(
+    'expected_version',
+  )
+  if (authority?.kind === 'agent' && !expectedCurrentVersionId)
     return errorResponse(
-      'forbidden',
-      'CLI agent scope does not allow this update.',
-      403,
+      'expected-version-required',
+      'Agent updates require the current version id.',
+      400,
     )
-  }
   const ctx = context.get(ctxContext)
   const waitUntil = (promise: Promise<unknown>) => ctx.waitUntil(promise)
   const permission = await checkUploadAccess(user)
@@ -107,6 +105,11 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   if (kindHint === 'static_site') {
     return await runStaticSiteVersionUpload(db, request, user, params.id, {
       waitUntil,
+      ...(authority ? { authority } : {}),
+      ...(expectedCurrentVersionId ? { expectedCurrentVersionId } : {}),
+      ...(authority?.kind === 'agent'
+        ? { agentProfileId: authority.agentProfileId }
+        : {}),
     })
   }
 
@@ -118,6 +121,10 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 
   const result = await updateShareable(db, user, params.id, file, {
     waitUntil,
+    authority,
+    expectedCurrentVersionId: expectedCurrentVersionId ?? undefined,
+    agentProfileId:
+      authority?.kind === 'agent' ? authority.agentProfileId : null,
   })
   if (result.kind === 'ok') {
     return Response.json({
@@ -126,6 +133,17 @@ export async function action({ request, context, params }: Route.ActionArgs) {
       shareUrl: `${new URL(request.url).origin}/a/${params.id}`,
     })
   }
+  if (result.kind === 'version-conflict')
+    return Response.json(
+      {
+        error: {
+          code: 'version_conflict',
+          message: 'The artifact changed before the update was committed.',
+          details: { current_version_id: result.currentVersionId },
+        },
+      },
+      { status: 409 },
+    )
   return createVersionFailureResponse(result, () =>
     errorResponse('copy-forbidden', 'This file cannot be copied.', 403),
   )

--- a/apps/web/app/routes/api.shareables.uploads.tsx
+++ b/apps/web/app/routes/api.shareables.uploads.tsx
@@ -89,7 +89,8 @@ export async function action({ request, context }: Route.ActionArgs) {
 
   const searchParams = new URL(request.url).searchParams
   const rawPublishKey = searchParams.get('publish_key')
-  const expectedCurrentVersionId = searchParams.get('expected_version')
+  const expectedCurrentVersionId =
+    searchParams.get('expected_version')?.trim() || null
   let publishKey: string | null = null
   if (rawPublishKey !== null) {
     publishKey = normalizeArtifactKey(rawPublishKey)

--- a/apps/web/app/routes/api.shareables.uploads.tsx
+++ b/apps/web/app/routes/api.shareables.uploads.tsx
@@ -48,10 +48,7 @@ import {
 } from '~/services/artifact-keys.server'
 import { createDb } from '~/services/db.server'
 import { resolveUploadContainer } from '~/services/projects.server'
-import {
-  isAgentOwnedArtifact,
-  isAgentPublishableDestination,
-} from '~/services/agent-scope.server'
+import { isAgentPublishableDestination } from '~/services/agent-scope.server'
 import {
   beginStaticSiteBundleUploadSession,
   createVersion,
@@ -92,6 +89,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 
   const searchParams = new URL(request.url).searchParams
   const rawPublishKey = searchParams.get('publish_key')
+  const expectedCurrentVersionId = searchParams.get('expected_version')
   let publishKey: string | null = null
   if (rawPublishKey !== null) {
     publishKey = normalizeArtifactKey(rawPublishKey)
@@ -117,6 +115,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         : 'web',
       waitUntil,
       authority,
+      expectedCurrentVersionId,
     )
   }
 
@@ -207,19 +206,11 @@ export async function action({ request, context }: Route.ActionArgs) {
     const failure = keyResolutionFailureResponse(resolution)
     if (failure) return failure
     if (resolution.kind === 'update') {
-      if (
-        authority?.kind === 'agent' &&
-        !(await isAgentOwnedArtifact(
-          db,
-          user,
-          authority,
-          resolution.shareableId,
-        ))
-      ) {
+      if (authority?.kind === 'agent' && !expectedCurrentVersionId) {
         return errorResponse(
-          'forbidden',
-          'CLI agent scope does not allow this update.',
-          403,
+          'expected-version-required',
+          'Agent updates require the current version id.',
+          400,
         )
       }
       const updated = await createVersion({
@@ -229,8 +220,27 @@ export async function action({ request, context }: Route.ActionArgs) {
         file,
         touchArtifactKeyId: resolution.keyId,
         waitUntil,
+        authority,
+        expectedCurrentVersionId: expectedCurrentVersionId ?? undefined,
+        agentProfileId:
+          authority?.kind === 'agent' ? authority.agentProfileId : null,
       })
       if (updated.kind !== 'ok') {
+        if (updated.kind === 'version-conflict') {
+          return Response.json(
+            {
+              error: {
+                code: 'version_conflict',
+                message:
+                  'The artifact changed before the update was committed.',
+                details: {
+                  current_version_id: updated.currentVersionId,
+                },
+              },
+            },
+            { status: 409 },
+          )
+        }
         if (updated.kind === 'quota-exceeded') {
           return storageQuotaExceededResponse(
             db,
@@ -521,6 +531,7 @@ async function uploadStaticSiteWithSession(
   channel: 'web' | 'cli',
   waitUntil?: (promise: Promise<unknown>) => void,
   authority?: CliAuthority | null,
+  expectedCurrentVersionId?: string | null,
 ): Promise<Response> {
   const urlContainerId = new URL(request.url).searchParams.get('container_id')
   const containerId = parseUploadContainerId(urlContainerId)
@@ -561,19 +572,11 @@ async function uploadStaticSiteWithSession(
     const failure = keyResolutionFailureResponse(resolution)
     if (failure) return failure
     if (resolution.kind === 'update') {
-      if (
-        authority?.kind === 'agent' &&
-        !(await isAgentOwnedArtifact(
-          db,
-          user,
-          authority,
-          resolution.shareableId,
-        ))
-      ) {
+      if (authority?.kind === 'agent' && !expectedCurrentVersionId) {
         return errorResponse(
-          'forbidden',
-          'CLI agent scope does not allow this update.',
-          403,
+          'expected-version-required',
+          'Agent updates require the current version id.',
+          400,
         )
       }
       const response = await runStaticSiteVersionUpload(
@@ -589,6 +592,11 @@ async function uploadStaticSiteWithSession(
             created: false,
           },
           waitUntil,
+          ...(authority ? { authority } : {}),
+          ...(expectedCurrentVersionId ? { expectedCurrentVersionId } : {}),
+          ...(authority?.kind === 'agent'
+            ? { agentProfileId: authority.agentProfileId }
+            : {}),
         },
       )
       return (await hasErrorCode(response, 'quota-exceeded'))

--- a/apps/web/app/services/artifact-readback-service.server.ts
+++ b/apps/web/app/services/artifact-readback-service.server.ts
@@ -14,7 +14,10 @@ import {
   loadCommentThreads,
 } from '~/services/comments.server'
 import { fetchArtifactSource } from '~/services/content.server'
-import { listOwnedArtifactVersions } from '~/services/shareables.server'
+import {
+  listArtifactVersions,
+  listOwnedArtifactVersions,
+} from '~/services/shareables.server'
 import type { DB } from '~/types/db'
 
 export type ArtifactReadbackInclude = 'versions' | 'comments'
@@ -43,6 +46,12 @@ export type ArtifactReadbackData = {
     created_at: string
     published_at: string | null
     is_current: boolean
+    creator: {
+      kind: 'human' | 'agent'
+      name: string
+      email: string | null
+      agent_profile_id: string | null
+    } | null
   }>
   versions_has_more?: boolean
   comments?: ReturnType<typeof toAgentCommentThread>[]
@@ -57,6 +66,7 @@ export async function getArtifactReadback(
     baseUrl: string
     offset?: number
     include?: ArtifactReadbackInclude[]
+    includeSharedVersions?: boolean
   },
 ): Promise<ArtifactReadbackResult> {
   const access = await loadCommentAccess(db, user, args.id)
@@ -94,8 +104,12 @@ export async function getArtifactReadback(
   const isOwner = access.ownerUserId === user.id
   await Promise.all([
     (async () => {
-      if (!include.has('versions') || !isOwner) return
-      const history = await listOwnedArtifactVersions(db, user, args.id)
+      if (!include.has('versions') || (!isOwner && !args.includeSharedVersions))
+        return
+      const history = isOwner
+        ? await listOwnedArtifactVersions(db, user, args.id)
+        : await listArtifactVersions(db, args.id, access.currentVersionId)
+      const maySeeEmail = access.workspaceId === user.workspaceId
       data.versions = (history?.versions ?? []).map((version) => ({
         version_id: version.versionId,
         status: version.status,
@@ -103,6 +117,14 @@ export async function getArtifactReadback(
         created_at: version.createdAt,
         published_at: version.publishedAt,
         is_current: version.isCurrent,
+        creator: version.creator
+          ? {
+              kind: version.creator.kind,
+              name: version.creator.name,
+              email: maySeeEmail ? version.creator.email : null,
+              agent_profile_id: version.creator.agentProfileId,
+            }
+          : null,
       }))
       data.versions_has_more = history?.hasMore ?? false
     })(),

--- a/apps/web/app/services/cli-artifacts.server.test.ts
+++ b/apps/web/app/services/cli-artifacts.server.test.ts
@@ -4,6 +4,7 @@ const loadCommentAccessMock = vi.hoisted(() => vi.fn())
 const loadCommentThreadsMock = vi.hoisted(() => vi.fn())
 const fetchArtifactSourceMock = vi.hoisted(() => vi.fn())
 const listOwnedArtifactVersionsMock = vi.hoisted(() => vi.fn())
+const listArtifactVersionsMock = vi.hoisted(() => vi.fn())
 const listOwnedShareablesMock = vi.hoisted(() => vi.fn())
 const findWorkspaceProjectMock = vi.hoisted(() => vi.fn())
 const findSharedProjectForViewerMock = vi.hoisted(() => vi.fn())
@@ -18,6 +19,7 @@ vi.mock('~/services/content.server', () => ({
 }))
 vi.mock('~/services/shareables.server', () => ({
   listOwnedArtifactVersions: listOwnedArtifactVersionsMock,
+  listArtifactVersions: listArtifactVersionsMock,
   listOwnedShareables: listOwnedShareablesMock,
 }))
 vi.mock('~/services/projects.server', () => ({

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -2434,6 +2434,13 @@ function versionError(
   switch (result.kind) {
     case 'not-found':
       return artifactNotFoundError()
+    case 'version-conflict':
+      return toolError({
+        code: 'version-conflict',
+        message: 'The artifact changed before the update was committed.',
+        recoverable_by: 'agent',
+        hint: 'Read the latest artifact, reapply the change, and try again.',
+      })
     case 'copy-forbidden':
       return toolError({
         code: 'update-unsupported',

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -171,6 +171,14 @@ const VERSION_ITEM_SCHEMA = z.object({
   created_at: z.string(),
   published_at: z.string().nullable(),
   is_current: z.boolean(),
+  creator: z
+    .object({
+      kind: z.enum(['human', 'agent']),
+      name: z.string(),
+      email: z.string().nullable(),
+      agent_profile_id: z.string().nullable(),
+    })
+    .nullable(),
 })
 
 const COMMENT_THREAD_SCHEMA = z.object({

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -2436,7 +2436,7 @@ function versionError(
       return artifactNotFoundError()
     case 'version-conflict':
       return toolError({
-        code: 'version-conflict',
+        code: 'version_conflict',
         message: 'The artifact changed before the update was committed.',
         recoverable_by: 'agent',
         hint: 'Read the latest artifact, reapply the change, and try again.',

--- a/apps/web/app/services/shareables.server.test.ts
+++ b/apps/web/app/services/shareables.server.test.ts
@@ -85,6 +85,7 @@ import {
   commitDialogChanges,
   createVersion,
   deleteShareable,
+  editShareableSettings,
   generateUniqueShareableId,
   getOwnedArtifactRef,
   getOwnedShareableSummary,
@@ -4529,6 +4530,7 @@ describe('cross-workspace owner operations', () => {
       workspaceId: 'ws-a',
       email: 'collaborator@example.com',
       emailVerified: true,
+      hd: null,
     }
     const versionResult = await createVersion({
       db,
@@ -4542,6 +4544,23 @@ describe('cross-workspace owner operations', () => {
         titleOverride: 'Shared title',
       }),
     ).resolves.toEqual({ kind: 'ok', linkExpiresAt: null })
+
+    await expect(
+      editShareableSettings(db, collaborator, uploaded.id, {
+        title: 'Must not partially apply',
+        visibility: 'private',
+      }),
+    ).resolves.toEqual({ kind: 'not-found' })
+    await expect(
+      db
+        .selectFrom('shareables')
+        .select(['title_override', 'visibility'])
+        .where('id', '=', uploaded.id)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({
+      title_override: 'Shared title',
+      visibility: 'workspace',
+    })
 
     await db
       .updateTable('shareables')

--- a/apps/web/app/services/shareables.server.test.ts
+++ b/apps/web/app/services/shareables.server.test.ts
@@ -4562,6 +4562,39 @@ describe('cross-workspace owner operations', () => {
       visibility: 'workspace',
     })
 
+    await seedProjectShareDefault(
+      db,
+      'collaborator-project',
+      collaborator.email,
+    )
+    const projectArtifact = await uploadShareable(
+      db,
+      OWNER,
+      htmlFile('project.html', '<p>project</p>'),
+      'project',
+      [],
+      'project-a',
+    )
+    expect(projectArtifact.kind).toBe('ok')
+    if (projectArtifact.kind !== 'ok') throw new Error('expected ok')
+    await expect(
+      editShareableSettings(db, collaborator, projectArtifact.id, {
+        title: 'Must not partially move',
+        destination: { type: 'inbox' },
+      }),
+    ).resolves.toEqual({ kind: 'not-found' })
+    await expect(
+      db
+        .selectFrom('shareables')
+        .select(['container_id', 'title_override', 'visibility'])
+        .where('id', '=', projectArtifact.id)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({
+      container_id: 'project-a',
+      title_override: null,
+      visibility: 'project',
+    })
+
     await db
       .updateTable('shareables')
       .set({ visibility: 'private' })

--- a/apps/web/app/services/shareables.server.test.ts
+++ b/apps/web/app/services/shareables.server.test.ts
@@ -4508,6 +4508,55 @@ describe('cross-workspace owner operations', () => {
       }),
     ).toEqual({ kind: 'not-found' })
   })
+
+  test('active workspace members can version and rename workspace-visible artifacts but not private ones', async () => {
+    const uploaded = await uploadShareable(
+      db,
+      OWNER,
+      htmlFile('shared.html', '<p>owner</p>'),
+      'workspace',
+      [],
+      null,
+      null,
+    )
+    expect(uploaded.kind).toBe('ok')
+    if (uploaded.kind !== 'ok') throw new Error('expected ok')
+
+    await seedUser(db, 'collaborator')
+    await seedContributor(db, 'collaborator')
+    const collaborator = {
+      id: 'collaborator',
+      workspaceId: 'ws-a',
+      email: 'collaborator@example.com',
+      emailVerified: true,
+    }
+    const versionResult = await createVersion({
+      db,
+      user: collaborator,
+      shareableId: uploaded.id,
+      file: htmlFile('shared-v2.html', '<p>collaborator</p>'),
+    })
+    expect(versionResult.kind).toBe('ok')
+    await expect(
+      updateShareableMetadata(db, collaborator, uploaded.id, {
+        titleOverride: 'Shared title',
+      }),
+    ).resolves.toEqual({ kind: 'ok', linkExpiresAt: null })
+
+    await db
+      .updateTable('shareables')
+      .set({ visibility: 'private' })
+      .where('id', '=', uploaded.id)
+      .execute()
+    await expect(
+      createVersion({
+        db,
+        user: collaborator,
+        shareableId: uploaded.id,
+        file: htmlFile('blocked.html', '<p>blocked</p>'),
+      }),
+    ).resolves.toEqual({ kind: 'not-found' })
+  })
 })
 
 describe('deleteShareable', () => {

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -59,6 +59,8 @@ import {
 } from './projects.server'
 import { slackNotificationEnqueueQuery } from './slack-notifications.server'
 import { STATIC_SITE_UPLOAD_LIMITS } from '~/lib/product-contracts'
+import type { CliAuthority } from './cli-authority.server'
+import { isAgentPublishableDestination } from './agent-scope.server'
 
 const MAX_SHAREABLE_ID_ATTEMPTS = 5
 const MAX_STATIC_SITE_FILES = STATIC_SITE_UPLOAD_LIMITS.files
@@ -102,6 +104,9 @@ type ArtifactLiveBinding = {
 
 type BackgroundTaskOptions = {
   waitUntil?: (promise: Promise<unknown>) => void
+  authority?: CliAuthority | null
+  expectedCurrentVersionId?: string
+  agentProfileId?: string | null
 }
 
 export async function notifyArtifactVersionChanged(
@@ -309,6 +314,7 @@ export type UploadStaticSiteBundleResult =
 
 export type UpdateStaticSiteBundleResult =
   | { kind: 'ok'; id: string; versionId: string }
+  | { kind: 'version-conflict'; currentVersionId: string | null }
   | { kind: 'too-many-files'; limit: number }
   | { kind: 'too-large'; limitBytes: number }
   | { kind: 'file-too-large'; path: string; limitBytes: number }
@@ -362,7 +368,7 @@ type AppendVersionResult =
   | CreateVersionResult
   | { kind: 'version-conflict'; currentVersionId: string | null }
 
-export type UpdateShareableResult = CreateVersionResult
+export type UpdateShareableResult = AppendVersionResult
 
 export type UpdateShareableMetadataResult =
   | { kind: 'ok'; linkExpiresAt?: string | null }
@@ -777,6 +783,7 @@ export async function beginStaticSiteBundleVersionUploadSession(
   user: {
     id: string
     email?: string | null
+    emailVerified?: boolean
     workspaceId: string
     hd?: string | null
   },
@@ -784,7 +791,12 @@ export async function beginStaticSiteBundleVersionUploadSession(
   touchArtifactKeyId: string | null = null,
   options?: BackgroundTaskOptions,
 ): Promise<StaticSiteBundleVersionUploadSessionResult> {
-  const shareable = await findOwnedShareable(db, user, shareableId)
+  const shareable = await findWritableShareable(
+    db,
+    user,
+    shareableId,
+    options?.authority ?? null,
+  )
   if (!shareable) return { kind: 'not-found' }
   if (shareable.artifact_kind !== 'static_site') {
     return { kind: 'copy-forbidden' }
@@ -831,7 +843,13 @@ export async function beginStaticSiteBundleVersionUploadSession(
         workspaceRow.storage_used_bytes,
         workspaceRow.storage_quota_bytes,
       ),
-      { kind: 'version', touchArtifactKeyId },
+      {
+        kind: 'version',
+        touchArtifactKeyId,
+        expectedCurrentVersionId: options?.expectedCurrentVersionId ?? null,
+        authority: options?.authority ?? null,
+        agentProfileId: options?.agentProfileId ?? null,
+      },
       accounting,
       true,
       options,
@@ -844,6 +862,7 @@ export async function updateShareable(
   user: {
     id: string
     email?: string | null
+    emailVerified?: boolean
     workspaceId: string
     hd?: string | null
   },
@@ -942,6 +961,7 @@ type CreateVersionArgs = {
     email?: string | null
     workspaceId: string
     hd?: string | null
+    emailVerified?: boolean
   }
   shareableId: string
   file: File
@@ -949,6 +969,8 @@ type CreateVersionArgs = {
   waitUntil?: (promise: Promise<unknown>) => void
   preserveName?: boolean
   expectedCurrentVersionId?: string
+  authority?: CliAuthority | null
+  agentProfileId?: string | null
   auditQuery?: (input: {
     workspaceId: string
     shareableId: string
@@ -962,6 +984,9 @@ export function createVersion(
 export function createVersion(
   args: CreateVersionArgs & { expectedCurrentVersionId?: undefined },
 ): Promise<CreateVersionResult>
+export function createVersion(
+  args: CreateVersionArgs,
+): Promise<AppendVersionResult>
 export async function createVersion(
   args: CreateVersionArgs,
 ): Promise<AppendVersionResult> {
@@ -972,11 +997,19 @@ export async function createVersion(
     file,
     touchArtifactKeyId,
     waitUntil,
-    preserveName,
+    preserveName: requestedPreserveName,
     expectedCurrentVersionId,
+    authority,
+    agentProfileId,
     auditQuery,
   } = args
-  const shareable = await findOwnedShareable(db, user, shareableId)
+  const preserveName = requestedPreserveName || authority?.kind === 'agent'
+  const shareable = await findWritableShareable(
+    db,
+    user,
+    shareableId,
+    authority ?? null,
+  )
   if (!shareable) return { kind: 'not-found' }
   if (shareable.artifact_kind === 'static_site') {
     return { kind: 'copy-forbidden' }
@@ -1051,6 +1084,7 @@ export async function createVersion(
           'size_bytes',
           'sha256',
           'created_by_id',
+          'created_by_agent_profile_id',
           'created_at',
           'published_at',
         ])
@@ -1067,6 +1101,7 @@ export async function createVersion(
               sel.val(prepared.sizeBytes).as('size_bytes'),
               sel.val(prepared.sha256).as('sha256'),
               sel.val(user.id).as('created_by_id'),
+              sel.val(agentProfileId ?? null).as('created_by_agent_profile_id'),
               sel.val(prepared.now).as('created_at'),
               sel.val(prepared.now).as('published_at'),
             ])
@@ -1086,6 +1121,7 @@ export async function createVersion(
         size_bytes: prepared.sizeBytes,
         sha256: prepared.sha256,
         created_by_id: user.id,
+        created_by_agent_profile_id: agentProfileId ?? null,
         created_at: prepared.now,
         published_at: prepared.now,
       }),
@@ -1114,6 +1150,24 @@ export async function createVersion(
   versionQueries.push(
     versionPublishedEventQuery(db, { versionId: prepared.versionId }),
   )
+  if (
+    !(await findWritableShareable(db, user, shareableId, authority ?? null))
+  ) {
+    await deleteArtifact(env.BUCKET, prepared.r2Key).catch((err) => {
+      console.error('unauthorized_version_r2_compensation_failed', {
+        shareable_id: shareableId,
+        r2_key: prepared.r2Key,
+        err,
+      })
+    })
+    await releaseQuota(
+      db,
+      accounting.workspaceId,
+      prepared.sizeBytes,
+      prepared.now,
+    )
+    return { kind: 'not-found' }
+  }
   try {
     if (auditQuery) {
       versionQueries.push(
@@ -1183,7 +1237,12 @@ export async function createVersion(
 
 export async function updateShareableMetadata(
   db: Kysely<DB>,
-  user: { id: string; workspaceId: string },
+  user: {
+    id: string
+    workspaceId: string
+    email?: string | null
+    emailVerified?: boolean
+  },
   shareableId: string,
   patch: {
     visibility?: EditableVisibility
@@ -1207,10 +1266,15 @@ export async function updateShareableMetadata(
   // Owner-only, with one extension: workspace admins act as the owner for
   // bot-owned artifacts (a stopped bot's metadata would otherwise be frozen
   // forever). Human-owned artifacts are unaffected.
-  const authorized =
+  const ownerAuthorized =
     shareable.owner_user_id === user.id ||
     (await isBotOwnedArtifactAdmin(db, user, shareable.owner_user_id))
-  if (!authorized) return { kind: 'not-found' }
+  const collaborativeRename =
+    patch.titleOverride !== undefined &&
+    patch.visibility === undefined &&
+    patch.linkExpiresAt === undefined &&
+    (await findWritableShareable(db, user, shareableId, null)) !== null
+  if (!ownerAuthorized && !collaborativeRename) return { kind: 'not-found' }
   const changesLinkSettings =
     patch.visibility !== undefined || patch.linkExpiresAt !== undefined
   const linkWrite = changesLinkSettings
@@ -1489,7 +1553,8 @@ export async function moveShareableContainer(
   const allowed =
     shareable.owner_user_id === user.id ||
     (await isTeamWorkspaceAdmin(db, user, user.workspaceId)) ||
-    (await isBotOwnedArtifactAdmin(db, user, shareable.owner_user_id))
+    (await isBotOwnedArtifactAdmin(db, user, shareable.owner_user_id)) ||
+    (await findWritableShareable(db, user, shareableId, null)) !== null
   if (!allowed) return { kind: 'not-found' }
 
   const now = nowIso()
@@ -1633,7 +1698,8 @@ export async function listMoveDestinations(
     (await isTeamWorkspaceAdmin(db, user, user.workspaceId)) ||
     // Same bot-owner exception as moveShareableContainer, or the move UI
     // 404s on free/plus workspaces while the POST would succeed.
-    (await isBotOwnedArtifactAdmin(db, user, shareable.owner_user_id))
+    (await isBotOwnedArtifactAdmin(db, user, shareable.owner_user_id)) ||
+    (await findWritableShareable(db, user, shareableId, null)) !== null
   if (!allowed) return { kind: 'not-found' }
 
   const [projects, externalRows] = await Promise.all([
@@ -1866,6 +1932,7 @@ async function createNewShareableFromFile(
         size_bytes: prepared.sizeBytes,
         sha256: prepared.sha256,
         created_by_id: user.id,
+        created_by_agent_profile_id: options?.agentProfileId ?? null,
         created_at: prepared.now,
         published_at: prepared.now,
       }),
@@ -2009,7 +2076,13 @@ type StaticSiteBundleUploadTarget =
       stableKey: string | null
       agentProfileId: string | null
     }
-  | { kind: 'version'; touchArtifactKeyId: string | null }
+  | {
+      kind: 'version'
+      touchArtifactKeyId: string | null
+      expectedCurrentVersionId: string | null
+      authority: CliAuthority | null
+      agentProfileId: string | null
+    }
 
 export class StaticSiteBundleUploadSession {
   readonly shareableId: string
@@ -2277,6 +2350,7 @@ export class StaticSiteBundleUploadSession {
         fallback_to_index:
           staticSiteEntrypointKind(entrypointFile.path) === 'html' ? 1 : 0,
         created_by_id: this.user.id,
+        created_by_agent_profile_id: this.target.agentProfileId,
         created_at: this.now,
         published_at: this.now,
       }),
@@ -2374,6 +2448,18 @@ export class StaticSiteBundleUploadSession {
     if (this.#closed) return { kind: 'storage-failed' }
     this.#closed = true
     if (this.target.kind !== 'version') return { kind: 'storage-failed' }
+    const versionTarget = this.target
+
+    const writable = await findWritableShareable(
+      this.db,
+      this.user,
+      this.shareableId,
+      versionTarget.authority,
+    )
+    if (!writable) {
+      await this.abortUploadedFiles()
+      return { kind: 'storage-failed' }
+    }
 
     const entrypointFile = this.entrypointFile()
     if (!entrypointFile) {
@@ -2419,6 +2505,7 @@ export class StaticSiteBundleUploadSession {
           'sha256',
           'fallback_to_index',
           'created_by_id',
+          'created_by_agent_profile_id',
           'created_at',
           'published_at',
         ])
@@ -2436,13 +2523,22 @@ export class StaticSiteBundleUploadSession {
               sql<string>`${sha256}`.as('sha256'),
               sql<number>`${fallbackToIndex}`.as('fallback_to_index'),
               sql<string>`${this.user.id}`.as('created_by_id'),
+              sql<string | null>`${versionTarget.agentProfileId}`.as(
+                'created_by_agent_profile_id',
+              ),
               sql<string>`${this.now}`.as('created_at'),
               sql<string>`${this.now}`.as('published_at'),
             ])
             .where('id', '=', this.shareableId)
             .where('workspace_id', '=', this.accounting.workspaceId)
-            .where('owner_user_id', '=', this.user.id)
-            .where('artifact_kind', '=', 'static_site'),
+            .where('artifact_kind', '=', 'static_site')
+            .$if(versionTarget.expectedCurrentVersionId !== null, (q) =>
+              q.where(
+                'current_version_id',
+                '=',
+                versionTarget.expectedCurrentVersionId!,
+              ),
+            ),
         ),
       ...chunkArray(versionFileRows, VERSION_FILE_INSERT_CHUNK_SIZE).map(
         (rows) => this.db.insertInto('version_files').values(rows),
@@ -2450,7 +2546,12 @@ export class StaticSiteBundleUploadSession {
       this.db
         .updateTable('shareables')
         .set({
-          name: entrypointFile.derivedTitle ?? entrypointFile.path.slice(1),
+          ...(versionTarget.authority?.kind === 'agent'
+            ? {}
+            : {
+                name:
+                  entrypointFile.derivedTitle ?? entrypointFile.path.slice(1),
+              }),
           artifact_kind: 'static_site',
           derived_title: entrypointFile.derivedTitle,
           current_version_id: this.versionId,
@@ -2458,14 +2559,20 @@ export class StaticSiteBundleUploadSession {
         })
         .where('id', '=', this.shareableId)
         .where('workspace_id', '=', this.accounting.workspaceId)
-        .where('owner_user_id', '=', this.user.id)
-        .where('artifact_kind', '=', 'static_site'),
+        .where('artifact_kind', '=', 'static_site')
+        .$if(versionTarget.expectedCurrentVersionId !== null, (q) =>
+          q.where(
+            'current_version_id',
+            '=',
+            versionTarget.expectedCurrentVersionId!,
+          ),
+        ),
     ]
-    if (this.target.touchArtifactKeyId !== null) {
+    if (versionTarget.touchArtifactKeyId !== null) {
       versionQueries.push(
         artifactKeyTouchQuery(
           this.db,
-          this.target.touchArtifactKeyId,
+          versionTarget.touchArtifactKeyId,
           this.now,
         ),
       )
@@ -2490,6 +2597,22 @@ export class StaticSiteBundleUploadSession {
         this.#totalSizeBytes,
         this.now,
       )
+      if (versionTarget.expectedCurrentVersionId !== null) {
+        const latest = await this.db
+          .selectFrom('shareables')
+          .select('current_version_id')
+          .where('id', '=', this.shareableId)
+          .executeTakeFirst()
+        if (
+          latest &&
+          latest.current_version_id !== versionTarget.expectedCurrentVersionId
+        ) {
+          return {
+            kind: 'version-conflict',
+            currentVersionId: latest.current_version_id,
+          }
+        }
+      }
       return { kind: 'storage-failed' }
     }
 
@@ -3108,6 +3231,93 @@ async function findOwnedShareable(
   )
 }
 
+async function findWritableShareable(
+  db: Kysely<DB>,
+  user: {
+    id: string
+    workspaceId: string
+    email?: string | null
+    emailVerified?: boolean
+  },
+  shareableId: string,
+  authority: CliAuthority | null,
+) {
+  const shareable = await db
+    .selectFrom('shareables')
+    .leftJoin('artifact_containers as c', 'c.id', 'shareables.container_id')
+    .select([
+      'shareables.id',
+      'shareables.workspace_id',
+      'shareables.owner_user_id',
+      'shareables.current_version_id',
+      'shareables.artifact_kind',
+      'shareables.visibility',
+      'shareables.container_id',
+      'c.kind as container_kind',
+      'c.base_visibility as container_base_visibility',
+      'c.created_by_id as container_created_by_id',
+      'c.archived_at as container_archived_at',
+    ])
+    .where('shareables.id', '=', shareableId)
+    .executeTakeFirst()
+  if (!shareable) return null
+  if (shareable.owner_user_id === user.id) return shareable
+
+  if (authority?.kind === 'agent') {
+    if (
+      shareable.container_id !== authority.projectId ||
+      !(await isAgentPublishableDestination(
+        db,
+        { workspaceId: user.workspaceId, email: user.email ?? '' },
+        authority,
+        shareable.container_id,
+      ))
+    ) {
+      return null
+    }
+    return shareable
+  }
+  if (
+    authority?.kind === 'bridge' ||
+    user.workspaceId !== shareable.workspace_id
+  )
+    return null
+
+  const member = await db
+    .selectFrom('workspace_members')
+    .innerJoin('users', 'users.id', 'workspace_members.user_id')
+    .select('workspace_members.user_id')
+    .where('workspace_members.workspace_id', '=', shareable.workspace_id)
+    .where('workspace_members.user_id', '=', user.id)
+    .where('workspace_members.status', '=', 'active')
+    .where('users.kind', '=', 'human')
+    .executeTakeFirst()
+  if (!member) return null
+  if (shareable.visibility === 'workspace') return shareable
+  if (
+    shareable.visibility !== 'project' ||
+    shareable.container_kind !== 'project' ||
+    shareable.container_archived_at !== null
+  ) {
+    return null
+  }
+  if (
+    shareable.container_base_visibility === 'workspace' ||
+    shareable.container_created_by_id === user.id ||
+    (await isTeamWorkspaceAdmin(db, user, shareable.workspace_id))
+  ) {
+    return shareable
+  }
+  if (!user.email || !user.emailVerified) return null
+  const projectMember = await db
+    .selectFrom('project_share_defaults')
+    .select('id')
+    .where('project_container_id', '=', shareable.container_id!)
+    .where(lowerEmail('email'), '=', user.email.toLowerCase())
+    .executeTakeFirst()
+  return projectMember ? shareable : null
+}
+
 export interface OwnedShareableSummary {
   id: string
   title: string
@@ -3175,6 +3385,30 @@ function toOwnedShareableSummary(row: {
   }
 }
 
+async function getShareableSummaryById(
+  db: Kysely<DB>,
+  shareableId: string,
+): Promise<OwnedShareableSummary | null> {
+  const row = await db
+    .selectFrom('shareables')
+    .leftJoin('artifact_containers as c', 'c.id', 'shareables.container_id')
+    .select([
+      'shareables.id',
+      'shareables.name',
+      'shareables.derived_title',
+      'shareables.title_override',
+      'shareables.visibility',
+      'shareables.artifact_kind',
+      'shareables.link_expires_at',
+      'shareables.updated_at',
+      'shareables.container_id',
+      'c.kind as container_kind',
+    ])
+    .where('shareables.id', '=', shareableId)
+    .executeTakeFirst()
+  return row ? toOwnedShareableSummary(row) : null
+}
+
 // The shareables a user owns in their workspace, newest first. Used by the MCP
 // `list_artifacts` tool to let an agent pick an update target; bounded so the
 // response stays small. `projectId` filters by placement (a project id, or ''
@@ -3240,7 +3474,10 @@ export async function editShareableSettings(
   shareableId: string,
   payload: EditShareableSettingsPayload,
 ): Promise<EditShareableSettingsResult> {
-  const before = await getOwnedShareableSummary(db, user, shareableId)
+  let before = await getOwnedShareableSummary(db, user, shareableId)
+  if (!before && (await findWritableShareable(db, user, shareableId, null))) {
+    before = await getShareableSummaryById(db, shareableId)
+  }
   if (!before) return { kind: 'not-found' }
 
   if (payload.destination !== undefined) {
@@ -3280,6 +3517,9 @@ export async function editShareableSettings(
   let after: OwnedShareableSummary | null = null
   try {
     after = await getOwnedShareableSummary(db, user, shareableId)
+    if (!after && (await findWritableShareable(db, user, shareableId, null))) {
+      after = await getShareableSummaryById(db, shareableId)
+    }
   } catch (err) {
     console.error('shareable_edit_summary_failed', { shareableId, err })
   }
@@ -3330,6 +3570,12 @@ export interface ArtifactVersionSummary {
   createdAt: string
   publishedAt: string | null
   isCurrent: boolean
+  creator: {
+    kind: 'human' | 'agent'
+    name: string
+    email: string | null
+    agentProfileId: string | null
+  } | null
 }
 
 const OWNED_VERSION_LIST_LIMIT = 50
@@ -3351,14 +3597,32 @@ export async function listOwnedArtifactVersions(
 ): Promise<OwnedArtifactVersions | null> {
   const owned = await findOwnedShareable(db, user, shareableId)
   if (!owned) return null
+  return await listArtifactVersions(db, shareableId, owned.current_version_id)
+}
+
+export async function listArtifactVersions(
+  db: Kysely<DB>,
+  shareableId: string,
+  currentVersionId: string | null,
+): Promise<OwnedArtifactVersions> {
   const rows = await db
     .selectFrom('versions')
-    .select(['id', 'status', 'size_bytes', 'created_at', 'published_at'])
+    .leftJoin('users', 'users.id', 'versions.created_by_id')
+    .select([
+      'versions.id',
+      'versions.status',
+      'versions.size_bytes',
+      'versions.created_at',
+      'versions.published_at',
+      'versions.created_by_agent_profile_id',
+      'users.name as creator_name',
+      'users.email as creator_email',
+    ])
     .where('shareable_id', '=', shareableId)
-    .orderBy('created_at', 'desc')
+    .orderBy('versions.created_at', 'desc')
     // Tiebreaker: rapid updates can share a millisecond timestamp, so order by
     // id too to keep the list (and the has_more cut) deterministic across calls.
-    .orderBy('id', 'desc')
+    .orderBy('versions.id', 'desc')
     .limit(OWNED_VERSION_LIST_LIMIT + 1)
     .execute()
   const hasMore = rows.length > OWNED_VERSION_LIST_LIMIT
@@ -3371,7 +3635,22 @@ export async function listOwnedArtifactVersions(
       sizeBytes: row.size_bytes,
       createdAt: row.created_at,
       publishedAt: row.published_at ?? null,
-      isCurrent: row.id === owned.current_version_id,
+      isCurrent: row.id === currentVersionId,
+      creator: row.created_by_agent_profile_id
+        ? {
+            kind: 'agent' as const,
+            name: 'Agent',
+            email: null,
+            agentProfileId: row.created_by_agent_profile_id,
+          }
+        : row.creator_name || row.creator_email
+          ? {
+              kind: 'human' as const,
+              name: row.creator_name ?? row.creator_email ?? 'User',
+              email: row.creator_email ?? null,
+              agentProfileId: null,
+            }
+          : null,
     })),
   }
 }

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -11,7 +11,7 @@ import { MAX_GRANT_EMAILS, normalizeGrantEmail } from '~/lib/grant-emails'
 import { lowerEmail } from '~/lib/grant-emails.server'
 import { computeFileSha256 } from '~/lib/sha256'
 import { isSqliteConstraintError } from '~/lib/d1-errors.server'
-import { runD1Batch } from '~/lib/d1-batch.server'
+import { runD1Batch, runD1BatchWithResults } from '~/lib/d1-batch.server'
 import type {
   ArtifactKind,
   EditableVisibility,
@@ -369,6 +369,21 @@ export type CreateVersionResult =
 type AppendVersionResult = CreateVersionResult
 
 export type UpdateShareableResult = AppendVersionResult
+
+function batchMutationCount(result: unknown): number {
+  const value = Array.isArray(result) ? result[0] : result
+  if (!value || typeof value !== 'object') return 0
+  if ('numInsertedOrUpdatedRows' in value) {
+    return Number(value.numInsertedOrUpdatedRows ?? 0)
+  }
+  if ('meta' in value) {
+    const meta = value.meta
+    if (meta && typeof meta === 'object' && 'changes' in meta) {
+      return Number(meta.changes ?? 0)
+    }
+  }
+  return 0
+}
 
 export type UpdateShareableMetadataResult =
   | { kind: 'ok'; linkExpiresAt?: string | null }
@@ -2601,8 +2616,12 @@ export class StaticSiteBundleUploadSession {
     versionQueries.push(
       versionPublishedEventQuery(this.db, { versionId: this.versionId }),
     )
+    let versionInsertResult: unknown
     try {
-      await runD1Batch(this.db, ...versionQueries)
+      ;[versionInsertResult] = await runD1BatchWithResults(
+        this.db,
+        ...versionQueries,
+      )
     } catch (err) {
       console.error('static_site_version_d1_commit_failed', {
         shareable_id: this.shareableId,
@@ -2647,12 +2666,7 @@ export class StaticSiteBundleUploadSession {
       return { kind: 'storage-failed' }
     }
 
-    const committed = await this.db
-      .selectFrom('versions')
-      .select('id')
-      .where('id', '=', this.versionId)
-      .executeTakeFirst()
-    if (!committed) {
+    if (batchMutationCount(versionInsertResult) === 0) {
       await this.abortUploadedFiles()
       await releaseQuota(
         this.db,

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -1,4 +1,4 @@
-import type { Compilable, Kysely } from 'kysely'
+import type { Compilable, Kysely, RawBuilder } from 'kysely'
 import { sql } from 'kysely'
 import { externalGrantDomainSql } from './project-membership.server'
 import { env } from 'cloudflare:workers'
@@ -314,6 +314,7 @@ export type UploadStaticSiteBundleResult =
 
 export type UpdateStaticSiteBundleResult =
   | { kind: 'ok'; id: string; versionId: string }
+  | { kind: 'not-found' }
   | { kind: 'version-conflict'; currentVersionId: string | null }
   | { kind: 'too-many-files'; limit: number }
   | { kind: 'too-large'; limitBytes: number }
@@ -1011,6 +1012,11 @@ export async function createVersion(
     authority ?? null,
   )
   if (!shareable) return { kind: 'not-found' }
+  const commitExpectedVersionId =
+    expectedCurrentVersionId ??
+    (shareable.owner_user_id !== user.id
+      ? (shareable.current_version_id ?? undefined)
+      : undefined)
   if (shareable.artifact_kind === 'static_site') {
     return { kind: 'copy-forbidden' }
   }
@@ -1070,7 +1076,7 @@ export async function createVersion(
   }
 
   const versionQueries: Compilable<unknown>[] = []
-  if (expectedCurrentVersionId !== undefined) {
+  if (commitExpectedVersionId !== undefined) {
     versionQueries.push(
       db
         .insertInto('versions')
@@ -1106,7 +1112,8 @@ export async function createVersion(
               sel.val(prepared.now).as('published_at'),
             ])
             .where('id', '=', shareableId)
-            .where('current_version_id', '=', expectedCurrentVersionId),
+            .where('current_version_id', '=', commitExpectedVersionId)
+            .where(writableShareableSql(user, authority ?? null)),
         ),
     )
   } else {
@@ -1138,8 +1145,9 @@ export async function createVersion(
         updated_at: prepared.now,
       })
       .where('id', '=', shareableId)
-      .$if(expectedCurrentVersionId !== undefined, (q) =>
-        q.where('current_version_id', '=', expectedCurrentVersionId!),
+      .where(writableShareableSql(user, authority ?? null))
+      .$if(commitExpectedVersionId !== undefined, (q) =>
+        q.where('current_version_id', '=', commitExpectedVersionId!),
       ),
   )
   if (touchArtifactKeyId !== undefined && touchArtifactKeyId !== null) {
@@ -1196,7 +1204,7 @@ export async function createVersion(
     return { kind: 'storage-failed' }
   }
 
-  if (expectedCurrentVersionId !== undefined) {
+  if (commitExpectedVersionId !== undefined) {
     const committed = await db
       .selectFrom('versions')
       .select('id')
@@ -1249,6 +1257,7 @@ export async function updateShareableMetadata(
     linkExpiresAt?: string | null
     titleOverride?: string | null
   },
+  authority: CliAuthority | null = null,
 ): Promise<UpdateShareableMetadataResult> {
   if (
     patch.visibility === undefined &&
@@ -1257,6 +1266,8 @@ export async function updateShareableMetadata(
   ) {
     return { kind: 'ok' }
   }
+  if (authority?.kind === 'agent' || authority?.kind === 'bridge')
+    return { kind: 'not-found' }
   const shareable = await db
     .selectFrom('shareables')
     .select(['workspace_id', 'visibility', 'link_expires_at', 'owner_user_id'])
@@ -1310,6 +1321,7 @@ export async function updateShareableMetadata(
     .set(set)
     .where('id', '=', shareableId)
     .where('owner_user_id', '=', shareable.owner_user_id)
+    .$if(!ownerAuthorized, (q) => q.where(writableShareableSql(user, null)))
     .executeTakeFirst()
   if (Number(result.numUpdatedRows) === 0) return { kind: 'not-found' }
   return { kind: 'ok', linkExpiresAt: linkWrite.linkExpiresAt }
@@ -1532,7 +1544,10 @@ export async function moveShareableContainer(
   user: { id: string; workspaceId: string },
   shareableId: string,
   destination: MoveDestination,
+  authority: CliAuthority | null = null,
 ): Promise<MoveShareableResult> {
+  if (authority?.kind === 'agent' || authority?.kind === 'bridge')
+    return { kind: 'not-found' }
   const shareable = await db
     .selectFrom('shareables')
     .select([
@@ -1550,11 +1565,13 @@ export async function moveShareableContainer(
   // Only the owner or a workspace admin may move it; hide existence otherwise.
   // Bot-owned artifacts accept any workspace admin regardless of plan, same
   // as metadata edit and delete (bots exist on free workspaces too).
-  const allowed =
+  const privileged =
     shareable.owner_user_id === user.id ||
     (await isTeamWorkspaceAdmin(db, user, user.workspaceId)) ||
-    (await isBotOwnedArtifactAdmin(db, user, shareable.owner_user_id)) ||
+    (await isBotOwnedArtifactAdmin(db, user, shareable.owner_user_id))
+  const collaborativeMove =
     (await findWritableShareable(db, user, shareableId, null)) !== null
+  const allowed = privileged || collaborativeMove
   if (!allowed) return { kind: 'not-found' }
 
   const now = nowIso()
@@ -1614,6 +1631,7 @@ export async function moveShareableContainer(
       })
       .where('id', '=', shareableId)
       .where('workspace_id', '=', user.workspaceId)
+      .$if(!privileged, (q) => q.where(writableShareableSql(user, null)))
     if (destination.type === 'project') {
       // Re-check the destination is still a non-archived project at write time,
       // closing the window between the validation read above and this update
@@ -2458,7 +2476,7 @@ export class StaticSiteBundleUploadSession {
     )
     if (!writable) {
       await this.abortUploadedFiles()
-      return { kind: 'storage-failed' }
+      return { kind: 'not-found' }
     }
 
     const entrypointFile = this.entrypointFile()
@@ -2532,6 +2550,7 @@ export class StaticSiteBundleUploadSession {
             .where('id', '=', this.shareableId)
             .where('workspace_id', '=', this.accounting.workspaceId)
             .where('artifact_kind', '=', 'static_site')
+            .where(writableShareableSql(this.user, versionTarget.authority))
             .$if(versionTarget.expectedCurrentVersionId !== null, (q) =>
               q.where(
                 'current_version_id',
@@ -2560,6 +2579,7 @@ export class StaticSiteBundleUploadSession {
         .where('id', '=', this.shareableId)
         .where('workspace_id', '=', this.accounting.workspaceId)
         .where('artifact_kind', '=', 'static_site')
+        .where(writableShareableSql(this.user, versionTarget.authority))
         .$if(versionTarget.expectedCurrentVersionId !== null, (q) =>
           q.where(
             'current_version_id',
@@ -2597,6 +2617,16 @@ export class StaticSiteBundleUploadSession {
         this.#totalSizeBytes,
         this.now,
       )
+      if (
+        !(await findWritableShareable(
+          this.db,
+          this.user,
+          this.shareableId,
+          versionTarget.authority,
+        ))
+      ) {
+        return { kind: 'not-found' }
+      }
       if (versionTarget.expectedCurrentVersionId !== null) {
         const latest = await this.db
           .selectFrom('shareables')
@@ -3261,10 +3291,11 @@ async function findWritableShareable(
     .where('shareables.id', '=', shareableId)
     .executeTakeFirst()
   if (!shareable) return null
-  if (shareable.owner_user_id === user.id) return shareable
-
   if (authority?.kind === 'agent') {
     if (
+      !['workspace', 'project'].includes(shareable.visibility) ||
+      shareable.container_kind !== 'project' ||
+      shareable.container_archived_at !== null ||
       shareable.container_id !== authority.projectId ||
       !(await isAgentPublishableDestination(
         db,
@@ -3277,11 +3308,9 @@ async function findWritableShareable(
     }
     return shareable
   }
-  if (
-    authority?.kind === 'bridge' ||
-    user.workspaceId !== shareable.workspace_id
-  )
-    return null
+  if (authority?.kind === 'bridge') return null
+  if (shareable.owner_user_id === user.id) return shareable
+  if (user.workspaceId !== shareable.workspace_id) return null
 
   const member = await db
     .selectFrom('workspace_members')
@@ -3293,7 +3322,12 @@ async function findWritableShareable(
     .where('users.kind', '=', 'human')
     .executeTakeFirst()
   if (!member) return null
-  if (shareable.visibility === 'workspace') return shareable
+  if (
+    shareable.visibility === 'workspace' &&
+    (shareable.container_kind !== 'project' ||
+      shareable.container_archived_at === null)
+  )
+    return shareable
   if (
     shareable.visibility !== 'project' ||
     shareable.container_kind !== 'project' ||
@@ -3316,6 +3350,95 @@ async function findWritableShareable(
     .where(lowerEmail('email'), '=', user.email.toLowerCase())
     .executeTakeFirst()
   return projectMember ? shareable : null
+}
+
+function writableShareableSql(
+  user: {
+    id: string
+    workspaceId: string
+    email?: string | null
+    emailVerified?: boolean
+  },
+  authority: CliAuthority | null,
+): RawBuilder<boolean> {
+  if (authority?.kind === 'agent') {
+    return sql<boolean>`
+      shareables.workspace_id = ${authority.workspaceId}
+      AND shareables.container_id = ${authority.projectId}
+      AND shareables.visibility IN ('workspace', 'project')
+      AND EXISTS (
+        SELECT 1 FROM artifact_containers writable_project
+        WHERE writable_project.id = shareables.container_id
+          AND writable_project.workspace_id = ${authority.workspaceId}
+          AND writable_project.kind = 'project'
+          AND writable_project.archived_at IS NULL
+          AND (
+            writable_project.base_visibility = 'workspace'
+            OR EXISTS (
+              SELECT 1 FROM project_share_defaults writable_agent_grant
+              WHERE writable_agent_grant.project_container_id = writable_project.id
+                AND lower(writable_agent_grant.email) = ${user.email?.toLowerCase() ?? ''}
+                AND writable_agent_grant.role IN ('contributor', 'manager')
+            )
+          )
+      )`
+  }
+  if (authority?.kind === 'bridge') return sql<boolean>`0 = 1`
+  const verifiedEmail = user.emailVerified
+    ? (user.email?.toLowerCase() ?? '')
+    : ''
+  return sql<boolean>`
+    (shareables.owner_user_id = ${user.id}
+    OR (
+      shareables.workspace_id = ${user.workspaceId}
+      AND EXISTS (
+        SELECT 1 FROM workspace_members writable_member
+        JOIN users writable_user ON writable_user.id = writable_member.user_id
+        WHERE writable_member.workspace_id = shareables.workspace_id
+          AND writable_member.user_id = ${user.id}
+          AND writable_member.status = 'active'
+          AND writable_user.kind = 'human'
+      )
+      AND (
+        (
+          shareables.visibility = 'workspace'
+          AND NOT EXISTS (
+            SELECT 1 FROM artifact_containers archived_project
+            WHERE archived_project.id = shareables.container_id
+              AND archived_project.kind = 'project'
+              AND archived_project.archived_at IS NOT NULL
+          )
+        )
+        OR (
+          shareables.visibility = 'project'
+          AND EXISTS (
+            SELECT 1 FROM artifact_containers writable_project
+            WHERE writable_project.id = shareables.container_id
+              AND writable_project.kind = 'project'
+              AND writable_project.archived_at IS NULL
+              AND (
+                writable_project.base_visibility = 'workspace'
+                OR writable_project.created_by_id = ${user.id}
+                OR EXISTS (
+                  SELECT 1 FROM workspace_members writable_admin
+                  JOIN workspaces writable_workspace ON writable_workspace.id = writable_admin.workspace_id
+                  WHERE writable_admin.workspace_id = shareables.workspace_id
+                    AND writable_admin.user_id = ${user.id}
+                    AND writable_admin.role IN ('owner', 'admin')
+                    AND writable_admin.status = 'active'
+                    AND writable_workspace.plan = 'team'
+                )
+                OR EXISTS (
+                  SELECT 1 FROM project_share_defaults writable_grant
+                  WHERE writable_grant.project_container_id = writable_project.id
+                    AND lower(writable_grant.email) = ${verifiedEmail}
+                    AND ${verifiedEmail} <> ''
+                )
+              )
+          )
+        )
+      )
+    ))`
 }
 
 export interface OwnedShareableSummary {
@@ -3473,12 +3596,26 @@ export async function editShareableSettings(
   },
   shareableId: string,
   payload: EditShareableSettingsPayload,
+  authority: CliAuthority | null = null,
 ): Promise<EditShareableSettingsResult> {
+  if (authority?.kind === 'agent' || authority?.kind === 'bridge')
+    return { kind: 'not-found' }
   let before = await getOwnedShareableSummary(db, user, shareableId)
+  let isCollaborativeEdit = false
   if (!before && (await findWritableShareable(db, user, shareableId, null))) {
     before = await getShareableSummaryById(db, shareableId)
+    isCollaborativeEdit = true
   }
   if (!before) return { kind: 'not-found' }
+
+  const wantsShareChange =
+    payload.visibility !== undefined ||
+    payload.linkExpiresAt !== undefined ||
+    payload.addEmails !== undefined ||
+    payload.removeEmails !== undefined
+  // Collaborators may rename and move workspace-visible artifacts, but sharing
+  // controls remain owner-only. Reject mixed requests before applying any edit.
+  if (isCollaborativeEdit && wantsShareChange) return { kind: 'not-found' }
 
   if (payload.destination !== undefined) {
     const moved = await moveShareableContainer(
@@ -3486,6 +3623,7 @@ export async function editShareableSettings(
       user,
       shareableId,
       payload.destination,
+      authority,
     )
     if (moved.kind !== 'ok') return moved
   }
@@ -3493,17 +3631,18 @@ export async function editShareableSettings(
   if (payload.title !== undefined) {
     const titleOverride =
       payload.title.trim().slice(0, MAX_TITLE_OVERRIDE_LENGTH) || null
-    const renamed = await updateShareableMetadata(db, user, shareableId, {
-      titleOverride,
-    })
+    const renamed = await updateShareableMetadata(
+      db,
+      user,
+      shareableId,
+      {
+        titleOverride,
+      },
+      authority,
+    )
     if (renamed.kind !== 'ok') return renamed
   }
 
-  const wantsShareChange =
-    payload.visibility !== undefined ||
-    payload.linkExpiresAt !== undefined ||
-    payload.addEmails !== undefined ||
-    payload.removeEmails !== undefined
   if (wantsShareChange) {
     const shared = await commitDialogChanges(db, user, shareableId, {
       visibility: payload.visibility,

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -1190,6 +1190,7 @@ export async function createVersion(
     )
     return { kind: 'not-found' }
   }
+  let versionInsertResult: unknown
   try {
     if (auditQuery) {
       versionQueries.push(
@@ -1200,7 +1201,7 @@ export async function createVersion(
         }),
       )
     }
-    await runD1Batch(db, ...versionQueries)
+    ;[versionInsertResult] = await runD1BatchWithResults(db, ...versionQueries)
   } catch {
     await deleteArtifact(env.BUCKET, prepared.r2Key).catch((err) => {
       console.error('r2_compensation_failed', {
@@ -1219,12 +1220,7 @@ export async function createVersion(
   }
 
   if (commitExpectedVersionId !== undefined) {
-    const committed = await db
-      .selectFrom('versions')
-      .select('id')
-      .where('id', '=', prepared.versionId)
-      .executeTakeFirst()
-    if (!committed) {
+    if (batchMutationCount(versionInsertResult) === 0) {
       const [, , writable, latest] = await Promise.all([
         deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
         releaseQuota(

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -355,6 +355,7 @@ type UploadDestination = {
 
 export type CreateVersionResult =
   | { kind: 'ok'; versionId: string; artifactKind: ArtifactKind }
+  | { kind: 'version-conflict'; currentVersionId: string | null }
   | { kind: 'not-found' }
   | { kind: 'copy-forbidden' }
   | { kind: 'too-large' }
@@ -365,9 +366,7 @@ export type CreateVersionResult =
   | { kind: 'storage-failed' }
   | { kind: 'invalid-container' }
 
-type AppendVersionResult =
-  | CreateVersionResult
-  | { kind: 'version-conflict'; currentVersionId: string | null }
+type AppendVersionResult = CreateVersionResult
 
 export type UpdateShareableResult = AppendVersionResult
 
@@ -1014,7 +1013,7 @@ export async function createVersion(
   if (!shareable) return { kind: 'not-found' }
   const commitExpectedVersionId =
     expectedCurrentVersionId ??
-    (shareable.owner_user_id !== user.id
+    (authority?.kind === 'agent' || shareable.owner_user_id !== user.id
       ? (shareable.current_version_id ?? undefined)
       : undefined)
   if (shareable.artifact_kind === 'static_site') {
@@ -1211,7 +1210,7 @@ export async function createVersion(
       .where('id', '=', prepared.versionId)
       .executeTakeFirst()
     if (!committed) {
-      const [, , latest] = await Promise.all([
+      const [, , writable, latest] = await Promise.all([
         deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
         releaseQuota(
           db,
@@ -1219,12 +1218,14 @@ export async function createVersion(
           prepared.sizeBytes,
           prepared.now,
         ),
+        findWritableShareable(db, user, shareableId, authority ?? null),
         db
           .selectFrom('shareables')
           .select('current_version_id')
           .where('id', '=', shareableId)
           .executeTakeFirst(),
       ])
+      if (!writable) return { kind: 'not-found' }
       return {
         kind: 'version-conflict',
         currentVersionId: latest?.current_version_id ?? null,
@@ -2646,6 +2647,44 @@ export class StaticSiteBundleUploadSession {
       return { kind: 'storage-failed' }
     }
 
+    const committed = await this.db
+      .selectFrom('versions')
+      .select('id')
+      .where('id', '=', this.versionId)
+      .executeTakeFirst()
+    if (!committed) {
+      await this.abortUploadedFiles()
+      await releaseQuota(
+        this.db,
+        this.accounting.workspaceId,
+        this.#totalSizeBytes,
+        this.now,
+      )
+      const writableAfterCommit = await findWritableShareable(
+        this.db,
+        this.user,
+        this.shareableId,
+        versionTarget.authority,
+      )
+      if (!writableAfterCommit) return { kind: 'not-found' }
+      if (versionTarget.expectedCurrentVersionId !== null) {
+        const latest = await this.db
+          .selectFrom('shareables')
+          .select('current_version_id')
+          .where('id', '=', this.shareableId)
+          .executeTakeFirst()
+        if (
+          latest?.current_version_id !== versionTarget.expectedCurrentVersionId
+        ) {
+          return {
+            kind: 'version-conflict',
+            currentVersionId: latest?.current_version_id ?? null,
+          }
+        }
+      }
+      return { kind: 'storage-failed' }
+    }
+
     await scheduleArtifactVersionChanged(
       this.shareableId,
       this.versionId,
@@ -3615,7 +3654,12 @@ export async function editShareableSettings(
     payload.removeEmails !== undefined
   // Collaborators may rename and move workspace-visible artifacts, but sharing
   // controls remain owner-only. Reject mixed requests before applying any edit.
-  if (isCollaborativeEdit && wantsShareChange) return { kind: 'not-found' }
+  if (
+    isCollaborativeEdit &&
+    (wantsShareChange ||
+      (payload.destination !== undefined && payload.title !== undefined))
+  )
+    return { kind: 'not-found' }
 
   if (payload.destination !== undefined) {
     const moved = await moveShareableContainer(

--- a/apps/web/app/test/d1-batch-mock.ts
+++ b/apps/web/app/test/d1-batch-mock.ts
@@ -45,11 +45,25 @@ export function createD1BatchDbMock(options: D1BatchMockOptions) {
 
       sqlite.exec('BEGIN')
       try {
-        const results: Array<{ results: unknown[]; success: true }> = []
+        const results: Array<{
+          results: unknown[]
+          success: true
+          meta: { changes: number }
+        }> = []
         for (const stmt of stmts) {
+          const before = sqlite
+            .prepare('SELECT total_changes() AS value')
+            .get() as { value: number }
+          const statementResults = sqlite
+            .prepare(stmt.sql)
+            .all(...(stmt.params as never[]))
+          const after = sqlite
+            .prepare('SELECT total_changes() AS value')
+            .get() as { value: number }
           results.push({
-            results: sqlite.prepare(stmt.sql).all(...(stmt.params as never[])),
+            results: statementResults,
             success: true,
+            meta: { changes: after.value - before.value },
           })
         }
         sqlite.exec('COMMIT')

--- a/apps/web/app/types/db.ts
+++ b/apps/web/app/types/db.ts
@@ -491,6 +491,7 @@ interface VersionsTable {
   sha256: string
   fallback_to_index: Generated<number>
   created_by_id: string
+  created_by_agent_profile_id: Generated<string | null>
   created_at: string
   published_at: string | null
 }

--- a/apps/web/db/migrations/0099_version_agent_attribution.sql
+++ b/apps/web/db/migrations/0099_version_agent_attribution.sql
@@ -1,0 +1,5 @@
+ALTER TABLE versions
+  ADD COLUMN created_by_agent_profile_id TEXT REFERENCES agent_profiles(id) ON DELETE RESTRICT;
+
+CREATE INDEX versions_created_by_agent_profile_id
+  ON versions(created_by_agent_profile_id);

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -650,11 +650,13 @@ CREATE TABLE versions (
   sha256                    TEXT NOT NULL,
   fallback_to_index         INTEGER NOT NULL DEFAULT 0,                               -- 0 / 1
   created_by_id             TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_by_agent_profile_id TEXT REFERENCES agent_profiles(id) ON DELETE RESTRICT,
   created_at                TEXT NOT NULL,
   published_at              TEXT
 );
 CREATE INDEX versions_shareable_id ON versions(shareable_id);
 CREATE INDEX versions_r2_key ON versions(r2_key);
+CREATE INDEX versions_created_by_agent_profile_id ON versions(created_by_agent_profile_id);
 
 CREATE TABLE bridge_operations (
   id                         TEXT PRIMARY KEY,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,6 +40,9 @@ To keep an existing share URL, update it with
 sharing again. For CI, scheduled reports, or other repeat jobs, use
 `share <path> --key <key>`: the first run creates the shared file, and later
 runs add versions to the same file.
+Pass `--expected-version <version-id>` to reject an update when another version
+became current first. Project-scoped agent profiles must pass it to `update`
+and to repeat `share --key` updates; initial key creation does not require it.
 
 ## Authentication
 

--- a/packages/cli/skills/artifactshare/SKILL.md
+++ b/packages/cli/skills/artifactshare/SKILL.md
@@ -180,6 +180,11 @@ Use `update` to add a new version to an existing artifact while keeping its URL.
 npm exec --yes --package=@artifactshare/cli -- artifactshare update <artifact-id-or-url> ./report.html --json
 ```
 
+- Pass `--expected-version <version-id>` to reject an update when another
+  version became current first. Project-scoped agent profiles must pass it.
+  Repeat `share --key` updates accept the same option; initial creation does
+  not require it.
+
 - To keep an existing share URL, do not run `share --artifact-id`; use `update`.
 - Pass the same kind of input (single file vs directory) it was created with.
 - `update` does not change title, visibility, viewers, or placement. Use `edit`

--- a/packages/cli/src/command-runners/share.ts
+++ b/packages/cli/src/command-runners/share.ts
@@ -145,9 +145,6 @@ export async function runShare(
       request.init,
       {
         authenticated: true,
-        ...(shareKey !== null
-          ? { artifactTarget: true, operation: 'share' as const }
-          : {}),
         baseUrl,
         credentialSource: credential.source,
         profile: credential.profile,
@@ -232,6 +229,9 @@ export async function runShare(
       requestInit: request.init,
       errorOptions: {
         authenticated: true,
+        ...(shareKey !== null
+          ? { artifactTarget: true, operation: 'share' as const }
+          : {}),
         baseUrl,
         credentialSource: credential.source,
         profile: credential.profile,

--- a/packages/cli/src/command-runners/share.ts
+++ b/packages/cli/src/command-runners/share.ts
@@ -206,6 +206,12 @@ export async function runShare(
   if (shareKey !== null) {
     uploadUrl.searchParams.set('publish_key', shareKey)
   }
+  if (parsed.options.expectedVersion) {
+    uploadUrl.searchParams.set(
+      'expected_version',
+      parsed.options.expectedVersion,
+    )
+  }
   const upload = await prepareUploadPayload(targetPath, fileStat, initialForm)
   if (upload.error) return writeFailure(command, upload.error, mode, 1)
   if (upload.payload.kind === 'static_site') {

--- a/packages/cli/src/command-runners/share.ts
+++ b/packages/cli/src/command-runners/share.ts
@@ -145,6 +145,9 @@ export async function runShare(
       request.init,
       {
         authenticated: true,
+        ...(shareKey !== null
+          ? { artifactTarget: true, operation: 'share' as const }
+          : {}),
         baseUrl,
         credentialSource: credential.source,
         profile: credential.profile,

--- a/packages/cli/src/command-runners/update.ts
+++ b/packages/cli/src/command-runners/update.ts
@@ -115,6 +115,12 @@ export async function runUpdate(
   if (upload.payload.kind === 'static_site') {
     updateUrl.searchParams.set('artifact_kind', 'static_site')
   }
+  if (parsed.options.expectedVersion) {
+    updateUrl.searchParams.set(
+      'expected_version',
+      parsed.options.expectedVersion,
+    )
+  }
 
   const response = await cliFetch(updateUrl, {
     method: 'POST',

--- a/packages/cli/src/command-runners/update.ts
+++ b/packages/cli/src/command-runners/update.ts
@@ -140,6 +140,7 @@ export async function runUpdate(
       mapApiError(response.status, body, {
         authenticated: true,
         artifactTarget: true,
+        operation: 'update',
         baseUrl,
         credentialSource: credential.source,
         profile: credential.profile,

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -111,6 +111,7 @@ export const SUBCOMMANDS: Record<string, readonly string[]> = {
 export const UPDATE_OPTION_KEYS = new Set([
   'allowPlaintextTokenStore',
   'baseUrl',
+  'expectedVersion',
   'help',
   'insecureLocalhost',
   'json',

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -319,7 +319,9 @@ export function mapApiError(
           : 'Read the current version, reapply your changes, and retry with its version id.',
       agentRecoverable: true,
       requiresHuman: false,
-      recovery: { kind: 'retry_later' },
+      recovery: {
+        kind: options.operation === 'append' ? 'retry_later' : 'change_input',
+      },
       ...(currentVersionId
         ? { details: { current_version_id: currentVersionId } }
         : {}),

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -298,7 +298,7 @@ export function mapApiError(
   }
   if (
     options.artifactTarget &&
-    options.operation === 'append' &&
+    ['append', 'update', 'share'].includes(options.operation ?? '') &&
     apiCode === 'version_conflict'
   ) {
     const current =
@@ -309,11 +309,14 @@ export function mapApiError(
         : null
     return cliError({
       code: 'version_conflict',
-      message: apiMessage ?? 'The artifact changed before append.',
+      message: apiMessage ?? 'The artifact changed before the update.',
       why: currentVersionId
         ? `The current version is ${currentVersionId}.`
         : 'Another update was committed first.',
-      hint: 'Run the same append command again to append to the latest content.',
+      hint:
+        options.operation === 'append'
+          ? 'Run the same append command again to append to the latest content.'
+          : 'Read the current version, reapply your changes, and retry with its version id.',
       agentRecoverable: true,
       requiresHuman: false,
       recovery: { kind: 'retry_later' },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -366,6 +366,12 @@ const shareDefinition = define({
       description:
         'Stable key for create-or-update: the first share creates the artifact, repeats add versions. Not a secret; it appears in logs and JSON',
     },
+    expectedVersion: {
+      type: 'string',
+      toKebab: true,
+      description:
+        'Require this current version when --key updates an existing artifact',
+    },
   },
   examples: `npm exec --yes --package=@artifactshare/cli -- artifactshare share report.html --project-id <id> --json
 npm exec --yes --package=@artifactshare/cli -- artifactshare share report.html --project-id <id> --key nightly-report --json
@@ -411,6 +417,11 @@ const updateDefinition = define({
     path: {
       type: 'positional',
       description: 'File or directory to add as the new version',
+    },
+    expectedVersion: {
+      type: 'string',
+      toKebab: true,
+      description: 'Only update when this is still the current version id',
     },
   },
   examples: `Target:

--- a/packages/cli/src/share.test.ts
+++ b/packages/cli/src/share.test.ts
@@ -918,6 +918,53 @@ test('share --key sends publish_key and reports created and key', async () => {
   assert.match(urls[0] ?? '', /publish_key=pr-482/)
 })
 
+test('share --key preserves version conflicts as recoverable input changes', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'artifactshare-cli-'))
+  const target = join(root, 'report.html')
+  await writeFile(target, '<html></html>')
+
+  await withServer(
+    async (request, response) => {
+      await collectBody(request)
+      response.statusCode = 409
+      response.setHeader('content-type', 'application/json')
+      response.end(
+        JSON.stringify({
+          error: {
+            code: 'version_conflict',
+            message: 'changed',
+            details: { current_version_id: 'v3' },
+          },
+        }),
+      )
+    },
+    async (baseUrl) => {
+      const result = await runAsync(
+        [
+          'share',
+          target,
+          '--home',
+          '--key',
+          'report',
+          '--expected-version',
+          'v2',
+          '--base-url',
+          baseUrl,
+          '--json',
+        ],
+        { ARTIFACTSHARE_TOKEN: 'test-token' },
+      )
+
+      const payload = expectFailure(result, {
+        command: 'share',
+        code: 'version_conflict',
+      })
+      assert.deepEqual(payload.error.recovery, { kind: 'change_input' })
+      assert.equal(payload.error.details?.current_version_id, 'v3')
+    },
+  )
+})
+
 test('share --key maps key error codes from the server', async () => {
   const root = await mkdtemp(join(tmpdir(), 'artifactshare-cli-'))
   const target = join(root, 'report.html')

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -5,6 +5,7 @@ export type CliOptions = {
   baseUrl?: string
   body?: string
   dryRun?: boolean
+  expectedVersion?: string
   force?: boolean
   grantEmail?: string | string[]
   help?: boolean

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -252,7 +252,7 @@ export type RequestConfig =
 
 export type ApiErrorOptions = {
   botProfile?: boolean | undefined
-  operation?: 'append'
+  operation?: 'append' | 'update' | 'share'
   authenticated?: boolean
   artifactTarget?: boolean
   baseUrl?: string

--- a/packages/cli/src/update.test.ts
+++ b/packages/cli/src/update.test.ts
@@ -311,7 +311,16 @@ test('update --json with invalid token returns token_invalid without pending aut
     },
     async (baseUrl) => {
       const result = await runAsync(
-        ['update', 'abc123def4', file, '--base-url', baseUrl, '--json'],
+        [
+          'update',
+          'abc123def4',
+          file,
+          '--expected-version',
+          'ver122',
+          '--base-url',
+          baseUrl,
+          '--json',
+        ],
         {
           ...deviceAuthEnv,
           ARTIFACTSHARE_CONFIG_HOME: configHome,
@@ -449,7 +458,16 @@ test('update --json maps a successful version response', async () => {
     },
     async (baseUrl) => {
       const result = await runAsync(
-        ['update', 'abc123def4', file, '--base-url', baseUrl, '--json'],
+        [
+          'update',
+          'abc123def4',
+          file,
+          '--expected-version',
+          'ver122',
+          '--base-url',
+          baseUrl,
+          '--json',
+        ],
         { ARTIFACTSHARE_TOKEN: 'test-token' },
       )
 
@@ -462,7 +480,10 @@ test('update --json maps a successful version response', async () => {
   )
 
   assert.deepEqual(requests, [
-    { method: 'POST', url: '/api/shareables/abc123def4/versions' },
+    {
+      method: 'POST',
+      url: '/api/shareables/abc123def4/versions?expected_version=ver122',
+    },
   ])
 })
 


### PR DESCRIPTION
## Change

- Allow active workspace members to update, rename, and move workspace-visible artifacts while keeping private artifacts and sharing controls owner-only.
- Restrict agent updates to the agent's fixed active project and deny agent rename, move, inbox, cross-project, and cross-workspace writes.
- Add optimistic version checks to CLI `share --key` and `update`, with structured `version_conflict` responses and current-version recovery details.
- Attribute each version to a human or agent profile and expose that attribution in Web and CLI version history.
- Recheck write authority inside D1 mutations so access changes and concurrent updates cannot commit stale or unauthorized writes.

## Validation

- `pnpm validate:static` — passed, including formatting, lint, migration/schema/D1 checks, typechecks, 3,338 Web tests (1 skipped), 81 bridge tests, React Doctor 100, and public scan with 0 findings.
- Targeted collaborative update, MCP, static-site, and CLI conflict tests — passed.
- `pnpm visual:compose` — 98 browser/visual tests passed, including viewer states at desktop/mobile and light/dark.
- Trusted `origin/main` public-development boundary guard — passed.
- Standalone screen capture was attempted twice after resetting local development fixtures, but the local multi-Worker topology failed during startup with a Wrangler SQLite `SQLITE_BUSY_RECOVERY` environment error. The isolated Compose viewer matrix passed on the reviewed commit.

## Review

- Codex and Claude both deeply reviewed final HEAD `ddfec17`; neither reported an actionable correctness issue.
- A Kysely-only batch-result test suggestion was classified non-actionable for this change because production always uses the D1 batch path and the changed production path is covered through the D1 batch mock.
- No implementation findings are deferred.
