### PR TITLE
Release CLI 0.13.3

### DIFF
--- a/apps/web/app/lib/cli-reference-surface.generated.json
+++ b/apps/web/app/lib/cli-reference-surface.generated.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "package_version": "0.13.2",
+  "package_version": "0.13.3",
   "commands": [
     {
       "path": "",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,15 @@ For user-facing announcements, see https://artifactshare.com/updates?product=cli
 
 ## Unreleased
 
+## 0.13.3 - 2026-09-02
+
+- Allow workspace members to update, rename, and move artifacts they can view,
+  while preserving owner-only sharing controls and private artifacts.
+- Add `--expected-version <version-id>` to `update` and repeat `share --key`
+  operations, returning a recoverable `version_conflict` when another update
+  commits first.
+- Include human or agent creator attribution in `versions --json` output.
+
 ## 0.13.2 - 2026-08-30
 
 - Define preview startup in the bundled agent skill as one owned long-lived

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artifactshare/cli",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Upload and share HTML, Markdown, folders, and static sites from terminals, AI agents, automation, and CI.",
   "homepage": "https://artifactshare.com/connect",
   "repository": {


### PR DESCRIPTION
## Summary

- release `@artifactshare/cli` 0.13.3
- document collaborative artifact updates, optimistic concurrency, and version creator attribution
- regenerate the web CLI reference package version

## Validation

- `pnpm --filter @artifactshare/cli build`
- `pnpm --filter @artifactshare/cli typecheck`
- CLI tests: 576 passed, 1 skipped
- `pnpm check:cli-release`
- `pnpm check:cli-reference`
- `pnpm validate:static`
- trusted public-development guard

## Review

This PR contains release metadata and generated package-version output only. The underlying runtime changes were already reviewed and merged; no runtime code changes are introduced here.
