### PR TITLE
Allow external artifact grantees to update

### DIFF
--- a/apps/web/app/services/shareables.server.test.ts
+++ b/apps/web/app/services/shareables.server.test.ts
@@ -4519,6 +4519,13 @@ describe('cross-workspace owner operations', () => {
         .executeTakeFirstOrThrow(),
     ).resolves.toEqual({ created_by_id: EXTERNAL_VIEWER.id })
     await expect(
+      db
+        .selectFrom('shareables')
+        .select(['name', 'derived_title'])
+        .where('id', '=', uploaded.id)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ name: 'shared.html', derived_title: null })
+    await expect(
       createVersion({
         db,
         user: EXTERNAL_VIEWER,
@@ -4688,7 +4695,9 @@ describe('cross-workspace owner operations', () => {
     const begun = await beginStaticSiteBundleUploadSession(db, OWNER)
     expect(begun.kind).toBe('ok')
     if (begun.kind !== 'ok') throw new Error('expected ok')
-    await begun.session.addFile(siteFile('/index.html', 16, 'text/html'))
+    await begun.session.addFile(
+      siteTextFile('/index.html', '<title>Owner site</title>', 'text/html'),
+    )
     const created = await begun.session.commit('private', [
       EXTERNAL_VIEWER.email,
     ])
@@ -4700,11 +4709,12 @@ describe('cross-workspace owner operations', () => {
       EXTERNAL_VIEWER,
       created.id,
       null,
-      { expectedCurrentVersionId: created.versionId },
     )
     expect(versionBegun.kind).toBe('ok')
     if (versionBegun.kind !== 'ok') throw new Error('expected ok')
-    await versionBegun.session.addFile(siteFile('/index.html', 18, 'text/html'))
+    await versionBegun.session.addFile(
+      siteTextFile('/index.html', '<title>External site</title>', 'text/html'),
+    )
 
     const result = await versionBegun.session.commitVersion()
 
@@ -4717,6 +4727,98 @@ describe('cross-workspace owner operations', () => {
         .where('id', '=', result.versionId)
         .executeTakeFirstOrThrow(),
     ).resolves.toEqual({ created_by_id: EXTERNAL_VIEWER.id })
+    await expect(
+      db
+        .selectFrom('shareables')
+        .select(['name', 'derived_title'])
+        .where('id', '=', created.id)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ name: 'Owner site', derived_title: 'Owner site' })
+  })
+
+  test('external static-site update snapshots the current version by default', async () => {
+    await seedExternalProject(db)
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'plus', external_posting_enabled: 1 })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    const initial = await beginStaticSiteBundleUploadSession(db, OWNER)
+    expect(initial.kind).toBe('ok')
+    if (initial.kind !== 'ok') throw new Error('expected ok')
+    await initial.session.addFile(siteFile('/index.html', 16, 'text/html'))
+    const created = await initial.session.commit('private', [
+      EXTERNAL_VIEWER.email,
+    ])
+    expect(created.kind).toBe('ok')
+    if (created.kind !== 'ok') throw new Error('expected ok')
+
+    const external = await beginStaticSiteBundleVersionUploadSession(
+      db,
+      EXTERNAL_VIEWER,
+      created.id,
+    )
+    expect(external.kind).toBe('ok')
+    if (external.kind !== 'ok') throw new Error('expected ok')
+    await external.session.addFile(siteFile('/index.html', 18, 'text/html'))
+
+    const owner = await beginStaticSiteBundleVersionUploadSession(
+      db,
+      OWNER,
+      created.id,
+    )
+    expect(owner.kind).toBe('ok')
+    if (owner.kind !== 'ok') throw new Error('expected ok')
+    await owner.session.addFile(siteFile('/index.html', 20, 'text/html'))
+    const ownerResult = await owner.session.commitVersion()
+    expect(ownerResult.kind).toBe('ok')
+    if (ownerResult.kind !== 'ok') throw new Error('expected ok')
+
+    await expect(external.session.commitVersion()).resolves.toEqual({
+      kind: 'version-conflict',
+      currentVersionId: ownerResult.versionId,
+    })
+  })
+
+  test('static-site update reports policy revocation and compensates uploaded files', async () => {
+    await seedExternalProject(db)
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'plus', external_posting_enabled: 1 })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    const initial = await beginStaticSiteBundleUploadSession(db, OWNER)
+    expect(initial.kind).toBe('ok')
+    if (initial.kind !== 'ok') throw new Error('expected ok')
+    await initial.session.addFile(siteFile('/index.html', 16, 'text/html'))
+    const created = await initial.session.commit('private', [
+      EXTERNAL_VIEWER.email,
+    ])
+    expect(created.kind).toBe('ok')
+    if (created.kind !== 'ok') throw new Error('expected ok')
+    const version = await beginStaticSiteBundleVersionUploadSession(
+      db,
+      EXTERNAL_VIEWER,
+      created.id,
+    )
+    expect(version.kind).toBe('ok')
+    if (version.kind !== 'ok') throw new Error('expected ok')
+    await version.session.addFile(siteFile('/index.html', 18, 'text/html'))
+    sqliteRef.beforeNextBatch = async () => {
+      await db
+        .updateTable('workspaces')
+        .set({ external_posting_enabled: 0 })
+        .where('id', '=', OWNER.workspaceId)
+        .execute()
+    }
+
+    await expect(version.session.commitVersion()).resolves.toEqual({
+      kind: 'invalid-container',
+    })
+    expect(storageMock.deleteArtifactsByPrefix).toHaveBeenCalledWith(
+      {},
+      version.session.r2Prefix,
+    )
   })
 
   test('non-owner cannot operate on cross-workspace artifacts owned by someone else', async () => {

--- a/apps/web/app/services/shareables.server.test.ts
+++ b/apps/web/app/services/shareables.server.test.ts
@@ -263,6 +263,13 @@ async function seedProjectShareDefault(
 // external contributor. Cross-workspace posting must bill THIS workspace.
 const EXT_WS = 'ws-ext'
 const EXT_PROJECT = 'project-ext'
+const EXTERNAL_VIEWER = {
+  id: 'ext-admin-1',
+  email: 'admin@client.example',
+  emailVerified: true,
+  workspaceId: EXT_WS,
+  hd: 'client.example',
+} as const
 
 async function seedExternalProject(
   db: Kysely<DB>,
@@ -4475,6 +4482,241 @@ describe('cross-workspace owner operations', () => {
       .where('id', '=', uploaded.id)
       .executeTakeFirstOrThrow()
     expect(row).toEqual({ visibility: 'private', link_expires_at: null })
+  })
+
+  test('verified external artifact grantee can create a version but cannot change metadata', async () => {
+    await seedExternalProject(db)
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'plus', external_posting_enabled: 1 })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    const uploaded = await uploadShareable(
+      db,
+      OWNER,
+      htmlFile('shared.html', '<p>owner</p>'),
+      'private',
+      ['ADMIN@CLIENT.EXAMPLE'],
+    )
+    expect(uploaded.kind).toBe('ok')
+    if (uploaded.kind !== 'ok') throw new Error('expected ok')
+
+    const result = await createVersion({
+      db,
+      user: EXTERNAL_VIEWER,
+      shareableId: uploaded.id,
+      file: htmlFile('external.html', '<p>external viewer</p>'),
+      expectedCurrentVersionId: uploaded.versionId,
+    })
+
+    expect(result.kind).toBe('ok')
+    if (result.kind !== 'ok') throw new Error('expected ok')
+    await expect(
+      db
+        .selectFrom('versions')
+        .select('created_by_id')
+        .where('id', '=', result.versionId)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ created_by_id: EXTERNAL_VIEWER.id })
+    await expect(
+      createVersion({
+        db,
+        user: EXTERNAL_VIEWER,
+        shareableId: uploaded.id,
+        file: htmlFile('stale.html', '<p>stale</p>'),
+        expectedCurrentVersionId: uploaded.versionId,
+      }),
+    ).resolves.toEqual({
+      kind: 'version-conflict',
+      currentVersionId: result.versionId,
+    })
+    await expect(
+      updateShareableMetadata(db, EXTERNAL_VIEWER, uploaded.id, {
+        titleOverride: 'External rename',
+      }),
+    ).resolves.toEqual({ kind: 'not-found' })
+  })
+
+  test('external artifact grant requires a verified current email and enabled posting policy', async () => {
+    await seedExternalProject(db)
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'plus', external_posting_enabled: 1 })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    const uploaded = await uploadShareable(
+      db,
+      OWNER,
+      htmlFile('shared.html', '<p>owner</p>'),
+      'private',
+      [EXTERNAL_VIEWER.email],
+    )
+    expect(uploaded.kind).toBe('ok')
+    if (uploaded.kind !== 'ok') throw new Error('expected ok')
+
+    await expect(
+      createVersion({
+        db,
+        user: { ...EXTERNAL_VIEWER, emailVerified: false },
+        shareableId: uploaded.id,
+        file: htmlFile('unverified.html', '<p>blocked</p>'),
+      }),
+    ).resolves.toEqual({ kind: 'not-found' })
+
+    await db
+      .updateTable('workspaces')
+      .set({ external_posting_enabled: 0 })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    await expect(
+      createVersion({
+        db,
+        user: EXTERNAL_VIEWER,
+        shareableId: uploaded.id,
+        file: htmlFile('disabled.html', '<p>blocked</p>'),
+      }),
+    ).resolves.toEqual({ kind: 'invalid-container' })
+  })
+
+  test('disabling external posting before commit rejects and compensates the upload', async () => {
+    await seedExternalProject(db)
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'plus', external_posting_enabled: 1 })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    const uploaded = await uploadShareable(
+      db,
+      OWNER,
+      htmlFile('shared.html', '<p>owner</p>'),
+      'private',
+      [EXTERNAL_VIEWER.email],
+    )
+    expect(uploaded.kind).toBe('ok')
+    if (uploaded.kind !== 'ok') throw new Error('expected ok')
+    const storageBefore = await db
+      .selectFrom('workspaces')
+      .select('storage_used_bytes')
+      .where('id', '=', OWNER.workspaceId)
+      .executeTakeFirstOrThrow()
+    sqliteRef.beforeNextBatch = async () => {
+      await db
+        .updateTable('workspaces')
+        .set({ external_posting_enabled: 0 })
+        .where('id', '=', OWNER.workspaceId)
+        .execute()
+    }
+
+    const result = await createVersion({
+      db,
+      user: EXTERNAL_VIEWER,
+      shareableId: uploaded.id,
+      file: htmlFile('disabled-during-upload.html', '<p>blocked</p>'),
+      expectedCurrentVersionId: uploaded.versionId,
+    })
+
+    expect(result).toEqual({ kind: 'invalid-container' })
+    expect(storageMock.deleteArtifact).toHaveBeenCalledTimes(1)
+    await expect(
+      db
+        .selectFrom('workspaces')
+        .select('storage_used_bytes')
+        .where('id', '=', OWNER.workspaceId)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual(storageBefore)
+  })
+
+  test('revoking an external artifact grant before commit rejects and compensates the upload', async () => {
+    await seedExternalProject(db)
+    await db
+      .updateTable('workspaces')
+      .set({
+        plan: 'plus',
+        external_posting_enabled: 1,
+        storage_used_bytes: 20,
+      })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    const uploaded = await uploadShareable(
+      db,
+      OWNER,
+      htmlFile('shared.html', '<p>owner</p>'),
+      'private',
+      [EXTERNAL_VIEWER.email],
+    )
+    expect(uploaded.kind).toBe('ok')
+    if (uploaded.kind !== 'ok') throw new Error('expected ok')
+    const storageBefore = await db
+      .selectFrom('workspaces')
+      .select('storage_used_bytes')
+      .where('id', '=', OWNER.workspaceId)
+      .executeTakeFirstOrThrow()
+    sqliteRef.beforeNextBatch = async () => {
+      await db
+        .deleteFrom('shareable_grants')
+        .where('shareable_id', '=', uploaded.id)
+        .where('granted_email', '=', EXTERNAL_VIEWER.email)
+        .execute()
+    }
+
+    const result = await createVersion({
+      db,
+      user: EXTERNAL_VIEWER,
+      shareableId: uploaded.id,
+      file: htmlFile('revoked.html', '<p>revoked</p>'),
+      expectedCurrentVersionId: uploaded.versionId,
+    })
+
+    expect(result).toEqual({ kind: 'not-found' })
+    expect(storageMock.deleteArtifact).toHaveBeenCalledTimes(1)
+    await expect(
+      db
+        .selectFrom('workspaces')
+        .select('storage_used_bytes')
+        .where('id', '=', OWNER.workspaceId)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual(storageBefore)
+  })
+
+  test('verified external artifact grantee can create a static-site version', async () => {
+    await seedExternalProject(db)
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'plus', external_posting_enabled: 1 })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
+    const begun = await beginStaticSiteBundleUploadSession(db, OWNER)
+    expect(begun.kind).toBe('ok')
+    if (begun.kind !== 'ok') throw new Error('expected ok')
+    await begun.session.addFile(siteFile('/index.html', 16, 'text/html'))
+    const created = await begun.session.commit('private', [
+      EXTERNAL_VIEWER.email,
+    ])
+    expect(created.kind).toBe('ok')
+    if (created.kind !== 'ok') throw new Error('expected ok')
+
+    const versionBegun = await beginStaticSiteBundleVersionUploadSession(
+      db,
+      EXTERNAL_VIEWER,
+      created.id,
+      null,
+      { expectedCurrentVersionId: created.versionId },
+    )
+    expect(versionBegun.kind).toBe('ok')
+    if (versionBegun.kind !== 'ok') throw new Error('expected ok')
+    await versionBegun.session.addFile(siteFile('/index.html', 18, 'text/html'))
+
+    const result = await versionBegun.session.commitVersion()
+
+    expect(result.kind).toBe('ok')
+    if (result.kind !== 'ok') throw new Error('expected ok')
+    await expect(
+      db
+        .selectFrom('versions')
+        .select('created_by_id')
+        .where('id', '=', result.versionId)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ created_by_id: EXTERNAL_VIEWER.id })
   })
 
   test('non-owner cannot operate on cross-workspace artifacts owned by someone else', async () => {

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -315,6 +315,7 @@ export type UploadStaticSiteBundleResult =
 export type UpdateStaticSiteBundleResult =
   | { kind: 'ok'; id: string; versionId: string }
   | { kind: 'not-found' }
+  | { kind: 'invalid-container' }
   | { kind: 'version-conflict'; currentVersionId: string | null }
   | { kind: 'too-many-files'; limit: number }
   | { kind: 'too-large'; limitBytes: number }
@@ -862,7 +863,15 @@ export async function beginStaticSiteBundleVersionUploadSession(
       {
         kind: 'version',
         touchArtifactKeyId,
-        expectedCurrentVersionId: options?.expectedCurrentVersionId ?? null,
+        expectedCurrentVersionId:
+          options?.expectedCurrentVersionId ??
+          (options?.authority?.kind === 'agent' ||
+          shareable.owner_user_id !== user.id
+            ? shareable.current_version_id
+            : null),
+        preserveArtifactIdentity:
+          shareable.owner_user_id !== user.id &&
+          shareable.workspace_id !== user.workspaceId,
         authority: options?.authority ?? null,
         agentProfileId: options?.agentProfileId ?? null,
       },
@@ -1019,7 +1028,6 @@ export async function createVersion(
     agentProfileId,
     auditQuery,
   } = args
-  const preserveName = requestedPreserveName || authority?.kind === 'agent'
   const shareable = await findWritableShareable(
     db,
     user,
@@ -1028,6 +1036,13 @@ export async function createVersion(
     'version',
   )
   if (!shareable) return { kind: 'not-found' }
+  const preserveArtifactIdentity =
+    shareable.owner_user_id !== user.id &&
+    shareable.workspace_id !== user.workspaceId
+  const preserveName =
+    requestedPreserveName ||
+    authority?.kind === 'agent' ||
+    preserveArtifactIdentity
   const commitExpectedVersionId =
     expectedCurrentVersionId ??
     (authority?.kind === 'agent' || shareable.owner_user_id !== user.id
@@ -1156,7 +1171,9 @@ export async function createVersion(
       .set({
         ...(preserveName ? {} : { name: file.name }),
         artifact_kind: prepared.artifactKind,
-        derived_title: prepared.derivedTitle,
+        ...(preserveArtifactIdentity
+          ? {}
+          : { derived_title: prepared.derivedTitle }),
         current_version_id: prepared.versionId,
         updated_at: prepared.now,
       })
@@ -2132,6 +2149,7 @@ type StaticSiteBundleUploadTarget =
       kind: 'version'
       touchArtifactKeyId: string | null
       expectedCurrentVersionId: string | null
+      preserveArtifactIdentity: boolean
       authority: CliAuthority | null
       agentProfileId: string | null
     }
@@ -2607,14 +2625,17 @@ export class StaticSiteBundleUploadSession {
       this.db
         .updateTable('shareables')
         .set({
-          ...(versionTarget.authority?.kind === 'agent'
+          ...(versionTarget.authority?.kind === 'agent' ||
+          versionTarget.preserveArtifactIdentity
             ? {}
             : {
                 name:
                   entrypointFile.derivedTitle ?? entrypointFile.path.slice(1),
               }),
           artifact_kind: 'static_site',
-          derived_title: entrypointFile.derivedTitle,
+          ...(versionTarget.preserveArtifactIdentity
+            ? {}
+            : { derived_title: entrypointFile.derivedTitle }),
           current_version_id: this.versionId,
           updated_at: this.now,
         })
@@ -2676,6 +2697,14 @@ export class StaticSiteBundleUploadSession {
       ) {
         return { kind: 'not-found' }
       }
+      const externalPostingAfterCommit =
+        await checkExternalVersionUploadAllowed(
+          this.db,
+          this.accounting.workspaceId,
+          this.user.workspaceId,
+        )
+      if (externalPostingAfterCommit.kind !== 'ok')
+        return externalPostingAfterCommit
       if (versionTarget.expectedCurrentVersionId !== null) {
         const latest = await this.db
           .selectFrom('shareables')
@@ -2717,7 +2746,8 @@ export class StaticSiteBundleUploadSession {
           this.accounting.workspaceId,
           this.user.workspaceId,
         )
-      if (externalPostingAfterCommit.kind !== 'ok') return { kind: 'not-found' }
+      if (externalPostingAfterCommit.kind !== 'ok')
+        return externalPostingAfterCommit
       if (versionTarget.expectedCurrentVersionId !== null) {
         const latest = await this.db
           .selectFrom('shareables')

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -811,6 +811,7 @@ export async function beginStaticSiteBundleVersionUploadSession(
     user,
     shareableId,
     options?.authority ?? null,
+    'version',
   )
   if (!shareable) return { kind: 'not-found' }
   if (shareable.artifact_kind !== 'static_site') {
@@ -1024,6 +1025,7 @@ export async function createVersion(
     user,
     shareableId,
     authority ?? null,
+    'version',
   )
   if (!shareable) return { kind: 'not-found' }
   const commitExpectedVersionId =
@@ -1127,7 +1129,7 @@ export async function createVersion(
             ])
             .where('id', '=', shareableId)
             .where('current_version_id', '=', commitExpectedVersionId)
-            .where(writableShareableSql(user, authority ?? null)),
+            .where(writableShareableSql(user, authority ?? null, 'version')),
         ),
     )
   } else {
@@ -1159,7 +1161,7 @@ export async function createVersion(
         updated_at: prepared.now,
       })
       .where('id', '=', shareableId)
-      .where(writableShareableSql(user, authority ?? null))
+      .where(writableShareableSql(user, authority ?? null, 'version'))
       .$if(commitExpectedVersionId !== undefined, (q) =>
         q.where('current_version_id', '=', commitExpectedVersionId!),
       ),
@@ -1173,7 +1175,13 @@ export async function createVersion(
     versionPublishedEventQuery(db, { versionId: prepared.versionId }),
   )
   if (
-    !(await findWritableShareable(db, user, shareableId, authority ?? null))
+    !(await findWritableShareable(
+      db,
+      user,
+      shareableId,
+      authority ?? null,
+      'version',
+    ))
   ) {
     await deleteArtifact(env.BUCKET, prepared.r2Key).catch((err) => {
       console.error('unauthorized_version_r2_compensation_failed', {
@@ -1221,22 +1229,36 @@ export async function createVersion(
 
   if (commitExpectedVersionId !== undefined) {
     if (batchMutationCount(versionInsertResult) === 0) {
-      const [, , writable, latest] = await Promise.all([
-        deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
-        releaseQuota(
-          db,
-          accounting.workspaceId,
-          prepared.sizeBytes,
-          prepared.now,
-        ),
-        findWritableShareable(db, user, shareableId, authority ?? null),
-        db
-          .selectFrom('shareables')
-          .select('current_version_id')
-          .where('id', '=', shareableId)
-          .executeTakeFirst(),
-      ])
+      const [, , writable, latest, externalPostingAfterCommit] =
+        await Promise.all([
+          deleteArtifact(env.BUCKET, prepared.r2Key).catch(() => undefined),
+          releaseQuota(
+            db,
+            accounting.workspaceId,
+            prepared.sizeBytes,
+            prepared.now,
+          ),
+          findWritableShareable(
+            db,
+            user,
+            shareableId,
+            authority ?? null,
+            'version',
+          ),
+          db
+            .selectFrom('shareables')
+            .select('current_version_id')
+            .where('id', '=', shareableId)
+            .executeTakeFirst(),
+          checkExternalVersionUploadAllowed(
+            db,
+            accounting.workspaceId,
+            user.workspaceId,
+          ),
+        ])
       if (!writable) return { kind: 'not-found' }
+      if (externalPostingAfterCommit.kind !== 'ok')
+        return externalPostingAfterCommit
       return {
         kind: 'version-conflict',
         currentVersionId: latest?.current_version_id ?? null,
@@ -2129,6 +2151,7 @@ export class StaticSiteBundleUploadSession {
     private readonly user: {
       id: string
       email?: string | null
+      emailVerified?: boolean
       workspaceId: string
       hd?: string | null
     },
@@ -2485,6 +2508,7 @@ export class StaticSiteBundleUploadSession {
       this.user,
       this.shareableId,
       versionTarget.authority,
+      'version',
     )
     if (!writable) {
       await this.abortUploadedFiles()
@@ -2562,7 +2586,13 @@ export class StaticSiteBundleUploadSession {
             .where('id', '=', this.shareableId)
             .where('workspace_id', '=', this.accounting.workspaceId)
             .where('artifact_kind', '=', 'static_site')
-            .where(writableShareableSql(this.user, versionTarget.authority))
+            .where(
+              writableShareableSql(
+                this.user,
+                versionTarget.authority,
+                'version',
+              ),
+            )
             .$if(versionTarget.expectedCurrentVersionId !== null, (q) =>
               q.where(
                 'current_version_id',
@@ -2591,7 +2621,9 @@ export class StaticSiteBundleUploadSession {
         .where('id', '=', this.shareableId)
         .where('workspace_id', '=', this.accounting.workspaceId)
         .where('artifact_kind', '=', 'static_site')
-        .where(writableShareableSql(this.user, versionTarget.authority))
+        .where(
+          writableShareableSql(this.user, versionTarget.authority, 'version'),
+        )
         .$if(versionTarget.expectedCurrentVersionId !== null, (q) =>
           q.where(
             'current_version_id',
@@ -2639,6 +2671,7 @@ export class StaticSiteBundleUploadSession {
           this.user,
           this.shareableId,
           versionTarget.authority,
+          'version',
         ))
       ) {
         return { kind: 'not-found' }
@@ -2675,8 +2708,16 @@ export class StaticSiteBundleUploadSession {
         this.user,
         this.shareableId,
         versionTarget.authority,
+        'version',
       )
       if (!writableAfterCommit) return { kind: 'not-found' }
+      const externalPostingAfterCommit =
+        await checkExternalVersionUploadAllowed(
+          this.db,
+          this.accounting.workspaceId,
+          this.user.workspaceId,
+        )
+      if (externalPostingAfterCommit.kind !== 'ok') return { kind: 'not-found' }
       if (versionTarget.expectedCurrentVersionId !== null) {
         const latest = await this.db
           .selectFrom('shareables')
@@ -3320,6 +3361,7 @@ async function findWritableShareable(
   },
   shareableId: string,
   authority: CliAuthority | null,
+  access: 'collaboration' | 'version' = 'collaboration',
 ) {
   const shareable = await db
     .selectFrom('shareables')
@@ -3359,7 +3401,27 @@ async function findWritableShareable(
   }
   if (authority?.kind === 'bridge') return null
   if (shareable.owner_user_id === user.id) return shareable
-  if (user.workspaceId !== shareable.workspace_id) return null
+  if (user.workspaceId !== shareable.workspace_id) {
+    if (access !== 'version' || !user.email || !user.emailVerified) return null
+    const externalGrant = await db
+      .selectFrom('shareable_grants as external_grant')
+      .innerJoin('users as external_user', (join) =>
+        join
+          .on('external_user.id', '=', user.id)
+          .on('external_user.kind', '=', 'human')
+          .on('external_user.email_verified', '=', 1),
+      )
+      .select('external_grant.shareable_id')
+      .where('external_grant.shareable_id', '=', shareableId)
+      .where(
+        lowerEmail('external_grant.granted_email'),
+        '=',
+        user.email.toLowerCase(),
+      )
+      .where(lowerEmail('external_user.email'), '=', user.email.toLowerCase())
+      .executeTakeFirst()
+    return externalGrant ? shareable : null
+  }
 
   const member = await db
     .selectFrom('workspace_members')
@@ -3409,6 +3471,7 @@ function writableShareableSql(
     emailVerified?: boolean
   },
   authority: CliAuthority | null,
+  access: 'collaboration' | 'version' = 'collaboration',
 ): RawBuilder<boolean> {
   if (authority?.kind === 'agent') {
     return sql<boolean>`
@@ -3436,6 +3499,32 @@ function writableShareableSql(
   const verifiedEmail = user.emailVerified
     ? (user.email?.toLowerCase() ?? '')
     : ''
+  const externalGrant =
+    access === 'version'
+      ? sql<boolean>`
+      OR (
+        shareables.workspace_id != ${user.workspaceId}
+        AND ${verifiedEmail} <> ''
+        AND EXISTS (
+          SELECT 1 FROM users writable_external_user
+          WHERE writable_external_user.id = ${user.id}
+            AND writable_external_user.kind = 'human'
+            AND writable_external_user.email_verified = 1
+            AND lower(writable_external_user.email) = ${verifiedEmail}
+        )
+        AND EXISTS (
+          SELECT 1 FROM shareable_grants writable_external_grant
+          WHERE writable_external_grant.shareable_id = shareables.id
+            AND lower(writable_external_grant.granted_email) = ${verifiedEmail}
+        )
+        AND EXISTS (
+          SELECT 1 FROM workspaces writable_external_workspace
+          WHERE writable_external_workspace.id = shareables.workspace_id
+            AND writable_external_workspace.plan != 'free'
+            AND writable_external_workspace.external_posting_enabled = 1
+        )
+      )`
+      : sql<boolean>``
   return sql<boolean>`
     (shareables.owner_user_id = ${user.id}
     OR (
@@ -3487,7 +3576,7 @@ function writableShareableSql(
           )
         )
       )
-    ))`
+    )${externalGrant})`
 }
 
 export interface OwnedShareableSummary {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -43,6 +43,9 @@ runs add versions to the same file.
 Pass `--expected-version <version-id>` to reject an update when another version
 became current first. Project-scoped agent profiles must pass it to `update`
 and to repeat `share --key` updates; initial key creation does not require it.
+A signed-in external human whose verified email is explicitly granted on an
+artifact can also update it when the artifact workspace allows external
+posting. Link access alone does not grant update access.
 
 ## Authentication
 

--- a/packages/cli/skills/artifactshare/SKILL.md
+++ b/packages/cli/skills/artifactshare/SKILL.md
@@ -184,6 +184,9 @@ npm exec --yes --package=@artifactshare/cli -- artifactshare update <artifact-id
   version became current first. Project-scoped agent profiles must pass it.
   Repeat `share --key` updates accept the same option; initial creation does
   not require it.
+- A signed-in external human whose verified email is explicitly granted on an
+  artifact can update it when the artifact workspace allows external posting.
+  Link access alone does not grant update access.
 
 - To keep an existing share URL, do not run `share --artifact-id`; use `update`.
 - Pass the same kind of input (single file vs directory) it was created with.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -428,6 +428,11 @@ const updateDefinition = define({
   Accepts an artifact ID, /a/<id> share URL, or <id>.sandbox.* URL.
   Titles and project names are not updated directly; resolve them to an ID first.
 
+Access:
+  You can update your own artifact or another artifact you have collaborative access to.
+  A verified external viewer can update an artifact explicitly shared with their email
+  when the artifact workspace allows external posting.
+
 Common failures:
   auth_required          Set ARTIFACTSHARE_TOKEN before update
   target_not_found       Retry with an artifact ID, share URL, or sandbox URL


### PR DESCRIPTION
## Summary

- allow an authenticated external human with a verified per-artifact email grant to add new single-file and static-site versions when the artifact workspace allows external posting
- recheck the grant, verified identity, workspace policy, and expected version at commit time while compensating rejected uploads
- preserve artifact titles and owner-only settings during external updates
- document the external-grantee update behavior in CLI help, README, and the bundled skill

## Validation

- `pnpm validate:static` (Web: 3,345 passed, 1 skipped; D1: 12 passed; bridge: 81 passed; React Doctor: 100; public scan: 0 findings)
- `pnpm --filter @artifactshare/cli test` (576 passed, 1 skipped)
- `pnpm --filter @artifactshare/cli typecheck`
- `pnpm check:cli-reference`
- trusted public-development guard

## Review

- specification review: Codex and Claude completed with no blockers
- implementation review round 1: fixed title mutation, static-site optimistic concurrency, and static-site policy-race handling
- implementation review round 2: Codex and Claude reported no findings
- deferred findings: none
