### PR TITLE
Viewerとアプリのサイドパネルがヘッダー操作を覆わないようにする

### DIFF
--- a/apps/web/app/components/app/access-requests-sheet.tsx
+++ b/apps/web/app/components/app/access-requests-sheet.tsx
@@ -2,12 +2,7 @@ import { IconChevronLeft, IconX } from '@tabler/icons-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '~/components/ui/button'
 import { RadioGroup, RadioGroupItem } from '~/components/ui/radio-group'
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from '~/components/ui/sheet'
+import { SheetHeader, SheetTitle } from '~/components/ui/sheet'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import type {
   AccessRequestScope,
@@ -15,6 +10,10 @@ import type {
   SentAccessRequest,
 } from '~/services/access-requests.server'
 import { useT } from '~/hooks/use-t'
+import {
+  AppSidePanel,
+  type SidePanelTopbar,
+} from '~/components/app/app-side-panel'
 
 interface AccessRequestsResponse {
   received: ReceivedAccessRequest[]
@@ -228,6 +227,7 @@ function AccessRequestLists({
           <button
             key={item.id}
             type="button"
+            data-access-request-id={item.id}
             disabled={loading || error === 'load'}
             className="hover:bg-muted w-full rounded-lg p-3 text-left"
             onClick={() => onSelect(item.id)}
@@ -278,11 +278,13 @@ export function AccessRequestsSheet({
   onOpenChange,
   initialRequestId,
   onCountChange,
+  topbar = 'none',
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   initialRequestId?: string | null
   onCountChange?: (count: number) => void
+  topbar?: SidePanelTopbar
 }) {
   const { t } = useT()
   const [data, setData] = useState<AccessRequestsResponse | null>(null)
@@ -457,66 +459,66 @@ export function AccessRequestsSheet({
   }
 
   return (
-    <Sheet modal={false} open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        side="right"
-        className="max-sheet:inset-x-2.5 max-sheet:top-auto max-sheet:bottom-0 max-sheet:h-[var(--height-comment-panel-sheet)] max-sheet:w-auto max-sheet:max-w-none max-sheet:rounded-t-[var(--r-lg)] max-sheet:border-t-divider max-sheet:border-r-divider max-sheet:border-l-divider gap-0"
-      >
-        <SheetHeader>
-          <div className="flex min-w-0 items-center gap-2">
-            {selected && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                aria-label={t('accessRequests.back')}
-                disabled={submitting}
-                onClick={backToList}
-              >
-                <IconChevronLeft aria-hidden="true" />
-              </Button>
-            )}
-            <SheetTitle>{t('accessRequests.title')}</SheetTitle>
-          </div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label={t('common.close')}
-            onClick={() => onOpenChange(false)}
-          >
-            <IconX aria-hidden="true" />
-          </Button>
-        </SheetHeader>
+    <AppSidePanel
+      open={open}
+      onOpenChange={onOpenChange}
+      topbar={topbar}
+      side="right"
+    >
+      <SheetHeader>
+        <div className="flex min-w-0 items-center gap-2">
+          {selected && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={t('accessRequests.back')}
+              disabled={submitting}
+              onClick={backToList}
+            >
+              <IconChevronLeft aria-hidden="true" />
+            </Button>
+          )}
+          <SheetTitle>{t('accessRequests.title')}</SheetTitle>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={t('common.close')}
+          onClick={() => onOpenChange(false)}
+        >
+          <IconX aria-hidden="true" />
+        </Button>
+      </SheetHeader>
 
-        {selected ? (
-          <AccessRequestDetail
-            request={selected}
-            scope={scope}
-            error={error}
-            loading={loading}
-            submitting={submitting}
-            onScopeChange={(value) =>
-              setScopeChoice({ contextKey: scopeContextKey, value })
-            }
-            onRetry={retryLoad}
-            onDecide={(decision) => void decide(decision)}
-          />
-        ) : (
-          <AccessRequestLists
-            data={data}
-            error={error}
-            loading={loading}
-            onRetry={retryLoad}
-            onSelect={(id) => {
-              clearDecisionError()
-              unverifiedInitialIdRef.current = null
-              selectedIdRef.current = id
-              setSelectedId(id)
-            }}
-          />
-        )}
-      </SheetContent>
-    </Sheet>
+      {selected ? (
+        <AccessRequestDetail
+          request={selected}
+          scope={scope}
+          error={error}
+          loading={loading}
+          submitting={submitting}
+          onScopeChange={(value) =>
+            setScopeChoice({ contextKey: scopeContextKey, value })
+          }
+          onRetry={retryLoad}
+          onDecide={(decision) => void decide(decision)}
+        />
+      ) : (
+        <AccessRequestLists
+          data={data}
+          error={error}
+          loading={loading}
+          onRetry={retryLoad}
+          onSelect={(id) => {
+            clearDecisionError()
+            unverifiedInitialIdRef.current = null
+            selectedIdRef.current = id
+            setSelectedId(id)
+          }}
+        />
+      )}
+    </AppSidePanel>
   )
 }

--- a/apps/web/app/components/app/app-side-panel.tsx
+++ b/apps/web/app/components/app/app-side-panel.tsx
@@ -1,0 +1,112 @@
+import {
+  type ComponentProps,
+  type KeyboardEvent,
+  useLayoutEffect,
+  useState,
+} from 'react'
+import { Sheet, SheetContent } from '~/components/ui/sheet'
+import { cn } from '~/lib/utils'
+
+export type SidePanelTopbar = 'app' | 'viewer' | 'none'
+
+type AppSidePanelProps = Omit<
+  ComponentProps<typeof SheetContent>,
+  'onInteractOutside' | 'showOverlay'
+> & {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  topbar: SidePanelTopbar
+}
+
+export function AppSidePanel({
+  open,
+  onOpenChange,
+  topbar,
+  className,
+  onKeyDown,
+  style,
+  ...props
+}: AppSidePanelProps) {
+  const [viewerTop, setViewerTop] = useState<number | null>(null)
+
+  useLayoutEffect(() => {
+    if (topbar !== 'viewer') {
+      setViewerTop(null)
+      return
+    }
+    if (!open) return
+    const topbarElement = document.getElementById('viewer-topbar')
+    if (!topbarElement) return
+    const update = () => {
+      const sheetBreakpoint = Number.parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          '--breakpoint-sheet',
+        ),
+      )
+      setViewerTop(
+        window.innerWidth >= sheetBreakpoint
+          ? topbarElement.getBoundingClientRect().bottom
+          : null,
+      )
+    }
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(topbarElement)
+    window.addEventListener('resize', update)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', update)
+    }
+  }, [open, topbar])
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event)
+    if (event.defaultPrevented || event.key !== 'Tab' || topbar === 'none')
+      return
+
+    const panelItems = focusableElements(event.currentTarget)
+    const activeElement = document.activeElement
+    const leavingBackward = event.shiftKey && activeElement === panelItems[0]
+    const leavingForward =
+      !event.shiftKey && activeElement === panelItems.at(-1)
+    if (!leavingBackward && !leavingForward) return
+
+    const topbarElement =
+      topbar === 'viewer'
+        ? document.getElementById('viewer-topbar')
+        : document.querySelector<HTMLElement>('header')
+    if (!topbarElement) return
+    const topbarItems = focusableElements(topbarElement)
+    const target = leavingBackward ? topbarItems.at(-1) : topbarItems[0]
+    if (!target) return
+    event.preventDefault()
+    target.focus()
+  }
+
+  return (
+    <Sheet modal={false} open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        showOverlay={false}
+        onInteractOutside={(event) => event.preventDefault()}
+        onKeyDown={handleKeyDown}
+        style={{ ...style, top: viewerTop ?? style?.top }}
+        className={cn(
+          'max-sheet:data-open:slide-in-from-right-0 max-sheet:data-open:slide-in-from-bottom max-sheet:data-closed:slide-out-to-right-0 max-sheet:data-closed:slide-out-to-bottom max-sheet:inset-x-2.5 max-sheet:top-auto max-sheet:bottom-0 max-sheet:h-[var(--height-comment-panel-sheet)] max-sheet:w-auto max-sheet:max-w-none max-sheet:rounded-t-[var(--r-lg)] max-sheet:border-t-divider max-sheet:border-r-divider max-sheet:border-l-divider gap-0',
+          topbar === 'app' && 'sheet:top-12 sheet:h-auto',
+          topbar === 'viewer' && 'sheet:top-topbar-expanded sheet:h-auto',
+          className,
+        )}
+        {...props}
+      />
+    </Sheet>
+  )
+}
+
+const focusableSelector =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+function focusableElements(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(focusableSelector),
+  ).filter((element) => element.getClientRects().length > 0)
+}

--- a/apps/web/app/components/app/app-side-panel.tsx
+++ b/apps/web/app/components/app/app-side-panel.tsx
@@ -1,7 +1,9 @@
 import {
   type ComponentProps,
   type KeyboardEvent,
+  useEffect,
   useLayoutEffect,
+  useRef,
   useState,
 } from 'react'
 import { Sheet, SheetContent } from '~/components/ui/sheet'
@@ -28,6 +30,7 @@ export function AppSidePanel({
   ...props
 }: AppSidePanelProps) {
   const [viewerTop, setViewerTop] = useState<number | null>(null)
+  const panelRef = useRef<HTMLDivElement | null>(null)
 
   useLayoutEffect(() => {
     if (topbar !== 'viewer') {
@@ -59,6 +62,32 @@ export function AppSidePanel({
     }
   }, [open, topbar])
 
+  useEffect(() => {
+    if (!open || topbar === 'none') return
+    const handleTopbarKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== 'Tab') return
+      const topbarElement = getTopbarElement(topbar)
+      const panelElement = panelRef.current
+      if (!topbarElement || !panelElement) return
+      if (!topbarElement.contains(event.target as Node)) return
+
+      const topbarItems = focusableElements(topbarElement)
+      const panelItems = focusableElements(panelElement)
+      const activeElement = document.activeElement
+      const leavingBackward = event.shiftKey && activeElement === topbarItems[0]
+      const leavingForward =
+        !event.shiftKey && activeElement === topbarItems.at(-1)
+      if (!leavingBackward && !leavingForward) return
+
+      const target = leavingBackward ? panelItems.at(-1) : panelItems[0]
+      if (!target) return
+      event.preventDefault()
+      target.focus()
+    }
+    document.addEventListener('keydown', handleTopbarKeyDown)
+    return () => document.removeEventListener('keydown', handleTopbarKeyDown)
+  }, [open, topbar])
+
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     onKeyDown?.(event)
     if (event.defaultPrevented || event.key !== 'Tab' || topbar === 'none')
@@ -71,10 +100,7 @@ export function AppSidePanel({
       !event.shiftKey && activeElement === panelItems.at(-1)
     if (!leavingBackward && !leavingForward) return
 
-    const topbarElement =
-      topbar === 'viewer'
-        ? document.getElementById('viewer-topbar')
-        : document.querySelector<HTMLElement>('header')
+    const topbarElement = getTopbarElement(topbar)
     if (!topbarElement) return
     const topbarItems = focusableElements(topbarElement)
     const target = leavingBackward ? topbarItems.at(-1) : topbarItems[0]
@@ -86,6 +112,7 @@ export function AppSidePanel({
   return (
     <Sheet modal={false} open={open} onOpenChange={onOpenChange}>
       <SheetContent
+        ref={panelRef}
         showOverlay={false}
         onInteractOutside={(event) => event.preventDefault()}
         onKeyDown={handleKeyDown}
@@ -99,6 +126,12 @@ export function AppSidePanel({
         {...props}
       />
     </Sheet>
+  )
+}
+
+function getTopbarElement(topbar: Exclude<SidePanelTopbar, 'none'>) {
+  return document.getElementById(
+    topbar === 'viewer' ? 'viewer-topbar' : 'app-topbar',
   )
 }
 

--- a/apps/web/app/components/app/app-topbar.tsx
+++ b/apps/web/app/components/app/app-topbar.tsx
@@ -14,6 +14,7 @@ export function AppTopbar({
 } & Pick<ComponentProps<'header'>, 'id' | 'aria-labelledby'>) {
   return (
     <header
+      id="app-topbar"
       className={cn(
         'bg-background border-divider sticky top-0 z-[var(--z-topbar)] flex h-12 items-center gap-1.5 border-b px-3',
         'max-nav:gap-1 max-nav:px-2',

--- a/apps/web/app/components/app/avatar-menu.behavior.browser.test.tsx
+++ b/apps/web/app/components/app/avatar-menu.behavior.browser.test.tsx
@@ -5,6 +5,7 @@ import { page } from 'vitest/browser'
 import { AvatarMenu } from './avatar-menu'
 import { TooltipProvider } from '~/components/ui/tooltip'
 import { ViewerFixture } from '~/routes/dev.scenarios.$scenario/+components/viewer-fixture'
+import { AppTopbar } from './app-topbar'
 import '~/app.css'
 
 const submitMock = vi.hoisted(() => vi.fn())
@@ -40,7 +41,15 @@ afterEach(() => {
 })
 
 describe('AvatarMenu access requests', () => {
-  test('keeps the sheet open after selecting it when there are no requests', async () => {
+  test.each([
+    { name: 'app avatar', variant: undefined, accessRequestsTopbar: undefined },
+    {
+      name: 'viewer-styled avatar in an app-height error topbar',
+      variant: 'viewer' as const,
+      accessRequestsTopbar: 'app' as const,
+    },
+  ])('keeps the sheet below the $name', async (menuProps) => {
+    await page.viewport(1440, 900)
     vi.stubGlobal(
       'fetch',
       vi.fn((input: RequestInfo | URL) => {
@@ -62,20 +71,28 @@ describe('AvatarMenu access requests', () => {
     )
 
     const host = document.createElement('div')
+    const onAccessRequestsOpen = vi.fn()
     document.body.appendChild(host)
     root = createRoot(host)
     root.render(
       <TooltipProvider>
-        <AvatarMenu
-          variant="viewer"
-          user={{
-            id: 'user-1',
-            email: 'user@example.com',
-            name: 'User',
-            image: null,
-            initial: 'U',
-          }}
-        />
+        <AppTopbar>
+          <button type="button" data-home-header-action>
+            Home action
+          </button>
+          <AvatarMenu
+            user={{
+              id: 'user-1',
+              email: 'user@example.com',
+              name: 'User',
+              image: null,
+              initial: 'U',
+            }}
+            variant={menuProps.variant}
+            accessRequestsTopbar={menuProps.accessRequestsTopbar}
+            onAccessRequestsOpen={onAccessRequestsOpen}
+          />
+        </AppTopbar>
       </TooltipProvider>,
     )
 
@@ -89,8 +106,23 @@ describe('AvatarMenu access requests', () => {
     )
     await new Promise((resolve) => window.setTimeout(resolve, 600))
 
-    const sheet = document.querySelector('[data-slot="sheet-content"]')
+    const sheet = document.querySelector<HTMLElement>(
+      '[data-slot="sheet-content"]',
+    )
+    const topbar = document.querySelector<HTMLElement>('header')
     expect(sheet).not.toBeNull()
+    expect(sheet?.getBoundingClientRect().top).toBe(
+      topbar?.getBoundingClientRect().bottom,
+    )
+    expect(document.querySelector('[data-slot="sheet-overlay"]')).toBeNull()
+    expect(onAccessRequestsOpen).toHaveBeenCalledOnce()
+    const headerAction = document.querySelector<HTMLButtonElement>(
+      '[data-home-header-action]',
+    )!
+    const headerClick = vi.fn()
+    headerAction.addEventListener('click', headerClick)
+    headerAction.click()
+    expect(headerClick).toHaveBeenCalledOnce()
     expect(sheet?.contains(document.activeElement)).toBe(true)
     expect(document.body.textContent).toContain(
       '未対応のリクエストはありません。',
@@ -154,6 +186,13 @@ describe('AvatarMenu access requests', () => {
 
       const sheet = document.querySelector('[data-slot="sheet-content"]')
       expect(sheet).not.toBeNull()
+      if (width > 820) {
+        const topbar = document.querySelector('#viewer-topbar')
+        expect(sheet?.getBoundingClientRect().top).toBe(
+          topbar?.getBoundingClientRect().bottom,
+        )
+      }
+      expect(document.querySelector('[data-slot="sheet-overlay"]')).toBeNull()
       expect(sheet?.contains(document.activeElement)).toBe(true)
       expect(document.body.textContent).toContain(
         '未対応のリクエストはありません。',

--- a/apps/web/app/components/app/avatar-menu.tsx
+++ b/apps/web/app/components/app/avatar-menu.tsx
@@ -34,13 +34,19 @@ import type { UserInfo } from '~/lib/user'
 import { DEFAULT_APP_THEME, isAppTheme, type AppTheme } from '~/lib/app-theme'
 import { cn } from '~/lib/utils'
 import { AccessRequestsSheet } from '~/components/app/access-requests-sheet'
+import type { SidePanelTopbar } from '~/components/app/app-side-panel'
 
 interface AvatarMenuProps {
   user: UserInfo
   variant?: 'default' | 'viewer'
   className?: string
   initialAccessRequestId?: string | null
+  accessRequestsOpen?: boolean
+  onAccessRequestsOpenChange?: (open: boolean) => void
   onAccessRequestDismiss?: () => void
+  onAccessRequestsOpen?: () => void
+  topbarCollapsed?: boolean
+  accessRequestsTopbar?: SidePanelTopbar
 }
 
 const triggerClassName = cn(
@@ -59,7 +65,12 @@ export function AvatarMenu({
   variant = 'default',
   className,
   initialAccessRequestId = null,
+  accessRequestsOpen: controlledAccessRequestsOpen,
+  onAccessRequestsOpenChange,
   onAccessRequestDismiss,
+  onAccessRequestsOpen,
+  topbarCollapsed = false,
+  accessRequestsTopbar,
 }: AvatarMenuProps) {
   const { t, locale } = useT()
   const { openBanner } = useAnalyticsConsent()
@@ -78,9 +89,16 @@ export function AvatarMenu({
     ? submittedAppTheme
     : resolvedAppTheme
   const [menuOpen, setMenuOpen] = useState(false)
-  const [accessRequestsOpen, setAccessRequestsOpen] = useState(
+  const [localAccessRequestsOpen, setLocalAccessRequestsOpen] = useState(
     initialAccessRequestId !== null,
   )
+  const accessRequestsOpen =
+    controlledAccessRequestsOpen ?? localAccessRequestsOpen
+  const setAccessRequestsOpen = (open: boolean) => {
+    if (controlledAccessRequestsOpen === undefined)
+      setLocalAccessRequestsOpen(open)
+    onAccessRequestsOpenChange?.(open)
+  }
   const [accessRequestCount, setAccessRequestCount] = useState(
     rootData?.accessRequestNotice?.count ?? 0,
   )
@@ -147,6 +165,7 @@ export function AvatarMenu({
 
   const handleAccessRequestsOpen = () => {
     openingAccessRequests.current = true
+    onAccessRequestsOpen?.()
     setAccessRequestsOpen(true)
   }
 
@@ -170,6 +189,7 @@ export function AvatarMenu({
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
+                data-avatar-menu-trigger
                 className={cn(
                   triggerClassName,
                   variant === 'viewer' && 'max-phone:size-7.5',
@@ -228,7 +248,10 @@ export function AvatarMenu({
             </div>
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={handleAccessRequestsOpen}>
+          <DropdownMenuItem
+            data-access-requests-menu-item
+            onSelect={handleAccessRequestsOpen}
+          >
             {t('accessRequests.title')}
             {accessRequestCount > 0 && (
               <Badge variant="info" className="ml-auto">
@@ -318,6 +341,10 @@ export function AvatarMenu({
           if (!open && initialAccessRequestId) onAccessRequestDismiss?.()
         }}
         onCountChange={setAccessRequestCount}
+        topbar={
+          accessRequestsTopbar ??
+          (variant === 'viewer' ? (topbarCollapsed ? 'none' : 'viewer') : 'app')
+        }
       />
     </>
   )

--- a/apps/web/app/components/app/viewer-error-shell.tsx
+++ b/apps/web/app/components/app/viewer-error-shell.tsx
@@ -35,6 +35,7 @@ export function ViewerErrorShell({
         <AvatarMenu
           user={user}
           variant="viewer"
+          accessRequestsTopbar="app"
           className="max-phone:col-start-2 max-phone:justify-self-end ml-auto"
         />
       ) : null}

--- a/apps/web/app/components/ui/sheet.tsx
+++ b/apps/web/app/components/ui/sheet.tsx
@@ -48,13 +48,15 @@ function SheetContent({
   className,
   children,
   side = 'right',
+  showOverlay = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   side?: 'top' | 'right' | 'bottom' | 'left'
+  showOverlay?: boolean
 }) {
   return (
     <SheetPortal>
-      <SheetOverlay />
+      {showOverlay ? <SheetOverlay /> : null}
       <DialogPrimitive.Content
         data-slot="sheet-content"
         className={cn(

--- a/apps/web/app/routes/a.$id/+components/comment-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/comment-panel.tsx
@@ -8,13 +8,7 @@ import {
   type FormEvent,
   type RefObject,
 } from 'react'
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from '~/components/ui/sheet'
+import { SheetClose, SheetHeader, SheetTitle } from '~/components/ui/sheet'
 import { Button } from '~/components/ui/button'
 import { IconButton } from '~/components/app/icon-button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
@@ -44,6 +38,7 @@ import {
 } from './comment-reply-state'
 import { IconMessage, IconX } from '@tabler/icons-react'
 import { useAnalyticsConsent } from '~/components/app/analytics-consent-provider'
+import { AppSidePanel } from '~/components/app/app-side-panel'
 
 type CommentFilter = 'open' | 'all' | 'resolved'
 type TargetThreadScroll = 'center' | 'start'
@@ -65,6 +60,7 @@ interface CommentPanelProps {
   onThreadNavigate: (thread: CommentThreadView) => void
   returnFocusRef?: RefObject<HTMLElement | null>
   requestedFilter?: CommentFilter
+  topbarCollapsed?: boolean
   // 本文選択できない成果物 (static_site) 向けに、ファイル全体への
   // コメントを新規作成する composer をパネル下部に出す。
   showNewThreadComposer?: boolean
@@ -83,6 +79,7 @@ export function CommentPanel({
   onThreadNavigate,
   returnFocusRef,
   requestedFilter,
+  topbarCollapsed = false,
   showNewThreadComposer = false,
 }: CommentPanelProps) {
   const translator = useT()
@@ -293,70 +290,69 @@ export function CommentPanel({
   )
 
   return (
-    <Sheet modal={false} open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        onInteractOutside={(event) => event.preventDefault()}
-        onEscapeKeyDown={(event) => {
-          if (
-            replyState.activeThreadId &&
-            visibleThreads.some(
-              (thread) =>
-                thread.id === replyState.activeThreadId &&
-                thread.status === 'open',
-            )
-          ) {
-            event.preventDefault()
-            dispatchReply({
-              type: 'cancel',
-            })
-          }
-        }}
-        className="max-sheet:inset-x-2.5 max-sheet:top-auto max-sheet:bottom-0 max-sheet:h-[var(--height-comment-panel-sheet)] max-sheet:w-auto max-sheet:max-w-none max-sheet:rounded-t-[var(--r-lg)] max-sheet:border-t-divider max-sheet:border-r-divider max-sheet:border-l-divider gap-0"
-        aria-describedby={undefined}
-      >
-        <CommentPanelHeader />
+    <AppSidePanel
+      open={open}
+      onOpenChange={onOpenChange}
+      topbar={topbarCollapsed ? 'none' : 'viewer'}
+      onEscapeKeyDown={(event) => {
+        if (
+          replyState.activeThreadId &&
+          visibleThreads.some(
+            (thread) =>
+              thread.id === replyState.activeThreadId &&
+              thread.status === 'open',
+          )
+        ) {
+          event.preventDefault()
+          dispatchReply({
+            type: 'cancel',
+          })
+        }
+      }}
+      aria-describedby={undefined}
+    >
+      <CommentPanelHeader />
 
-        <Tabs
-          className="flex min-h-0 flex-1 flex-col"
-          value={visibleFilter}
-          onValueChange={(value) => {
-            const item = value as CommentFilter
-            setActiveRequestedFilter(undefined)
-            setAutoFilterTarget(
-              targetThreadFilterKey
-                ? { key: targetThreadFilterKey, filter: item }
-                : null,
-            )
-            setFilter(item)
-          }}
-        >
-          <TabsList aria-label={t('comments.filterLabel')}>
-            {(['open', 'all', 'resolved'] as const).map((item) => (
-              <TabsTrigger key={item} value={item}>
-                {t(`comments.filter.${item}`)}
-              </TabsTrigger>
-            ))}
-          </TabsList>
+      <Tabs
+        className="flex min-h-0 flex-1 flex-col"
+        value={visibleFilter}
+        onValueChange={(value) => {
+          const item = value as CommentFilter
+          setActiveRequestedFilter(undefined)
+          setAutoFilterTarget(
+            targetThreadFilterKey
+              ? { key: targetThreadFilterKey, filter: item }
+              : null,
+          )
+          setFilter(item)
+        }}
+      >
+        <TabsList aria-label={t('comments.filterLabel')}>
           {(['open', 'all', 'resolved'] as const).map((item) => (
-            <TabsContent
-              key={item}
-              value={item}
-              className="flex min-h-0 flex-1 flex-col"
-            >
-              {commentList}
-            </TabsContent>
+            <TabsTrigger key={item} value={item}>
+              {t(`comments.filter.${item}`)}
+            </TabsTrigger>
           ))}
-        </Tabs>
-        {showNewThreadComposer ? (
-          <NewThreadComposer
-            pending={pendingKeys.has('create-thread')}
-            onSubmit={(body) =>
-              mutate({ intent: 'create-thread', body }, 'create-thread')
-            }
-          />
-        ) : null}
-      </SheetContent>
-    </Sheet>
+        </TabsList>
+        {(['open', 'all', 'resolved'] as const).map((item) => (
+          <TabsContent
+            key={item}
+            value={item}
+            className="flex min-h-0 flex-1 flex-col"
+          >
+            {commentList}
+          </TabsContent>
+        ))}
+      </Tabs>
+      {showNewThreadComposer ? (
+        <NewThreadComposer
+          pending={pendingKeys.has('create-thread')}
+          onSubmit={(body) =>
+            mutate({ intent: 'create-thread', body }, 'create-thread')
+          }
+        />
+      ) : null}
+    </AppSidePanel>
   )
 }
 

--- a/apps/web/app/routes/a.$id/+components/history-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/history-panel.tsx
@@ -1,13 +1,7 @@
 import { IconHistory as HistoryIcon, IconX } from '@tabler/icons-react'
 import { useEffect, useRef, useState, type RefObject } from 'react'
 import { toast } from 'sonner'
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from '~/components/ui/sheet'
+import { SheetClose, SheetHeader, SheetTitle } from '~/components/ui/sheet'
 import { Button } from '~/components/ui/button'
 import { IconButton } from '~/components/app/icon-button'
 import { useT } from '~/hooks/use-t'
@@ -15,6 +9,7 @@ import { formatRelative } from '~/lib/datetime'
 import { ReplaceVersionDropzone } from './replace-version-dropzone'
 import type { VersionRow } from './version-history-types'
 import { VersionRows } from './version-rows'
+import { AppSidePanel } from '~/components/app/app-side-panel'
 
 export type { VersionRow } from './version-history-types'
 export { VersionWidget } from './version-widget'
@@ -29,6 +24,7 @@ interface HistoryPanelProps {
   uploading?: boolean
   dropActive?: boolean
   returnFocusRef?: RefObject<HTMLElement | null>
+  topbarCollapsed?: boolean
 }
 
 export function HistoryPanel({
@@ -41,6 +37,7 @@ export function HistoryPanel({
   uploading = false,
   dropActive = false,
   returnFocusRef,
+  topbarCollapsed = false,
 }: HistoryPanelProps) {
   const { locale, t } = useT()
   const inputRef = useRef<HTMLInputElement>(null)
@@ -69,36 +66,39 @@ export function HistoryPanel({
     : 'vw.versionHistoryReadonly'
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent aria-describedby={undefined}>
-        <SheetHeader>
-          <SheetTitle>
-            <HistoryIcon size={16} aria-hidden="true" />
-            <span>{t(titleKey)}</span>
-          </SheetTitle>
-          <SheetClose asChild>
-            <IconButton
-              type="button"
-              icon={IconX}
-              size="md"
-              aria-label={t('common.close')}
-            />
-          </SheetClose>
-        </SheetHeader>
-        <HistoryPanelBody
-          versions={versions}
-          canReplaceFile={canReplaceFile}
-          active={active}
-          uploading={uploading}
-          inputRef={inputRef}
-          replaceMode={replaceMode}
-          setLocalDropActive={setLocalDropActive}
-          submitFiles={submitFiles}
-          locale={locale}
-          t={t}
-        />
-      </SheetContent>
-    </Sheet>
+    <AppSidePanel
+      open={open}
+      onOpenChange={onOpenChange}
+      topbar={topbarCollapsed ? 'none' : 'viewer'}
+      aria-describedby={undefined}
+    >
+      <SheetHeader>
+        <SheetTitle>
+          <HistoryIcon size={16} aria-hidden="true" />
+          <span>{t(titleKey)}</span>
+        </SheetTitle>
+        <SheetClose asChild>
+          <IconButton
+            type="button"
+            icon={IconX}
+            size="md"
+            aria-label={t('common.close')}
+          />
+        </SheetClose>
+      </SheetHeader>
+      <HistoryPanelBody
+        versions={versions}
+        canReplaceFile={canReplaceFile}
+        active={active}
+        uploading={uploading}
+        inputRef={inputRef}
+        replaceMode={replaceMode}
+        setLocalDropActive={setLocalDropActive}
+        submitFiles={submitFiles}
+        locale={locale}
+        t={t}
+      />
+    </AppSidePanel>
   )
 }
 

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
@@ -162,6 +162,9 @@ interface ViewerChromeProps {
   onDownloadHtml?: () => void
   onDownloadMarkdown?: () => void
   onDownloadPdf?: () => void
+  onAccessRequestsOpen?: () => void
+  accessRequestsOpen?: boolean
+  onAccessRequestsOpenChange?: (open: boolean) => void
   collapsible?: boolean
   collapsed?: boolean
   onCollapsedChange?: (collapsed: boolean) => void
@@ -198,6 +201,9 @@ export function ViewerChrome({
   onDownloadHtml,
   onDownloadMarkdown,
   onDownloadPdf,
+  onAccessRequestsOpen,
+  accessRequestsOpen,
+  onAccessRequestsOpenChange,
   collapsible = true,
   collapsed = false,
   onCollapsedChange,
@@ -385,8 +391,12 @@ export function ViewerChrome({
           onDownloadHtml={onDownloadHtml}
           onDownloadMarkdown={onDownloadMarkdown}
           onDownloadPdf={onDownloadPdf}
+          onAccessRequestsOpen={onAccessRequestsOpen}
+          accessRequestsOpen={accessRequestsOpen}
+          onAccessRequestsOpenChange={onAccessRequestsOpenChange}
           onAccessRequestDismiss={dismissAccessRequest}
           translator={translator}
+          topbarCollapsed={collapsed}
           user={user}
         />
 
@@ -449,39 +459,58 @@ export function ViewerChrome({
         />
       ) : null}
       {collapsible ? (
-        <div className="relative z-[var(--z-topbar-raised)] h-0">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className={cn(
-              'bg-background text-muted-foreground hover:bg-muted hover:text-foreground aria-expanded:bg-background aria-expanded:text-muted-foreground hover:aria-expanded:bg-muted hover:aria-expanded:text-foreground dark:border-border dark:bg-background dark:hover:bg-muted dark:aria-expanded:bg-background dark:hover:aria-expanded:bg-muted min-h-chrome-knob border-border absolute -top-px right-3 h-auto gap-0 rounded-t-none rounded-b-[var(--r-md)] border-t-0 px-3.5 py-0 text-xs font-semibold transition-colors motion-reduce:transition-none [&_svg]:size-3.5 [&_svg]:transition-transform [&_svg]:duration-[var(--duration-fast)] [&_svg]:ease-[ease] motion-reduce:[&_svg]:transition-none',
-              collapsed && 'px-2 py-1 [&_svg]:rotate-180',
-            )}
-            aria-label={
-              collapsed ? t('vw.expandChrome') : t('vw.collapseChrome')
-            }
-            aria-expanded={!collapsed}
-            aria-controls="viewer-topbar"
-            onClick={() => onCollapsedChange?.(!collapsed)}
-          >
-            <span
-              className={cn(
-                'inline-flex items-center gap-1.5 overflow-hidden whitespace-nowrap transition-[max-width,opacity,margin] duration-[var(--duration-fast)] ease-[ease] motion-reduce:transition-none',
-                collapsed
-                  ? 'max-w-collapse-label-max mr-1.5 opacity-100'
-                  : 'max-w-0 opacity-0',
-              )}
-              aria-hidden="true"
-            >
-              <BrandMark size={16} aria-hidden="true" />
-              <span>Artifact Share</span>
-            </span>
-            <IconChevronUp aria-hidden="true" strokeWidth={2.5} />
-          </Button>
-        </div>
+        <ViewerChromeCollapseToggle
+          collapsed={collapsed}
+          expandLabel={t('vw.expandChrome')}
+          collapseLabel={t('vw.collapseChrome')}
+          onToggle={() => onCollapsedChange?.(!collapsed)}
+        />
       ) : null}
     </>
+  )
+}
+
+function ViewerChromeCollapseToggle({
+  collapsed,
+  expandLabel,
+  collapseLabel,
+  onToggle,
+}: {
+  collapsed: boolean
+  expandLabel: string
+  collapseLabel: string
+  onToggle: () => void
+}) {
+  return (
+    <div className="relative z-[var(--z-topbar-raised)] h-0">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className={cn(
+          'bg-background text-muted-foreground hover:bg-muted hover:text-foreground aria-expanded:bg-background aria-expanded:text-muted-foreground hover:aria-expanded:bg-muted hover:aria-expanded:text-foreground dark:border-border dark:bg-background dark:hover:bg-muted dark:aria-expanded:bg-background dark:hover:aria-expanded:bg-muted min-h-chrome-knob border-border absolute -top-px right-3 h-auto gap-0 rounded-t-none rounded-b-[var(--r-md)] border-t-0 px-3.5 py-0 text-xs font-semibold transition-colors motion-reduce:transition-none [&_svg]:size-3.5 [&_svg]:transition-transform [&_svg]:duration-[var(--duration-fast)] [&_svg]:ease-[ease] motion-reduce:[&_svg]:transition-none',
+          collapsed && 'px-2 py-1 [&_svg]:rotate-180',
+        )}
+        aria-label={collapsed ? expandLabel : collapseLabel}
+        aria-expanded={!collapsed}
+        aria-controls="viewer-topbar"
+        onClick={onToggle}
+      >
+        <span
+          className={cn(
+            'inline-flex items-center gap-1.5 overflow-hidden whitespace-nowrap transition-[max-width,opacity,margin] duration-[var(--duration-fast)] ease-[ease] motion-reduce:transition-none',
+            collapsed
+              ? 'max-w-collapse-label-max mr-1.5 opacity-100'
+              : 'max-w-0 opacity-0',
+          )}
+          aria-hidden="true"
+        >
+          <BrandMark size={16} aria-hidden="true" />
+          <span>Artifact Share</span>
+        </span>
+        <IconChevronUp aria-hidden="true" strokeWidth={2.5} />
+      </Button>
+    </div>
   )
 }
 
@@ -928,9 +957,13 @@ interface ViewerActionsProps {
   onDownloadHtml?: () => void
   onDownloadMarkdown?: () => void
   onDownloadPdf?: () => void
+  onAccessRequestsOpen?: () => void
+  accessRequestsOpen?: boolean
+  onAccessRequestsOpenChange?: (open: boolean) => void
   onAccessRequestDismiss: () => void
   presence: ReadonlyArray<ViewerPresence>
   translator: ReturnType<typeof useT>
+  topbarCollapsed: boolean
   user: UserInfo | null
 }
 
@@ -956,13 +989,18 @@ function ViewerActions({
   onDownloadHtml,
   onDownloadMarkdown,
   onDownloadPdf,
+  onAccessRequestsOpen,
+  accessRequestsOpen,
+  onAccessRequestsOpenChange,
   onAccessRequestDismiss,
   presence,
   translator,
+  topbarCollapsed,
   user,
 }: ViewerActionsProps) {
   const { openBanner } = useAnalyticsConsent()
   const { t } = translator
+  const historyOpeningRef = useRef(false)
 
   return (
     <div className={actionsClassName}>
@@ -1087,7 +1125,15 @@ function ViewerActions({
               </TooltipTrigger>
               <TooltipContent sideOffset={24}>{t('vw.more')}</TooltipContent>
             </Tooltip>
-            <DropdownMenuContent align="end" className="w-60">
+            <DropdownMenuContent
+              align="end"
+              className="w-60"
+              onCloseAutoFocus={(event) => {
+                if (!historyOpeningRef.current) return
+                historyOpeningRef.current = false
+                event.preventDefault()
+              }}
+            >
               {onCopyMarkdown ||
               onDownloadHtml ||
               onDownloadMarkdown ||
@@ -1124,11 +1170,13 @@ function ViewerActions({
               ) : null}
               {artifactCanViewHistory ? (
                 <DropdownMenuItem
-                  onSelect={() =>
+                  data-viewer-history-menu-item
+                  onSelect={() => {
+                    historyOpeningRef.current = true
                     onHistoryOpenChange?.(true, {
                       returnFocusTo: moreButtonRef.current,
                     })
-                  }
+                  }}
                 >
                   {historyLabel}
                 </DropdownMenuItem>
@@ -1161,7 +1209,11 @@ function ViewerActions({
             key={accessRequestId ?? 'account'}
             user={user}
             variant="viewer"
+            topbarCollapsed={topbarCollapsed}
             initialAccessRequestId={accessRequestId}
+            accessRequestsOpen={accessRequestsOpen}
+            onAccessRequestsOpenChange={onAccessRequestsOpenChange}
+            onAccessRequestsOpen={onAccessRequestsOpen}
             onAccessRequestDismiss={onAccessRequestDismiss}
           />
         </>

--- a/apps/web/app/routes/a.$id/+components/viewer-list-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-list-panel.tsx
@@ -1,12 +1,6 @@
 import { IconEye, IconX } from '@tabler/icons-react'
 import { useEffect, useRef, type RefObject } from 'react'
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from '~/components/ui/sheet'
+import { SheetClose, SheetHeader, SheetTitle } from '~/components/ui/sheet'
 import { Button } from '~/components/ui/button'
 import { IconButton } from '~/components/app/icon-button'
 import { AuthorAvatar } from '~/components/app/author-avatar'
@@ -17,6 +11,7 @@ import type {
   ViewerListRowView,
   ViewerListStatus,
 } from '../+hooks/use-viewer-list'
+import { AppSidePanel } from '~/components/app/app-side-panel'
 
 // イニシャルは trim 後の先頭 1 文字を大文字化、空なら「?」。
 // `getOwnerInitial` はメールへフォールバックするためここでは使わない。
@@ -44,6 +39,7 @@ interface ViewerListPanelProps {
   closeReason?: 'user' | 'forced' | null
   // chrome 折りたたみ中は入口が不可視のためフォーカス復帰をスキップする。
   skipReturnFocus?: boolean
+  topbarCollapsed?: boolean
 }
 
 export function ViewerListPanel({
@@ -59,6 +55,7 @@ export function ViewerListPanel({
   returnFocusRef,
   closeReason,
   skipReturnFocus = false,
+  topbarCollapsed = false,
 }: ViewerListPanelProps) {
   const translator = useT()
   const { t, tPlural, locale } = translator
@@ -86,42 +83,41 @@ export function ViewerListPanel({
   }, [closeReasonRef, open, returnFocusRef, skipReturnFocusRef])
 
   return (
-    <Sheet modal={false} open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        onInteractOutside={(event) => event.preventDefault()}
-        className="max-sheet:inset-x-2.5 max-sheet:top-auto max-sheet:bottom-0 max-sheet:h-[var(--height-comment-panel-sheet)] max-sheet:w-auto max-sheet:max-w-none max-sheet:rounded-t-[var(--r-lg)] max-sheet:border-t-divider max-sheet:border-r-divider max-sheet:border-l-divider gap-0"
-        aria-describedby={undefined}
-      >
-        <SheetHeader>
-          <SheetTitle>
-            <IconEye size={16} aria-hidden="true" />
-            <span>
-              {totalViewers === null
-                ? t('vw.viewerListMenuItem')
-                : tPlural('vw.viewerListPanelTitle', totalViewers)}
-            </span>
-          </SheetTitle>
-          <SheetClose asChild>
-            <IconButton
-              type="button"
-              icon={IconX}
-              size="md"
-              aria-label={t('common.close')}
-            />
-          </SheetClose>
-        </SheetHeader>
-        <ViewerListPanelBody
-          rows={rows}
-          status={status}
-          loadingMore={loadingMore}
-          nextCursor={nextCursor}
-          onLoadMore={onLoadMore}
-          onRetry={onRetry}
-          locale={locale}
-          t={t}
-        />
-      </SheetContent>
-    </Sheet>
+    <AppSidePanel
+      open={open}
+      onOpenChange={onOpenChange}
+      topbar={topbarCollapsed ? 'none' : 'viewer'}
+      aria-describedby={undefined}
+    >
+      <SheetHeader>
+        <SheetTitle>
+          <IconEye size={16} aria-hidden="true" />
+          <span>
+            {totalViewers === null
+              ? t('vw.viewerListMenuItem')
+              : tPlural('vw.viewerListPanelTitle', totalViewers)}
+          </span>
+        </SheetTitle>
+        <SheetClose asChild>
+          <IconButton
+            type="button"
+            icon={IconX}
+            size="md"
+            aria-label={t('common.close')}
+          />
+        </SheetClose>
+      </SheetHeader>
+      <ViewerListPanelBody
+        rows={rows}
+        status={status}
+        loadingMore={loadingMore}
+        nextCursor={nextCursor}
+        onLoadMore={onLoadMore}
+        onRetry={onRetry}
+        locale={locale}
+        t={t}
+      />
+    </AppSidePanel>
   )
 }
 

--- a/apps/web/app/routes/a.$id/+components/viewer-list-wiring.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-list-wiring.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import React from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { createRoutesStub, Outlet } from 'react-router'
+import { createRoutesStub, Outlet, useLocation } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode, RefObject } from 'react'
 import { ViewerShell, type ViewerShellArtifact } from './viewer-shell'
@@ -195,6 +195,11 @@ const user = {
   initial: 'V',
 }
 
+function LocationProbe() {
+  const location = useLocation()
+  return <output data-testid="location-search">{location.search}</output>
+}
+
 describe('viewer list wiring in ViewerShell', () => {
   let root: Root
   let container: HTMLDivElement
@@ -244,7 +249,12 @@ describe('viewer list wiring in ViewerShell', () => {
         id: 'root',
         path: '/',
         loader: () => ({ locale: 'en' }),
-        Component: () => <Outlet />,
+        Component: () => (
+          <>
+            <LocationProbe />
+            <Outlet />
+          </>
+        ),
         children: [
           {
             path: 'a/:id',
@@ -447,6 +457,25 @@ describe('viewer list wiring in ViewerShell', () => {
     )
     expect(commentPanel().dataset.open).toBe('true')
     expect(accessRequests.dataset.open).toBe('false')
+  })
+
+  it('clears an access-request deep link when another panel opens', async () => {
+    await renderShell({ initialEntry: '/a/s1?access-request=request-1' })
+    const accessRequests = container.querySelector<HTMLElement>(
+      '[data-testid="access-requests"]',
+    )!
+    expect(accessRequests.dataset.open).toBe('true')
+
+    await click(
+      container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Comments"]',
+      )!,
+    )
+
+    expect(accessRequests.dataset.open).toBe('false')
+    expect(
+      container.querySelector('[data-testid="location-search"]')?.textContent,
+    ).toBe('')
   })
 
   it('returns focus to the meta entry when the panel closes', async () => {

--- a/apps/web/app/routes/a.$id/+components/viewer-list-wiring.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-list-wiring.test.tsx
@@ -122,7 +122,28 @@ vi.mock('~/components/ui/tooltip', () => ({
 }))
 
 vi.mock('~/components/app/avatar-menu', () => ({
-  AvatarMenu: () => <button type="button">Account</button>,
+  AvatarMenu: ({
+    onAccessRequestsOpen,
+    accessRequestsOpen,
+    onAccessRequestsOpenChange,
+  }: {
+    onAccessRequestsOpen?: () => void
+    accessRequestsOpen?: boolean
+    onAccessRequestsOpenChange?: (open: boolean) => void
+  }) => (
+    <div data-testid="access-requests" data-open={String(accessRequestsOpen)}>
+      <button
+        type="button"
+        data-testid="open-access-requests"
+        onClick={() => {
+          onAccessRequestsOpen?.()
+          onAccessRequestsOpenChange?.(true)
+        }}
+      >
+        Account
+      </button>
+    </div>
+  ),
 }))
 
 vi.mock('~/components/app/analytics-consent-provider', () => ({
@@ -387,6 +408,45 @@ describe('viewer list wiring in ViewerShell', () => {
     )
     expect(historyPanel().dataset.open).toBe('true')
     expect(viewerListSheet().dataset.open).toBe('false')
+  })
+
+  it('opening access requests closes every viewer side panel', async () => {
+    await renderShell()
+    const commentsButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Comments"]',
+    )!
+    await click(commentsButton)
+    expect(commentPanel().dataset.open).toBe('true')
+
+    await click(
+      container.querySelector<HTMLButtonElement>(
+        '[data-testid="open-access-requests"]',
+      )!,
+    )
+    expect(commentPanel().dataset.open).toBe('false')
+    expect(historyPanel().dataset.open).toBe('false')
+    expect(viewerListSheet().dataset.open).toBe('false')
+  })
+
+  it('opening another viewer panel closes access requests', async () => {
+    await renderShell()
+    const accessRequests = container.querySelector<HTMLElement>(
+      '[data-testid="access-requests"]',
+    )!
+    await click(
+      container.querySelector<HTMLButtonElement>(
+        '[data-testid="open-access-requests"]',
+      )!,
+    )
+    expect(accessRequests.dataset.open).toBe('true')
+
+    await click(
+      container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Comments"]',
+      )!,
+    )
+    expect(commentPanel().dataset.open).toBe('true')
+    expect(accessRequests.dataset.open).toBe('false')
   })
 
   it('returns focus to the meta entry when the panel closes', async () => {

--- a/apps/web/app/routes/a.$id/+components/viewer-list-wiring.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-list-wiring.test.tsx
@@ -142,6 +142,13 @@ vi.mock('~/components/app/avatar-menu', () => ({
       >
         Account
       </button>
+      <button
+        type="button"
+        data-testid="close-access-requests"
+        onClick={() => onAccessRequestsOpenChange?.(false)}
+      >
+        Close account
+      </button>
     </div>
   ),
 }))
@@ -476,6 +483,33 @@ describe('viewer list wiring in ViewerShell', () => {
     expect(
       container.querySelector('[data-testid="location-search"]')?.textContent,
     ).toBe('')
+  })
+
+  it('clears an access-request deep link when its panel closes', async () => {
+    await renderShell({ initialEntry: '/a/s1?access-request=request-1' })
+
+    await click(
+      container.querySelector<HTMLButtonElement>(
+        '[data-testid="close-access-requests"]',
+      )!,
+    )
+
+    expect(
+      container.querySelector('[data-testid="location-search"]')?.textContent,
+    ).toBe('')
+  })
+
+  it('does not restore an access-request deep link while consuming a comment deep link', async () => {
+    await renderShell({
+      initialEntry: '/a/s1?access-request=request-1&comment=thread-1',
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="location-search"]')?.textContent,
+      ).toBe('')
+    })
+    expect(commentPanel().dataset.open).toBe('true')
   })
 
   it('returns focus to the meta entry when the panel closes', async () => {

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -1456,6 +1456,9 @@ function useViewerShellController({
   const accessRequestId = new URLSearchParams(routerLocation.search).get(
     'access-request',
   )
+  const targetCommentId = new URLSearchParams(routerLocation.search).get(
+    'comment',
+  )
   const [accessRequestsOpen, setAccessRequestsOpen] = useState(
     accessRequestId !== null,
   )
@@ -1467,22 +1470,21 @@ function useViewerShellController({
     if (accessRequestId === null) return
     const params = new URLSearchParams(routerLocation.search)
     params.delete('access-request')
+    if (targetCommentId !== null) params.delete('comment')
     void navigate(
       {
         pathname: routerLocation.pathname,
         search: params.size > 0 ? `?${params.toString()}` : '',
       },
-      { replace: true },
+      { replace: true, preventScrollReset: true },
     )
   }, [
     accessRequestId,
     navigate,
     routerLocation.pathname,
     routerLocation.search,
+    targetCommentId,
   ])
-  const targetCommentId = new URLSearchParams(routerLocation.search).get(
-    'comment',
-  )
   // コメントパネル (全体コメントの表示・新規作成) と live 接続 (在席・
   // comments-changed) はコメント可能な種別で有効化する。接続は本文を抱える
   // sandbox iframe ではなく apex 側の閲覧画面から張るため、static_site でも
@@ -1712,6 +1714,7 @@ function useViewerShellController({
     if (!targetCommentId) return
     const params = new URLSearchParams(routerLocation.search)
     params.delete('comment')
+    if (accessRequestId !== null) params.delete('access-request')
     navigate(
       {
         pathname: routerLocation.pathname,
@@ -1723,6 +1726,7 @@ function useViewerShellController({
     routerLocation.pathname,
     routerLocation.search,
     navigate,
+    accessRequestId,
     targetCommentId,
   ])
 
@@ -1958,7 +1962,10 @@ function ViewerShellView({
           viewerListAvailable ? handleViewerListEntrySelect : undefined
         }
         accessRequestsOpen={accessRequestsOpen}
-        onAccessRequestsOpenChange={setAccessRequestsOpen}
+        onAccessRequestsOpenChange={(open) => {
+          if (open) setAccessRequestsOpen(true)
+          else closeAccessRequests()
+        }}
         onAccessRequestsOpen={() => {
           comments.returnFocusRef.current = null
           historyReturnFocusRef.current = null

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -1462,6 +1462,24 @@ function useViewerShellController({
   useEffect(() => {
     if (accessRequestId !== null) setAccessRequestsOpen(true)
   }, [accessRequestId])
+  const closeAccessRequests = useCallback(() => {
+    setAccessRequestsOpen(false)
+    if (accessRequestId === null) return
+    const params = new URLSearchParams(routerLocation.search)
+    params.delete('access-request')
+    void navigate(
+      {
+        pathname: routerLocation.pathname,
+        search: params.size > 0 ? `?${params.toString()}` : '',
+      },
+      { replace: true },
+    )
+  }, [
+    accessRequestId,
+    navigate,
+    routerLocation.pathname,
+    routerLocation.search,
+  ])
   const targetCommentId = new URLSearchParams(routerLocation.search).get(
     'comment',
   )
@@ -1503,7 +1521,7 @@ function useViewerShellController({
     [artifact],
   )
   const handleCommentsPanelOpened = useCallback(() => {
-    setAccessRequestsOpen(false)
+    closeAccessRequests()
     dispatch({ type: 'history-open-changed', open: false })
     // コメントパネルが開く合流点。閲覧者パネルとの排他 (AC 7) をここで足す。
     // 強制閉鎖なのでフォーカスは入口へ戻さない (開いたパネルに残す)。
@@ -1512,7 +1530,7 @@ function useViewerShellController({
       open: false,
       reason: 'forced',
     })
-  }, [])
+  }, [closeAccessRequests])
   // 本文範囲コメントは本文の選択を要するため html / md のみ。static_site の本文は
   // 別オリジンの sandbox iframe にあり選択を取得できない。
   const textAnchorsEnabled =
@@ -1543,14 +1561,14 @@ function useViewerShellController({
   const changeViewerListOpen = useCallback(
     (open: boolean) => {
       if (open) {
-        setAccessRequestsOpen(false)
+        closeAccessRequests()
         // 双方向排他: 閲覧者パネルを開くとコメントパネルも閉じる (AC 7)。
         comments.changePanelOpen(false)
         viewerList.openFetch()
       }
       dispatch({ type: 'viewer-list-open-changed', open })
     },
-    [comments.changePanelOpen, viewerList.openFetch],
+    [closeAccessRequests, comments.changePanelOpen, viewerList.openFetch],
   )
   const handleViewerListEntrySelect = useCallback(
     (from: ViewerListOpenedFrom, returnFocusTo: HTMLElement | null) => {
@@ -1559,12 +1577,17 @@ function useViewerShellController({
         return
       }
       viewerListReturnFocusRef.current = returnFocusTo ?? getActiveElement()
-      setAccessRequestsOpen(false)
+      closeAccessRequests()
       comments.changePanelOpen(false)
       viewerList.openFetch()
       dispatch({ type: 'viewer-list-open-changed', open: true })
     },
-    [comments.changePanelOpen, viewerList.openFetch, viewerListOpen],
+    [
+      closeAccessRequests,
+      comments.changePanelOpen,
+      viewerList.openFetch,
+      viewerListOpen,
+    ],
   )
   const exportSupported =
     !isHistoricalVersion && artifactSupportsExport(renderType)
@@ -1828,6 +1851,7 @@ function useViewerShellController({
     historyReturnFocusRef,
     accessRequestsOpen,
     setAccessRequestsOpen,
+    closeAccessRequests,
     latestVersion,
     comments,
     textAnchorsEnabled,
@@ -1885,6 +1909,7 @@ function ViewerShellView({
   historyReturnFocusRef,
   accessRequestsOpen,
   setAccessRequestsOpen,
+  closeAccessRequests,
   latestVersion,
   comments,
   textAnchorsEnabled,
@@ -1920,7 +1945,7 @@ function ViewerShellView({
           if (open) {
             historyReturnFocusRef.current =
               options?.returnFocusTo ?? getActiveElement()
-            setAccessRequestsOpen(false)
+            closeAccessRequests()
           }
           if (open) comments.changePanelOpen(false)
           dispatch({ type: 'history-open-changed', open })
@@ -2045,7 +2070,7 @@ function ViewerShellView({
           }}
           onOpenHistory={(returnFocusTo) => {
             historyReturnFocusRef.current = returnFocusTo ?? getActiveElement()
-            setAccessRequestsOpen(false)
+            closeAccessRequests()
             dispatch({ type: 'history-open-changed', open: true })
             comments.changePanelOpen(false)
           }}
@@ -2059,7 +2084,7 @@ function ViewerShellView({
           open={state.historyOpen}
           onOpenChange={(open) => {
             if (open) {
-              setAccessRequestsOpen(false)
+              closeAccessRequests()
               comments.changePanelOpen(false)
             }
             dispatch({ type: 'history-open-changed', open })

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -1453,6 +1453,15 @@ function useViewerShellController({
     renderType === 'static_site' ? 'static_site' : 'single'
   const frameTitle = displayTitle(artifact)
   const historyReturnFocusRef = useRef<HTMLElement | null>(null)
+  const accessRequestId = new URLSearchParams(routerLocation.search).get(
+    'access-request',
+  )
+  const [accessRequestsOpen, setAccessRequestsOpen] = useState(
+    accessRequestId !== null,
+  )
+  useEffect(() => {
+    if (accessRequestId !== null) setAccessRequestsOpen(true)
+  }, [accessRequestId])
   const targetCommentId = new URLSearchParams(routerLocation.search).get(
     'comment',
   )
@@ -1494,6 +1503,7 @@ function useViewerShellController({
     [artifact],
   )
   const handleCommentsPanelOpened = useCallback(() => {
+    setAccessRequestsOpen(false)
     dispatch({ type: 'history-open-changed', open: false })
     // コメントパネルが開く合流点。閲覧者パネルとの排他 (AC 7) をここで足す。
     // 強制閉鎖なのでフォーカスは入口へ戻さない (開いたパネルに残す)。
@@ -1533,6 +1543,7 @@ function useViewerShellController({
   const changeViewerListOpen = useCallback(
     (open: boolean) => {
       if (open) {
+        setAccessRequestsOpen(false)
         // 双方向排他: 閲覧者パネルを開くとコメントパネルも閉じる (AC 7)。
         comments.changePanelOpen(false)
         viewerList.openFetch()
@@ -1548,6 +1559,7 @@ function useViewerShellController({
         return
       }
       viewerListReturnFocusRef.current = returnFocusTo ?? getActiveElement()
+      setAccessRequestsOpen(false)
       comments.changePanelOpen(false)
       viewerList.openFetch()
       dispatch({ type: 'viewer-list-open-changed', open: true })
@@ -1814,6 +1826,8 @@ function useViewerShellController({
     currentVersionHref,
     frameTitle,
     historyReturnFocusRef,
+    accessRequestsOpen,
+    setAccessRequestsOpen,
     latestVersion,
     comments,
     textAnchorsEnabled,
@@ -1869,6 +1883,8 @@ function ViewerShellView({
   currentVersionHref,
   frameTitle,
   historyReturnFocusRef,
+  accessRequestsOpen,
+  setAccessRequestsOpen,
   latestVersion,
   comments,
   textAnchorsEnabled,
@@ -1904,6 +1920,7 @@ function ViewerShellView({
           if (open) {
             historyReturnFocusRef.current =
               options?.returnFocusTo ?? getActiveElement()
+            setAccessRequestsOpen(false)
           }
           if (open) comments.changePanelOpen(false)
           dispatch({ type: 'history-open-changed', open })
@@ -1915,6 +1932,19 @@ function ViewerShellView({
         onViewerListEntrySelect={
           viewerListAvailable ? handleViewerListEntrySelect : undefined
         }
+        accessRequestsOpen={accessRequestsOpen}
+        onAccessRequestsOpenChange={setAccessRequestsOpen}
+        onAccessRequestsOpen={() => {
+          comments.returnFocusRef.current = null
+          historyReturnFocusRef.current = null
+          comments.changePanelOpen(false)
+          dispatch({ type: 'history-open-changed', open: false })
+          dispatch({
+            type: 'viewer-list-open-changed',
+            open: false,
+            reason: 'forced',
+          })
+        }}
         collapsible={sandboxUrl !== null}
         collapsed={state.chromeCollapsed}
         onCollapsedChange={(collapsed) =>
@@ -2015,6 +2045,7 @@ function ViewerShellView({
           }}
           onOpenHistory={(returnFocusTo) => {
             historyReturnFocusRef.current = returnFocusTo ?? getActiveElement()
+            setAccessRequestsOpen(false)
             dispatch({ type: 'history-open-changed', open: true })
             comments.changePanelOpen(false)
           }}
@@ -2027,10 +2058,14 @@ function ViewerShellView({
           versions={artifact.versions ?? []}
           open={state.historyOpen}
           onOpenChange={(open) => {
-            if (open) comments.changePanelOpen(false)
+            if (open) {
+              setAccessRequestsOpen(false)
+              comments.changePanelOpen(false)
+            }
             dispatch({ type: 'history-open-changed', open })
           }}
           returnFocusRef={historyReturnFocusRef}
+          topbarCollapsed={state.chromeCollapsed}
           canReplaceFile={canReplaceFile}
           onSubmit={canReplaceFile ? submitReplaceVersion : undefined}
           replaceMode={replaceMode}
@@ -2099,6 +2134,7 @@ function ViewerShellView({
           }
           returnFocusRef={comments.returnFocusRef}
           requestedFilter={comments.requestedFilter}
+          topbarCollapsed={state.chromeCollapsed}
           showNewThreadComposer={newThreadComposerEnabled}
         />
       ) : null}
@@ -2116,6 +2152,7 @@ function ViewerShellView({
           returnFocusRef={viewerListReturnFocusRef}
           closeReason={state.viewerListCloseReason}
           skipReturnFocus={state.chromeCollapsed}
+          topbarCollapsed={state.chromeCollapsed}
         />
       ) : null}
     </div>

--- a/apps/web/app/routes/app-side-panel.behavior.browser.test.tsx
+++ b/apps/web/app/routes/app-side-panel.behavior.browser.test.tsx
@@ -29,7 +29,7 @@ function Harness({ topbar }: { topbar: SidePanelTopbar }) {
     <>
       {topbar !== 'none' ? (
         <header
-          id={topbar === 'viewer' ? 'viewer-topbar' : 'test-topbar'}
+          id={topbar === 'viewer' ? 'viewer-topbar' : 'app-topbar'}
           className={
             topbar === 'viewer'
               ? 'bg-background min-h-topbar-expanded flex items-center'
@@ -109,6 +109,15 @@ describe('app side panel browser behavior', () => {
       panelAction.focus()
       await userEvent.keyboard('{Tab}')
       expect(document.activeElement).toBe(action)
+
+      await userEvent.keyboard('{Tab}')
+      expect(document.activeElement).toBe(panelAction)
+
+      await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+      expect(document.activeElement).toBe(action)
+
+      await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+      expect(document.activeElement).toBe(panelAction)
 
       await userEvent.keyboard('{Escape}')
       await vi.waitFor(() => {

--- a/apps/web/app/routes/app-side-panel.behavior.browser.test.tsx
+++ b/apps/web/app/routes/app-side-panel.behavior.browser.test.tsx
@@ -1,0 +1,222 @@
+import { useRef, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import '~/app.css'
+import {
+  AppSidePanel,
+  type SidePanelTopbar,
+} from '~/components/app/app-side-panel'
+import { SheetTitle } from '~/components/ui/sheet'
+import { HistoryPanel } from '~/routes/a.$id/+components/history-panel'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '~/components/ui/dropdown-menu'
+import { waitForBrowserLayout } from '~/test/browser-layout'
+
+vi.mock('~/hooks/use-t', () => ({
+  useT: () => ({ locale: 'en', t: (key: string) => key }),
+}))
+
+function Harness({ topbar }: { topbar: SidePanelTopbar }) {
+  const [open, setOpen] = useState(true)
+  const [actionCount, setActionCount] = useState(0)
+
+  return (
+    <>
+      {topbar !== 'none' ? (
+        <header
+          id={topbar === 'viewer' ? 'viewer-topbar' : 'test-topbar'}
+          className={
+            topbar === 'viewer'
+              ? 'bg-background min-h-topbar-expanded flex items-center'
+              : 'bg-background flex h-12 items-center'
+          }
+        >
+          <button type="button" onClick={() => setActionCount((n) => n + 1)}>
+            Header action {actionCount}
+          </button>
+        </header>
+      ) : null}
+      <AppSidePanel
+        open={open}
+        onOpenChange={setOpen}
+        topbar={topbar}
+        aria-describedby={undefined}
+      >
+        <SheetTitle>App panel</SheetTitle>
+        <button type="button">Panel action</button>
+      </AppSidePanel>
+    </>
+  )
+}
+
+describe('app side panel browser behavior', () => {
+  let root: Root
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    root.unmount()
+    container.remove()
+  })
+
+  async function renderHarness(topbar: SidePanelTopbar) {
+    root.render(<Harness topbar={topbar} />)
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="sheet-content"]'),
+      ).not.toBeNull()
+    })
+    await waitForBrowserLayout()
+  }
+
+  it.each(['app', 'viewer'] as const)(
+    'starts below the %s topbar and keeps header controls operable',
+    async (topbarKind) => {
+      await page.viewport(1280, 800)
+      await renderHarness(topbarKind)
+
+      const topbar = document.querySelector<HTMLElement>('header')!
+      const panel = document.querySelector<HTMLElement>(
+        '[data-slot="sheet-content"]',
+      )!
+      const action = topbar.querySelector<HTMLButtonElement>('button')!
+
+      expect(panel.getBoundingClientRect().top).toBe(
+        topbar.getBoundingClientRect().bottom,
+      )
+      expect(panel.getBoundingClientRect().bottom).toBe(800)
+      expect(document.querySelector('[data-slot="sheet-overlay"]')).toBeNull()
+
+      action.focus()
+      action.click()
+      await vi.waitFor(() => {
+        expect(action.textContent).toBe('Header action 1')
+      })
+      expect(document.activeElement).toBe(action)
+      expect(document.querySelector('[data-slot="sheet-content"]')).toBe(panel)
+
+      const panelAction = panel.querySelector<HTMLButtonElement>('button')!
+      panelAction.focus()
+      await userEvent.keyboard('{Tab}')
+      expect(document.activeElement).toBe(action)
+
+      await userEvent.keyboard('{Escape}')
+      await vi.waitFor(() => {
+        expect(document.querySelector('[data-slot="sheet-content"]')).toBeNull()
+      })
+    },
+  )
+
+  it('tracks a viewer topbar that grows while the panel is open', async () => {
+    await page.viewport(1280, 800)
+    await renderHarness('viewer')
+
+    const topbar = document.querySelector<HTMLElement>('#viewer-topbar')!
+    topbar.style.height = '80px'
+    await vi.waitFor(() => {
+      expect(
+        document
+          .querySelector<HTMLElement>('[data-slot="sheet-content"]')!
+          .getBoundingClientRect().top,
+      ).toBe(80)
+    })
+
+    await userEvent.keyboard('{Escape}')
+    const exitingPanel = document.querySelector<HTMLElement>(
+      '[data-slot="sheet-content"]',
+    )
+    expect(exitingPanel).not.toBeNull()
+    expect(exitingPanel?.getBoundingClientRect().top).toBe(80)
+  })
+
+  it('restores History focus after a menu trigger tries to reclaim it', async () => {
+    await page.viewport(1280, 800)
+
+    function HistoryHarness() {
+      const [open, setOpen] = useState(false)
+      const historyOpeningRef = useRef(false)
+      return (
+        <>
+          <DropdownMenu>
+            <DropdownMenuTrigger>Open menu</DropdownMenuTrigger>
+            <DropdownMenuContent
+              onCloseAutoFocus={(event) => {
+                if (!historyOpeningRef.current) return
+                historyOpeningRef.current = false
+                event.preventDefault()
+              }}
+            >
+              <DropdownMenuItem
+                onSelect={() => {
+                  historyOpeningRef.current = true
+                  setOpen(true)
+                }}
+              >
+                History
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <HistoryPanel
+            open={open}
+            onOpenChange={setOpen}
+            versions={[]}
+            topbarCollapsed
+          />
+        </>
+      )
+    }
+
+    root.render(<HistoryHarness />)
+    await page.getByRole('button', { name: 'Open menu' }).click()
+    await page.getByRole('menuitem', { name: 'History' }).click()
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(
+        document.querySelector<HTMLButtonElement>(
+          '[data-slot="sheet-content"] button',
+        ),
+      )
+    })
+  })
+
+  it('uses the full-height edge without a topbar', async () => {
+    await page.viewport(1280, 800)
+    await renderHarness('none')
+
+    const panel = document.querySelector<HTMLElement>(
+      '[data-slot="sheet-content"]',
+    )!
+    expect(panel.getBoundingClientRect().top).toBe(0)
+    expect(panel.getBoundingClientRect().bottom).toBe(800)
+  })
+
+  it('keeps the existing bottom sheet presentation on phone', async () => {
+    await page.viewport(390, 844)
+    await renderHarness('viewer')
+
+    const panel = document.querySelector<HTMLElement>(
+      '[data-slot="sheet-content"]',
+    )!
+    await vi.waitFor(() => {
+      expect(panel.getBoundingClientRect().left).toBe(10)
+      expect(panel.getBoundingClientRect().bottom).toBe(844)
+    })
+    const rect = panel.getBoundingClientRect()
+    expect(rect.left).toBe(10)
+    expect(rect.right).toBe(380)
+    expect(rect.bottom).toBe(844)
+    expect(rect.top).toBeGreaterThan(0)
+    expect(
+      getComputedStyle(panel).getPropertyValue('--tw-enter-translate-x').trim(),
+    ).toBe('calc(0*100%)')
+  })
+})

--- a/scripts/screen-ledger.mjs
+++ b/scripts/screen-ledger.mjs
@@ -398,6 +398,28 @@ export const screens = [
         },
       },
       {
+        id: 'history-open',
+        description: '「…」メニューから履歴パネルを開いた状態',
+        setup: {
+          scenario: 'recent/content-rich',
+          scenarioArtifactIndex: 1,
+          interactions: [
+            {
+              action: 'click',
+              selector: '[data-viewer-more-menu-trigger]',
+            },
+            {
+              action: 'click',
+              selector: '[data-viewer-history-menu-item]',
+            },
+            {
+              action: 'click',
+              selector: '[data-slot="sheet-title"]',
+            },
+          ],
+        },
+      },
+      {
         id: 'viewer-list-entry',
         description:
           'メタ行の閲覧した人セグメントが phone の閉状態でも見える状態 (interaction なし。シード追加により既存 viewer/comments-open の capture も変わる)',
@@ -477,6 +499,28 @@ export const screens = [
         id: 'default',
         description: '新ホーム (ファイルあり)',
         setup: { scenario: 'home/content-rich' },
+      },
+      {
+        id: 'access-request-detail',
+        description: 'Homeヘッダーから閲覧リクエストの承認詳細を開いた状態',
+        setup: {
+          auth: 'team-owner',
+          scenario: 'viewer/access-requests',
+          interactions: [
+            {
+              action: 'click',
+              selector: '[data-avatar-menu-trigger]',
+            },
+            {
+              action: 'click',
+              selector: '[data-access-requests-menu-item]',
+            },
+            {
+              action: 'click',
+              selector: '[data-access-request-id="dev-screen-access-request"]',
+            },
+          ],
+        },
       },
       {
         id: 'unopened-file',


### PR DESCRIPTION
## 現状

Viewer のコメント・履歴・閲覧者一覧や、ログイン後の閲覧リクエストを開くと、デスクトップではサイドパネルがヘッダーを覆い、パネルを閉じるまでヘッダー操作を使えない状態でした。

## 変更

- Viewer とアプリ共通のサイドパネルを、デスクトップではヘッダー直下から画面下端まで表示
- パネル表示中もヘッダーをポインターとキーボードで操作可能に変更
- モバイルでは従来どおり画面下部から開くシートを維持
- コメント、履歴、閲覧者一覧、閲覧リクエストを相互排他にし、切替時のフォーカスとURL状態を同期
- Home、Viewer、Viewerエラー画面の閲覧リクエストに同じ配置規則を適用

## 検証

- `pnpm validate:static`（単体テスト 3,353件、React Doctor 100、公開スキャン 0件）
- `pnpm test:behavior-browser`（73件）
- `pnpm visual:compose`（98件）
- 影響画面のデスクトップ／モバイルキャプチャ（100件成功）
- シナリオルート検証
- Codex / Claude 実装レビュー（指摘なし）
