### PR TITLE
Fix sandbox refresh for named entrypoints

### DIFF
--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.test.ts
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.test.ts
@@ -125,37 +125,41 @@ describe('/api/shareables/:id/sandbox-token', () => {
   })
 
   test.each([
-    ['html_page', 'html'],
-    ['markdown_page', 'md'],
-  ])('returns a token for %s', async (artifactKind, renderType) => {
-    dbMock.selectFrom.mockReturnValue(
-      shareableQuery({
-        id: 'html123abc',
-        workspace_id: 'ws1',
-        owner_user_id: 'owner1',
-        name: 'demo.html',
-        visibility: 'private',
-        container_id: null,
-        current_version_id: 'v1',
-        project_container_kind: null,
-        project_container_base_visibility: null,
-        r2_key: 'ws1/html123abc/v1/demo.html',
-        entrypoint_path: '/demo.html',
-        artifact_kind: artifactKind,
-        version_artifact_kind: artifactKind,
-      }),
-    )
+    ['html_page', 'html', 'demo.html', '/demo.html'],
+    ['markdown_page', 'md', 'notes.md', '/notes.md'],
+  ])(
+    'returns a fresh sandbox URL for a named %s entrypoint',
+    async (artifactKind, renderType, name, entrypointPath) => {
+      dbMock.selectFrom.mockReturnValue(
+        shareableQuery({
+          id: 'html123abc',
+          workspace_id: 'ws1',
+          owner_user_id: 'owner1',
+          name,
+          visibility: 'private',
+          container_id: null,
+          current_version_id: 'v1',
+          project_container_kind: null,
+          project_container_base_visibility: null,
+          r2_key: `ws1/html123abc/v1/${name}`,
+          entrypoint_path: entrypointPath,
+          artifact_kind: artifactKind,
+          version_artifact_kind: artifactKind,
+        }),
+      )
 
-    const response = await loader(loaderArgs('html123abc'))
+      const response = await loader(loaderArgs('html123abc'))
 
-    expect(response.status).toBe(200)
-    const body = (await response.json()) as {
-      sandboxUrl: string
-      renderType: string
-    }
-    expect(body.renderType).toBe(renderType)
-    expect(body.sandboxUrl).not.toContain('as_next=')
-  })
+      expect(response.status).toBe(200)
+      const body = (await response.json()) as {
+        sandboxUrl: string
+        renderType: string
+      }
+      expect(body.renderType).toBe(renderType)
+      expect(new URL(body.sandboxUrl).pathname).toBe(entrypointPath)
+      expect(body.sandboxUrl).not.toContain('as_next=')
+    },
+  )
 
   test('refreshes the selected published historical version', async () => {
     let queryCount = 0
@@ -192,6 +196,7 @@ describe('/api/shareables/:id/sandbox-token', () => {
     expect(body.sandboxUrl).toContain(
       'html123abc--v-7631.sandbox.artifactshare.com',
     )
+    expect(new URL(body.sandboxUrl).pathname).toBe('/demo.html')
     const token = new URL(body.sandboxUrl).searchParams.get('t')
     await expect(
       verifySandboxToken(token!, 'test-secret-with-enough-entropy-for-hmac'),

--- a/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
+++ b/apps/web/app/routes/api.shareables.$id.sandbox-token.tsx
@@ -156,9 +156,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     shareable.id,
     version.id,
     token,
-    versionRenderType === 'static_site'
-      ? (version.entrypoint_path ?? undefined)
-      : undefined,
+    version.entrypoint_path ?? undefined,
   )
   return Response.json(
     { sandboxUrl, renderType: versionRenderType },


### PR DESCRIPTION
## 現状

名前付きentrypointを持つHTMLまたはMarkdown成果物では、期限切れのsandbox tokenを再発行した後も本文を表示できないことがありました。再発行URLが保存済みentrypointではなくルートを指すため、sandboxのpathname検証で拒否されていました。

## 変更

- sandbox token再発行時に、成果物形式を問わず保存済みentrypointをURL生成へ渡すようにしました。
- 名前付きHTML、名前付きMarkdown、過去versionの再発行URLについてpathnameを検査する回帰テストを追加しました。
- `/index.html`をルートURLとして扱う既存動作と、sandbox側のpathname検証は維持します。

## 検証

- `pnpm format`
- 対象routeとsandbox配信の単体テスト: 67件成功
- sandbox復旧のブラウザテスト: 4件成功
- `pnpm --filter @artifactshare/web typecheck`
- `pnpm public:scan .`: 0 findings
- `pnpm validate:static`: 成功（unit 3,353件、D1 12件、React Doctor 100）
- Codex / Claude implementation review: 指摘なし
- `origin/main`を信頼元にしたPR境界検査: 成功
