### PR TITLE
Hide Viewer overlays when chrome is collapsed

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -100,7 +100,6 @@
   --spacing-timeline-top-sm: 18px;
   --spacing-version-fab-bottom: 18px;
   --spacing-badge-max: 100px;
-  --spacing-collapse-label-max: 140px;
   --spacing-presence-max: 74px;
   --spacing-popover-thread-max: 238px;
   --spacing-sandbox-toast-max: 480px;

--- a/apps/web/app/routes/a.$id/+components/comment-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/comment-panel.tsx
@@ -1,5 +1,4 @@
 import {
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -39,6 +38,7 @@ import {
 import { IconMessage, IconX } from '@tabler/icons-react'
 import { useAnalyticsConsent } from '~/components/app/analytics-consent-provider'
 import { AppSidePanel } from '~/components/app/app-side-panel'
+import { restoreViewerPanelFocus } from './viewer-dom'
 
 type CommentFilter = 'open' | 'all' | 'resolved'
 type TargetThreadScroll = 'center' | 'start'
@@ -59,6 +59,7 @@ interface CommentPanelProps {
   targetThreadScroll: TargetThreadScroll
   onThreadNavigate: (thread: CommentThreadView) => void
   returnFocusRef?: RefObject<HTMLElement | null>
+  collapsedFallbackRef?: RefObject<HTMLElement | null>
   requestedFilter?: CommentFilter
   topbarCollapsed?: boolean
   // 本文選択できない成果物 (static_site) 向けに、ファイル全体への
@@ -78,6 +79,7 @@ export function CommentPanel({
   targetThreadScroll,
   onThreadNavigate,
   returnFocusRef,
+  collapsedFallbackRef,
   requestedFilter,
   topbarCollapsed = false,
   showNewThreadComposer = false,
@@ -107,7 +109,6 @@ export function CommentPanel({
     key: string
     filter: CommentFilter
   } | null>(null)
-  const wasOpenRef = useRef(open)
   useLayoutEffect(() => {
     setCommentPanelOpen(open)
     return () => setCommentPanelOpen(false)
@@ -117,13 +118,6 @@ export function CommentPanel({
     isCurrentShareableId,
     onThreadsChange,
   })
-
-  useEffect(() => {
-    if (wasOpenRef.current && !open) {
-      returnFocusRef?.current?.focus()
-    }
-    wasOpenRef.current = open
-  }, [open, returnFocusRef])
 
   const targetThread = useMemo(
     () => threads.find((thread) => thread.id === targetThreadId),
@@ -293,6 +287,14 @@ export function CommentPanel({
     <AppSidePanel
       open={open}
       onOpenChange={onOpenChange}
+      onCloseAutoFocus={(event) => {
+        event.preventDefault()
+        restoreViewerPanelFocus({
+          returnFocusRef,
+          collapsedFallbackRef,
+          topbarCollapsed,
+        })
+      }}
       topbar={topbarCollapsed ? 'none' : 'viewer'}
       onEscapeKeyDown={(event) => {
         if (

--- a/apps/web/app/routes/a.$id/+components/history-panel.tsx
+++ b/apps/web/app/routes/a.$id/+components/history-panel.tsx
@@ -1,5 +1,5 @@
 import { IconHistory as HistoryIcon, IconX } from '@tabler/icons-react'
-import { useEffect, useRef, useState, type RefObject } from 'react'
+import { useRef, useState, type RefObject } from 'react'
 import { toast } from 'sonner'
 import { SheetClose, SheetHeader, SheetTitle } from '~/components/ui/sheet'
 import { Button } from '~/components/ui/button'
@@ -10,6 +10,7 @@ import { ReplaceVersionDropzone } from './replace-version-dropzone'
 import type { VersionRow } from './version-history-types'
 import { VersionRows } from './version-rows'
 import { AppSidePanel } from '~/components/app/app-side-panel'
+import { restoreViewerPanelFocus } from './viewer-dom'
 
 export type { VersionRow } from './version-history-types'
 export { VersionWidget } from './version-widget'
@@ -24,6 +25,7 @@ interface HistoryPanelProps {
   uploading?: boolean
   dropActive?: boolean
   returnFocusRef?: RefObject<HTMLElement | null>
+  collapsedFallbackRef?: RefObject<HTMLElement | null>
   topbarCollapsed?: boolean
 }
 
@@ -37,20 +39,13 @@ export function HistoryPanel({
   uploading = false,
   dropActive = false,
   returnFocusRef,
+  collapsedFallbackRef,
   topbarCollapsed = false,
 }: HistoryPanelProps) {
   const { locale, t } = useT()
   const inputRef = useRef<HTMLInputElement>(null)
   const [localDropActive, setLocalDropActive] = useState(false)
-  const wasOpenRef = useRef(open)
   const active = dropActive || localDropActive
-
-  useEffect(() => {
-    if (wasOpenRef.current && !open) {
-      returnFocusRef?.current?.focus()
-    }
-    wasOpenRef.current = open
-  }, [open, returnFocusRef])
 
   const submitFiles = (files: FileList | File[] | null) => {
     const list = Array.from(files ?? [])
@@ -69,6 +64,14 @@ export function HistoryPanel({
     <AppSidePanel
       open={open}
       onOpenChange={onOpenChange}
+      onCloseAutoFocus={(event) => {
+        event.preventDefault()
+        restoreViewerPanelFocus({
+          returnFocusRef,
+          collapsedFallbackRef,
+          topbarCollapsed,
+        })
+      }}
       topbar={topbarCollapsed ? 'none' : 'viewer'}
       aria-describedby={undefined}
     >

--- a/apps/web/app/routes/a.$id/+components/version-widget.tsx
+++ b/apps/web/app/routes/a.$id/+components/version-widget.tsx
@@ -17,6 +17,7 @@ import type { VersionRow } from './version-history-types'
 import { VersionRows } from './version-rows'
 
 interface VersionWidgetProps {
+  hidden?: boolean
   versions: ReadonlyArray<VersionRow>
   canReplaceFile?: boolean
   onSubmit?: (files: File[]) => void
@@ -40,6 +41,7 @@ interface VersionWidgetProps {
 }
 
 export function VersionWidget({
+  hidden = false,
   versions,
   canReplaceFile = false,
   onSubmit,
@@ -102,7 +104,7 @@ export function VersionWidget({
   }, [open])
 
   useEffect(() => {
-    if (!open) return
+    if (!open || hidden) return
     function onKeyDown(event: KeyboardEvent) {
       if (event.key !== 'Escape') return
       event.preventDefault()
@@ -129,15 +131,16 @@ export function VersionWidget({
       document.removeEventListener('pointerdown', onPointerDown)
       window.removeEventListener('blur', onWindowBlur)
     }
-  }, [closePopover, open])
+  }, [closePopover, hidden, open])
 
   return (
     <aside
       ref={rootRef}
+      hidden={hidden}
       className="bottom-version-fab-bottom pointer-events-none fixed right-3 z-(--z-dropdown) flex max-w-(--width-version-panel) flex-col items-end gap-2"
       aria-label={t('vw.activityStatus')}
     >
-      {open ? (
+      {open && !hidden ? (
         <div
           className="bg-background border-border pointer-events-auto flex w-[var(--width-version-panel)] origin-bottom-right flex-col gap-2 rounded-[var(--r-md)] border p-2 shadow-[var(--shadow-lg)]"
           id={popoverId}
@@ -254,10 +257,10 @@ export function VersionWidget({
         type="button"
         className={cn(
           'bg-background text-muted-foreground hover:text-foreground pr-version-toggle-pad-end border-border pointer-events-auto inline-flex min-h-7 min-w-0 cursor-pointer items-center justify-center gap-1.5 rounded-[var(--r-md)] border py-0 pl-2 text-sm leading-(--lh-tight) font-semibold shadow-none transition-[background,color,translate,opacity] duration-[var(--duration-fast)] ease-[ease,ease,ease,ease] active:translate-y-px [&_svg]:size-3.5',
-          open && 'text-foreground',
+          open && !hidden && 'text-foreground',
         )}
-        aria-controls={open ? popoverId : undefined}
-        aria-expanded={open}
+        aria-controls={open && !hidden ? popoverId : undefined}
+        aria-expanded={open && !hidden}
         aria-label={t(
           hasNewerVersion
             ? 'vw.versionStatusWithUpdate'

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
@@ -289,7 +289,7 @@ describe('ViewerChrome', () => {
     expect(html).toContain('aria-controls="viewer-topbar"')
   })
 
-  test('collapsed chrome toggle expands the topbar and shows brand label', () => {
+  test('collapsed chrome toggle keeps only the brand mark and expand icon', () => {
     const html = renderChrome({
       artifact,
       user: {
@@ -305,7 +305,12 @@ describe('ViewerChrome', () => {
 
     expect(html).toContain('aria-expanded="false"')
     expect(html).toContain('aria-label="Show Artifact Share"')
-    expect(html).toContain('>Artifact Share<')
+    const toggle = html.match(
+      /<button[^>]*aria-label="Show Artifact Share"[^>]*>[\s\S]*?<\/button>/,
+    )?.[0]
+    expect(toggle).toBeDefined()
+    expect(toggle).toContain('bg-[url(/favicon.svg)]')
+    expect(toggle).not.toContain('>Artifact Share<')
   })
 
   test('logged-in user sees export actions in the more menu', () => {

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
@@ -167,6 +167,7 @@ interface ViewerChromeProps {
   onAccessRequestsOpenChange?: (open: boolean) => void
   collapsible?: boolean
   collapsed?: boolean
+  collapseToggleRef?: RefObject<HTMLButtonElement | null>
   onCollapsedChange?: (collapsed: boolean) => void
 }
 
@@ -206,6 +207,7 @@ export function ViewerChrome({
   onAccessRequestsOpenChange,
   collapsible = true,
   collapsed = false,
+  collapseToggleRef,
   onCollapsedChange,
 }: ViewerChromeProps) {
   const translator = useT()
@@ -460,6 +462,7 @@ export function ViewerChrome({
       ) : null}
       {collapsible ? (
         <ViewerChromeCollapseToggle
+          buttonRef={collapseToggleRef}
           collapsed={collapsed}
           expandLabel={t('vw.expandChrome')}
           collapseLabel={t('vw.collapseChrome')}
@@ -471,11 +474,13 @@ export function ViewerChrome({
 }
 
 function ViewerChromeCollapseToggle({
+  buttonRef,
   collapsed,
   expandLabel,
   collapseLabel,
   onToggle,
 }: {
+  buttonRef?: RefObject<HTMLButtonElement | null>
   collapsed: boolean
   expandLabel: string
   collapseLabel: string
@@ -484,6 +489,7 @@ function ViewerChromeCollapseToggle({
   return (
     <div className="relative z-[var(--z-topbar-raised)] h-0">
       <Button
+        ref={buttonRef}
         type="button"
         variant="outline"
         size="sm"

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
@@ -499,14 +499,11 @@ function ViewerChromeCollapseToggle({
         <span
           className={cn(
             'inline-flex items-center gap-1.5 overflow-hidden whitespace-nowrap transition-[max-width,opacity,margin] duration-[var(--duration-fast)] ease-[ease] motion-reduce:transition-none',
-            collapsed
-              ? 'max-w-collapse-label-max mr-1.5 opacity-100'
-              : 'max-w-0 opacity-0',
+            collapsed ? 'mr-1.5 max-w-4 opacity-100' : 'max-w-0 opacity-0',
           )}
           aria-hidden="true"
         >
           <BrandMark size={16} aria-hidden="true" />
-          <span>Artifact Share</span>
         </span>
         <IconChevronUp aria-hidden="true" strokeWidth={2.5} />
       </Button>

--- a/apps/web/app/routes/a.$id/+components/viewer-dom.test.ts
+++ b/apps/web/app/routes/a.$id/+components/viewer-dom.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test } from 'vitest'
+import { restoreViewerPanelFocus } from './viewer-dom'
+
+describe('restoreViewerPanelFocus', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  test('restores the original trigger while the chrome is expanded', () => {
+    const trigger = document.body.appendChild(document.createElement('button'))
+    const fallback = document.body.appendChild(document.createElement('button'))
+
+    restoreViewerPanelFocus({
+      returnFocusRef: { current: trigger },
+      collapsedFallbackRef: { current: fallback },
+      topbarCollapsed: false,
+    })
+
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  test('uses the visible collapse toggle after a user closes a panel', () => {
+    const fallback = document.body.appendChild(document.createElement('button'))
+
+    restoreViewerPanelFocus({
+      returnFocusRef: { current: document.createElement('button') },
+      collapsedFallbackRef: { current: fallback },
+      topbarCollapsed: true,
+    })
+
+    expect(document.activeElement).toBe(fallback)
+  })
+
+  test.each([false, true])(
+    'does not steal focus from a forced transition when collapsed is %s',
+    (topbarCollapsed) => {
+      const nextPanelControl = document.body.appendChild(
+        document.createElement('button'),
+      )
+      const fallback = document.body.appendChild(
+        document.createElement('button'),
+      )
+      nextPanelControl.focus()
+
+      restoreViewerPanelFocus({
+        returnFocusRef: { current: document.createElement('button') },
+        collapsedFallbackRef: { current: fallback },
+        topbarCollapsed,
+      })
+
+      expect(document.activeElement).toBe(nextPanelControl)
+    },
+  )
+})

--- a/apps/web/app/routes/a.$id/+components/viewer-dom.ts
+++ b/apps/web/app/routes/a.$id/+components/viewer-dom.ts
@@ -1,4 +1,24 @@
+import type { RefObject } from 'react'
+
 export function getActiveElement(): HTMLElement | null {
   const activeElement = document.activeElement
   return activeElement instanceof HTMLElement ? activeElement : null
+}
+
+export function restoreViewerPanelFocus({
+  returnFocusRef,
+  collapsedFallbackRef,
+  topbarCollapsed,
+}: {
+  returnFocusRef?: RefObject<HTMLElement | null>
+  collapsedFallbackRef?: RefObject<HTMLElement | null>
+  topbarCollapsed: boolean
+}) {
+  const activeElement = getActiveElement()
+  if (activeElement !== null && activeElement !== document.body) return
+
+  const target = topbarCollapsed
+    ? collapsedFallbackRef?.current
+    : returnFocusRef?.current
+  target?.focus()
 }

--- a/apps/web/app/routes/a.$id/+components/viewer-list-wiring.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-list-wiring.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode, RefObject } from 'react'
 import { ViewerShell, type ViewerShellArtifact } from './viewer-shell'
 import { ViewerListPanel } from './viewer-list-panel'
+import { restoreViewerPanelFocus } from './viewer-dom'
 
 vi.mock('~/components/ui/sheet', () => ({
   Sheet: ({
@@ -32,9 +33,42 @@ vi.mock('~/components/ui/sheet', () => ({
 }))
 
 vi.mock('./comment-panel', () => ({
-  CommentPanel: ({ open }: { open: boolean }) => (
-    <div data-testid="comment-panel" data-open={String(open)} />
-  ),
+  CommentPanel: ({
+    open,
+    onOpenChange,
+    returnFocusRef,
+    collapsedFallbackRef,
+    topbarCollapsed = false,
+  }: {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    returnFocusRef?: RefObject<HTMLElement | null>
+    collapsedFallbackRef?: RefObject<HTMLElement | null>
+    topbarCollapsed?: boolean
+  }) => {
+    const wasOpenRef = React.useRef(open)
+    React.useEffect(() => {
+      if (wasOpenRef.current && !open) {
+        restoreViewerPanelFocus({
+          returnFocusRef,
+          collapsedFallbackRef,
+          topbarCollapsed,
+        })
+      }
+      wasOpenRef.current = open
+    }, [collapsedFallbackRef, open, returnFocusRef, topbarCollapsed])
+    return (
+      <div data-testid="comment-panel" data-open={String(open)}>
+        {open ? (
+          <button
+            type="button"
+            data-testid="comment-panel-close"
+            onClick={() => onOpenChange(false)}
+          />
+        ) : null}
+      </div>
+    )
+  },
 }))
 
 vi.mock('./sandbox-frame', () => ({
@@ -44,17 +78,52 @@ vi.mock('./sandbox-frame', () => ({
 }))
 
 vi.mock('./history-panel', () => ({
-  HistoryPanel: ({ open }: { open: boolean }) => (
-    <div data-testid="history-panel" data-open={String(open)} />
-  ),
+  HistoryPanel: ({
+    open,
+    onOpenChange,
+    returnFocusRef,
+    collapsedFallbackRef,
+    topbarCollapsed = false,
+  }: {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    returnFocusRef?: RefObject<HTMLElement | null>
+    collapsedFallbackRef?: RefObject<HTMLElement | null>
+    topbarCollapsed?: boolean
+  }) => {
+    const wasOpenRef = React.useRef(open)
+    React.useEffect(() => {
+      if (wasOpenRef.current && !open) {
+        restoreViewerPanelFocus({
+          returnFocusRef,
+          collapsedFallbackRef,
+          topbarCollapsed,
+        })
+      }
+      wasOpenRef.current = open
+    }, [collapsedFallbackRef, open, returnFocusRef, topbarCollapsed])
+    return (
+      <div data-testid="history-panel" data-open={String(open)}>
+        {open ? (
+          <button
+            type="button"
+            data-testid="history-panel-close"
+            onClick={() => onOpenChange(false)}
+          />
+        ) : null}
+      </div>
+    )
+  },
   VersionWidget: ({
+    hidden,
     onOpenHistory,
     onCommentsOpen,
   }: {
+    hidden?: boolean
     onOpenHistory?: (returnFocusTo?: HTMLElement | null) => void
     onCommentsOpen?: (returnFocusTo?: HTMLElement | null) => void
   }) => (
-    <div>
+    <div data-testid="version-widget" hidden={hidden}>
       <button
         type="button"
         data-testid="widget-open-history"
@@ -559,22 +628,45 @@ describe('viewer list wiring in ViewerShell', () => {
 
   it('hides the version widget while the chrome is collapsed', async () => {
     await renderShell()
-    expect(
-      container.querySelector('[data-testid="widget-open-history"]'),
-    ).not.toBeNull()
+    const versionWidget = container.querySelector<HTMLElement>(
+      '[data-testid="version-widget"]',
+    )
+    expect(versionWidget?.hidden).toBe(false)
     const collapseToggle = container.querySelector<HTMLButtonElement>(
       'button[aria-controls="viewer-topbar"]',
     )
     expect(collapseToggle).not.toBeNull()
     await click(collapseToggle!)
-    expect(
-      container.querySelector('[data-testid="widget-open-history"]'),
-    ).toBeNull()
+    expect(versionWidget?.hidden).toBe(true)
     await click(collapseToggle!)
-    expect(
-      container.querySelector('[data-testid="widget-open-history"]'),
-    ).not.toBeNull()
+    expect(versionWidget?.hidden).toBe(false)
   })
+
+  it.each([
+    ['history', 'widget-open-history', 'history-panel-close'],
+    ['comments', 'widget-open-comments', 'comment-panel-close'],
+  ])(
+    'returns focus to the chrome toggle after collapsing an open %s panel',
+    async (_panel, openTestId, closeTestId) => {
+      await renderShell()
+      const openButton = container.querySelector<HTMLButtonElement>(
+        `[data-testid="${openTestId}"]`,
+      )
+      const collapseToggle = container.querySelector<HTMLButtonElement>(
+        'button[aria-controls="viewer-topbar"]',
+      )
+      expect(openButton).not.toBeNull()
+      expect(collapseToggle).not.toBeNull()
+      await click(openButton!)
+      await click(collapseToggle!)
+      const closeButton = container.querySelector<HTMLButtonElement>(
+        `[data-testid="${closeTestId}"]`,
+      )
+      expect(closeButton).not.toBeNull()
+      await click(closeButton!)
+      expect(document.activeElement).toBe(collapseToggle)
+    },
+  )
 
   it('skips focus return while the chrome is collapsed', async () => {
     await renderShell()

--- a/apps/web/app/routes/a.$id/+components/viewer-list-wiring.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-list-wiring.test.tsx
@@ -557,6 +557,25 @@ describe('viewer list wiring in ViewerShell', () => {
     expect(document.activeElement).not.toBe(entryButton())
   })
 
+  it('hides the version widget while the chrome is collapsed', async () => {
+    await renderShell()
+    expect(
+      container.querySelector('[data-testid="widget-open-history"]'),
+    ).not.toBeNull()
+    const collapseToggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-controls="viewer-topbar"]',
+    )
+    expect(collapseToggle).not.toBeNull()
+    await click(collapseToggle!)
+    expect(
+      container.querySelector('[data-testid="widget-open-history"]'),
+    ).toBeNull()
+    await click(collapseToggle!)
+    expect(
+      container.querySelector('[data-testid="widget-open-history"]'),
+    ).not.toBeNull()
+  })
+
   it('skips focus return while the chrome is collapsed', async () => {
     await renderShell()
     await click(entryButton())

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -1850,6 +1850,15 @@ function useViewerShellController({
     canReplaceFile: canReplaceCurrentFile,
     canViewHistory,
     isHistoricalVersion,
+    exportActions:
+      user && !isHistoricalVersion && artifactSupportsExport(renderType)
+        ? {
+            copyMarkdown: handleCopyMarkdown,
+            downloadHtml: handleDownloadHtml,
+            downloadMarkdown: handleDownloadMarkdown,
+            downloadPdf: handleDownloadPdf,
+          }
+        : null,
     currentVersionHref,
     frameTitle,
     historyReturnFocusRef,
@@ -1871,10 +1880,6 @@ function useViewerShellController({
     submitReplaceVersion,
     handleDrop,
     setFrameExportPath,
-    handleCopyMarkdown,
-    handleDownloadHtml,
-    handleDownloadMarkdown,
-    handleDownloadPdf,
   }
 }
 
@@ -1908,6 +1913,7 @@ function ViewerShellView({
   canReplaceFile,
   canViewHistory,
   isHistoricalVersion,
+  exportActions,
   currentVersionHref,
   frameTitle,
   historyReturnFocusRef,
@@ -1929,15 +1935,9 @@ function ViewerShellView({
   submitReplaceVersion,
   handleDrop,
   setFrameExportPath,
-  handleCopyMarkdown,
-  handleDownloadHtml,
-  handleDownloadMarkdown,
-  handleDownloadPdf,
 }: ViewerShellController) {
   const { t } = useT()
-  const showExportActions = Boolean(
-    user && !isHistoricalVersion && artifactSupportsExport(renderType),
-  )
+  const collapseToggleRef = useRef<HTMLButtonElement | null>(null)
 
   return (
     <div className="bg-surface-warm fixed inset-x-0 top-0 bottom-[var(--consent-banner-height)] flex flex-col overflow-hidden overscroll-none">
@@ -1979,15 +1979,14 @@ function ViewerShellView({
         }}
         collapsible={sandboxUrl !== null}
         collapsed={state.chromeCollapsed}
-        onCollapsedChange={(collapsed) =>
+        collapseToggleRef={collapseToggleRef}
+        onCollapsedChange={(collapsed) => {
           dispatch({ type: 'chrome-collapsed-changed', collapsed })
-        }
-        onCopyMarkdown={showExportActions ? handleCopyMarkdown : undefined}
-        onDownloadHtml={showExportActions ? handleDownloadHtml : undefined}
-        onDownloadMarkdown={
-          showExportActions ? handleDownloadMarkdown : undefined
-        }
-        onDownloadPdf={showExportActions ? handleDownloadPdf : undefined}
+        }}
+        onCopyMarkdown={exportActions?.copyMarkdown}
+        onDownloadHtml={exportActions?.downloadHtml}
+        onDownloadMarkdown={exportActions?.downloadMarkdown}
+        onDownloadPdf={exportActions?.downloadPdf}
       />
       {isHistoricalVersion ? (
         <div className="border-border bg-background flex min-h-11 items-center justify-between gap-3 border-b px-3 py-2 text-sm">
@@ -2063,8 +2062,9 @@ function ViewerShellView({
       ) : (
         children
       )}
-      {canViewHistory && !state.chromeCollapsed ? (
+      {canViewHistory ? (
         <VersionWidget
+          hidden={state.chromeCollapsed}
           versions={artifact.versions ?? []}
           canReplaceFile={canReplaceFile}
           onSubmit={canReplaceFile ? submitReplaceVersion : undefined}
@@ -2097,6 +2097,7 @@ function ViewerShellView({
             dispatch({ type: 'history-open-changed', open })
           }}
           returnFocusRef={historyReturnFocusRef}
+          collapsedFallbackRef={collapseToggleRef}
           topbarCollapsed={state.chromeCollapsed}
           canReplaceFile={canReplaceFile}
           onSubmit={canReplaceFile ? submitReplaceVersion : undefined}
@@ -2165,6 +2166,7 @@ function ViewerShellView({
             comments.targetThread(thread.id, { scroll: 'start' })
           }
           returnFocusRef={comments.returnFocusRef}
+          collapsedFallbackRef={collapseToggleRef}
           requestedFilter={comments.requestedFilter}
           topbarCollapsed={state.chromeCollapsed}
           showNewThreadComposer={newThreadComposerEnabled}

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -2063,7 +2063,7 @@ function ViewerShellView({
       ) : (
         children
       )}
-      {canViewHistory ? (
+      {canViewHistory && !state.chromeCollapsed ? (
         <VersionWidget
           versions={artifact.versions ?? []}
           canReplaceFile={canReplaceFile}


### PR DESCRIPTION
## Summary

- keep only the AS mark and expand icon on the collapsed Viewer knob
- hide the bottom-right version status UI while the Viewer chrome is collapsed
- preserve version-widget state and restore panel focus safely across collapse and forced panel transitions

## Validation

- `pnpm validate:static`
- `pnpm visual:compose`
- `pnpm check:scenario-routes`
- Viewer screen capture: 60 states succeeded at desktop and mobile
- Codex and Claude implementation reviews: no unresolved blockers

## UI review

- Reviewed the collapsed Viewer state in desktop/mobile and light/dark captures against the relevant source.
- The collapsed state leaves only the AS mark and expand icon; the version status UI no longer overlaps the content.
- No registered task walkthrough includes the collapsed Viewer state, so no task walkthrough was affected.
- No UI critique findings were deferred.
