### PR TITLE
Expose Artifact Share URLs as MCP resources

### DIFF
--- a/apps/web/app/services/mcp/artifact-resource.server.ts
+++ b/apps/web/app/services/mcp/artifact-resource.server.ts
@@ -1,0 +1,137 @@
+import {
+  ResourceTemplate,
+  type McpServer,
+} from '@modelcontextprotocol/sdk/server/mcp.js'
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { getArtifactReadback } from '~/services/artifact-readback-service.server'
+import {
+  loadMcpUser,
+  mcpUserAsSessionUser,
+  type McpRequestContext,
+} from './identity.server'
+
+const ARTIFACT_RESOURCE_UNAVAILABLE = 'Artifact resource is not available.'
+const ARTIFACT_RESOURCE_UNSUPPORTED = 'Artifact resource type is not supported.'
+const ARTIFACT_RESOURCE_TOO_LARGE =
+  'Artifact resource exceeds the supported size.'
+const ARTIFACT_RESOURCE_SOURCE_UNAVAILABLE =
+  'Artifact resource content is unavailable.'
+
+export function artifactResourceTemplate(appOrigin: string): string {
+  return `${appOrigin.replace(/\/$/, '')}/a/{id}`
+}
+
+async function enforcePerUserLimit(ctx: McpRequestContext): Promise<void> {
+  const limiter = ctx.rateLimiters.perUser
+  if (!limiter) return
+
+  let success: boolean
+  try {
+    const result = await limiter.limit({
+      key: `mcp:user:${ctx.identity.userId}`,
+    })
+    success = result.success
+  } catch (error) {
+    console.error('mcp_rate_limit_failed', error)
+    return
+  }
+
+  if (!success) {
+    throw new McpError(
+      ErrorCode.RequestTimeout,
+      'Artifact resource read is rate limited.',
+    )
+  }
+}
+
+export function registerArtifactResource(
+  server: McpServer,
+  ctx: McpRequestContext,
+): void {
+  const appOrigin = new URL(ctx.baseUrl).origin
+
+  server.registerResource(
+    'artifact',
+    new ResourceTemplate(artifactResourceTemplate(appOrigin), {
+      list: undefined,
+    }),
+    {
+      title: 'Artifact Share artifact',
+      description:
+        'Reads the current Markdown or HTML source of an Artifact Share artifact.',
+    },
+    async (uri, variables) => {
+      await enforcePerUserLimit(ctx)
+
+      const id = uri.pathname.slice('/a/'.length)
+      if (
+        typeof variables.id !== 'string' ||
+        id.length === 0 ||
+        id.includes('/')
+      ) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          ARTIFACT_RESOURCE_UNAVAILABLE,
+        )
+      }
+
+      const user = await loadMcpUser(ctx.db, ctx.identity.userId)
+      if (!user) {
+        throw new McpError(
+          ErrorCode.InternalError,
+          'Artifact resource user is unavailable.',
+        )
+      }
+
+      const result = await getArtifactReadback(
+        ctx.db,
+        mcpUserAsSessionUser(user),
+        {
+          id,
+          baseUrl: ctx.baseUrl,
+        },
+      )
+
+      switch (result.kind) {
+        case 'ok':
+          if (result.data.truncated) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              ARTIFACT_RESOURCE_TOO_LARGE,
+            )
+          }
+          return {
+            contents: [
+              {
+                uri: uri.href,
+                mimeType:
+                  result.data.format === 'markdown'
+                    ? 'text/markdown'
+                    : 'text/html',
+                text: result.data.content,
+              },
+            ],
+          }
+        case 'not-found':
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            ARTIFACT_RESOURCE_UNAVAILABLE,
+          )
+        case 'unsupported-kind':
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            ARTIFACT_RESOURCE_UNSUPPORTED,
+          )
+        case 'source-unavailable':
+          throw new McpError(
+            ErrorCode.InternalError,
+            ARTIFACT_RESOURCE_SOURCE_UNAVAILABLE,
+          )
+        default: {
+          const exhaustive: never = result
+          return exhaustive
+        }
+      }
+    },
+  )
+}

--- a/apps/web/app/services/mcp/server.server.ts
+++ b/apps/web/app/services/mcp/server.server.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker'
 import { mcpResourceUrl } from '~/lib/mcp-metadata'
 import type { McpRequestContext } from './identity.server'
+import { registerArtifactResource } from './artifact-resource.server'
 import { registerArtifactPreviewResource } from './preview-widget.server'
 import { registerArtifactTools } from './tools.server'
 
@@ -26,6 +27,7 @@ export function createMcpServer(ctx: McpRequestContext): McpServer {
     jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
   })
   registerArtifactTools(server, ctx)
+  registerArtifactResource(server, ctx)
   registerArtifactPreviewResource(
     server,
     new URL(ctx.baseUrl).origin,

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -860,6 +860,248 @@ describe('headless publish wiring', () => {
     expect(description).toContain('concatenate the content parts')
   })
 
+  test('advertises artifact URLs as a resource template without listing artifacts', async () => {
+    const templates = await callMcp(db, 'resources/templates/list')
+    expect(templates.error).toBeUndefined()
+    expect(templates.result?.resourceTemplates).toContainEqual({
+      name: 'artifact',
+      uriTemplate: 'https://artifactshare.com/a/{id}',
+      title: 'Artifact Share artifact',
+      description:
+        'Reads the current Markdown or HTML source of an Artifact Share artifact.',
+    })
+
+    const listed = await callMcp(db, 'resources/list')
+    const resources = listed.result?.resources as Array<{ uri?: string }>
+    expect(resources.map((resource) => resource.uri)).toEqual([
+      'ui://artifact-preview.html',
+    ])
+  })
+
+  test.each([
+    ['markdown', '# Resource\n\nbody', 'text/markdown'],
+    ['html', '<html><body>Resource</body></html>', 'text/html'],
+  ] as const)(
+    'reads a viewable %s artifact through resources/read',
+    async (format, source, mimeType) => {
+      const user = await loadMcpUser(db, 'owner-1')
+      if (!user) throw new Error('seed failed')
+      const published = await uploadShareable(
+        db,
+        user,
+        buildArtifactFile(source, format),
+        'private',
+        [],
+        null,
+      )
+      if (published.kind !== 'ok') throw new Error('publish failed')
+      storageMock.getArtifact.mockResolvedValue({
+        text: async () => source,
+        size: source.length,
+      })
+
+      const uri = `https://artifactshare.com/a/${published.id}`
+      const body = await callMcp(db, 'resources/read', { uri })
+
+      expect(body.error).toBeUndefined()
+      expect(body.result?.contents).toEqual([{ uri, mimeType, text: source }])
+    },
+  )
+
+  test('ignores viewer state when reading an artifact resource URL', async () => {
+    const user = await loadMcpUser(db, 'owner-1')
+    if (!user) throw new Error('seed failed')
+    const source = '# Resource with viewer state'
+    const published = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile(source, 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    if (published.kind !== 'ok') throw new Error('publish failed')
+    storageMock.getArtifact.mockResolvedValue({
+      text: async () => source,
+      size: source.length,
+    })
+
+    const uri = `https://artifactshare.com/a/${published.id}?comment=thread-1#message-1`
+    const body = await callMcp(db, 'resources/read', { uri })
+
+    expect(body.error).toBeUndefined()
+    expect(body.result?.contents).toEqual([
+      { uri, mimeType: 'text/markdown', text: source },
+    ])
+  })
+
+  test('reads a workspace artifact owned by another user', async () => {
+    await seedUser(db, { id: 'mate-shared-resource', workspaceId: 'ws-a' })
+    const mate = await loadMcpUser(db, 'mate-shared-resource')
+    if (!mate) throw new Error('seed failed')
+    const source = '# Shared resource'
+    const published = await uploadShareable(
+      db,
+      mate,
+      buildArtifactFile(source, 'markdown'),
+      'workspace',
+      [],
+      null,
+    )
+    if (published.kind !== 'ok') throw new Error('publish failed')
+    storageMock.getArtifact.mockResolvedValue({
+      text: async () => source,
+      size: source.length,
+    })
+
+    const uri = `https://artifactshare.com/a/${published.id}`
+    const body = await callMcp(db, 'resources/read', { uri })
+
+    expect(body.error).toBeUndefined()
+    expect(body.result?.contents).toEqual([
+      { uri, mimeType: 'text/markdown', text: source },
+    ])
+  })
+
+  test('does not distinguish a hidden artifact from a missing artifact resource', async () => {
+    await seedUser(db, { id: 'mate-resource', workspaceId: 'ws-a' })
+    const mate = await loadMcpUser(db, 'mate-resource')
+    if (!mate) throw new Error('seed failed')
+    const published = await uploadShareable(
+      db,
+      mate,
+      buildArtifactFile('# Private', 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    if (published.kind !== 'ok') throw new Error('publish failed')
+
+    const hidden = await callMcp(db, 'resources/read', {
+      uri: `https://artifactshare.com/a/${published.id}`,
+    })
+    const missing = await callMcp(db, 'resources/read', {
+      uri: new URL('/a/not-present', 'https://artifactshare.com').href,
+    })
+
+    expect(hidden.error).toEqual(missing.error)
+    expect(hidden.error).toEqual({
+      code: -32602,
+      message: 'MCP error -32602: Artifact resource is not available.',
+    })
+    expect(storageMock.getArtifact).not.toHaveBeenCalled()
+  })
+
+  test.each(['static_site', 'spa', 'workspace_app'] as const)(
+    'refuses the unsupported %s artifact kind as a resource',
+    async (artifactKind) => {
+      const user = await loadMcpUser(db, 'owner-1')
+      if (!user) throw new Error('seed failed')
+      const published = await uploadShareable(
+        db,
+        user,
+        buildArtifactFile('# Bundle', 'markdown'),
+        'private',
+        [],
+        null,
+      )
+      if (published.kind !== 'ok') throw new Error('publish failed')
+      await db
+        .updateTable('shareables')
+        .set({ artifact_kind: artifactKind })
+        .where('id', '=', published.id)
+        .execute()
+      await db
+        .updateTable('versions')
+        .set({ artifact_kind: artifactKind })
+        .where('shareable_id', '=', published.id)
+        .execute()
+
+      const body = await callMcp(db, 'resources/read', {
+        uri: `https://artifactshare.com/a/${published.id}`,
+      })
+
+      expect(body.error).toEqual({
+        code: -32602,
+        message: 'MCP error -32602: Artifact resource type is not supported.',
+      })
+      expect(storageMock.getArtifact).not.toHaveBeenCalled()
+    },
+  )
+
+  test('refuses a large artifact resource instead of returning partial content', async () => {
+    const user = await loadMcpUser(db, 'owner-1')
+    if (!user) throw new Error('seed failed')
+    const published = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile('# Large', 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    if (published.kind !== 'ok') throw new Error('publish failed')
+    const source = 'x'.repeat(200_001)
+    storageMock.getArtifact.mockResolvedValue({
+      text: async () => source,
+      size: source.length,
+    })
+
+    const body = await callMcp(db, 'resources/read', {
+      uri: `https://artifactshare.com/a/${published.id}`,
+    })
+
+    expect(body.result).toBeUndefined()
+    expect(body.error).toEqual({
+      code: -32602,
+      message:
+        'MCP error -32602: Artifact resource exceeds the supported size.',
+    })
+  })
+
+  test('applies the per-user rate limit to artifact resources', async () => {
+    const limiter: RateLimiter = {
+      limit: vi.fn().mockResolvedValue({ success: false }),
+    }
+
+    const body = await callMcp(
+      db,
+      'resources/read',
+      { uri: new URL('/a/any-id', 'https://artifactshare.com').href },
+      { perUser: limiter, perWorkspace: null },
+    )
+
+    expect(limiter.limit).toHaveBeenCalledWith({ key: 'mcp:user:owner-1' })
+    expect(body.error).toEqual({
+      code: -32001,
+      message: 'MCP error -32001: Artifact resource read is rate limited.',
+    })
+  })
+
+  test('reports unavailable source as a resource protocol error', async () => {
+    const user = await loadMcpUser(db, 'owner-1')
+    if (!user) throw new Error('seed failed')
+    const published = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile('# Missing source', 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    if (published.kind !== 'ok') throw new Error('publish failed')
+    storageMock.getArtifact.mockResolvedValue(null)
+
+    const body = await callMcp(db, 'resources/read', {
+      uri: `https://artifactshare.com/a/${published.id}`,
+    })
+
+    expect(body.error).toEqual({
+      code: -32603,
+      message: 'MCP error -32603: Artifact resource content is unavailable.',
+    })
+  })
+
   test('publishes an HTML string and reads it back through the list query', async () => {
     const user = await loadMcpUser(db, 'owner-1')
     if (!user) throw new Error('seed failed')


### PR DESCRIPTION
## Summary

- advertise Artifact Share artifact URLs through the MCP resource template API
- read authorized Markdown and single-file HTML artifacts with the same access rules as `get_artifact`
- reject hidden, unsupported, unavailable, and oversized resources without leaking artifact existence or returning partial content
- accept viewer URLs that include comment or version state while resolving the artifact from the URL path

## Validation

- `pnpm review:spec` (Codex and Claude; no unresolved blockers)
- `pnpm review:implementation` (Codex and Claude; no unresolved blockers on the final commit)
- `pnpm validate:static`
- `pnpm public:scan .` (0 findings)
- `pnpm --filter @artifactshare/web build`
- trusted `origin/main` public-development PR boundary guard

## Notes

- MCP `resources/list` continues to expose only fixed application resources; user artifacts are resolved through `resources/templates/list` and `resources/read`.
- This change has no user-interface diff.
