### PR TITLE
Show Artifact Share titles in Claude project resources

### DIFF
--- a/apps/web/app/services/artifact-readback.server.ts
+++ b/apps/web/app/services/artifact-readback.server.ts
@@ -6,7 +6,7 @@ export type ArtifactSourceFormat = 'html' | 'markdown'
 
 // Single-file docs agents edit sit well under this; the cap keeps one outsized
 // artifact from flooding a model context while allowing chunked continuation.
-export const MAX_ARTIFACT_SOURCE_CHARS = 200_000
+const MAX_ARTIFACT_SOURCE_CHARS = 200_000
 
 export function singleFileFormat(
   artifactKind: ArtifactKind,

--- a/apps/web/app/services/artifact-readback.server.ts
+++ b/apps/web/app/services/artifact-readback.server.ts
@@ -6,7 +6,7 @@ export type ArtifactSourceFormat = 'html' | 'markdown'
 
 // Single-file docs agents edit sit well under this; the cap keeps one outsized
 // artifact from flooding a model context while allowing chunked continuation.
-const MAX_ARTIFACT_SOURCE_CHARS = 200_000
+export const MAX_ARTIFACT_SOURCE_CHARS = 200_000
 
 export function singleFileFormat(
   artifactKind: ArtifactKind,

--- a/apps/web/app/services/mcp/artifact-resource.server.ts
+++ b/apps/web/app/services/mcp/artifact-resource.server.ts
@@ -6,6 +6,7 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { displayTitle } from '~/lib/display-title'
 import { lowerEmail } from '~/lib/grant-emails.server'
 import { grantMatchEmail, isTeamWorkspaceAdmin } from '~/services/access.server'
+import { MAX_ARTIFACT_SOURCE_CHARS } from '~/services/artifact-readback.server'
 import { getArtifactReadback } from '~/services/artifact-readback-service.server'
 import {
   visibleShareableToViewerSql,
@@ -24,6 +25,7 @@ const ARTIFACT_RESOURCE_TOO_LARGE =
 const ARTIFACT_RESOURCE_SOURCE_UNAVAILABLE =
   'Artifact resource content is unavailable.'
 const ARTIFACT_RESOURCE_LIST_LIMIT = 50
+const MAX_UTF8_BYTES_FOR_ARTIFACT_SOURCE = MAX_ARTIFACT_SOURCE_CHARS * 3
 
 export function artifactResourceTemplate(appOrigin: string): string {
   return `${appOrigin.replace(/\/$/, '')}/a/{id}`
@@ -78,106 +80,157 @@ export function registerArtifactResource(
           viewer,
           viewer.workspaceId,
         )
-        const rows = await ctx.db
-          .selectFrom('shareables')
-          .innerJoin('versions', (join) =>
-            join
-              .onRef('versions.id', '=', 'shareables.current_version_id')
-              .onRef('versions.shareable_id', '=', 'shareables.id'),
-          )
-          .select([
-            'shareables.id',
-            'shareables.name',
-            'shareables.derived_title',
-            'shareables.title_override',
-            'versions.artifact_kind',
-          ])
-          .where('versions.status', '=', 'published')
-          .where('versions.artifact_kind', 'in', ['markdown_page', 'html_page'])
-          .where((eb) =>
-            eb.or([
-              eb('shareables.owner_user_id', '=', viewer.id),
-              eb.exists(
-                eb
-                  .selectFrom('shareable_grants')
-                  .select('shareable_grants.shareable_id')
-                  .whereRef(
-                    'shareable_grants.shareable_id',
-                    '=',
-                    'shareables.id',
-                  )
-                  .where(
-                    lowerEmail('shareable_grants.granted_email'),
-                    '=',
-                    grantMatchEmail(viewer),
-                  ),
-              ),
-              eb.and([
-                eb('shareables.workspace_id', '=', viewer.workspaceId),
-                eb('shareables.visibility', '!=', 'link'),
-                visibleShareableToViewerSql(viewer),
-              ]),
-              eb.and([
-                eb('shareables.workspace_id', '!=', viewer.workspaceId),
-                eb('shareables.visibility', '!=', 'link'),
+        const resources: Array<{
+          uri: string
+          name: string
+          title: string
+          mimeType: string
+        }> = []
+        let cursor: { updatedAt: string; id: string } | null = null
+
+        while (resources.length < ARTIFACT_RESOURCE_LIST_LIMIT) {
+          let query = ctx.db
+            .selectFrom('shareables')
+            .innerJoin('versions', (join) =>
+              join
+                .onRef('versions.id', '=', 'shareables.current_version_id')
+                .onRef('versions.shareable_id', '=', 'shareables.id'),
+            )
+            .select([
+              'shareables.id',
+              'shareables.name',
+              'shareables.derived_title',
+              'shareables.title_override',
+              'shareables.updated_at',
+              'versions.artifact_kind',
+              'versions.size_bytes',
+            ])
+            .where('versions.status', '=', 'published')
+            .where('versions.artifact_kind', 'in', [
+              'markdown_page',
+              'html_page',
+            ])
+            .where(
+              'versions.size_bytes',
+              '<=',
+              MAX_UTF8_BYTES_FOR_ARTIFACT_SOURCE,
+            )
+            .where((eb) =>
+              eb.or([
+                eb('shareables.owner_user_id', '=', viewer.id),
                 eb.exists(
                   eb
-                    .selectFrom('project_members')
-                    .select('project_members.user_id')
+                    .selectFrom('shareable_grants')
+                    .select('shareable_grants.shareable_id')
                     .whereRef(
-                      'project_members.container_id',
+                      'shareable_grants.shareable_id',
                       '=',
-                      'shareables.container_id',
-                    )
-                    .where('project_members.user_id', '=', viewer.id),
-                ),
-                eb.exists(
-                  eb
-                    .selectFrom('project_share_defaults')
-                    .select('project_share_defaults.id')
-                    .whereRef(
-                      'project_share_defaults.project_container_id',
-                      '=',
-                      'shareables.container_id',
+                      'shareables.id',
                     )
                     .where(
-                      lowerEmail('project_share_defaults.email'),
+                      lowerEmail('shareable_grants.granted_email'),
                       '=',
                       grantMatchEmail(viewer),
                     ),
                 ),
-                visibleSharedProjectShareableToViewerSql(viewer),
+                eb.and([
+                  eb('shareables.workspace_id', '=', viewer.workspaceId),
+                  eb('shareables.visibility', '!=', 'link'),
+                  visibleShareableToViewerSql(viewer),
+                ]),
+                eb.and([
+                  eb('shareables.workspace_id', '!=', viewer.workspaceId),
+                  eb('shareables.visibility', '!=', 'link'),
+                  eb.exists(
+                    eb
+                      .selectFrom('project_members')
+                      .select('project_members.user_id')
+                      .whereRef(
+                        'project_members.container_id',
+                        '=',
+                        'shareables.container_id',
+                      )
+                      .where('project_members.user_id', '=', viewer.id),
+                  ),
+                  eb.exists(
+                    eb
+                      .selectFrom('project_share_defaults')
+                      .select('project_share_defaults.id')
+                      .whereRef(
+                        'project_share_defaults.project_container_id',
+                        '=',
+                        'shareables.container_id',
+                      )
+                      .where(
+                        lowerEmail('project_share_defaults.email'),
+                        '=',
+                        grantMatchEmail(viewer),
+                      ),
+                  ),
+                  visibleSharedProjectShareableToViewerSql(viewer),
+                ]),
+                ...(isWorkspaceAdmin
+                  ? [
+                      eb.and([
+                        eb('shareables.workspace_id', '=', viewer.workspaceId),
+                        eb('shareables.visibility', '=', 'link'),
+                      ]),
+                    ]
+                  : []),
               ]),
-              ...(isWorkspaceAdmin
-                ? [
-                    eb.and([
-                      eb('shareables.workspace_id', '=', viewer.workspaceId),
-                      eb('shareables.visibility', '=', 'link'),
-                    ]),
-                  ]
-                : []),
-            ]),
-          )
-          .orderBy('shareables.updated_at', 'desc')
-          .orderBy('shareables.id', 'desc')
-          .limit(ARTIFACT_RESOURCE_LIST_LIMIT)
-          .execute()
+            )
 
-        return {
-          resources: rows.map((row) => ({
-            uri: `${appOrigin}/a/${row.id}`,
-            name: row.id,
-            title: displayTitle({
-              titleOverride: row.title_override,
-              derivedTitle: row.derived_title,
-              name: row.name,
-            }),
-            mimeType:
-              row.artifact_kind === 'markdown_page'
-                ? 'text/markdown'
-                : 'text/html',
-          })),
+          if (cursor) {
+            const currentCursor = cursor
+            query = query.where((eb) =>
+              eb.or([
+                eb('shareables.updated_at', '<', currentCursor.updatedAt),
+                eb.and([
+                  eb('shareables.updated_at', '=', currentCursor.updatedAt),
+                  eb('shareables.id', '<', currentCursor.id),
+                ]),
+              ]),
+            )
+          }
+
+          const rows = await query
+            .orderBy('shareables.updated_at', 'desc')
+            .orderBy('shareables.id', 'desc')
+            .limit(ARTIFACT_RESOURCE_LIST_LIMIT)
+            .execute()
+          if (rows.length === 0) break
+
+          for (const row of rows) {
+            if (row.size_bytes > MAX_ARTIFACT_SOURCE_CHARS) {
+              const readback = await getArtifactReadback(ctx.db, viewer, {
+                id: row.id,
+                baseUrl: ctx.baseUrl,
+              })
+              if (readback.kind !== 'ok' || readback.data.truncated) continue
+            }
+
+            resources.push({
+              uri: `${appOrigin}/a/${row.id}`,
+              name: row.id,
+              title: displayTitle({
+                titleOverride: row.title_override,
+                derivedTitle: row.derived_title,
+                name: row.name,
+              }),
+              mimeType:
+                row.artifact_kind === 'markdown_page'
+                  ? 'text/markdown'
+                  : 'text/html',
+            })
+            if (resources.length === ARTIFACT_RESOURCE_LIST_LIMIT) break
+          }
+
+          const last = rows.at(-1)
+          if (!last || rows.length < ARTIFACT_RESOURCE_LIST_LIMIT) break
+          cursor = { updatedAt: last.updated_at, id: last.id }
         }
+
+        return { resources }
       },
     }),
     {

--- a/apps/web/app/services/mcp/artifact-resource.server.ts
+++ b/apps/web/app/services/mcp/artifact-resource.server.ts
@@ -3,7 +3,15 @@ import {
   type McpServer,
 } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { displayTitle } from '~/lib/display-title'
+import { lowerEmail } from '~/lib/grant-emails.server'
+import { grantMatchEmail, isTeamWorkspaceAdmin } from '~/services/access.server'
+import { MAX_ARTIFACT_SOURCE_CHARS } from '~/services/artifact-readback.server'
 import { getArtifactReadback } from '~/services/artifact-readback-service.server'
+import {
+  visibleShareableToViewerSql,
+  visibleSharedProjectShareableToViewerSql,
+} from '~/services/projects.server'
 import {
   loadMcpUser,
   mcpUserAsSessionUser,
@@ -16,6 +24,7 @@ const ARTIFACT_RESOURCE_TOO_LARGE =
   'Artifact resource exceeds the supported size.'
 const ARTIFACT_RESOURCE_SOURCE_UNAVAILABLE =
   'Artifact resource content is unavailable.'
+const ARTIFACT_RESOURCE_LIST_LIMIT = 50
 
 export function artifactResourceTemplate(appOrigin: string): string {
   return `${appOrigin.replace(/\/$/, '')}/a/{id}`
@@ -53,7 +62,110 @@ export function registerArtifactResource(
   server.registerResource(
     'artifact',
     new ResourceTemplate(artifactResourceTemplate(appOrigin), {
-      list: undefined,
+      list: async () => {
+        await enforcePerUserLimit(ctx)
+
+        const user = await loadMcpUser(ctx.db, ctx.identity.userId)
+        if (!user) {
+          throw new McpError(
+            ErrorCode.InternalError,
+            'Artifact resource user is unavailable.',
+          )
+        }
+
+        const viewer = mcpUserAsSessionUser(user)
+        const isWorkspaceAdmin = await isTeamWorkspaceAdmin(
+          ctx.db,
+          viewer,
+          viewer.workspaceId,
+        )
+        const rows = await ctx.db
+          .selectFrom('shareables')
+          .innerJoin('versions', (join) =>
+            join
+              .onRef('versions.id', '=', 'shareables.current_version_id')
+              .onRef('versions.shareable_id', '=', 'shareables.id'),
+          )
+          .select([
+            'shareables.id',
+            'shareables.name',
+            'shareables.derived_title',
+            'shareables.title_override',
+            'versions.artifact_kind',
+          ])
+          .where('versions.status', '=', 'published')
+          .where('versions.artifact_kind', 'in', ['markdown_page', 'html_page'])
+          .where('versions.size_bytes', '<=', MAX_ARTIFACT_SOURCE_CHARS)
+          .where((eb) =>
+            eb.or([
+              eb('shareables.owner_user_id', '=', viewer.id),
+              eb.exists(
+                eb
+                  .selectFrom('shareable_grants')
+                  .select('shareable_grants.shareable_id')
+                  .whereRef(
+                    'shareable_grants.shareable_id',
+                    '=',
+                    'shareables.id',
+                  )
+                  .where(
+                    lowerEmail('shareable_grants.granted_email'),
+                    '=',
+                    grantMatchEmail(viewer),
+                  ),
+              ),
+              eb.and([
+                eb('shareables.workspace_id', '=', viewer.workspaceId),
+                eb('shareables.visibility', '!=', 'link'),
+                visibleShareableToViewerSql(viewer),
+              ]),
+              eb.and([
+                eb('shareables.workspace_id', '!=', viewer.workspaceId),
+                eb('shareables.visibility', '!=', 'link'),
+                eb.exists(
+                  eb
+                    .selectFrom('project_members')
+                    .select('project_members.user_id')
+                    .whereRef(
+                      'project_members.container_id',
+                      '=',
+                      'shareables.container_id',
+                    )
+                    .where('project_members.user_id', '=', viewer.id),
+                ),
+                visibleSharedProjectShareableToViewerSql(viewer),
+              ]),
+              ...(isWorkspaceAdmin
+                ? [
+                    eb.and([
+                      eb('shareables.workspace_id', '=', viewer.workspaceId),
+                      eb('shareables.visibility', '=', 'link'),
+                    ]),
+                  ]
+                : []),
+            ]),
+          )
+          .orderBy('shareables.updated_at', 'desc')
+          .orderBy('shareables.id', 'desc')
+          .limit(ARTIFACT_RESOURCE_LIST_LIMIT)
+          .execute()
+
+        return {
+          resources: rows.map((row) => ({
+            uri: `${appOrigin}/a/${row.id}`,
+            name: row.id,
+            title: displayTitle({
+              titleOverride: row.title_override,
+              derivedTitle: row.derived_title,
+              name: row.name,
+            }),
+            mimeType:
+              row.artifact_kind === 'markdown_page'
+                ? 'text/markdown'
+                : 'text/html',
+          })),
+        }
+      },
     }),
     {
       title: 'Artifact Share artifact',

--- a/apps/web/app/services/mcp/artifact-resource.server.ts
+++ b/apps/web/app/services/mcp/artifact-resource.server.ts
@@ -215,18 +215,32 @@ export function registerArtifactResource(
           if (rows.length === 0) break
           scannedCount += rows.length
 
+          const rowsToValidate = rows
+            .filter((row) => row.size_bytes > MAX_ARTIFACT_SOURCE_CHARS)
+            .slice(0, ARTIFACT_RESOURCE_VALIDATION_LIMIT - validationCount)
+          validationCount += rowsToValidate.length
+          const validatedIds = new Set(
+            (
+              await Promise.all(
+                rowsToValidate.map(async (row) => {
+                  const readback = await getArtifactReadback(ctx.db, viewer, {
+                    id: row.id,
+                    baseUrl: ctx.baseUrl,
+                  })
+                  return readback.kind === 'ok' && !readback.data.truncated
+                    ? row.id
+                    : null
+                }),
+              )
+            ).filter((id): id is string => id !== null),
+          )
+
           for (const row of rows) {
-            if (row.size_bytes > MAX_ARTIFACT_SOURCE_CHARS) {
-              if (validationCount === ARTIFACT_RESOURCE_VALIDATION_LIMIT) {
-                continue
-              }
-              validationCount += 1
-              const readback = await getArtifactReadback(ctx.db, viewer, {
-                id: row.id,
-                baseUrl: ctx.baseUrl,
-              })
-              if (readback.kind !== 'ok' || readback.data.truncated) continue
-            }
+            if (
+              row.size_bytes > MAX_ARTIFACT_SOURCE_CHARS &&
+              !validatedIds.has(row.id)
+            )
+              continue
 
             resources.push({
               uri: `${appOrigin}/a/${row.id}`,

--- a/apps/web/app/services/mcp/artifact-resource.server.ts
+++ b/apps/web/app/services/mcp/artifact-resource.server.ts
@@ -25,7 +25,11 @@ const ARTIFACT_RESOURCE_TOO_LARGE =
 const ARTIFACT_RESOURCE_SOURCE_UNAVAILABLE =
   'Artifact resource content is unavailable.'
 const ARTIFACT_RESOURCE_LIST_LIMIT = 50
-const MAX_UTF8_BYTES_FOR_ARTIFACT_SOURCE = MAX_ARTIFACT_SOURCE_CHARS * 3
+const ARTIFACT_RESOURCE_SCAN_LIMIT = 100
+const ARTIFACT_RESOURCE_VALIDATION_LIMIT = 10
+const UTF8_BOM_BYTES = 3
+const MAX_UTF8_BYTES_FOR_ARTIFACT_SOURCE =
+  MAX_ARTIFACT_SOURCE_CHARS * 3 + UTF8_BOM_BYTES
 
 export function artifactResourceTemplate(appOrigin: string): string {
   return `${appOrigin.replace(/\/$/, '')}/a/{id}`
@@ -87,8 +91,13 @@ export function registerArtifactResource(
           mimeType: string
         }> = []
         let cursor: { updatedAt: string; id: string } | null = null
+        let scannedCount = 0
+        let validationCount = 0
 
-        while (resources.length < ARTIFACT_RESOURCE_LIST_LIMIT) {
+        while (
+          resources.length < ARTIFACT_RESOURCE_LIST_LIMIT &&
+          scannedCount < ARTIFACT_RESOURCE_SCAN_LIMIT
+        ) {
           let query = ctx.db
             .selectFrom('shareables')
             .innerJoin('versions', (join) =>
@@ -196,12 +205,22 @@ export function registerArtifactResource(
           const rows = await query
             .orderBy('shareables.updated_at', 'desc')
             .orderBy('shareables.id', 'desc')
-            .limit(ARTIFACT_RESOURCE_LIST_LIMIT)
+            .limit(
+              Math.min(
+                ARTIFACT_RESOURCE_LIST_LIMIT,
+                ARTIFACT_RESOURCE_SCAN_LIMIT - scannedCount,
+              ),
+            )
             .execute()
           if (rows.length === 0) break
+          scannedCount += rows.length
 
           for (const row of rows) {
             if (row.size_bytes > MAX_ARTIFACT_SOURCE_CHARS) {
+              if (validationCount === ARTIFACT_RESOURCE_VALIDATION_LIMIT) {
+                continue
+              }
+              validationCount += 1
               const readback = await getArtifactReadback(ctx.db, viewer, {
                 id: row.id,
                 baseUrl: ctx.baseUrl,

--- a/apps/web/app/services/mcp/artifact-resource.server.ts
+++ b/apps/web/app/services/mcp/artifact-resource.server.ts
@@ -6,7 +6,6 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { displayTitle } from '~/lib/display-title'
 import { lowerEmail } from '~/lib/grant-emails.server'
 import { grantMatchEmail, isTeamWorkspaceAdmin } from '~/services/access.server'
-import { MAX_ARTIFACT_SOURCE_CHARS } from '~/services/artifact-readback.server'
 import { getArtifactReadback } from '~/services/artifact-readback-service.server'
 import {
   visibleShareableToViewerSql,
@@ -95,7 +94,6 @@ export function registerArtifactResource(
           ])
           .where('versions.status', '=', 'published')
           .where('versions.artifact_kind', 'in', ['markdown_page', 'html_page'])
-          .where('versions.size_bytes', '<=', MAX_ARTIFACT_SOURCE_CHARS)
           .where((eb) =>
             eb.or([
               eb('shareables.owner_user_id', '=', viewer.id),
@@ -132,6 +130,21 @@ export function registerArtifactResource(
                       'shareables.container_id',
                     )
                     .where('project_members.user_id', '=', viewer.id),
+                ),
+                eb.exists(
+                  eb
+                    .selectFrom('project_share_defaults')
+                    .select('project_share_defaults.id')
+                    .whereRef(
+                      'project_share_defaults.project_container_id',
+                      '=',
+                      'shareables.container_id',
+                    )
+                    .where(
+                      lowerEmail('project_share_defaults.email'),
+                      '=',
+                      grantMatchEmail(viewer),
+                    ),
                 ),
                 visibleSharedProjectShareableToViewerSql(viewer),
               ]),

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -1002,6 +1002,10 @@ describe('headless publish wiring', () => {
       .set({ artifact_kind: 'static_site' })
       .where('shareable_id', '=', unsupported.id)
       .execute()
+    storageMock.getArtifact.mockResolvedValue({
+      text: async () => multibyteSource,
+      size: new TextEncoder().encode(multibyteSource).byteLength,
+    })
     const listed = await callMcp(db, 'resources/list')
     const resources = listed.result?.resources as Array<{ uri?: string }>
     expect(resources.map((resource) => resource.uri)).not.toContain(
@@ -1010,10 +1014,6 @@ describe('headless publish wiring', () => {
     const multibyteUri = `https://artifactshare.com/a/${multibyte.id}`
     expect(resources.map((resource) => resource.uri)).toContain(multibyteUri)
 
-    storageMock.getArtifact.mockResolvedValue({
-      text: async () => multibyteSource,
-      size: new TextEncoder().encode(multibyteSource).byteLength,
-    })
     const read = await callMcp(db, 'resources/read', { uri: multibyteUri })
     expect(read.error).toBeUndefined()
     expect(read.result?.contents).toEqual([
@@ -1087,10 +1087,10 @@ describe('headless publish wiring', () => {
     expect(afterResources.map((resource) => resource.uri)).not.toContain(uri)
   })
 
-  test('bounds the artifact resource list to 50 entries', async () => {
+  test('returns 50 readable resources without letting a newer oversized artifact displace one', async () => {
     const user = await loadMcpUser(db, 'owner-1')
     if (!user) throw new Error('seed failed')
-    for (let index = 0; index < 51; index += 1) {
+    for (let index = 0; index < 50; index += 1) {
       const published = await uploadShareable(
         db,
         user,
@@ -1101,14 +1101,35 @@ describe('headless publish wiring', () => {
       )
       if (published.kind !== 'ok') throw new Error('publish failed')
     }
+    const oversizedSource = 'x'.repeat(200_001)
+    const oversized = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile(oversizedSource, 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    if (oversized.kind !== 'ok') throw new Error('publish failed')
+    await db
+      .updateTable('shareables')
+      .set({ updated_at: '9999-12-31T23:59:59.999Z' })
+      .where('id', '=', oversized.id)
+      .execute()
+    storageMock.getArtifact.mockResolvedValue({
+      text: async () => oversizedSource,
+      size: oversizedSource.length,
+    })
 
     const listed = await callMcp(db, 'resources/list')
     const resources = listed.result?.resources as Array<{ uri?: string }>
-    expect(
-      resources.filter((resource) =>
-        resource.uri?.startsWith('https://artifactshare.com/a/'),
-      ),
-    ).toHaveLength(50)
+    const artifactResources = resources.filter((resource) =>
+      resource.uri?.startsWith('https://artifactshare.com/a/'),
+    )
+    expect(artifactResources).toHaveLength(50)
+    expect(artifactResources.map((resource) => resource.uri)).not.toContain(
+      `https://artifactshare.com/a/${oversized.id}`,
+    )
   })
 
   test.each([

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -974,7 +974,7 @@ describe('headless publish wiring', () => {
     expect(grantedResources.map((resource) => resource.uri)).toContain(uri)
   })
 
-  test('omits unsupported and oversized artifacts from the resource list', async () => {
+  test('omits unsupported artifacts and lists readable multibyte artifacts', async () => {
     const user = await loadMcpUser(db, 'owner-1')
     if (!user) throw new Error('seed failed')
     const unsupported = await uploadShareable(
@@ -985,15 +985,16 @@ describe('headless publish wiring', () => {
       [],
       null,
     )
-    const oversized = await uploadShareable(
+    const multibyteSource = `# 日本語\n\n${'界'.repeat(70_000)}`
+    const multibyte = await uploadShareable(
       db,
       user,
-      buildArtifactFile('# Oversized', 'markdown'),
+      buildArtifactFile(multibyteSource, 'markdown'),
       'private',
       [],
       null,
     )
-    if (unsupported.kind !== 'ok' || oversized.kind !== 'ok') {
+    if (unsupported.kind !== 'ok' || multibyte.kind !== 'ok') {
       throw new Error('publish failed')
     }
     await db
@@ -1001,20 +1002,89 @@ describe('headless publish wiring', () => {
       .set({ artifact_kind: 'static_site' })
       .where('shareable_id', '=', unsupported.id)
       .execute()
-    await db
-      .updateTable('versions')
-      .set({ size_bytes: 200_001 })
-      .where('shareable_id', '=', oversized.id)
-      .execute()
-
     const listed = await callMcp(db, 'resources/list')
     const resources = listed.result?.resources as Array<{ uri?: string }>
     expect(resources.map((resource) => resource.uri)).not.toContain(
       `https://artifactshare.com/a/${unsupported.id}`,
     )
-    expect(resources.map((resource) => resource.uri)).not.toContain(
-      `https://artifactshare.com/a/${oversized.id}`,
+    const multibyteUri = `https://artifactshare.com/a/${multibyte.id}`
+    expect(resources.map((resource) => resource.uri)).toContain(multibyteUri)
+
+    storageMock.getArtifact.mockResolvedValue({
+      text: async () => multibyteSource,
+      size: new TextEncoder().encode(multibyteSource).byteLength,
+    })
+    const read = await callMcp(db, 'resources/read', { uri: multibyteUri })
+    expect(read.error).toBeUndefined()
+    expect(read.result?.contents).toEqual([
+      {
+        uri: multibyteUri,
+        mimeType: 'text/markdown',
+        text: multibyteSource,
+      },
+    ])
+  })
+
+  test('stops listing a shared-project resource after its audience grant is removed', async () => {
+    await seedWorkspace(db, { id: 'ws-b', hd: 'other.example' })
+    await seedUser(db, {
+      id: 'external-project-owner',
+      workspaceId: 'ws-b',
+      email: 'owner@other.example',
+    })
+    const externalOwner = await loadMcpUser(db, 'external-project-owner')
+    if (!externalOwner) throw new Error('seed failed')
+    const projectId = await createTestProject(db, 'ws-b', externalOwner.id, {
+      name: 'Shared project',
+      description: null,
+      baseVisibility: 'private',
+    })
+    await db
+      .insertInto('project_share_defaults')
+      .values({
+        id: 'audience-resource-list',
+        project_container_id: projectId,
+        email: 'OWNER-1@EXAMPLE.COM',
+        role: 'viewer',
+        display_name: null,
+        created_by_id: externalOwner.id,
+        created_at: NOW,
+        updated_at: NOW,
+      })
+      .execute()
+    await db
+      .insertInto('project_members')
+      .values({
+        container_id: projectId,
+        user_id: 'owner-1',
+        joined_at: NOW,
+        last_seen_at: NOW,
+      })
+      .execute()
+    const published = await uploadShareable(
+      db,
+      externalOwner,
+      buildArtifactFile('# Shared project resource', 'markdown'),
+      'project',
+      [],
+      projectId,
     )
+    if (published.kind !== 'ok') throw new Error('publish failed')
+    const uri = `https://artifactshare.com/a/${published.id}`
+
+    const before = await callMcp(db, 'resources/list')
+    const beforeResources = before.result?.resources as Array<{ uri?: string }>
+    expect(beforeResources.map((resource) => resource.uri)).toContain(uri)
+
+    await db
+      .deleteFrom('project_share_defaults')
+      .where('project_container_id', '=', projectId)
+      .where('email', '=', 'OWNER-1@EXAMPLE.COM')
+      .execute()
+
+    const after = await callMcp(db, 'resources/list')
+    const afterResources = after.result?.resources as Array<{ uri?: string }>
+    expect(afterResources.map((resource) => resource.uri)).not.toContain(uri)
   })
 
   test('bounds the artifact resource list to 50 entries', async () => {

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -860,7 +860,37 @@ describe('headless publish wiring', () => {
     expect(description).toContain('concatenate the content parts')
   })
 
-  test('advertises artifact URLs as a resource template without listing artifacts', async () => {
+  test('advertises artifact URLs as a template and lists readable artifacts by title', async () => {
+    const user = await loadMcpUser(db, 'owner-1')
+    if (!user) throw new Error('seed failed')
+    const markdown = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile('# Derived title\n\nbody', 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    const html = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile(
+        '<html><head><title>HTML title</title></head><body></body></html>',
+        'html',
+      ),
+      'private',
+      [],
+      null,
+    )
+    if (markdown.kind !== 'ok' || html.kind !== 'ok') {
+      throw new Error('publish failed')
+    }
+    await db
+      .updateTable('shareables')
+      .set({ title_override: 'Custom title' })
+      .where('id', '=', markdown.id)
+      .execute()
+
     const templates = await callMcp(db, 'resources/templates/list')
     expect(templates.error).toBeUndefined()
     expect(templates.result?.resourceTemplates).toContainEqual({
@@ -872,10 +902,143 @@ describe('headless publish wiring', () => {
     })
 
     const listed = await callMcp(db, 'resources/list')
+    expect(listed.error).toBeUndefined()
+    expect(listed.result?.resources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          uri: `https://artifactshare.com/a/${markdown.id}`,
+          name: markdown.id,
+          title: 'Custom title',
+          mimeType: 'text/markdown',
+        }),
+        expect.objectContaining({
+          uri: `https://artifactshare.com/a/${html.id}`,
+          name: html.id,
+          title: 'HTML title',
+          mimeType: 'text/html',
+        }),
+        expect.objectContaining({ uri: 'ui://artifact-preview.html' }),
+      ]),
+    )
+  })
+
+  test('does not reveal link-only artifacts in the resource list without identity-bound access', async () => {
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'plus', link_sharing_enabled: 1 })
+      .where('id', '=', 'ws-a')
+      .execute()
+    await seedUser(db, { id: 'mate-link-resource', workspaceId: 'ws-a' })
+    const mate = await loadMcpUser(db, 'mate-link-resource')
+    if (!mate) throw new Error('seed failed')
+    const source = '# Unlisted link resource'
+    const published = await uploadShareable(
+      db,
+      mate,
+      buildArtifactFile(source, 'markdown'),
+      'link',
+      [],
+      null,
+    )
+    if (published.kind !== 'ok') throw new Error('publish failed')
+
+    const uri = `https://artifactshare.com/a/${published.id}`
+    const ungranted = await callMcp(db, 'resources/list')
+    const ungrantedResources = ungranted.result?.resources as Array<{
+      uri?: string
+    }>
+    expect(ungrantedResources.map((resource) => resource.uri)).not.toContain(
+      uri,
+    )
+
+    storageMock.getArtifact.mockResolvedValue({
+      text: async () => source,
+      size: source.length,
+    })
+    const directRead = await callMcp(db, 'resources/read', { uri })
+    expect(directRead.error).toBeUndefined()
+
+    await db
+      .insertInto('shareable_grants')
+      .values({
+        shareable_id: published.id,
+        granted_email: 'OWNER-1@EXAMPLE.COM',
+        granted_at: NOW,
+        granted_by: mate.id,
+      })
+      .execute()
+    const granted = await callMcp(db, 'resources/list')
+    const grantedResources = granted.result?.resources as Array<{
+      uri?: string
+    }>
+    expect(grantedResources.map((resource) => resource.uri)).toContain(uri)
+  })
+
+  test('omits unsupported and oversized artifacts from the resource list', async () => {
+    const user = await loadMcpUser(db, 'owner-1')
+    if (!user) throw new Error('seed failed')
+    const unsupported = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile('# Unsupported', 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    const oversized = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile('# Oversized', 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    if (unsupported.kind !== 'ok' || oversized.kind !== 'ok') {
+      throw new Error('publish failed')
+    }
+    await db
+      .updateTable('versions')
+      .set({ artifact_kind: 'static_site' })
+      .where('shareable_id', '=', unsupported.id)
+      .execute()
+    await db
+      .updateTable('versions')
+      .set({ size_bytes: 200_001 })
+      .where('shareable_id', '=', oversized.id)
+      .execute()
+
+    const listed = await callMcp(db, 'resources/list')
     const resources = listed.result?.resources as Array<{ uri?: string }>
-    expect(resources.map((resource) => resource.uri)).toEqual([
-      'ui://artifact-preview.html',
-    ])
+    expect(resources.map((resource) => resource.uri)).not.toContain(
+      `https://artifactshare.com/a/${unsupported.id}`,
+    )
+    expect(resources.map((resource) => resource.uri)).not.toContain(
+      `https://artifactshare.com/a/${oversized.id}`,
+    )
+  })
+
+  test('bounds the artifact resource list to 50 entries', async () => {
+    const user = await loadMcpUser(db, 'owner-1')
+    if (!user) throw new Error('seed failed')
+    for (let index = 0; index < 51; index += 1) {
+      const published = await uploadShareable(
+        db,
+        user,
+        buildArtifactFile(`# Resource ${index}`, 'markdown'),
+        'private',
+        [],
+        null,
+      )
+      if (published.kind !== 'ok') throw new Error('publish failed')
+    }
+
+    const listed = await callMcp(db, 'resources/list')
+    const resources = listed.result?.resources as Array<{ uri?: string }>
+    expect(
+      resources.filter((resource) =>
+        resource.uri?.startsWith('https://artifactshare.com/a/'),
+      ),
+    ).toHaveLength(50)
   })
 
   test.each([

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -1087,6 +1087,76 @@ describe('headless publish wiring', () => {
     expect(afterResources.map((resource) => resource.uri)).not.toContain(uri)
   })
 
+  test('lists a BOM-prefixed resource at the character limit', async () => {
+    const user = await loadMcpUser(db, 'owner-1')
+    if (!user) throw new Error('seed failed')
+    const decodedSource = '界'.repeat(200_000)
+    const storedSource = `\uFEFF${decodedSource}`
+    const published = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile(storedSource, 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    if (published.kind !== 'ok') throw new Error('publish failed')
+    storageMock.getArtifact.mockResolvedValue({
+      text: async () => decodedSource,
+      size: new TextEncoder().encode(storedSource).byteLength,
+    })
+
+    const listed = await callMcp(db, 'resources/list')
+    const resources = listed.result?.resources as Array<{ uri?: string }>
+    expect(resources.map((resource) => resource.uri)).toContain(
+      `https://artifactshare.com/a/${published.id}`,
+    )
+  })
+
+  test('bounds exact-length validation while continuing to list small resources', async () => {
+    const user = await loadMcpUser(db, 'owner-1')
+    if (!user) throw new Error('seed failed')
+    const small = await uploadShareable(
+      db,
+      user,
+      buildArtifactFile('# Small', 'markdown'),
+      'private',
+      [],
+      null,
+    )
+    if (small.kind !== 'ok') throw new Error('publish failed')
+    const oversizedSource = 'x'.repeat(200_001)
+    for (let index = 0; index < 11; index += 1) {
+      const oversized = await uploadShareable(
+        db,
+        user,
+        buildArtifactFile(oversizedSource, 'markdown'),
+        'private',
+        [],
+        null,
+      )
+      if (oversized.kind !== 'ok') throw new Error('publish failed')
+      await db
+        .updateTable('shareables')
+        .set({
+          updated_at: `9999-12-31T23:59:${String(index).padStart(2, '0')}.999Z`,
+        })
+        .where('id', '=', oversized.id)
+        .execute()
+    }
+    storageMock.getArtifact.mockResolvedValue({
+      text: async () => oversizedSource,
+      size: oversizedSource.length,
+    })
+
+    const listed = await callMcp(db, 'resources/list')
+    const resources = listed.result?.resources as Array<{ uri?: string }>
+    expect(storageMock.getArtifact).toHaveBeenCalledTimes(10)
+    expect(resources.map((resource) => resource.uri)).toContain(
+      `https://artifactshare.com/a/${small.id}`,
+    )
+  })
+
   test('returns 50 readable resources without letting a newer oversized artifact displace one', async () => {
     const user = await loadMcpUser(db, 'owner-1')
     if (!user) throw new Error('seed failed')


### PR DESCRIPTION
## Summary

- expose readable Artifact Share Markdown and HTML artifacts through MCP `resources/list`
- return each resource's display title, canonical URL, stable id, and MIME type using standard MCP fields
- keep link-only URLs out of discovery unless the authenticated user has identity-bound access, and recheck current cross-workspace project audience membership
- bound each catalog response to 50 resources, 100 database candidates, and 10 exact source-length validations

## Validation

- `pnpm validate:static`
  - formatting, lint, D1 compatibility, schema, type checks, React Doctor (100), and public repository scan (0 findings)
  - 3,378 web unit tests passed; 1 skipped
  - 12 D1 tests and 81 qm-bridge tests passed
- `pnpm --filter @artifactshare/web exec vitest --config vitest.config.ts --run app/services/mcp/tools.server.test.ts`
  - 154 tests passed
- `pnpm review:implementation`
  - final committed review completed with no blocking findings
- trusted `origin/main` public-development boundary check passed

## Production verification

After deployment, refresh Artifact Share resources in Claude Projects and verify both flows:

- selecting an artifact from the Resource list shows its Artifact Share title and URL
- pasting an Artifact Share URL directly continues to load the artifact and is checked for title display separately
