### PR TITLE
Show Artifact Share titles in MCP resource pickers

### DIFF
--- a/apps/web/app/services/mcp/artifact-resource.server.ts
+++ b/apps/web/app/services/mcp/artifact-resource.server.ts
@@ -88,6 +88,7 @@ export function registerArtifactResource(
           uri: string
           name: string
           title: string
+          description: string
           mimeType: string
         }> = []
         let cursor: { updatedAt: string; id: string } | null = null
@@ -242,14 +243,20 @@ export function registerArtifactResource(
             )
               continue
 
+            const uri = `${appOrigin}/a/${row.id}`
+            const title = displayTitle({
+              titleOverride: row.title_override,
+              derivedTitle: row.derived_title,
+              name: row.name,
+            })
             resources.push({
-              uri: `${appOrigin}/a/${row.id}`,
-              name: row.id,
-              title: displayTitle({
-                titleOverride: row.title_override,
-                derivedTitle: row.derived_title,
-                name: row.name,
-              }),
+              uri,
+              // Some MCP clients still render `name` even when `title` is
+              // present. Keep the human-readable value in both fields while
+              // the URI remains the resource's stable identity.
+              name: title,
+              title,
+              description: uri,
               mimeType:
                 row.artifact_kind === 'markdown_page'
                   ? 'text/markdown'

--- a/apps/web/app/services/mcp/artifact-resource.server.ts
+++ b/apps/web/app/services/mcp/artifact-resource.server.ts
@@ -252,11 +252,13 @@ export function registerArtifactResource(
             resources.push({
               uri,
               // Some MCP clients still render `name` even when `title` is
-              // present. Keep the human-readable value in both fields while
-              // the URI remains the resource's stable identity.
-              name: title,
+              // present. Lead with the human-readable title and retain the
+              // unique URI so name-keying clients do not collapse duplicates.
+              name: `${title} — ${uri}`,
               title,
-              description: uri,
+              description: `Current ${
+                row.artifact_kind === 'markdown_page' ? 'Markdown' : 'HTML'
+              } source from Artifact Share.`,
               mimeType:
                 row.artifact_kind === 'markdown_page'
                   ? 'text/markdown'

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -907,16 +907,16 @@ describe('headless publish wiring', () => {
       expect.arrayContaining([
         expect.objectContaining({
           uri: `https://artifactshare.com/a/${markdown.id}`,
-          name: 'Custom title',
+          name: `Custom title — https://artifactshare.com/a/${markdown.id}`,
           title: 'Custom title',
-          description: `https://artifactshare.com/a/${markdown.id}`,
+          description: 'Current Markdown source from Artifact Share.',
           mimeType: 'text/markdown',
         }),
         expect.objectContaining({
           uri: `https://artifactshare.com/a/${html.id}`,
-          name: 'HTML title',
+          name: `HTML title — https://artifactshare.com/a/${html.id}`,
           title: 'HTML title',
-          description: `https://artifactshare.com/a/${html.id}`,
+          description: 'Current HTML source from Artifact Share.',
           mimeType: 'text/html',
         }),
         expect.objectContaining({ uri: 'ui://artifact-preview.html' }),

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -907,14 +907,16 @@ describe('headless publish wiring', () => {
       expect.arrayContaining([
         expect.objectContaining({
           uri: `https://artifactshare.com/a/${markdown.id}`,
-          name: markdown.id,
+          name: 'Custom title',
           title: 'Custom title',
+          description: `https://artifactshare.com/a/${markdown.id}`,
           mimeType: 'text/markdown',
         }),
         expect.objectContaining({
           uri: `https://artifactshare.com/a/${html.id}`,
-          name: html.id,
+          name: 'HTML title',
           title: 'HTML title',
+          description: `https://artifactshare.com/a/${html.id}`,
           mimeType: 'text/html',
         }),
         expect.objectContaining({ uri: 'ui://artifact-preview.html' }),


### PR DESCRIPTION
## What

- expose each artifact as `title — canonical URL` through the MCP Resource `name`
- keep the standard human-readable `title` metadata unchanged
- describe whether the listed resource is current Markdown or HTML source
- cover the exact MCP metadata in the resource-list test

## Why

Some custom-connector clients render the required Resource `name` even when the optional human-readable `title` is present. Returning the display title through both fields makes artifacts identifiable in those clients, while retaining the unique canonical URL in the rendered name.

## Validation

- `pnpm validate:static`
- `pnpm --dir apps/web exec vitest --config vitest.config.ts --run app/services/mcp/tools.server.test.ts` (154 tests)
- Codex and Claude implementation reviews: no unresolved findings
