### PR TITLE
MCPの内部プレビューResourceを一覧から除外する

### DIFF
--- a/apps/web/app/services/mcp/artifact-resource.server.ts
+++ b/apps/web/app/services/mcp/artifact-resource.server.ts
@@ -1,6 +1,7 @@
 import {
   ResourceTemplate,
   type McpServer,
+  type RegisteredResourceTemplate,
 } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { displayTitle } from '~/lib/display-title'
@@ -61,10 +62,10 @@ async function enforcePerUserLimit(ctx: McpRequestContext): Promise<void> {
 export function registerArtifactResource(
   server: McpServer,
   ctx: McpRequestContext,
-): void {
+): RegisteredResourceTemplate {
   const appOrigin = new URL(ctx.baseUrl).origin
 
-  server.registerResource(
+  return server.registerResource(
     'artifact',
     new ResourceTemplate(artifactResourceTemplate(appOrigin), {
       list: async () => {

--- a/apps/web/app/services/mcp/server.server.ts
+++ b/apps/web/app/services/mcp/server.server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { ListResourcesRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker'
 import { mcpResourceUrl } from '~/lib/mcp-metadata'
 import type { McpRequestContext } from './identity.server'
@@ -27,11 +28,24 @@ export function createMcpServer(ctx: McpRequestContext): McpServer {
     jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
   })
   registerArtifactTools(server, ctx)
-  registerArtifactResource(server, ctx)
+  const artifactResource = registerArtifactResource(server, ctx)
   registerArtifactPreviewResource(
     server,
     new URL(ctx.baseUrl).origin,
     mcpResourceUrl(ctx.baseUrl),
+  )
+
+  const listArtifacts = artifactResource.resourceTemplate.listCallback
+  if (!listArtifacts) {
+    throw new Error('Artifact resource listing is unavailable.')
+  }
+
+  // The SDK includes every static resource in resources/list. Keep the
+  // ui:// preview readable for MCP Apps, but expose only user-selectable
+  // artifacts through resource discovery.
+  server.server.setRequestHandler(
+    ListResourcesRequestSchema,
+    (_request, extra) => listArtifacts(extra),
   )
   return server
 }

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -893,13 +893,15 @@ describe('headless publish wiring', () => {
 
     const templates = await callMcp(db, 'resources/templates/list')
     expect(templates.error).toBeUndefined()
-    expect(templates.result?.resourceTemplates).toContainEqual({
-      name: 'artifact',
-      uriTemplate: 'https://artifactshare.com/a/{id}',
-      title: 'Artifact Share artifact',
-      description:
-        'Reads the current Markdown or HTML source of an Artifact Share artifact.',
-    })
+    expect(templates.result?.resourceTemplates).toEqual([
+      {
+        name: 'artifact',
+        uriTemplate: 'https://artifactshare.com/a/{id}',
+        title: 'Artifact Share artifact',
+        description:
+          'Reads the current Markdown or HTML source of an Artifact Share artifact.',
+      },
+    ])
 
     const listed = await callMcp(db, 'resources/list')
     expect(listed.error).toBeUndefined()
@@ -919,9 +921,24 @@ describe('headless publish wiring', () => {
           description: 'Current HTML source from Artifact Share.',
           mimeType: 'text/html',
         }),
+      ]),
+    )
+    expect(listed.result?.resources).not.toEqual(
+      expect.arrayContaining([
         expect.objectContaining({ uri: 'ui://artifact-preview.html' }),
       ]),
     )
+
+    const preview = await callMcp(db, 'resources/read', {
+      uri: 'ui://artifact-preview.html',
+    })
+    expect(preview.error).toBeUndefined()
+    expect(preview.result?.contents).toEqual([
+      expect.objectContaining({
+        uri: 'ui://artifact-preview.html',
+        mimeType: 'text/html;profile=mcp-app',
+      }),
+    ])
   })
 
   test('does not reveal link-only artifacts in the resource list without identity-bound access', async () => {


### PR DESCRIPTION
## 現状

MCP Appsのカード描画に使う内部UI Resourceが、通常の成果物と一緒に`resources/list`へ含まれていました。そのため、Resourceをコンテキストとして選択するクライアントでは、読み込み対象ではないUIテンプレートが候補に表示されます。

## 変更

- ユーザーが選択できる成果物だけを`resources/list`から返すようにしました
- 内部UI Resourceは`resources/read`で引き続き取得でき、MCP Appsのカード描画契約を維持します
- UI Resourceが一覧とテンプレート一覧へ出ず、直接読み取りは成功することをテストしました

## 検証

- `pnpm exec vitest --config vitest.config.ts --run app/services/mcp/tools.server.test.ts app/services/mcp/preview-widget.server.test.ts`（157 tests passed）
- `pnpm --filter web typecheck`
- `pnpm public:scan .`（0 findings）
- `pnpm validate:static`
- `pnpm review:implementation`（Codex / Claude、blockerなし）
