### PR TITLE
MCPツール説明を機能範囲へ限定

### DIFF
--- a/apps/web/app/lib/cli-capability-matrix.json
+++ b/apps/web/app/lib/cli-capability-matrix.json
@@ -2157,7 +2157,7 @@
           "kind": "reference",
           "path": "apps/web/app/services/mcp/tools.server.ts",
           "identifier": "share_artifact",
-          "recovery_identifier": "If the user already has a local file or folder, use the CLI instead",
+          "recovery_identifier": "MCP cannot read the user’s filesystem",
           "scope": {
             "kind": "mcp_tool",
             "name": "share_artifact"
@@ -2165,7 +2165,7 @@
           "contract_identifiers": {
             "mcp_name": ["'share_artifact'"],
             "mcp_description": [
-              "Share a single HTML or Markdown artifact and get a stable link back. Use when the user wants to shar"
+              "Share one HTML or Markdown document from the content input and return its stable Artifact Share link"
             ],
             "mcp_input": [
               "content",
@@ -2186,9 +2186,7 @@
               "visibility_label",
               "warnings"
             ],
-            "mcp_recovery": [
-              "If the user already has a local file or folder, use the CLI instead"
-            ]
+            "mcp_recovery": ["MCP cannot read the user’s filesystem"]
           }
         }
       },
@@ -2538,7 +2536,7 @@
           "kind": "reference",
           "path": "apps/web/app/services/mcp/tools.server.ts",
           "identifier": "update_artifact",
-          "recovery_identifier": "If you do not know the id, call list_artifacts first",
+          "recovery_identifier": "Use an artifact id returned by share_artifact or list_artifacts",
           "scope": {
             "kind": "mcp_tool",
             "name": "update_artifact"
@@ -2546,7 +2544,7 @@
           "contract_identifiers": {
             "mcp_name": ["'update_artifact'"],
             "mcp_description": [
-              "Replace an existing artifact with a new version. The share link stays the same. Pass the new full HT"
+              "Replace an existing artifact with a new HTML or Markdown version while keeping the same share link"
             ],
             "mcp_input": ["id", "content", "format"],
             "mcp_output": [
@@ -2559,7 +2557,7 @@
               "version_id"
             ],
             "mcp_recovery": [
-              "If you do not know the id, call list_artifacts first"
+              "Use an artifact id returned by share_artifact or list_artifacts"
             ]
           }
         }

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -746,6 +746,9 @@ describe('headless publish wiring', () => {
     const tools = body.result?.tools as Array<{
       name?: string
       description?: string
+      inputSchema?: {
+        properties?: Record<string, { description?: string }>
+      }
     }>
     const byName = new Map(tools.map((tool) => [tool.name, tool.description]))
     const names = tools.map((tool) => tool.name)
@@ -765,6 +768,13 @@ describe('headless publish wiring', () => {
     )
     expect(byName.get('append_artifact')).toContain(
       'No newline or separator is inserted',
+    )
+    expect(byName.get('append_artifact')).toContain(
+      'read the artifact with get_artifact before retrying',
+    )
+    const share = tools.find((tool) => tool.name === 'share_artifact')
+    expect(share?.inputSchema?.properties?.visibility?.description).toContain(
+      'private for a personal account',
     )
   })
 

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -694,22 +694,6 @@ describe('headless publish wiring', () => {
     expect(await loadMcpUser(db, 'nobody')).toBeNull()
   })
 
-  test('tools list advertises "as" as a short Artifact Share name', async () => {
-    const body = await callMcp(db, 'tools/list')
-    const tools = body.result?.tools as Array<{
-      name?: string
-      description?: string
-    }>
-
-    expect(tools.length).toBeGreaterThan(0)
-    expect(tools.every((tool) => tool.description?.includes('"as"'))).toBe(true)
-    expect(
-      tools.every((tool) =>
-        tool.description?.includes('If the user says "Artifact Share"'),
-      ),
-    ).toBe(true)
-  })
-
   test('tools list advertises accurate tool annotations', async () => {
     const body = await callMcp(db, 'tools/list')
     const tools = body.result?.tools as Array<{
@@ -757,7 +741,7 @@ describe('headless publish wiring', () => {
     }
   })
 
-  test('share and update descriptions direct local files to the CLI', async () => {
+  test('write tool descriptions stay scoped to MCP behavior', async () => {
     const body = await callMcp(db, 'tools/list')
     const tools = body.result?.tools as Array<{
       name?: string
@@ -774,74 +758,31 @@ describe('headless publish wiring', () => {
     expect(names).toContain('reopen_comment')
 
     expect(byName.get('share_artifact')).toContain(
-      'pass the full HTML or Markdown source in content, not a local file path',
-    )
-    expect(byName.get('share_artifact')).toContain(
-      'npm exec --yes --package=@artifactshare/cli -- artifactshare share <path>',
+      'Share one HTML or Markdown document from the content input',
     )
     expect(byName.get('update_artifact')).toContain(
-      'Pass the new full HTML or Markdown source in content, not a local file path',
-    )
-    expect(byName.get('update_artifact')).toContain(
-      'npm exec --yes --package=@artifactshare/cli -- artifactshare update <share-url> <path>',
+      'The content input must contain the complete new source',
     )
     expect(byName.get('append_artifact')).toContain(
       'No newline or separator is inserted',
     )
-    expect(byName.get('append_artifact')).toContain(
-      'npm exec --yes --package=@artifactshare/cli -- artifactshare append <share-url> <path>',
-    )
   })
 
-  test('tool descriptions share one routing boundary and write-tool auth recovery', async () => {
+  test('tool descriptions do not contain client routing or authentication instructions', async () => {
     const body = await callMcp(db, 'tools/list')
     const tools = body.result?.tools as Array<{
       name?: string
       description?: string
     }>
     const descriptions = tools.map((tool) => tool.description ?? '')
-    const writes = new Set([
-      'share_artifact',
-      'update_artifact',
-      'append_artifact',
-    ])
-
-    expect(
-      descriptions.every((description) =>
-        description.includes('Honor an explicit route choice'),
-      ),
-    ).toBe(true)
-    expect(
-      descriptions.every((description) =>
-        description.includes('otherwise route by capabilities'),
-      ),
-    ).toBe(true)
-    for (const tool of tools) {
-      if (!writes.has(tool.name ?? '')) {
-        expect(tool.description).not.toContain('auth_required')
-      } else {
-        expect(tool.description).toContain('MCP OAuth is separate')
-        expect(tool.description).toContain('auth_required')
-      }
+    for (const description of descriptions) {
+      expect(description).not.toContain('Honor an explicit route choice')
+      expect(description).not.toContain('otherwise route by capabilities')
+      expect(description).not.toContain('MCP OAuth is separate')
+      expect(description).not.toContain('auth_required')
+      expect(description).not.toContain('npm exec')
+      expect(description).not.toContain('briefly mention')
     }
-
-    const byName = new Map(
-      tools.map((tool) => [tool.name, tool.description ?? '']),
-    )
-    for (const name of writes) {
-      expect(byName.get(name)?.toLowerCase()).toContain(
-        'when no explicit route was chosen',
-      )
-    }
-    expect(byName.get('share_artifact')).toContain('temporary sandbox')
-    expect(byName.get('share_artifact')).toContain(
-      'the coding agent has a user-controlled workspace',
-    )
-    expect(byName.get('update_artifact')).toContain('temporary sandbox')
-    expect(byName.get('append_artifact')).toContain('temporary sandbox')
-    expect(byName.get('share_artifact')).toContain('user-controlled workspace')
-    expect(byName.get('update_artifact')).toContain('user-controlled workspace')
-    expect(byName.get('append_artifact')).toContain('user-controlled workspace')
   })
 
   test('get_artifact description names readback fields and continuation', async () => {

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -492,7 +492,7 @@ export function registerArtifactTools(
           .enum(['workspace', 'private', 'link'])
           .optional()
           .describe(
-            'Who can view it. "workspace" = everyone in the company; "private" = only the people listed in grant_emails; "link" = anyone with the URL. When omitted, the default is the project sharing scope if project_id is set, otherwise workspace.',
+            'Who can view it. "workspace" = everyone in the company; "private" = only the people listed in grant_emails; "link" = anyone with the URL. When omitted, a project uses its sharing scope; an unfiled artifact defaults to workspace for an organization account and private for a personal account.',
           ),
         link_expires_at: z
           .string()
@@ -781,7 +781,7 @@ export function registerArtifactTools(
     {
       title: 'Append to artifact',
       description: toolDescription(
-        'Append content exactly as provided to an existing single-file artifact and create a version at the same share link. No newline or separator is inserted. Markdown content is added at the end; HTML content is inserted immediately before a closing body tag, or at the end when no closing body tag exists. Static sites are not supported.',
+        'Append content exactly as provided to an existing single-file artifact and create a version at the same share link. No newline or separator is inserted. Markdown content is added at the end; HTML content is inserted immediately before a closing body tag, or at the end when no closing body tag exists. Static sites are not supported. After a transport error, read the artifact with get_artifact before retrying because the append may already have succeeded.',
       ),
       outputSchema: UPDATE_OUTPUT_SCHEMA,
       annotations: PUBLIC_WRITE_ANNOTATIONS,

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -94,10 +94,6 @@ const MAX_TITLE_OVERRIDE_LENGTH = 200
 // seconds, so this only needs to be long enough to absorb retries — not so long
 // that a deliberate re-publish of the same content reuses the old artifact.
 const IDEMPOTENCY_WINDOW_MS = 10 * 60_000
-const TOOL_ALIAS_HINT =
-  'Artifact Share is also called "as"; use these tools when the user says "as". If the user says "Artifact Share" or "artifactshare", briefly mention they can call it "as" next time. '
-const TOOL_ROUTING_HINT =
-  'Honor an explicit route choice; otherwise route by capabilities: MCP for chat/sandboxes, CLI for capable coding agents. '
 const CONNECT_AI_AGENTS_URL = `https://${APEX_HOST}/connect#${CONNECT_AI_AGENTS_ANCHOR}`
 
 // Text content is the universal baseline: every host can render a tool's text
@@ -387,7 +383,7 @@ const DESTRUCTIVE_ANNOTATIONS = {
 } as const
 
 function toolDescription(description: string): string {
-  return `${TOOL_ALIAS_HINT}${TOOL_ROUTING_HINT}${description}`
+  return description
 }
 
 export function registerArtifactTools(
@@ -471,7 +467,7 @@ export function registerArtifactTools(
     {
       title: 'Share artifact',
       description: toolDescription(
-        'Share a single HTML or Markdown artifact and get a stable link back. Use when the user wants to share source text produced in chat or a temporary sandbox: pass the full HTML or Markdown source in content, not a local file path; a temporary path such as /mnt/data existing alone is not a reason to try the CLI. When no explicit route was chosen and the coding agent has a user-controlled workspace, CLI package access, and Artifact Share network access, this instruction applies: If the user already has a local file or folder, use the CLI instead: `npm exec --yes --package=@artifactshare/cli -- artifactshare share <path>`. MCP OAuth is separate from CLI auth; if the CLI reports `auth_required`, follow its recovery to set up or reuse a CLI profile. Embed any images directly in the content as base64 data: URIs so the artifact is one self-contained file — temporary or external image URLs will not display for viewers. Defaults to everyone in the workspace; personal Google accounts default to specific people. Set visibility to "link" for unauthenticated link sharing and use link_expires_at to choose a future RFC3339 UTC expiry or null for unlimited expiry. Omit it to use the workspace default. Pass project_id (from list_projects) to file it under a project instead of the unfiled inbox. If the result includes warnings, tell the user each warning explicitly.',
+        'Share one HTML or Markdown document from the content input and return its stable Artifact Share link. Images must be embedded as base64 data URIs. The visibility input controls who can view the artifact, and project_id files it under an existing project.',
       ),
       outputSchema: ARTIFACT_OUTPUT_SCHEMA,
       annotations: PUBLIC_WRITE_ANNOTATIONS,
@@ -682,7 +678,7 @@ export function registerArtifactTools(
     {
       title: 'Update artifact',
       description: toolDescription(
-        'Replace an existing artifact with a new version. The share link stays the same. Pass the new full HTML or Markdown source in content, not a local file path. In chat or a temporary sandbox, keep the source inline. When no explicit route was chosen, use the CLI for a coding agent with a user-controlled workspace, CLI package access, and Artifact Share network access: `npm exec --yes --package=@artifactshare/cli -- artifactshare update <share-url> <path>`. MCP OAuth is separate from CLI auth; if the CLI reports `auth_required`, follow its recovery to set up or reuse a profile. If you do not know the id, call list_artifacts first.',
+        'Replace an existing artifact with a new HTML or Markdown version while keeping the same share link. The content input must contain the complete new source. Use an artifact id returned by share_artifact or list_artifacts.',
       ),
       outputSchema: UPDATE_OUTPUT_SCHEMA,
       annotations: PUBLIC_WRITE_ANNOTATIONS,
@@ -785,7 +781,7 @@ export function registerArtifactTools(
     {
       title: 'Append to artifact',
       description: toolDescription(
-        'Append content exactly as provided to an existing single-file artifact. Use inline source in chat or a temporary sandbox; when no explicit route was chosen, use the CLI for a coding agent with a user-controlled workspace, CLI package access, and Artifact Share network access: `npm exec --yes --package=@artifactshare/cli -- artifactshare append <share-url> <path>`. MCP OAuth is separate from CLI auth; follow the CLI `auth_required` recovery to set up or reuse a profile. No newline or separator is inserted. For Markdown, add it to the end of the current source with no separator. For HTML, insert it immediately before an ASCII case-insensitive </body> closing tag; if none exists, add it at the end. A new version is created at the same share URL. Retry the same append_artifact call after version_conflict to append to the latest version without overwriting the earlier update. After a transport error, call get_artifact before retrying because the append may have committed. Inspect the source end for Markdown; for HTML, inspect immediately before the selected closing body tag, or the source end when that tag is absent. Static sites are not supported.',
+        'Append content exactly as provided to an existing single-file artifact and create a version at the same share link. No newline or separator is inserted. Markdown content is added at the end; HTML content is inserted immediately before a closing body tag, or at the end when no closing body tag exists. Static sites are not supported.',
       ),
       outputSchema: UPDATE_OUTPUT_SCHEMA,
       annotations: PUBLIC_WRITE_ANNOTATIONS,


### PR DESCRIPTION
## Change

Limit MCP tool descriptions to each tool's own behavior and inputs. Remove cross-client routing, CLI command, authentication-recovery, and marketing instructions from advertised tool metadata so hosts can present write approvals without treating the metadata as unrelated instructions.

Keep the functional contracts needed for safe use: personal-account visibility defaults and append recovery after an ambiguous transport failure.

## Validation

- `pnpm --dir apps/web exec vitest --config vitest.config.ts --run app/services/mcp/tools.server.test.ts` — 153 tests passed.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm check:cli-reference` — passed.
- `pnpm format` — passed.
- `pnpm public:scan .` — 0 findings.
- `pnpm validate:static` — passed; 3377 tests passed, 1 skipped; React Doctor score 100.
- Pull-request boundary guard from a clean `origin/main` worktree — passed.

## Review

Codex and Claude both deeply reviewed final HEAD `bd378ce34354` with no unresolved blockers. The first review found that append retry safety guidance and the personal-account visibility default still needed to be advertised; both were restored as narrowly scoped MCP contracts. After CI exposed stale generated-reference identifiers, those identifiers were synchronized and the final commit passed both reviewers again. No follow-ups were deferred.
