### PR TITLE
OpenAI審査向けMCP hintと同梱スキルを整備

### DIFF
--- a/apps/web/app/services/mcp/skills/artifact-share/SKILL.md
+++ b/apps/web/app/services/mcp/skills/artifact-share/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: artifact-share
+description: Share, update, find, read, comment on, and organize HTML or Markdown artifacts with Artifact Share. Use when the user asks to save or manage content in Artifact Share or wants a durable Artifact Share link.
+---
+
+# Artifact Share
+
+Use the connected Artifact Share MCP tools for live data and changes. Do not
+claim that an operation succeeded unless the tool result confirms it.
+
+## Choose the workflow
+
+- For a new artifact, call `share_artifact` with complete HTML or Markdown
+  source. Respect an explicit visibility, project, audience, expiry, or Slack
+  notification choice. Do not invent recipients or widen visibility.
+- To replace content at the same URL, find the artifact if necessary, then call
+  `update_artifact` with the complete replacement source. Use
+  `append_artifact` only when the user explicitly wants to add exact content to
+  the existing source.
+- When the user identifies an artifact by title, use `list_artifacts` and
+  require one exact match before a read or mutation. Ask the user to choose if
+  there is no unique exact match.
+- Use `get_artifact` for source and version history, `preview_artifact` for the
+  interactive card, and `list_comments` before acting on an existing comment
+  thread.
+- Use project and settings tools only for the requested organizational or
+  sharing change. Never infer email addresses, project IDs, or access changes.
+
+## Unsupported inputs
+
+`share_artifact` accepts source text for one HTML or Markdown document. It
+cannot upload PDFs, office documents, arbitrary binary files, local paths, or
+static-site folders. Explain the limitation instead of converting the content
+or calling the tool unless the user explicitly asks for an HTML or Markdown
+alternative.
+
+## Confirm results and risky changes
+
+- After sharing, updating, appending, or editing an artifact, include the full
+  returned `share_url` and the returned visibility when present in the final
+  response.
+- For destructive or access-changing tools, preserve the host confirmation
+  step. Call them only when the user clearly requested that exact change.
+- If a tool reports that authentication, permission, plan, storage, or a
+  destination prevents the operation, report that reason and the stated next
+  step. Do not retry an unchanged destructive request.

--- a/apps/web/app/services/mcp/skills/artifact-share/agents/openai.yaml
+++ b/apps/web/app/services/mcp/skills/artifact-share/agents/openai.yaml
@@ -1,0 +1,10 @@
+interface:
+  display_name: 'Artifact Share'
+  short_description: 'Share and manage web artifacts'
+dependencies:
+  tools:
+    - type: 'mcp'
+      value: 'artifact-share'
+      description: 'Artifact Share MCP server'
+      transport: 'streamable_http'
+      url: 'https://artifactshare.com/mcp'

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -720,10 +720,16 @@ describe('headless publish wiring', () => {
     for (const name of ['post_comment', 'create_project', 'edit_project']) {
       expect(byName.get(name)?.openWorldHint).toBe(false)
     }
-    for (const name of ['delete_artifact', 'delete_comment']) {
+    for (const name of ['delete_comment', 'update_comment', 'edit_project']) {
       expect(byName.get(name)).toMatchObject({
         destructiveHint: true,
         openWorldHint: false,
+      })
+    }
+    for (const name of ['share_artifact', 'edit_artifact', 'delete_artifact']) {
+      expect(byName.get(name)).toMatchObject({
+        destructiveHint: true,
+        openWorldHint: true,
       })
     }
     for (const name of [

--- a/apps/web/app/services/mcp/tools.server.test.ts
+++ b/apps/web/app/services/mcp/tools.server.test.ts
@@ -726,7 +726,12 @@ describe('headless publish wiring', () => {
         openWorldHint: false,
       })
     }
-    for (const name of ['share_artifact', 'edit_artifact', 'delete_artifact']) {
+    for (const name of [
+      'share_artifact',
+      'update_artifact',
+      'edit_artifact',
+      'delete_artifact',
+    ]) {
       expect(byName.get(name)).toMatchObject({
         destructiveHint: true,
         openWorldHint: true,

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -353,7 +353,6 @@ const WHOAMI_OUTPUT_SCHEMA = {
 
 // Write tools that can create or change link-visible content are open-world;
 // other writes and comment tools only affect the closed, authenticated system.
-// All non-delete writes retain history, so they aren't destructive.
 const READ_ONLY_ANNOTATIONS = {
   readOnlyHint: true,
   destructiveHint: false,
@@ -685,7 +684,7 @@ export function registerArtifactTools(
         'Replace an existing artifact with a new HTML or Markdown version while keeping the same share link. The content input must contain the complete new source. Use an artifact id returned by share_artifact or list_artifacts.',
       ),
       outputSchema: UPDATE_OUTPUT_SCHEMA,
-      annotations: PUBLIC_WRITE_ANNOTATIONS,
+      annotations: PUBLIC_DESTRUCTIVE_ANNOTATIONS,
       inputSchema: {
         id: z
           .string()

--- a/apps/web/app/services/mcp/tools.server.ts
+++ b/apps/web/app/services/mcp/tools.server.ts
@@ -372,14 +372,18 @@ const PUBLIC_WRITE_ANNOTATIONS = {
   openWorldHint: true,
 } as const
 
-// Irreversible deletes carry destructiveHint so a host can prompt the user
-// before the call runs. The version history goes with the artifact, so there is
-// no undo — distinct from publish / update, which retain prior versions.
+// Overwrites, access revocation, irreversible messages, and deletes carry
+// destructiveHint so a host can confirm them before the call runs.
 const DESTRUCTIVE_ANNOTATIONS = {
   readOnlyHint: false,
   destructiveHint: true,
   idempotentHint: false,
   openWorldHint: false,
+} as const
+
+const PUBLIC_DESTRUCTIVE_ANNOTATIONS = {
+  ...DESTRUCTIVE_ANNOTATIONS,
+  openWorldHint: true,
 } as const
 
 function toolDescription(description: string): string {
@@ -470,7 +474,7 @@ export function registerArtifactTools(
         'Share one HTML or Markdown document from the content input and return its stable Artifact Share link. Images must be embedded as base64 data URIs. The visibility input controls who can view the artifact, and project_id files it under an existing project.',
       ),
       outputSchema: ARTIFACT_OUTPUT_SCHEMA,
-      annotations: PUBLIC_WRITE_ANNOTATIONS,
+      annotations: PUBLIC_DESTRUCTIVE_ANNOTATIONS,
       inputSchema: {
         content: z
           .string()
@@ -1200,7 +1204,7 @@ export function registerArtifactTools(
         'Edit a comment you wrote. Identify the thread with thread_id and the message with message_id (both from list_comments). Pass body with the new text — you can only edit your own comments.',
       ),
       outputSchema: UPDATE_COMMENT_OUTPUT_SCHEMA,
-      annotations: WRITE_ANNOTATIONS,
+      annotations: DESTRUCTIVE_ANNOTATIONS,
       inputSchema: {
         thread_id: z
           .string()
@@ -1530,7 +1534,7 @@ export function registerArtifactTools(
         "Change a project's settings in one call: rename it, edit its description, change its sharing scope, add or remove people from its audience, and archive or unarchive it. Pass only the fields you want to change; omitted fields are left as-is. The audience (add_emails / remove_emails) is who can view the project's private-scoped artifacts, including people outside the workspace. Set archived to true to hide the project from the active list, or false to bring it back. Only the project's creator or a workspace admin can edit it. Editing a project's name, description, scope, or audience requires it to be active — pass archived: false in the same call to unarchive and edit it together.",
       ),
       outputSchema: EDIT_PROJECT_OUTPUT_SCHEMA,
-      annotations: WRITE_ANNOTATIONS,
+      annotations: DESTRUCTIVE_ANNOTATIONS,
       inputSchema: {
         id: z
           .string()
@@ -1620,7 +1624,7 @@ export function registerArtifactTools(
         'Change an artifact\'s settings in one call: rename it, change who can view it, set or clear a link expiry, add or remove specific viewers, and file it under a project or back to the unfiled inbox. Pass only the fields you want to change; omitted fields are left as-is. The share link and version history stay the same — use update_artifact instead to replace the content. visibility "workspace" = everyone in the company, "private" = only the people you share with, and "link" = anyone with the URL. For an existing link, omitted link_expires_at preserves its current expiry; null requests unlimited expiry when allowed. To change the location, set project_id to a project id (from list_projects), or to "" (empty string) to return it to the unfiled inbox; omit project_id to leave the location unchanged. Moving never widens who can view it.',
       ),
       outputSchema: EDIT_OUTPUT_SCHEMA,
-      annotations: PUBLIC_WRITE_ANNOTATIONS,
+      annotations: PUBLIC_DESTRUCTIVE_ANNOTATIONS,
       inputSchema: {
         id: z
           .string()
@@ -1702,7 +1706,7 @@ export function registerArtifactTools(
         'Permanently delete an artifact you published, including its entire version history. This cannot be undone and the share link stops working. Only the owner can delete it. To stop sharing without deleting, use edit_artifact to set visibility to "private" instead.',
       ),
       outputSchema: DELETE_OUTPUT_SCHEMA,
-      annotations: DESTRUCTIVE_ANNOTATIONS,
+      annotations: PUBLIC_DESTRUCTIVE_ANNOTATIONS,
       inputSchema: {
         id: z
           .string()


### PR DESCRIPTION
## Summary

- align MCP tool hints with OpenAI review semantics for overwrites, access revocation, irreversible notifications, and public-link deletion
- add a focused Artifact Share skill for direct upload with the MCP-backed plugin submission
- cover the revised annotation contract in the MCP tool-list test

The skill bundle is intentionally uploaded through the submission form rather than imported from MCP discovery.

## Validation

- `pnpm validate:static`
- `pnpm --filter @artifactshare/web exec vitest --config vitest.config.ts --run app/services/mcp/tools.server.test.ts` (153 passed)
- skill structure validation with the OpenAI skill creator validator
- generated submission JSON validated against the current official OpenAI schema

## Review

- Codex implementation review: no blockers on `877d3bc`
- Claude implementation review: no findings on `877d3bc`
