### PR TITLE
fix: keep the per-ID viewer host crawlable for link previews

### DIFF
--- a/apps/web/workers/app.test.ts
+++ b/apps/web/workers/app.test.ts
@@ -255,6 +255,19 @@ describe('app worker link-domain routing', () => {
     expect(requestHandlerMock).not.toHaveBeenCalled()
   })
 
+  test('marks every viewer-host response noindex for crawlers', async () => {
+    for (const path of ['/', '/a/abc123def4/og-image', '/a/abc123def4.data']) {
+      requestHandlerMock.mockClear()
+      const response = await app.fetch(
+        workerRequest(`https://abc123def4.artifactshare.link${path}`),
+        productionEnv({ maintenance: false }),
+        executionContext(),
+      )
+      expect(response.status).toBe(200)
+      expect(response.headers.get('x-robots-tag')).toBe('noindex, nofollow')
+    }
+  })
+
   test('serves a crawlable robots response without entering the app', async () => {
     const response = await app.fetch(
       workerRequest('https://abc123def4.artifactshare.link/robots.txt'),
@@ -263,7 +276,9 @@ describe('app worker link-domain routing', () => {
     )
 
     expect(response.status).toBe(200)
-    await expect(response.text()).resolves.toBe('User-agent: *\nAllow: /\n')
+    await expect(response.text()).resolves.toBe(
+      'User-agent: GPTBot\nDisallow: /\n\nUser-agent: *\nAllow: /\n',
+    )
     expect(response.headers.get('cache-control')).toBe('private, no-store')
     expect(requestHandlerMock).not.toHaveBeenCalled()
   })

--- a/apps/web/workers/app.test.ts
+++ b/apps/web/workers/app.test.ts
@@ -255,7 +255,7 @@ describe('app worker link-domain routing', () => {
     expect(requestHandlerMock).not.toHaveBeenCalled()
   })
 
-  test('serves a disallow-all robots response without entering the app', async () => {
+  test('serves a crawlable robots response without entering the app', async () => {
     const response = await app.fetch(
       workerRequest('https://abc123def4.artifactshare.link/robots.txt'),
       productionEnv({ maintenance: false }),
@@ -263,7 +263,7 @@ describe('app worker link-domain routing', () => {
     )
 
     expect(response.status).toBe(200)
-    await expect(response.text()).resolves.toBe('User-agent: *\nDisallow: /\n')
+    await expect(response.text()).resolves.toBe('User-agent: *\nAllow: /\n')
     expect(response.headers.get('cache-control')).toBe('private, no-store')
     expect(requestHandlerMock).not.toHaveBeenCalled()
   })

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -279,7 +279,10 @@ function linkDomainRequest(
   const url = new URL(request.url)
   if (developmentHostname) url.hostname = developmentHostname
   if (url.pathname === '/robots.txt') {
-    return new Response('User-agent: *\nDisallow: /\n', {
+    // Preview crawlers (X, Slack, LinkedIn) honor robots.txt, so keep the host
+    // crawlable like the apex; indexing is refused by the noindex meta and
+    // X-Robots-Tag on the viewer page instead.
+    return new Response('User-agent: *\nAllow: /\n', {
       headers: {
         'Cache-Control': 'private, no-store',
         'Content-Type': 'text/plain; charset=utf-8',

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -249,10 +249,11 @@ export default {
     if (linkShareableId) {
       context.set(linkDomainContext, { shareableId: linkShareableId })
     }
-    return requestHandler(
+    const response = await requestHandler(
       requestWithDevelopmentOriginPort(handlerRequest, env),
       context,
     )
+    return linkShareableId ? withLinkHostRobotsHeader(response) : response
   },
 } satisfies ExportedHandler<Cloudflare.Env>
 
@@ -261,6 +262,17 @@ function isIntegrationTest(env: Cloudflare.Env): boolean {
     (env as Cloudflare.Env & { INTEGRATION_TEST?: string }).INTEGRATION_TEST ===
     'true'
   )
+}
+
+const LINK_HOST_ROBOTS_BODY =
+  'User-agent: GPTBot\nDisallow: /\n\nUser-agent: *\nAllow: /\n'
+const LINK_HOST_ROBOTS_HEADER = 'noindex, nofollow'
+
+function withLinkHostRobotsHeader(response: Response): Response {
+  if (response.headers.has('X-Robots-Tag')) return response
+  const copy = new Response(response.body, response)
+  copy.headers.set('X-Robots-Tag', LINK_HOST_ROBOTS_HEADER)
+  return copy
 }
 
 const LINK_DOMAIN_STATIC_PATHS = new Set([
@@ -280,9 +292,10 @@ function linkDomainRequest(
   if (developmentHostname) url.hostname = developmentHostname
   if (url.pathname === '/robots.txt') {
     // Preview crawlers (X, Slack, LinkedIn) honor robots.txt, so keep the host
-    // crawlable like the apex; indexing is refused by the noindex meta and
-    // X-Robots-Tag on the viewer page instead.
-    return new Response('User-agent: *\nAllow: /\n', {
+    // crawlable like the apex. Indexing is refused by the noindex meta on the
+    // viewer page and by the X-Robots-Tag header every viewer-host response
+    // carries; GPTBot is refused as on the apex.
+    return new Response(LINK_HOST_ROBOTS_BODY, {
       headers: {
         'Cache-Control': 'private, no-store',
         'Content-Type': 'text/plain; charset=utf-8',


### PR DESCRIPTION
## Summary

Link previews (X, Slack, LinkedIn) did not render for `https://<id>.artifactshare.link/` because the per-ID viewer host served a disallow-all `robots.txt`, and those preview crawlers honor robots.txt. The viewer page already carries the same Open Graph and Twitter Card tags and image as the apex.

- The viewer host now serves the apex policy: `GPTBot` refused, everyone else allowed.
- Every application response on the viewer host carries `X-Robots-Tag: noindex, nofollow`, so the non-HTML allowed paths (OG image, single-fetch data) also refuse indexing; the viewer page keeps its `noindex, nofollow` meta.

## Validation

- `pnpm validate:static`
- Worker unit tests (`workers/app.test.ts`): robots body, `X-Robots-Tag` on `/`, the OG image path, and the `.data` path
- Codex (Sol/high) + Claude (Opus/xhigh) gate, two rounds; round 2 has no blocker

Deferred: error responses (404/429/503) on the viewer host carry no `X-Robots-Tag`; the robots body duplicates the apex helper; the early return on an existing `X-Robots-Tag` is untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXuokajUGXo7wfP3edxxku
