### PR TITLE
fix: label link preview images with the viewer host

### DIFF
--- a/apps/web/app/routes/a.$id.og-image.test.tsx
+++ b/apps/web/app/routes/a.$id.og-image.test.tsx
@@ -16,7 +16,6 @@ vi.mock('~/services/og-image-worker.server', () => ({
 }))
 
 import { loader, safeOwnerAvatarUrl } from './a.$id.og-image'
-import { linkDomainContext } from '~/middleware/context'
 
 const pngResponse = new Response(new Uint8Array([137, 80, 78, 71]), {
   headers: { 'content-type': 'image/png' },
@@ -62,7 +61,7 @@ describe('/a/:id/og-image loader', () => {
       title: 'Demo Report',
       ownerLabel: 'Owner',
       ownerAvatarUrl: 'https://artifactshare.com/api/avatar/owner123',
-      urlLabel: 'artifactshare.com/a/link123abc',
+      urlLabel: 'link123abc.artifactshare.link',
     })
   })
 
@@ -97,7 +96,7 @@ describe('/a/:id/og-image loader', () => {
       title: 'Demo Report',
       ownerLabel: 'owner@example.com',
       ownerAvatarUrl: null,
-      urlLabel: 'artifactshare.com/a/link123abc',
+      urlLabel: 'link123abc.artifactshare.link',
     })
   })
 
@@ -123,17 +122,11 @@ describe('/a/:id/og-image loader', () => {
         r2_key: 'artifacts/link123abc/v1/index.html',
       }),
     )
-    const context = {
-      get: <T,>(key: unknown) =>
-        (key === linkDomainContext ? { shareableId: 'link123abc' } : null) as T,
-    }
-
     await loader({
       params: { id: 'link123abc' },
       request: new Request(
         'https://link123abc.artifactshare.link/a/link123abc/og-image',
       ),
-      context,
     })
 
     expect(fetchShareOgImageMock).toHaveBeenCalledWith(

--- a/apps/web/app/routes/a.$id.og-image.test.tsx
+++ b/apps/web/app/routes/a.$id.og-image.test.tsx
@@ -5,6 +5,9 @@ const dbMock = vi.hoisted(() => ({
 }))
 const fetchShareOgImageMock = vi.hoisted(() => vi.fn())
 
+vi.mock('cloudflare:workers', () => ({
+  env: { APP_ENV: 'production', BETTER_AUTH_URL: 'https://artifactshare.com' },
+}))
 vi.mock('~/services/db.server', () => ({
   createDb: () => dbMock,
 }))
@@ -13,6 +16,7 @@ vi.mock('~/services/og-image-worker.server', () => ({
 }))
 
 import { loader, safeOwnerAvatarUrl } from './a.$id.og-image'
+import { linkDomainContext } from '~/middleware/context'
 
 const pngResponse = new Response(new Uint8Array([137, 80, 78, 71]), {
   headers: { 'content-type': 'image/png' },
@@ -95,6 +99,46 @@ describe('/a/:id/og-image loader', () => {
       ownerAvatarUrl: null,
       urlLabel: 'artifactshare.com/a/link123abc',
     })
+  })
+
+  test('labels the per-ID viewer host without repeating the ID as a path', async () => {
+    dbMock.selectFrom.mockReturnValue(
+      shareableQuery({
+        id: 'link123abc',
+        workspace_id: 'workspace123',
+        owner_user_id: 'owner123',
+        name: 'demo.html',
+        derived_title: 'Demo Report',
+        title_override: null,
+        visibility: 'link',
+        plan: 'plus',
+        link_sharing_enabled: 1,
+        external_posting_enabled: 1,
+        link_expiry_default_days: 30,
+        link_expiry_max_days: 90,
+        link_expires_at: null,
+        owner_email: 'owner@example.com',
+        owner_name: 'Owner',
+        owner_image: null,
+        r2_key: 'artifacts/link123abc/v1/index.html',
+      }),
+    )
+    const context = {
+      get: <T,>(key: unknown) =>
+        (key === linkDomainContext ? { shareableId: 'link123abc' } : null) as T,
+    }
+
+    await loader({
+      params: { id: 'link123abc' },
+      request: new Request(
+        'https://link123abc.artifactshare.link/a/link123abc/og-image',
+      ),
+      context,
+    })
+
+    expect(fetchShareOgImageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ urlLabel: 'link123abc.artifactshare.link' }),
+    )
   })
 
   test('rejects a same-origin URL that only resembles the avatar route', async () => {

--- a/apps/web/app/routes/a.$id.og-image.tsx
+++ b/apps/web/app/routes/a.$id.og-image.tsx
@@ -4,14 +4,20 @@ import {
   type ArtifactSnapshot,
 } from '~/services/access.server'
 import { createDb } from '~/services/db.server'
+import { env } from 'cloudflare:workers'
+import type { RouterContext } from 'react-router'
+import { isProduction, linkViewerUrl } from '~/lib/hosts'
+import { linkDomainContext } from '~/middleware/context'
 import { fetchShareOgImage } from '~/services/og-image-worker.server'
 
 export async function loader({
   params,
   request,
+  context,
 }: {
   params: { id?: string }
   request: Request
+  context?: { get<T>(key: RouterContext<T>): T }
 }) {
   if (!params.id) {
     throw new Response('Not found', { status: 404 })
@@ -69,7 +75,12 @@ export async function loader({
     throw new Response('Not found', { status: 404 })
   }
 
-  const canonicalUrl = new URL(`/a/${shareable.id}`, request.url)
+  // On the per-ID viewer host the share URL is the host itself, so the label
+  // must not repeat the ID as a path.
+  const linkDomain = context?.get(linkDomainContext) ?? null
+  const canonicalUrl = linkDomain
+    ? new URL(linkViewerUrl(isProduction(env), shareable.id))
+    : new URL(`/a/${shareable.id}`, request.url)
   const ownerAvatarUrl = safeOwnerAvatarUrl(shareable.owner_image, canonicalUrl)
   return fetchShareOgImage({
     title: displayTitle({
@@ -79,7 +90,9 @@ export async function loader({
     }),
     ownerLabel: shareable.owner_name?.trim() || shareable.owner_email,
     ownerAvatarUrl,
-    urlLabel: canonicalUrl.host + canonicalUrl.pathname,
+    urlLabel: linkDomain
+      ? canonicalUrl.host
+      : canonicalUrl.host + canonicalUrl.pathname,
   })
 }
 

--- a/apps/web/app/routes/a.$id.og-image.tsx
+++ b/apps/web/app/routes/a.$id.og-image.tsx
@@ -5,19 +5,15 @@ import {
 } from '~/services/access.server'
 import { createDb } from '~/services/db.server'
 import { env } from 'cloudflare:workers'
-import type { RouterContext } from 'react-router'
 import { isProduction, linkViewerUrl } from '~/lib/hosts'
-import { linkDomainContext } from '~/middleware/context'
 import { fetchShareOgImage } from '~/services/og-image-worker.server'
 
 export async function loader({
   params,
   request,
-  context,
 }: {
   params: { id?: string }
   request: Request
-  context?: { get<T>(key: RouterContext<T>): T }
 }) {
   if (!params.id) {
     throw new Response('Not found', { status: 404 })
@@ -75,13 +71,14 @@ export async function loader({
     throw new Response('Not found', { status: 404 })
   }
 
-  // On the per-ID viewer host the share URL is the host itself, so the label
-  // must not repeat the ID as a path.
-  const linkDomain = context?.get(linkDomainContext) ?? null
-  const canonicalUrl = linkDomain
-    ? new URL(linkViewerUrl(isProduction(env), shareable.id))
-    : new URL(`/a/${shareable.id}`, request.url)
-  const ownerAvatarUrl = safeOwnerAvatarUrl(shareable.owner_image, canonicalUrl)
+  // Only link-visibility shares render a preview card, and their share URL is
+  // the per-ID viewer host itself, so the label is that host. App-hosted owner
+  // avatars still resolve against the app origin.
+  const canonicalUrl = new URL(linkViewerUrl(isProduction(env), shareable.id))
+  const ownerAvatarUrl = safeOwnerAvatarUrl(
+    shareable.owner_image,
+    new URL(`/a/${shareable.id}`, env.BETTER_AUTH_URL),
+  )
   return fetchShareOgImage({
     title: displayTitle({
       name: shareable.name,
@@ -90,9 +87,7 @@ export async function loader({
     }),
     ownerLabel: shareable.owner_name?.trim() || shareable.owner_email,
     ownerAvatarUrl,
-    urlLabel: linkDomain
-      ? canonicalUrl.host
-      : canonicalUrl.host + canonicalUrl.pathname,
+    urlLabel: canonicalUrl.host,
   })
 }
 


### PR DESCRIPTION
## Summary

The link preview image for `https://<id>.artifactshare.link/` showed `<id>.artifactshare.link/a/<id>` in its footer because the label was built from the request path. Preview cards exist only for link-visibility shares, whose share URL is the per-ID viewer host, so the label is now that host unconditionally (also when the image is requested through the apex path). App-hosted owner avatars keep resolving against the app origin.

## Validation

- `pnpm validate:static`
- og-image route unit tests (15), including the viewer-host label case
- Codex (Sol/high) + Claude (Opus/xhigh) gate, two rounds; round 2 has no blocker

Deferred: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXuokajUGXo7wfP3edxxku
