### PR TITLE
test(scripts): pr-publish tests use a temporary landing ledger

### DIFF
--- a/scripts/pr-publish.mjs
+++ b/scripts/pr-publish.mjs
@@ -64,6 +64,10 @@ function currentPrNumber(exec, branch) {
       `GitHub PR query failed; no write performed: ${error.message}`,
     )
   }
+  if (!Array.isArray(rows))
+    throw new Error(
+      'GitHub PR query returned an unexpected result; no write performed',
+    )
   return rows.find((row) => row.headRefName === branch)?.number ?? null
 }
 

--- a/scripts/pr-publish.test.mjs
+++ b/scripts/pr-publish.test.mjs
@@ -27,7 +27,7 @@ function harness({
       return JSON.stringify(pr ? [{ headRefName: 'feature/x', ...pr }] : [])
     return ''
   }
-  // One ledger per harness, so a seeded first run is seen by the second.
+  // One ledger per harness; publish never writes it, so no cleanup is needed.
   const ledger = tempLedger()
   return {
     calls,

--- a/scripts/pr-publish.test.mjs
+++ b/scripts/pr-publish.test.mjs
@@ -8,7 +8,11 @@ import {
 } from './landing-ledger.mjs'
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { randomUUID } from 'node:crypto'
 import { parsePublishArgs, publishPullRequest } from './pr-publish.mjs'
+
+const tempLedger = () =>
+  joinPath(osTmpdir(), `pr-publish-ledger-${randomUUID()}.json`)
 
 function harness({
   pr = null,
@@ -31,6 +35,9 @@ function harness({
         title,
         readFile: () => body,
         exec,
+        // Never the checkout's own ledger: an undischarged deferral from a
+        // real PR would fail these tests in every other worktree.
+        ledger: tempLedger(),
         ...options,
       }),
   }

--- a/scripts/pr-publish.test.mjs
+++ b/scripts/pr-publish.test.mjs
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { rmSync, writeFileSync } from 'node:fs'
 import { tmpdir as osTmpdir } from 'node:os'
 import { join as joinPath } from 'node:path'
 import {
@@ -35,10 +35,10 @@ function harness({
         title,
         readFile: () => body,
         exec,
-        // Never the checkout's own ledger: an undischarged deferral from a
-        // real PR would fail these tests in every other worktree.
-        ledger: tempLedger(),
         ...options,
+        // Never the checkout's own ledger: an undischarged deferral from a
+        // real PR would fail these tests in every worktree of the checkout.
+        ledger: options.ledger ?? tempLedger(),
       }),
   }
 }
@@ -82,6 +82,7 @@ test('rejects private metadata before any command or remote write', () => {
         bodyFile: 'body.md',
         title: 'fix #1552',
         readFile: () => 'Public body',
+        ledger: tempLedger(),
         exec: () => {
           called = true
         },
@@ -98,6 +99,7 @@ test('requires a topic branch, main base, and no other open PR', () => {
         bodyFile: 'body.md',
         title: 'Public title',
         readFile: () => 'Public body',
+        ledger: tempLedger(),
         exec: (file, args) => {
           if (file === 'git' && args[0] === 'branch') return 'main\n'
           return ''
@@ -133,11 +135,9 @@ test('parses the small publication option set', () => {
   assert.throws(() => parsePublishArgs(['--unknown']), /unknown argument/u)
 })
 
-test('publishing refuses while a previous change has undischarged deferrals', () => {
-  const path = joinPath(
-    mkdtempSync(joinPath(osTmpdir(), 'as-publish-ledger-')),
-    'ledger.json',
-  )
+test('publishing refuses while a previous change has undischarged deferrals', (t) => {
+  const path = tempLedger()
+  t.after(() => rmSync(path, { force: true }))
   writeLandingLedger(
     path,
     recordLandingDeferred(readLandingLedger(path), {
@@ -165,11 +165,9 @@ test('publishing refuses while a previous change has undischarged deferrals', ()
   )
 })
 
-test('a change may update its own body while its deferrals are still pending', () => {
-  const path = joinPath(
-    mkdtempSync(joinPath(osTmpdir(), 'as-publish-own-')),
-    'ledger.json',
-  )
+test('a change may update its own body while its deferrals are still pending', (t) => {
+  const path = tempLedger()
+  t.after(() => rmSync(path, { force: true }))
   writeLandingLedger(
     path,
     recordLandingDeferred(readLandingLedger(path), {
@@ -194,11 +192,9 @@ test('a change may update its own body while its deferrals are still pending', (
   assert.deepEqual(result, { mode: 'update', number: 52, dryRun: true })
 })
 
-test('a corrupt ledger refuses the publish rather than reading as empty', () => {
-  const path = joinPath(
-    mkdtempSync(joinPath(osTmpdir(), 'as-publish-corrupt-')),
-    'ledger.json',
-  )
+test('a corrupt ledger refuses the publish rather than reading as empty', (t) => {
+  const path = tempLedger()
+  t.after(() => rmSync(path, { force: true }))
   writeFileSync(path, '{ truncated')
   assert.throws(
     () =>

--- a/scripts/pr-publish.test.mjs
+++ b/scripts/pr-publish.test.mjs
@@ -27,8 +27,11 @@ function harness({
       return JSON.stringify(pr ? [{ headRefName: 'feature/x', ...pr }] : [])
     return ''
   }
+  // One ledger per harness, so a seeded first run is seen by the second.
+  const ledger = tempLedger()
   return {
     calls,
+    ledger,
     run: (options = {}) =>
       publishPullRequest({
         bodyFile: 'body.md',
@@ -38,7 +41,7 @@ function harness({
         ...options,
         // Never the checkout's own ledger: an undischarged deferral from a
         // real PR would fail these tests in every worktree of the checkout.
-        ledger: options.ledger ?? tempLedger(),
+        ledger: options.ledger ?? ledger,
       }),
   }
 }


### PR DESCRIPTION
## Summary

The pr-publish tests read the checkout's own landing ledger. While a real PR had undischarged deferrals (right after `pnpm pr:ready --deferred-file`), three of them failed in every worktree of the checkout with "A previous change deferred review findings that were never discharged", which made `pnpm test:scripts` red on unrelated branches until `pnpm pr:landed` ran.

- `scripts/pr-publish.test.mjs`: the harness allocates one temporary ledger path and passes it unless a test supplies its own; the direct `publishPullRequest` calls pass one too; the three ledger tests use the same helper and remove their file.
- `scripts/pr-publish.mjs`: `currentPrNumber` guards a non-array `gh` payload the way `branchPullRequest` does, so a bad response is reported as "no write performed" instead of a TypeError.

## Validation

- format, lint, `pnpm test:scripts` (536 passed), `pnpm public:scan .` 0 findings; the suite passes with an undischarged deferral in the checkout's ledger.
- Review: Claude (Opus/xhigh) only, three rounds, stop rule applied — the Codex leg is out of weekly quota (owner-approved exception). Remaining findings are in the deferred list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXuokajUGXo7wfP3edxxku
