### PR TITLE
fix(cli): preserve link policy errors on forbidden responses

### DIFF
--- a/packages/cli/src/edit.test.ts
+++ b/packages/cli/src/edit.test.ts
@@ -232,15 +232,134 @@ test('edit rejects --title without a value before auth', () => {
 })
 
 test.each([
-  ['link-sharing-plan-required', 'link_sharing_plan_required'],
-  ['link-sharing-disabled', 'link_sharing_disabled'],
-  ['link-expiry-invalid', 'link_expiry_invalid'],
-  ['link-publish-rate-limited', 'link_publish_rate_limited'],
-] as const)('maps %s to the CLI underscore contract', (apiCode, code) => {
-  const mapped = mapApiError(400, {
-    error: { code: apiCode, message: 'Link policy error.' },
+  [
+    'link-sharing-plan-required',
+    402,
+    'link_sharing_plan_required',
+    'Link sharing is unavailable for this workspace.',
+    'Ask a workspace owner or administrator to review the workspace plan or link sharing policy.',
+    true,
+    false,
+    'ask_human',
+  ],
+  [
+    'link-sharing-disabled',
+    403,
+    'link_sharing_disabled',
+    'Link sharing is paused for this workspace; the owner or a Team admin can resume it.',
+    'Ask a workspace owner or administrator to review the workspace plan or link sharing policy.',
+    true,
+    false,
+    'ask_human',
+  ],
+  [
+    'link-expiry-invalid',
+    400,
+    'link_expiry_invalid',
+    'The requested link expiry does not match the link sharing policy.',
+    'Pass a future RFC3339 UTC timestamp within the workspace maximum, or use --no-link-expiry when unlimited expiry is allowed.',
+    false,
+    true,
+    'change_input',
+  ],
+  [
+    'link-publish-rate-limited',
+    429,
+    'link_publish_rate_limited',
+    'New Free workspaces may publish a bounded number of links per day; the limit protects link sharing from abuse.',
+    'Share with specific people now and retry the link visibility after the window passes (about a day), or ask the owner about the workspace plan.',
+    false,
+    true,
+    'retry_later',
+  ],
+] as const)(
+  'maps %s from its API status to the CLI error contract',
+  (
+    apiCode,
+    status,
+    code,
+    why,
+    hint,
+    requiresHuman,
+    agentRecoverable,
+    recoveryKind,
+  ) => {
+    const mapped = mapApiError(status, {
+      error: { code: apiCode, message: 'Link policy error.' },
+    })
+    assert.equal(mapped.code, code)
+    assert.equal(mapped.why, why)
+    assert.equal(mapped.hint, hint)
+    assert.equal(mapped.requires_human, requiresHuman)
+    assert.equal(mapped.agent_recoverable, agentRecoverable)
+    assert.deepEqual(mapped.recovery, { kind: recoveryKind })
+  },
+)
+
+test('keeps unknown 403 responses on the generic forbidden contract', () => {
+  const mapped = mapApiError(403, {
+    error: { code: 'unrecognized-policy-error', message: 'No access.' },
   })
-  assert.equal(mapped.code, code)
+
+  assert.equal(mapped.code, 'forbidden')
+  assert.equal(mapped.requires_human, true)
+})
+
+test('keeps 401 auth recovery ahead of link policy mapping', () => {
+  const mapped = mapApiError(
+    401,
+    { error: { code: 'link-sharing-disabled', message: 'Expired token.' } },
+    { authenticated: true },
+  )
+
+  assert.equal(mapped.code, 'token_invalid')
+})
+
+test('edit emits actionable JSON for a link policy 403 from the API', async () => {
+  await withServer(
+    (_request, response) => {
+      response.statusCode = 403
+      response.setHeader('content-type', 'application/json')
+      response.end(
+        JSON.stringify({
+          error: {
+            code: 'link-sharing-disabled',
+            message: 'Link sharing is disabled for this workspace.',
+          },
+        }),
+      )
+    },
+    async (baseUrl) => {
+      const result = await runAsync(
+        [
+          'edit',
+          'abc123def4',
+          '--visibility',
+          'link',
+          '--base-url',
+          baseUrl,
+          '--json',
+        ],
+        { ARTIFACTSHARE_TOKEN: 'test-token' },
+      )
+
+      const payload = expectFailure(result, {
+        command: 'edit',
+        code: 'link_sharing_disabled',
+      })
+      assert.equal(
+        payload.error.why,
+        'Link sharing is paused for this workspace; the owner or a Team admin can resume it.',
+      )
+      assert.equal(
+        payload.error.hint,
+        'Ask a workspace owner or administrator to review the workspace plan or link sharing policy.',
+      )
+      assert.equal(payload.error.agent_recoverable, false)
+      assert.equal(payload.error.requires_human, true)
+      assert.deepEqual(payload.error.recovery, { kind: 'ask_human' })
+    },
+  )
 })
 
 test('edit maps missing targets to target_not_found', async () => {

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -350,6 +350,46 @@ export function mapApiError(
         : {}),
     })
   }
+  if (apiCode === 'link-publish-rate-limited') {
+    return cliError({
+      code: 'link_publish_rate_limited',
+      message:
+        apiMessage ??
+        'This new workspace has reached its daily link share limit.',
+      why: 'New Free workspaces may publish a bounded number of links per day; the limit protects link sharing from abuse.',
+      hint: 'Share with specific people now and retry the link visibility after the window passes (about a day), or ask the owner about the workspace plan.',
+      agentRecoverable: true,
+      requiresHuman: false,
+      recovery: { kind: 'retry_later' },
+    })
+  }
+  if (
+    apiCode === 'link-sharing-plan-required' ||
+    apiCode === 'link-sharing-disabled' ||
+    apiCode === 'link-expiry-invalid'
+  ) {
+    const code = apiCode.replaceAll('-', '_')
+    return cliError({
+      code,
+      message: apiMessage ?? 'The link sharing option is invalid.',
+      why:
+        apiCode === 'link-sharing-plan-required'
+          ? 'Link sharing is unavailable for this workspace.'
+          : apiCode === 'link-sharing-disabled'
+            ? 'Link sharing is paused for this workspace; the owner or a Team admin can resume it.'
+            : 'The requested link expiry does not match the link sharing policy.',
+      hint:
+        apiCode === 'link-expiry-invalid'
+          ? 'Pass a future RFC3339 UTC timestamp within the workspace maximum, or use --no-link-expiry when unlimited expiry is allowed.'
+          : 'Ask a workspace owner or administrator to review the workspace plan or link sharing policy.',
+      agentRecoverable: apiCode === 'link-expiry-invalid',
+      requiresHuman: apiCode !== 'link-expiry-invalid',
+      recovery:
+        apiCode === 'link-expiry-invalid'
+          ? { kind: 'change_input' }
+          : { kind: 'ask_human' },
+    })
+  }
   if (apiCode === 'forbidden' || status === 403) {
     return cliError({
       code: 'forbidden',
@@ -415,46 +455,6 @@ export function mapApiError(
       agentRecoverable: true,
       requiresHuman: false,
       recovery: { kind: 'change_input' },
-    })
-  }
-  if (apiCode === 'link-publish-rate-limited') {
-    return cliError({
-      code: 'link_publish_rate_limited',
-      message:
-        apiMessage ??
-        'This new workspace has reached its daily link share limit.',
-      why: 'New Free workspaces may publish a bounded number of links per day; the limit protects link sharing from abuse.',
-      hint: 'Share with specific people now and retry the link visibility after the window passes (about a day), or ask the owner about the workspace plan.',
-      agentRecoverable: true,
-      requiresHuman: false,
-      recovery: { kind: 'retry_later' },
-    })
-  }
-  if (
-    apiCode === 'link-sharing-plan-required' ||
-    apiCode === 'link-sharing-disabled' ||
-    apiCode === 'link-expiry-invalid'
-  ) {
-    const code = apiCode.replaceAll('-', '_')
-    return cliError({
-      code,
-      message: apiMessage ?? 'The link sharing option is invalid.',
-      why:
-        apiCode === 'link-sharing-plan-required'
-          ? 'Link sharing is unavailable for this workspace.'
-          : apiCode === 'link-sharing-disabled'
-            ? 'Link sharing is paused for this workspace; the owner or a Team admin can resume it.'
-            : 'The requested link expiry does not match the link sharing policy.',
-      hint:
-        apiCode === 'link-expiry-invalid'
-          ? 'Pass a future RFC3339 UTC timestamp within the workspace maximum, or use --no-link-expiry when unlimited expiry is allowed.'
-          : 'Ask a workspace owner or administrator to review the workspace plan or link sharing policy.',
-      agentRecoverable: apiCode === 'link-expiry-invalid',
-      requiresHuman: apiCode !== 'link-expiry-invalid',
-      recovery:
-        apiCode === 'link-expiry-invalid'
-          ? { kind: 'change_input' }
-          : { kind: 'ask_human' },
     })
   }
   if (


### PR DESCRIPTION
When a workspace disables link sharing, `edit --visibility link --json` now returns `link_sharing_disabled` with the existing owner/admin recovery guidance instead of the generic `forbidden` error. Known link-policy mappings run before the HTTP 403 fallback; authentication errors and unknown 403 responses retain their existing handling.

The regression tests use the API's actual status codes and cover a mocked HTTP response through the real CLI JSON output, including recovery fields.

Validation: `pnpm validate:static` passed (React Doctor 100; public scan 0 findings), CLI typecheck passed, the full CLI suite passed 582 tests with 1 skip, and `pnpm check:cli-reference` passed. The new real-status mapper and HTTP-to-CLI regressions both failed before the fix and passed after it. The trusted-main boundary guard passed for the complete commit range.

Final paired implementation review completed on `418cf52` (Codex Sol/high and Claude Opus/xhigh). No unresolved blocker remains. Observations about pre-existing expiry/rate-limit guidance and metadata, legacy copy, generic fallback behavior, refactoring/test style, and broader release notes were not adopted: this change restores the documented disabled-sharing 403 contract and preserves the other existing mappings. Those observations are not claimed as fixed.
