### PR TITLE
Make sharing grant saves atomic

### DIFF
--- a/apps/web/app/d1-tests/platform-limits.test.ts
+++ b/apps/web/app/d1-tests/platform-limits.test.ts
@@ -148,6 +148,66 @@ describe.sequential('D1 compatibility', () => {
     expect(result?.position).toBeGreaterThan(0)
   })
 
+  it('rolls back atomic sharing attempts on the final named assertions', async () => {
+    await db
+      .prepare(
+        `INSERT INTO workspaces (id, name, created_at)
+         VALUES ('atomic-grants-ws', 'Atomic grants', '2026-09-08T00:00:00.000Z')`,
+      )
+      .run()
+    const insertAttempt = (shareableId: string, consumed: number) =>
+      db
+        .prepare(
+          `INSERT INTO link_publication_attempts (
+             workspace_id, shareable_id, published_at, window_start,
+             daily_limit, limit_applies, consumed
+           ) VALUES (
+             'atomic-grants-ws', ?, '2026-09-08T00:00:00.000Z',
+             '2026-09-07T00:00:00.000Z', 20, 0, ?
+           )`,
+        )
+        .bind(shareableId, consumed)
+
+    await expect(
+      db.batch([
+        insertAttempt('unconsumed', 0),
+        db.prepare(
+          `DELETE FROM link_publication_attempts
+           WHERE workspace_id = 'atomic-grants-ws'
+             AND shareable_id = 'unconsumed'`,
+        ),
+      ]),
+    ).rejects.toThrow(/link publication mutation missing/i)
+
+    await expect(
+      db.batch([
+        insertAttempt('missing-grant', 1),
+        db.prepare(
+          `UPDATE link_publication_attempts
+           SET requested_grants_present = 0
+           WHERE workspace_id = 'atomic-grants-ws'
+             AND shareable_id = 'missing-grant'`,
+        ),
+      ]),
+    ).rejects.toThrow(/link_publication_all_requested_grants_present/i)
+
+    await db.batch([
+      insertAttempt('consumed', 1),
+      db.prepare(
+        `DELETE FROM link_publication_attempts
+         WHERE workspace_id = 'atomic-grants-ws'
+           AND shareable_id = 'consumed'`,
+      ),
+    ])
+    const attempts = await db
+      .prepare(
+        `SELECT shareable_id FROM link_publication_attempts
+         WHERE workspace_id = 'atomic-grants-ws'`,
+      )
+      .all()
+    expect(attempts.results).toEqual([])
+  })
+
   it('preserves parent and child rows during a protected table rebuild', async () => {
     await server.reset()
     db = (await worker.getEnv()).DB

--- a/apps/web/app/services/shareables.server.test.ts
+++ b/apps/web/app/services/shareables.server.test.ts
@@ -2467,6 +2467,44 @@ describe('commitDialogChanges', () => {
     ).resolves.toEqual([])
   })
 
+  test('keeps a mixed-case stored grant idempotent across normalized repeated additions', async () => {
+    await db
+      .insertInto('shareable_grants')
+      .values({
+        shareable_id: 'share1',
+        granted_email: 'Viewer@Example.com',
+        granted_at: '2026-05-22T00:00:00.000Z',
+        granted_by: OWNER.id,
+      })
+      .execute()
+
+    const result = await commitDialogChanges(db, OWNER, 'share1', {
+      addEmails: [
+        'viewer@example.com',
+        'VIEWER@EXAMPLE.COM',
+        ' viewer@example.com ',
+      ],
+    })
+
+    expect(result.kind).toBe('ok')
+    if (result.kind !== 'ok') return
+    expect(result.grants.map((grant) => grant.email)).toEqual([
+      'Viewer@Example.com',
+    ])
+    const stored = await db
+      .selectFrom('shareable_grants')
+      .select('granted_email')
+      .where('shareable_id', '=', 'share1')
+      .execute()
+    expect(stored).toHaveLength(1)
+    expect(
+      new Set(stored.map((grant) => grant.granted_email.toLowerCase())),
+    ).toEqual(new Set(['viewer@example.com']))
+    await expect(
+      db.selectFrom('link_publication_attempts').selectAll().execute(),
+    ).resolves.toEqual([])
+  })
+
   test('rejects dialog additions beyond 50 entries', async () => {
     await insertGrants(db, 'share1', numberedEmails(50))
 

--- a/apps/web/app/services/shareables.server.test.ts
+++ b/apps/web/app/services/shareables.server.test.ts
@@ -2090,9 +2090,11 @@ describe('uploadShareable', () => {
 
 describe('commitDialogChanges', () => {
   let db: Kysely<DB>
+  let batchCount: { current: number }
 
   beforeEach(async () => {
-    const fixture = createD1BatchFixture({ sqlite: sqliteRef })
+    batchCount = { current: 0 }
+    const fixture = createD1BatchFixture({ sqlite: sqliteRef, batchCount })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
     sqliteRef.failNextBatch = false
@@ -2417,6 +2419,52 @@ describe('commitDialogChanges', () => {
     expect(result.kind).toBe('ok')
     if (result.kind !== 'ok') return
     expect(result.grants).toHaveLength(50)
+    await expect(
+      db.selectFrom('link_publication_attempts').selectAll().execute(),
+    ).resolves.toEqual([])
+  })
+
+  test('keeps existing requested grants idempotent and deletes publication context last', async () => {
+    let statements: Array<{ sql: string; params: unknown[] }> = []
+    sqliteRef.beforeNextBatch = async (nextStatements) => {
+      statements = nextStatements
+    }
+
+    const first = await commitDialogChanges(db, OWNER, 'share1', {
+      addEmails: ['viewer@example.com'],
+    })
+    const second = await commitDialogChanges(db, OWNER, 'share1', {
+      addEmails: ['VIEWER@example.com'],
+    })
+
+    expect(first.kind).toBe('ok')
+    expect(second.kind).toBe('ok')
+    expect(batchCount.current).toBe(2)
+    expect(statements[0]?.sql).toContain(
+      'insert into "link_publication_attempts"',
+    )
+    expect(statements[0]?.params.slice(0, 2)).toEqual(['ws-a', 'share1'])
+    const publishedAt = statements[0]?.params[2]
+    const windowStart = statements[0]?.params[3]
+    expect(typeof publishedAt).toBe('string')
+    expect(typeof windowStart).toBe('string')
+    expect(
+      Date.parse(publishedAt as string) - Date.parse(windowStart as string),
+    ).toBe(24 * 60 * 60 * 1000)
+    expect(statements[0]?.params.slice(-3)).toEqual([20, 0, 1])
+    expect(statements.at(-1)?.sql).toContain(
+      'delete from "link_publication_attempts"',
+    )
+    await expect(
+      db
+        .selectFrom('shareable_grants')
+        .select('granted_email')
+        .where('shareable_id', '=', 'share1')
+        .execute(),
+    ).resolves.toEqual([{ granted_email: 'viewer@example.com' }])
+    await expect(
+      db.selectFrom('link_publication_attempts').selectAll().execute(),
+    ).resolves.toEqual([])
   })
 
   test('rejects dialog additions beyond 50 entries', async () => {
@@ -2434,8 +2482,13 @@ describe('commitDialogChanges', () => {
     expect(result).toEqual({ kind: 'too-many-grants', limit: 50 })
   })
 
-  test('rolls back its own dialog additions if a concurrent save reaches the limit first', async () => {
+  test('rolls back a private-to-link save if a concurrent grant reaches the limit first', async () => {
     await insertGrants(db, 'share1', numberedEmails(49))
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'plus', link_sharing_enabled: 1 })
+      .where('id', '=', OWNER.workspaceId)
+      .execute()
     sqliteRef.beforeNextBatch = async () => {
       await db
         .insertInto('shareable_grants')
@@ -2454,7 +2507,7 @@ describe('commitDialogChanges', () => {
       'share1',
       {
         addEmails: ['person-51@example.com'],
-        visibility: 'workspace',
+        visibility: 'link',
       },
     )
 
@@ -2472,10 +2525,10 @@ describe('commitDialogChanges', () => {
     await expect(
       db
         .selectFrom('shareables')
-        .select('visibility')
+        .select(['visibility', 'link_expires_at'])
         .where('id', '=', 'share1')
         .executeTakeFirstOrThrow(),
-    ).resolves.toEqual({ visibility: 'private' })
+    ).resolves.toEqual({ visibility: 'private', link_expires_at: null })
     await expect(
       db
         .selectFrom('events')
@@ -2484,6 +2537,98 @@ describe('commitDialogChanges', () => {
         .where('type', '=', 'visibility_changed')
         .execute(),
     ).resolves.toHaveLength(0)
+    await expect(
+      db.selectFrom('link_publication_attempts').selectAll().execute(),
+    ).resolves.toEqual([])
+    expect(batchCount.current).toBe(1)
+  })
+
+  test('rolls back a link-to-private save if a concurrent grant reaches the limit first', async () => {
+    const originalExpiry = '2026-10-01T00:00:00.000Z'
+    await db
+      .updateTable('shareables')
+      .set({ visibility: 'link', link_expires_at: originalExpiry })
+      .where('id', '=', 'share1')
+      .execute()
+    await insertGrants(db, 'share1', numberedEmails(49))
+    sqliteRef.beforeNextBatch = async () => {
+      await db
+        .insertInto('shareable_grants')
+        .values({
+          shareable_id: 'share1',
+          granted_email: 'person-50@example.com',
+          granted_at: '2026-05-22T00:00:00.000Z',
+          granted_by: OWNER.id,
+        })
+        .execute()
+    }
+
+    const result = await commitDialogChanges(db, OWNER, 'share1', {
+      addEmails: ['person-51@example.com'],
+      visibility: 'private',
+    })
+
+    expect(result).toEqual({ kind: 'too-many-grants', limit: 50 })
+    await expect(
+      db
+        .selectFrom('shareables')
+        .select(['visibility', 'link_expires_at'])
+        .where('id', '=', 'share1')
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ visibility: 'link', link_expires_at: originalExpiry })
+    await expect(
+      db
+        .selectFrom('events')
+        .select('id')
+        .where('shareable_id', '=', 'share1')
+        .where('type', '=', 'visibility_changed')
+        .execute(),
+    ).resolves.toEqual([])
+    await expect(
+      db.selectFrom('link_publication_attempts').selectAll().execute(),
+    ).resolves.toEqual([])
+    expect(batchCount.current).toBe(1)
+  })
+
+  test('rolls back grant-only removals and additions when the in-batch assertion fails', async () => {
+    await insertGrants(db, 'share1', numberedEmails(49))
+    sqliteRef.beforeNextBatch = async () => {
+      await db
+        .insertInto('shareable_grants')
+        .values({
+          shareable_id: 'share1',
+          granted_email: 'person-50@example.com',
+          granted_at: '2026-05-22T00:00:00.000Z',
+          granted_by: OWNER.id,
+        })
+        .execute()
+    }
+
+    const result = await commitDialogChanges(db, OWNER, 'share1', {
+      removeEmails: ['person-1@example.com'],
+      addEmails: ['person-51@example.com', 'person-52@example.com'],
+    })
+
+    expect(result).toEqual({ kind: 'too-many-grants', limit: 50 })
+    const grants = await db
+      .selectFrom('shareable_grants')
+      .select('granted_email')
+      .where('shareable_id', '=', 'share1')
+      .execute()
+    expect(grants).toHaveLength(50)
+    expect(grants.map((grant) => grant.granted_email)).toContain(
+      'person-1@example.com',
+    )
+    expect(grants.map((grant) => grant.granted_email)).not.toContain(
+      'person-51@example.com',
+    )
+    expect(grants.map((grant) => grant.granted_email)).not.toContain(
+      'person-52@example.com',
+    )
+    await expect(
+      db.selectFrom('link_publication_attempts').selectAll().execute(),
+    ).resolves.toEqual([])
+    expect(batchCount.current).toBe(1)
   })
 
   test('allows replacing a grant when existing data is already over the limit', async () => {
@@ -3308,6 +3453,44 @@ describe('StaticSiteBundleUploadSession', () => {
       .where('id', '=', begun.session.shareableId)
       .executeTakeFirst()
     expect(shareable).toBeUndefined()
+  })
+
+  test('maps a late shareable id collision to id-exhausted after cleanup', async () => {
+    const begun = await beginStaticSiteBundleUploadSession(db, OWNER)
+    expect(begun.kind).toBe('ok')
+    if (begun.kind !== 'ok') throw new Error('expected ok')
+    await expect(
+      begun.session.addFile(siteFile('/index.html', 16, 'text/html')),
+    ).resolves.toEqual({ kind: 'ok' })
+    sqliteRef.beforeNextBatch = async () => {
+      await seedShareableWithVersions(db, {
+        shareableId: begun.session.shareableId,
+        versions: [],
+      })
+    }
+
+    const result = await begun.session.commit('private')
+
+    expect(result).toEqual({ kind: 'id-exhausted' })
+    expect(storageMock.deleteArtifactsByPrefix).toHaveBeenCalledWith(
+      {},
+      `ws-a/${begun.session.shareableId}/${begun.session.versionId}/`,
+    )
+    await expect(
+      db
+        .selectFrom('workspaces')
+        .select('storage_used_bytes')
+        .where('id', '=', OWNER.workspaceId)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ storage_used_bytes: 0 })
+    await expect(
+      db
+        .selectFrom('workspace_members')
+        .select('pending_uploads')
+        .where('workspace_id', '=', OWNER.workspaceId)
+        .where('user_id', '=', OWNER.id)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ pending_uploads: 0 })
   })
 
   test('external posting bills the project workspace for storage, contributor, R2 prefix, and ownership', async () => {

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -9,6 +9,10 @@ import { displayTitle } from '~/lib/display-title'
 import { extractTitleFromBytes } from '~/lib/extract-title'
 import { MAX_GRANT_EMAILS, normalizeGrantEmail } from '~/lib/grant-emails'
 import { lowerEmail } from '~/lib/grant-emails.server'
+import {
+  LINK_PUBLISH_RATE_WINDOW_MS,
+  linkPublishRateLimitFromEnv,
+} from '~/lib/link-trust-policy'
 import { computeFileSha256 } from '~/lib/sha256'
 import { isSqliteConstraintError } from '~/lib/d1-errors.server'
 import { runD1Batch, runD1BatchWithResults } from '~/lib/d1-batch.server'
@@ -546,6 +550,8 @@ export async function commitDialogChanges(
   const owned = await findOwnedShareableForGrants(db, user, shareableId)
   if (!owned) return { kind: 'not-found' }
 
+  const now = nowIso()
+
   let newVisibility = payload.visibility ?? owned.visibility
   if (newVisibility === 'workspace' && !isOrgWorkspace(user)) {
     return { kind: 'workspace-unavailable' }
@@ -557,7 +563,7 @@ export async function commitDialogChanges(
     currentLinkExpiresAt: owned.link_expires_at,
     nextVisibility: newVisibility,
     requestedLinkExpiresAt: payload.linkExpiresAt,
-    now: nowIso(),
+    now,
   })
   if (linkWrite.kind !== 'ok') return linkWrite
 
@@ -566,14 +572,12 @@ export async function commitDialogChanges(
     payload.removeEmails ?? [],
     user.email,
   ).filter((email) => !addEmails.includes(email))
-  let newAddEmails: string[] = []
   let allowedGrantCount = MAX_GRANT_EMAILS
   if (addEmails.length > 0) {
     const currentGrantEmails = new Set(
       await loadGrantEmails(db, shareableId, user.email),
     )
     allowedGrantCount = Math.max(MAX_GRANT_EMAILS, currentGrantEmails.size)
-    newAddEmails = addEmails.filter((email) => !currentGrantEmails.has(email))
     const nextGrantEmails = new Set(currentGrantEmails)
     for (const email of removeEmails) nextGrantEmails.delete(email)
     for (const email of addEmails) nextGrantEmails.add(email)
@@ -586,8 +590,21 @@ export async function commitDialogChanges(
   }
   const ownerGrantEmail = normalizedEmail(user.email)
   const queries: Compilable<unknown>[] = []
-  const now = nowIso()
-  let visibilityEventId: string | null = null
+  if (addEmails.length > 0) {
+    queries.push(
+      db.insertInto('link_publication_attempts').values({
+        workspace_id: owned.workspace_id,
+        shareable_id: shareableId,
+        published_at: now,
+        window_start: new Date(
+          Date.parse(now) - LINK_PUBLISH_RATE_WINDOW_MS,
+        ).toISOString(),
+        daily_limit: linkPublishRateLimitFromEnv(env).dailyLimit,
+        limit_applies: 0,
+        consumed: 1,
+      }),
+    )
+  }
   if (
     newVisibility !== owned.visibility ||
     linkWrite.linkExpiresAt !== owned.link_expires_at
@@ -601,7 +618,6 @@ export async function commitDialogChanges(
       changedAt: now,
       predicate: visibilityPredicate,
     })
-    visibilityEventId = visibilityEvent.eventId
     queries.push(
       visibilityEvent.query,
       db
@@ -640,6 +656,15 @@ export async function commitDialogChanges(
         ownerEmail: user.email,
         limit: allowedGrantCount,
       }),
+      assertRequestedGrantEmailsQuery({
+        workspaceId: owned.workspace_id,
+        shareableId,
+        emails: addEmails,
+      }),
+      db
+        .deleteFrom('link_publication_attempts')
+        .where('workspace_id', '=', owned.workspace_id)
+        .where('shareable_id', '=', shareableId),
     )
   }
 
@@ -653,42 +678,6 @@ export async function commitDialogChanges(
       return { kind: 'commit-failed' }
     }
   }
-  if (newAddEmails.length > 0) {
-    const committedGrantEmails = new Set(
-      await loadGrantEmails(db, shareableId, user.email),
-    )
-    const missingAdd = newAddEmails.some(
-      (email) => !committedGrantEmails.has(email),
-    )
-    if (missingAdd) {
-      if (
-        newVisibility !== owned.visibility ||
-        linkWrite.linkExpiresAt !== owned.link_expires_at
-      ) {
-        try {
-          await runD1Batch(
-            db,
-            db
-              .deleteFrom('events')
-              .where('id', '=', visibilityEventId!)
-              .where('type', '=', 'visibility_changed'),
-            db
-              .updateTable('shareables')
-              .set({
-                visibility: owned.visibility,
-                link_expires_at: owned.link_expires_at,
-                updated_at: nowIso(),
-              })
-              .where('id', '=', shareableId),
-          )
-        } catch {
-          return { kind: 'commit-failed' }
-        }
-      }
-      return { kind: 'too-many-grants', limit: MAX_GRANT_EMAILS }
-    }
-  }
-
   return {
     kind: 'ok',
     visibility: newVisibility,
@@ -2542,7 +2531,15 @@ export class StaticSiteBundleUploadSession {
         containerId: this.target.destination.containerId,
         stableKey: this.target.stableKey,
       })
-      if (!keyConflict) {
+      const idConflict =
+        !keyConflict &&
+        (hasShareableIdPrimaryKeyConflictMessage(err) ||
+          (isSqliteConstraintError(err) &&
+            (await didShareableIdAppearAfterBatchFailure(
+              this.db,
+              this.shareableId,
+            ))))
+      if (!keyConflict && !idConflict) {
         console.error('static_site_d1_commit_failed', {
           shareable_id: this.shareableId,
           version_id: this.versionId,
@@ -2566,7 +2563,9 @@ export class StaticSiteBundleUploadSession {
           this.now,
         ),
       ])
-      return keyConflict ? { kind: 'key-conflict' } : { kind: 'storage-failed' }
+      if (keyConflict) return { kind: 'key-conflict' }
+      if (idConflict) return { kind: 'id-exhausted' }
+      return { kind: 'storage-failed' }
     }
 
     return {
@@ -4236,6 +4235,41 @@ function insertGrantEmailsWithinLimitQuery({
     WHERE NOT (SELECT ok FROM limit_check)
   `,
         parameters,
+      }) as unknown as ReturnType<Compilable<unknown>['compile']>,
+  }
+}
+
+function assertRequestedGrantEmailsQuery({
+  workspaceId,
+  shareableId,
+  emails,
+}: {
+  workspaceId: string
+  shareableId: string
+  emails: ReadonlyArray<string>
+}): Compilable<unknown> {
+  return {
+    compile: () =>
+      ({
+        sql: `
+      WITH requested(granted_email) AS (
+        VALUES ${emails.map(() => '(?)').join(', ')}
+      )
+      UPDATE link_publication_attempts
+      SET requested_grants_present = NOT EXISTS (
+        SELECT 1
+        FROM requested
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM shareable_grants AS grant_row
+          WHERE grant_row.shareable_id = link_publication_attempts.shareable_id
+            AND lower(grant_row.granted_email) = requested.granted_email
+        )
+      )
+      WHERE workspace_id = ?
+        AND shareable_id = ?
+    `,
+        parameters: [...emails, workspaceId, shareableId],
       }) as unknown as ReturnType<Compilable<unknown>['compile']>,
   }
 }

--- a/apps/web/app/services/shareables.server.ts
+++ b/apps/web/app/services/shareables.server.ts
@@ -4192,6 +4192,7 @@ function insertGrantEmailsWithinLimitQuery({
     grantedAt,
     grantedBy,
     shareableId,
+    shareableId,
     grantedAt,
     grantedBy,
   ]
@@ -4230,6 +4231,12 @@ function insertGrantEmailsWithinLimitQuery({
     SELECT ?, p.granted_email, ?, ?
     FROM proposed AS p
     WHERE (SELECT ok FROM limit_check)
+      AND NOT EXISTS (
+        SELECT 1
+        FROM shareable_grants AS existing_grant
+        WHERE existing_grant.shareable_id = ?
+          AND lower(existing_grant.granted_email) = p.granted_email
+      )
     UNION ALL
     SELECT ?, NULL, ?, ?
     WHERE NOT (SELECT ok FROM limit_check)

--- a/apps/web/app/test/atomic-sharing-grants-migration.test.ts
+++ b/apps/web/app/test/atomic-sharing-grants-migration.test.ts
@@ -1,0 +1,132 @@
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, test } from 'vitest'
+import {
+  applyMigrations,
+  createMigratedInMemoryDb,
+  loadMigrations,
+} from './sqlite-fixture'
+
+const migrationName = '0106_atomic_sharing_grants.sql'
+
+describe('atomic sharing grants migration', () => {
+  test('is additive for old-shaped shareable and grant writes', () => {
+    const migrations = loadMigrations()
+    const sqlite = new DatabaseSync(':memory:')
+    applyMigrations(
+      sqlite,
+      migrations.filter((migration) => migration.name < migrationName),
+    )
+    sqlite.exec(`
+      INSERT INTO workspaces (id, name, created_at)
+      VALUES ('ws-a', 'Workspace', '2026-09-08T00:00:00.000Z');
+      INSERT INTO users (
+        id, email, name, created_at, updated_at, workspace_id, google_sub
+      )
+      VALUES (
+        'owner-1',
+        'owner@example.com',
+        'Owner',
+        '2026-09-08T00:00:00.000Z',
+        '2026-09-08T00:00:00.000Z',
+        'ws-a',
+        'owner-sub'
+      );
+      INSERT INTO artifact_containers (
+        id, workspace_id, kind, owner_user_id, created_by_id, name,
+        created_at, updated_at
+      ) VALUES (
+        'inbox-1', 'ws-a', 'inbox', 'owner-1', 'owner-1', 'Inbox',
+        '2026-09-08T00:00:00.000Z', '2026-09-08T00:00:00.000Z'
+      );
+      INSERT INTO shareables (
+        id, workspace_id, owner_user_id, name, artifact_kind, visibility,
+        created_at, updated_at, container_id
+      ) VALUES (
+        'share-1', 'ws-a', 'owner-1', 'Document', 'html_page', 'private',
+        '2026-09-08T00:00:00.000Z', '2026-09-08T00:00:00.000Z', 'inbox-1'
+      );
+    `)
+    const migration = migrations.find((item) => item.name === migrationName)
+    expect(migration).toBeDefined()
+    sqlite.exec(migration!.sql)
+
+    sqlite.exec(`
+      UPDATE shareables
+      SET visibility = 'link', updated_at = '2026-09-08T00:01:00.000Z'
+      WHERE id = 'share-1';
+      INSERT OR IGNORE INTO shareable_grants (
+        shareable_id, granted_email, granted_at, granted_by
+      ) VALUES (
+        'share-1', 'viewer@example.com', '2026-09-08T00:01:00.000Z', 'owner-1'
+      );
+    `)
+
+    expect(sqlite.prepare('SELECT visibility FROM shareables').get()).toEqual({
+      visibility: 'link',
+    })
+    expect(
+      sqlite.prepare('SELECT COUNT(*) AS count FROM shareable_grants').get(),
+    ).toEqual({ count: 1 })
+    expect(
+      sqlite
+        .prepare('SELECT COUNT(*) AS count FROM link_publication_attempts')
+        .get(),
+    ).toEqual({ count: 0 })
+  })
+
+  test('enforces the named requested-grant assertion', () => {
+    const { sqlite } = createMigratedInMemoryDb()
+    sqlite.exec(`
+      INSERT INTO workspaces (id, name, created_at)
+      VALUES ('ws-a', 'Workspace', '2026-09-08T00:00:00.000Z');
+      INSERT INTO link_publication_attempts (
+        workspace_id, shareable_id, published_at, window_start,
+        daily_limit, limit_applies, consumed
+      ) VALUES (
+        'ws-a', 'share-1', '2026-09-08T00:00:00.000Z',
+        '2026-09-07T00:00:00.000Z', 20, 0, 1
+      );
+    `)
+
+    expect(() =>
+      sqlite.exec(`
+        UPDATE link_publication_attempts
+        SET requested_grants_present = 0
+        WHERE workspace_id = 'ws-a' AND shareable_id = 'share-1'
+      `),
+    ).toThrow(
+      'CHECK constraint failed: link_publication_all_requested_grants_present',
+    )
+  })
+
+  test('refuses deletion until an attempt is consumed', () => {
+    const { sqlite } = createMigratedInMemoryDb()
+    sqlite.exec(`
+      INSERT INTO workspaces (id, name, created_at)
+      VALUES ('ws-a', 'Workspace', '2026-09-08T00:00:00.000Z');
+      INSERT INTO link_publication_attempts (
+        workspace_id, shareable_id, published_at, window_start,
+        daily_limit, limit_applies
+      ) VALUES (
+        'ws-a', 'share-1', '2026-09-08T00:00:00.000Z',
+        '2026-09-07T00:00:00.000Z', 20, 0
+      );
+    `)
+
+    expect(() =>
+      sqlite.exec(`
+        DELETE FROM link_publication_attempts
+        WHERE workspace_id = 'ws-a' AND shareable_id = 'share-1'
+      `),
+    ).toThrow('link publication mutation missing')
+    sqlite.exec(`
+      UPDATE link_publication_attempts SET consumed = 1;
+      DELETE FROM link_publication_attempts;
+    `)
+    expect(
+      sqlite
+        .prepare('SELECT COUNT(*) AS count FROM link_publication_attempts')
+        .get(),
+    ).toEqual({ count: 0 })
+  })
+})

--- a/apps/web/app/types/db.ts
+++ b/apps/web/app/types/db.ts
@@ -45,6 +45,7 @@ export interface DB {
   anonymous_view_signals: AnonymousViewSignalsTable
   link_abuse_judgment_gates: LinkAbuseJudgmentGatesTable
   link_abuse_judgments: LinkAbuseJudgmentsTable
+  link_publication_attempts: LinkPublicationAttemptsTable
   shareable_grants: ShareableGrantsTable
   access_requests: AccessRequestsTable
   versions: VersionsTable
@@ -512,6 +513,17 @@ interface ShareableGrantsTable {
   granted_email: string
   granted_at: string
   granted_by: string
+}
+
+interface LinkPublicationAttemptsTable {
+  workspace_id: string
+  shareable_id: string
+  published_at: string
+  window_start: string
+  daily_limit: number
+  limit_applies: number
+  consumed: Generated<number>
+  requested_grants_present: Generated<number>
 }
 
 interface AccessRequestsTable {

--- a/apps/web/db/migrations/0106_atomic_sharing_grants.sql
+++ b/apps/web/db/migrations/0106_atomic_sharing_grants.sql
@@ -1,0 +1,21 @@
+CREATE TABLE link_publication_attempts (
+  workspace_id   TEXT NOT NULL
+                 REFERENCES workspaces(id) ON DELETE CASCADE,
+  shareable_id   TEXT NOT NULL,
+  published_at   TEXT NOT NULL,
+  window_start   TEXT NOT NULL,
+  daily_limit    INTEGER NOT NULL CHECK (daily_limit >= 0),
+  limit_applies  INTEGER NOT NULL CHECK (limit_applies IN (0, 1)),
+  consumed       INTEGER NOT NULL DEFAULT 0 CHECK (consumed IN (0, 1)),
+  requested_grants_present INTEGER NOT NULL DEFAULT 1
+    CONSTRAINT link_publication_all_requested_grants_present
+    CHECK (requested_grants_present = 1),
+  PRIMARY KEY (workspace_id, shareable_id)
+);
+
+CREATE TRIGGER link_publication_attempt_must_be_consumed
+BEFORE DELETE ON link_publication_attempts
+WHEN OLD.consumed <> 1
+BEGIN
+  SELECT RAISE(ABORT, 'link publication mutation missing');
+END;

--- a/apps/web/db/schema.sql
+++ b/apps/web/db/schema.sql
@@ -651,6 +651,28 @@ CREATE TABLE shareable_grants (
 );
 CREATE INDEX idx_shareable_grants_email ON shareable_grants(granted_email);
 
+CREATE TABLE link_publication_attempts (
+  workspace_id   TEXT NOT NULL
+                 REFERENCES workspaces(id) ON DELETE CASCADE,
+  shareable_id   TEXT NOT NULL,
+  published_at   TEXT NOT NULL,
+  window_start   TEXT NOT NULL,
+  daily_limit    INTEGER NOT NULL CHECK (daily_limit >= 0),
+  limit_applies  INTEGER NOT NULL CHECK (limit_applies IN (0, 1)),
+  consumed       INTEGER NOT NULL DEFAULT 0 CHECK (consumed IN (0, 1)),
+  requested_grants_present INTEGER NOT NULL DEFAULT 1
+    CONSTRAINT link_publication_all_requested_grants_present
+    CHECK (requested_grants_present = 1),
+  PRIMARY KEY (workspace_id, shareable_id)
+);
+
+CREATE TRIGGER link_publication_attempt_must_be_consumed
+BEFORE DELETE ON link_publication_attempts
+WHEN OLD.consumed <> 1
+BEGIN
+  SELECT RAISE(ABORT, 'link publication mutation missing');
+END;
+
 CREATE TABLE access_requests (
   id                    TEXT PRIMARY KEY,
   shareable_id          TEXT NOT NULL REFERENCES shareables(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

Make sharing-dialog recipient changes fail in their original transaction when concurrent additions exhaust the recipient limit. Visibility, expiry, recipient removals/additions, and their events now roll back together, so an error cannot leave only part of the requested settings saved.

Existing recipients also remain idempotent when their stored email casing differs from the requested address.

An additive assertion table replaces the post-commit recipient check and visibility compensation. Static-site commit also maps a late artifact-ID collision to the existing `id-exhausted` result after cleaning staged objects and reservations.

## Validation

`pnpm validate:static` passed on `12d2417`, including migration/schema parity, the Wrangler D1 harness (14 tests), script tests (542), web unit tests (3,607 passed, 1 skipped), qm-bridge tests (81), typecheck, React Doctor (100), and public scan (0 findings). Focused service tests passed 165/165. A red/green regression confirms that adding a normalized address to an existing mixed-case grant preserves one recipient. The pre-push commit-range boundary check passed using the guard and manifest from a clean `origin/main` checkout.

Coverage includes both visibility directions, grant-only additions/removals, expiry and event rollback, idempotence, final attempt deletion, old-shaped writes on the additive schema, and late static-upload ID collision cleanup.

## Review

Independent Codex and Claude deep reviews completed on `12d2417`; all findings were classified and no unresolved blocker remains. The first round identified the existing mixed-case recipient duplication covered by the repair and regression test. The final round raised no new reproducible failure; repeated design alternatives, hypothetical future changes, and out-of-scope normalization work were classified as non-actionable. No deferred work remains. The fixed specification gate also passed.
