### PR TITLE
Preserve analytics across viewer sign-in

### DIFF
--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
@@ -220,10 +220,9 @@ describe('ViewerChrome', () => {
       renderType: 'html',
     })
 
-    expect(html).toContain(
-      '<a href="https://artifactshare.com/sign-in?next=%2Fa%2Fs1"',
+    expect(html).toMatch(
+      /<a[^>]*href="https:\/\/artifactshare\.com\/sign-in\?next=%2Fa%2Fs1"/,
     )
-    expect(html).not.toContain('type="button">Sign in')
   })
 
   test('keeps the copy-link focus ring without the resting shadow', () => {
@@ -540,10 +539,6 @@ describe('ViewerChrome', () => {
     )?.[0]
     expect(toggleOpenTag).toBeDefined()
     expect(toggleOpenTag).not.toContain('href')
-    expect(html.match(/href="[^"]*"/g)).toEqual([
-      'href="/"',
-      'href="/sign-in?next=%2Fa%2Fs1"',
-    ])
   })
 })
 

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
@@ -212,6 +212,20 @@ describe('ViewerChrome', () => {
     expect(html).toContain('aria-label="Change analytics consent"')
   })
 
+  test('anonymous link viewer uses a link for cross-domain sign-in', () => {
+    const html = renderChrome({
+      artifact,
+      user: null,
+      appOrigin: 'https://artifactshare.com',
+      renderType: 'html',
+    })
+
+    expect(html).toContain(
+      '<a href="https://artifactshare.com/sign-in?next=%2Fa%2Fs1"',
+    )
+    expect(html).not.toContain('type="button">Sign in')
+  })
+
   test('keeps the copy-link focus ring without the resting shadow', () => {
     const html = renderChrome({
       artifact,
@@ -526,7 +540,10 @@ describe('ViewerChrome', () => {
     )?.[0]
     expect(toggleOpenTag).toBeDefined()
     expect(toggleOpenTag).not.toContain('href')
-    expect(html.match(/href="[^"]*"/g)).toEqual(['href="/"'])
+    expect(html.match(/href="[^"]*"/g)).toEqual([
+      'href="/"',
+      'href="/sign-in?next=%2Fa%2Fs1"',
+    ])
   })
 })
 

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
@@ -221,8 +221,9 @@ describe('ViewerChrome', () => {
     })
 
     expect(html).toMatch(
-      /<a[^>]*href="https:\/\/artifactshare\.com\/sign-in\?next=%2Fa%2Fs1"/,
+      /<a(?=[^>]*href="https:\/\/artifactshare\.com\/sign-in\?next=%2Fa%2Fs1")[^>]*>signin\.cta<\/a>/,
     )
+    expect(html).not.toMatch(/<button[^>]*>signin\.cta<\/button>/)
   })
 
   test('keeps the copy-link focus ring without the resting shadow', () => {

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
@@ -1387,17 +1387,14 @@ function ViewerActions({
             onClick={(event) => openBanner(event.currentTarget)}
           />
           <Button
-            type="button"
+            asChild
             variant="outline"
             size="default"
             className="text-foreground hover:bg-accent border-border bg-card h-8 rounded-[var(--r-md)] px-3 text-sm font-medium"
-            onClick={() => {
-              window.location.assign(
-                anonymousViewerSignInUrl(appOrigin, artifactId),
-              )
-            }}
           >
-            {t('signin.cta')}
+            <a href={anonymousViewerSignInUrl(appOrigin, artifactId)}>
+              {t('signin.cta')}
+            </a>
           </Button>
         </>
       )}


### PR DESCRIPTION
The anonymous viewer’s Sign in control now uses a real cross-domain link while preserving its destination and styling. This lets the configured Google tag linker decorate the click, so an analytics-enabled visit can retain the same browser identity when moving from a shared file to sign-in.

The destination continues to carry only the internal file return path. When analytics is refused, Google tag remains unloaded, and the authentication flow is unchanged.

Validation:
- focused viewer tests: 25 passed
- `pnpm validate:static`
- Web production build
- React Doctor: 100
- `pnpm visual:compose`: 98 passed
- final desktop/mobile viewer captures: 80 succeeded, 0 failed
- desktop/mobile sharing walkthrough captured on the final commit
- UI critique confirmed the Sign in label, destination, and responsive presentation; observations about the existing sharing-recovery walkthrough were outside this change
- final Codex and Claude implementation gate completed with no unresolved blocker
