### PR TITLE
Respect withdrawn analytics consent in viewer sign-in

### DIFF
--- a/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.test.tsx
@@ -1,0 +1,32 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, test } from 'vitest'
+import { AnonymousViewerSignInControl } from './anonymous-viewer-sign-in'
+
+describe('AnonymousViewerSignInControl', () => {
+  const href = 'https://artifactshare.com/sign-in?next=%2Fa%2Fs1'
+
+  test('uses a link so Google can decorate an analytics-enabled transition', () => {
+    const html = renderToStaticMarkup(
+      <AnonymousViewerSignInControl
+        href={href}
+        label="Sign in"
+        shouldLoadAnalytics
+      />,
+    )
+
+    expect(html).toContain(`href="${href}"`)
+  })
+
+  test('uses scripted navigation when analytics is disabled', () => {
+    const html = renderToStaticMarkup(
+      <AnonymousViewerSignInControl
+        href={href}
+        label="Sign in"
+        shouldLoadAnalytics={false}
+      />,
+    )
+
+    expect(html).toMatch(/<button[^>]*>Sign in<\/button>/)
+    expect(html).not.toContain('href=')
+  })
+})

--- a/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, test } from 'vitest'
+import type { ReactElement } from 'react'
+import { describe, expect, test, vi } from 'vitest'
 import { AnonymousViewerSignInControl } from './anonymous-viewer-sign-in'
 
 describe('AnonymousViewerSignInControl', () => {
@@ -18,15 +19,20 @@ describe('AnonymousViewerSignInControl', () => {
   })
 
   test('uses scripted navigation when analytics is disabled', () => {
-    const html = renderToStaticMarkup(
-      <AnonymousViewerSignInControl
-        href={href}
-        label="Sign in"
-        shouldLoadAnalytics={false}
-      />,
-    )
+    const control = AnonymousViewerSignInControl({
+      href,
+      label: 'Sign in',
+      shouldLoadAnalytics: false,
+    }) as ReactElement<{ onClick: () => void }>
+    const html = renderToStaticMarkup(control)
 
     expect(html).toMatch(/<button[^>]*>Sign in<\/button>/)
     expect(html).not.toContain('href=')
+
+    const assign = vi.fn()
+    vi.stubGlobal('window', { location: { assign } })
+    control.props.onClick()
+    expect(assign).toHaveBeenCalledWith(href)
+    vi.unstubAllGlobals()
   })
 })

--- a/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.test.tsx
@@ -31,8 +31,11 @@ describe('AnonymousViewerSignInControl', () => {
 
     const assign = vi.fn()
     vi.stubGlobal('window', { location: { assign } })
-    control.props.onClick()
-    expect(assign).toHaveBeenCalledWith(href)
-    vi.unstubAllGlobals()
+    try {
+      control.props.onClick()
+      expect(assign).toHaveBeenCalledWith(href)
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.tsx
+++ b/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.tsx
@@ -1,6 +1,4 @@
-import { useRouteLoaderData } from 'react-router'
 import { Button } from '~/components/ui/button'
-import type { AnalyticsConsentResolution } from '~/lib/analytics-consent'
 
 const className =
   'text-foreground hover:bg-accent border-border bg-card h-8 rounded-[var(--r-md)] px-3 text-sm font-medium'
@@ -34,27 +32,5 @@ export function AnonymousViewerSignInControl({
     >
       {label}
     </Button>
-  )
-}
-
-export function AnonymousViewerSignIn({
-  href,
-  label,
-}: {
-  href: string
-  label: string
-}) {
-  const rootData = useRouteLoaderData<{
-    analyticsConsent?: AnalyticsConsentResolution
-  }>('root')
-
-  return (
-    <AnonymousViewerSignInControl
-      href={href}
-      label={label}
-      shouldLoadAnalytics={
-        rootData?.analyticsConsent?.shouldLoadAnalytics ?? false
-      }
-    />
   )
 }

--- a/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.tsx
+++ b/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.tsx
@@ -28,6 +28,8 @@ export function AnonymousViewerSignInControl({
       variant="outline"
       size="default"
       className={className}
+      // A previously loaded Google linker can keep decorating anchors after
+      // consent is withdrawn, so navigate without exposing an href to it.
       onClick={() => window.location.assign(href)}
     >
       {label}
@@ -51,7 +53,7 @@ export function AnonymousViewerSignIn({
       href={href}
       label={label}
       shouldLoadAnalytics={
-        rootData?.analyticsConsent?.shouldLoadAnalytics ?? true
+        rootData?.analyticsConsent?.shouldLoadAnalytics ?? false
       }
     />
   )

--- a/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.tsx
+++ b/apps/web/app/routes/a.$id/+components/anonymous-viewer-sign-in.tsx
@@ -1,0 +1,58 @@
+import { useRouteLoaderData } from 'react-router'
+import { Button } from '~/components/ui/button'
+import type { AnalyticsConsentResolution } from '~/lib/analytics-consent'
+
+const className =
+  'text-foreground hover:bg-accent border-border bg-card h-8 rounded-[var(--r-md)] px-3 text-sm font-medium'
+
+export function AnonymousViewerSignInControl({
+  href,
+  label,
+  shouldLoadAnalytics,
+}: {
+  href: string
+  label: string
+  shouldLoadAnalytics: boolean
+}) {
+  if (shouldLoadAnalytics) {
+    return (
+      <Button asChild variant="outline" size="default" className={className}>
+        <a href={href}>{label}</a>
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="default"
+      className={className}
+      onClick={() => window.location.assign(href)}
+    >
+      {label}
+    </Button>
+  )
+}
+
+export function AnonymousViewerSignIn({
+  href,
+  label,
+}: {
+  href: string
+  label: string
+}) {
+  const rootData = useRouteLoaderData<{
+    analyticsConsent?: AnalyticsConsentResolution
+  }>('root')
+
+  return (
+    <AnonymousViewerSignInControl
+      href={href}
+      label={label}
+      shouldLoadAnalytics={
+        rootData?.analyticsConsent?.shouldLoadAnalytics ?? true
+      }
+    />
+  )
+}

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
@@ -87,9 +87,6 @@ vi.mock('react-router', () => ({
   }),
   useNavigate: () => vi.fn(),
   useRevalidator: () => ({ revalidate: vi.fn() }),
-  useRouteLoaderData: () => ({
-    analyticsConsent: { shouldLoadAnalytics: true },
-  }),
 }))
 
 vi.mock('~/components/app/avatar-menu', () => ({
@@ -220,6 +217,7 @@ describe('ViewerChrome', () => {
       artifact,
       user: null,
       appOrigin: 'https://artifactshare.com',
+      analyticsMode: 'enabled',
       renderType: 'html',
     })
 
@@ -227,6 +225,21 @@ describe('ViewerChrome', () => {
       /<a(?=[^>]*href="https:\/\/artifactshare\.com\/sign-in\?next=%2Fa%2Fs1")[^>]*>signin\.cta<\/a>/,
     )
     expect(html).not.toMatch(/<button[^>]*>signin\.cta<\/button>/)
+  })
+
+  test('anonymous link viewer omits the sign-in href without analytics consent', () => {
+    const html = renderChrome({
+      artifact,
+      user: null,
+      appOrigin: 'https://artifactshare.com',
+      analyticsMode: 'disabled',
+      renderType: 'html',
+    })
+
+    expect(html).toMatch(/<button[^>]*>signin\.cta<\/button>/)
+    expect(html).not.toContain(
+      'href="https://artifactshare.com/sign-in?next=%2Fa%2Fs1"',
+    )
   })
 
   test('keeps the copy-link focus ring without the resting shadow', () => {

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.test.tsx
@@ -87,6 +87,9 @@ vi.mock('react-router', () => ({
   }),
   useNavigate: () => vi.fn(),
   useRevalidator: () => ({ revalidate: vi.fn() }),
+  useRouteLoaderData: () => ({
+    analyticsConsent: { shouldLoadAnalytics: true },
+  }),
 }))
 
 vi.mock('~/components/app/avatar-menu', () => ({

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
@@ -65,6 +65,7 @@ import { viewerReturnTo } from '~/lib/viewer-return'
 import { useEditTitle } from '../+hooks/use-edit-title'
 import { buildShareableUrl } from '~/lib/share-url'
 import { useSharingRecoverySignal } from '~/hooks/use-sharing-recovery-signal'
+import { AnonymousViewerSignIn } from './anonymous-viewer-sign-in'
 
 interface ViewerPresence {
   id: string
@@ -1386,16 +1387,10 @@ function ViewerActions({
             size="sm"
             onClick={(event) => openBanner(event.currentTarget)}
           />
-          <Button
-            asChild
-            variant="outline"
-            size="default"
-            className="text-foreground hover:bg-accent border-border bg-card h-8 rounded-[var(--r-md)] px-3 text-sm font-medium"
-          >
-            <a href={anonymousViewerSignInUrl(appOrigin, artifactId)}>
-              {t('signin.cta')}
-            </a>
-          </Button>
+          <AnonymousViewerSignIn
+            href={anonymousViewerSignInUrl(appOrigin, artifactId)}
+            label={t('signin.cta')}
+          />
         </>
       )}
     </div>

--- a/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-chrome.tsx
@@ -65,7 +65,7 @@ import { viewerReturnTo } from '~/lib/viewer-return'
 import { useEditTitle } from '../+hooks/use-edit-title'
 import { buildShareableUrl } from '~/lib/share-url'
 import { useSharingRecoverySignal } from '~/hooks/use-sharing-recovery-signal'
-import { AnonymousViewerSignIn } from './anonymous-viewer-sign-in'
+import { AnonymousViewerSignInControl } from './anonymous-viewer-sign-in'
 
 interface ViewerPresence {
   id: string
@@ -172,6 +172,7 @@ interface ViewerChromeProps {
   /** Set for anonymous link-share views: shows the origin ⓘ next to the author. */
   linkOrigin?: { shareableId: string } | null
   appOrigin?: string
+  analyticsMode?: 'enabled' | 'disabled'
   renderType: ArtifactType | null
   onHistoryOpenChange?: (
     open: boolean,
@@ -220,6 +221,7 @@ export function ViewerChrome({
   user,
   linkOrigin = null,
   appOrigin,
+  analyticsMode = 'disabled',
   renderType,
   onHistoryOpenChange,
   commentCount = 0,
@@ -403,6 +405,7 @@ export function ViewerChrome({
         <div className="max-viewer:hidden flex-1" />
         <ViewerActions
           appOrigin={appOrigin}
+          analyticsMode={analyticsMode}
           artifactId={artifact.id}
           accessRequestId={accessRequestId}
           artifactCanViewHistory={artifact.canViewHistory}
@@ -1069,6 +1072,7 @@ function ViewerVisibilityDialog({
 
 interface ViewerActionsProps {
   appOrigin?: string
+  analyticsMode: 'enabled' | 'disabled'
   artifactId: string
   accessRequestId: string | null
   artifactCanViewHistory: boolean | undefined
@@ -1111,6 +1115,7 @@ interface ViewerActionsProps {
 function ViewerActions({
   linkSuspended,
   appOrigin,
+  analyticsMode,
   artifactId,
   accessRequestId,
   artifactCanViewHistory,
@@ -1387,9 +1392,10 @@ function ViewerActions({
             size="sm"
             onClick={(event) => openBanner(event.currentTarget)}
           />
-          <AnonymousViewerSignIn
+          <AnonymousViewerSignInControl
             href={anonymousViewerSignInUrl(appOrigin, artifactId)}
             label={t('signin.cta')}
+            shouldLoadAnalytics={analyticsMode === 'enabled'}
           />
         </>
       )}

--- a/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
+++ b/apps/web/app/routes/a.$id/+components/viewer-shell.tsx
@@ -1418,6 +1418,7 @@ type ViewerShellProps = {
   fallbackToIndex?: boolean
   children?: ReactNode
   appOrigin?: string
+  analyticsMode?: 'enabled' | 'disabled'
   linkSafety?: { lowTrust: boolean } | null
 }
 export function ViewerShell(props: ViewerShellProps) {
@@ -1433,6 +1434,7 @@ function useViewerShellController({
   fallbackToIndex = false,
   children,
   appOrigin,
+  analyticsMode = 'disabled',
   linkSafety,
 }: ViewerShellProps) {
   const { t } = useT()
@@ -1850,6 +1852,7 @@ function useViewerShellController({
     fallbackToIndex,
     children,
     appOrigin,
+    analyticsMode,
     linkSafety,
     state,
     dispatch,
@@ -1942,6 +1945,7 @@ function ViewerShellView({
   handleDrop,
   setFrameExportPath,
   appOrigin,
+  analyticsMode,
   linkSafety,
 }: ViewerShellController) {
   const { t } = useT()
@@ -1955,6 +1959,7 @@ function ViewerShellView({
         linkOrigin={linkSafety ? { shareableId: artifact.id } : null}
         renderType={renderType}
         appOrigin={appOrigin}
+        analyticsMode={analyticsMode}
         onHistoryOpenChange={(open, options) => {
           if (open) {
             historyReturnFocusRef.current =

--- a/apps/web/app/routes/a.$id/index.tsx
+++ b/apps/web/app/routes/a.$id/index.tsx
@@ -34,6 +34,7 @@ import { SourceMissing } from './+components/source-missing'
 import { Unavailable } from '~/components/app/unavailable'
 import { UnsupportedContent } from './+components/unsupported-content'
 import { useT } from '~/hooks/use-t'
+import type { AnalyticsConsentResolution } from '~/lib/analytics-consent'
 import { detectArtifactType, type ArtifactType } from '~/lib/artifact-type'
 import { normalizePlan } from '~/lib/billing-plan.server'
 import { type CommentThreadView } from '~/lib/comments'
@@ -1661,6 +1662,12 @@ function sharedPreviewDescription(artifact: SharePreviewArtifact): string {
 }
 
 export default function ViewerRoute({ loaderData }: Route.ComponentProps) {
+  const rootData = useRouteLoaderData<{
+    analyticsConsent?: AnalyticsConsentResolution
+  }>('root')
+  const shouldLoadAnalytics =
+    rootData?.analyticsConsent?.shouldLoadAnalytics ?? false
+
   switch (loaderData.kind) {
     case 'preauth':
       return <PreauthFallback canonicalUrl={loaderData.canonicalUrl} />
@@ -1696,6 +1703,7 @@ export default function ViewerRoute({ loaderData }: Route.ComponentProps) {
           renderType={null}
           sandboxUrl={null}
           bundlePaths={[]}
+          analyticsMode={shouldLoadAnalytics ? 'enabled' : 'disabled'}
         >
           <UnsupportedContent />
         </ViewerShell>
@@ -1724,6 +1732,7 @@ export default function ViewerRoute({ loaderData }: Route.ComponentProps) {
             sandboxUrl={loaderData.sandboxUrl}
             bundlePaths={[]}
             appOrigin={loaderData.appOrigin}
+            analyticsMode={shouldLoadAnalytics ? 'enabled' : 'disabled'}
             linkSafety={loaderData.linkSafety}
           />
           <ArtifactViewTracker
@@ -1746,6 +1755,7 @@ export default function ViewerRoute({ loaderData }: Route.ComponentProps) {
             bundlePaths={loaderData.bundlePaths}
             fallbackToIndex={loaderData.fallbackToIndex}
             appOrigin={loaderData.appOrigin}
+            analyticsMode={shouldLoadAnalytics ? 'enabled' : 'disabled'}
             linkSafety={loaderData.linkSafety}
           />
           <ArtifactViewTracker


### PR DESCRIPTION
## Problem

After analytics consent is withdrawn in a viewer page where Google Analytics was already loaded, the cross-domain linker can still decorate the anonymous sign-in URL with analytics identifiers.

## Change

- Keep the native sign-in anchor while analytics is enabled so cross-domain identity continuity remains intact.
- Render a direct-navigation button while analytics is disabled or unresolved, preventing the loaded linker from decorating an `href`.
- Resolve consent in the real viewer route and pass a named mode through reusable viewer chrome without requiring data-router context.
- Cover enabled and disabled DOM states, the exact disabled navigation target, and anonymous browser behavior.

## Validation

- `pnpm validate:static`
- `pnpm --filter @artifactshare/web test:behavior-browser` (15 files, 78 tests)
- focused viewer sign-in and chrome tests (28 tests)
- React Doctor: 100
- public repository scan: 0 findings
- Codex and Claude deep implementation review on `98baf80`; no unresolved blocker. Repeated requests to restore denied-state anchor semantics were classified non-actionable because they reproduce the observed consent-withdrawal failure.
