### PR TITLE
Harden suspended link access and operator actions

### DIFF
--- a/apps/web/app/d1-tests/link-suspension-atomicity.test.ts
+++ b/apps/web/app/d1-tests/link-suspension-atomicity.test.ts
@@ -1,23 +1,41 @@
 import { fileURLToPath } from 'node:url'
 import { createTestHarness } from 'wrangler'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('cloudflare:workers', () => ({
+  env: { ['BETTER_AUTH_' + 'SECRET']: 'd1-test-secret-with-enough-entropy' },
+}))
+
+import { createDb } from '../services/db.server'
+import {
+  appealLinkSuspension,
+  resumeLink,
+  suspendLink,
+} from '../services/link-suspension.server'
 
 const server = createTestHarness({
   root: fileURLToPath(new URL('../..', import.meta.url)),
   workers: [{ configPath: './wrangler.sandbox.jsonc' }],
 })
 const worker = server.getWorker<{ DB: D1Database }>()
-let db: D1Database
+let database: D1Database
+
+const at = '2026-09-08T00:00:00.000Z'
+const ops = {
+  credentialId: 'credential-atomic-1234567890',
+  source: { kind: 'judgment' as const, id: 'judgment-atomic' },
+  notify: async () => 'skipped' as const,
+}
 
 beforeAll(async () => {
   await server.listen()
   await worker.applyD1Migrations('DB')
-  db = (await worker.getEnv()).DB
-  await db.batch([
-    db
+  database = (await worker.getEnv()).DB
+  await database.batch([
+    database
       .prepare('INSERT INTO workspaces (id, name, created_at) VALUES (?, ?, ?)')
-      .bind('atomic-ws', 'Atomic', '2026-09-08T00:00:00.000Z'),
-    db
+      .bind('atomic-ws', 'Atomic', at),
+    database
       .prepare(
         `INSERT INTO users (
           id, email, email_verified, name, created_at, updated_at, workspace_id,
@@ -28,12 +46,12 @@ beforeAll(async () => {
         'atomic-owner',
         'atomic@example.com',
         'Owner',
-        '2026-09-08T00:00:00.000Z',
-        '2026-09-08T00:00:00.000Z',
+        at,
+        at,
         'atomic-ws',
         'atomic-owner-sub',
       ),
-    db
+    database
       .prepare(
         `INSERT INTO artifact_containers (
           id, workspace_id, kind, owner_user_id, created_by_id, name,
@@ -41,7 +59,7 @@ beforeAll(async () => {
         ) VALUES ('atomic-inbox', 'atomic-ws', 'inbox', 'atomic-owner',
           'atomic-owner', 'Inbox', ?, ?)`,
       )
-      .bind('2026-09-08T00:00:00.000Z', '2026-09-08T00:00:00.000Z'),
+      .bind(at, at),
   ])
 })
 
@@ -49,152 +67,163 @@ afterAll(async () => {
   await server.close()
 })
 
-async function seedShareable(id: string) {
-  await db
+async function seedShareable(id: string, suspended = false) {
+  await database
     .prepare(
       `INSERT INTO shareables (
         id, workspace_id, owner_user_id, name, artifact_kind, visibility,
-        created_at, updated_at, container_id
+        created_at, updated_at, container_id, link_suspended_at
       ) VALUES (?, 'atomic-ws', 'atomic-owner', ?, 'html_page', 'link', ?, ?,
-        'atomic-inbox')`,
+        'atomic-inbox', ?)`,
     )
-    .bind(id, id, '2026-09-08T00:00:00.000Z', '2026-09-08T00:00:00.000Z')
+    .bind(id, id, at, at, suspended ? '2026-09-08T01:00:00.000Z' : null)
     .run()
 }
 
-function transitionBatch(shareableId: string, eventId: string) {
-  const now = '2026-09-08T01:00:00.000Z'
-  const payload = JSON.stringify({
-    actor: { kind: 'operator_credential', credentialId: eventId },
-    source: { kind: 'judgment', id: 'judgment-1' },
-    reason: 'review',
-    notify: true,
-    recipients: [],
-  })
-  return db.batch([
-    db
+async function transitionCounts(shareableId: string) {
+  const [event, audit, shareable] = await Promise.all([
+    database
       .prepare(
-        `INSERT INTO events (
-          id, workspace_id, type, shareable_id, actor_user_id, subject_id,
-          payload, created_at
-        )
-        SELECT ?, workspace_id, 'link_suspended', id, NULL, ?, ?, ?
-        FROM shareables
-        WHERE id = ? AND visibility = 'link' AND link_suspended_at IS NULL`,
+        "SELECT COUNT(*) AS count FROM events WHERE shareable_id = ? AND type IN ('link_suspended', 'link_resumed')",
       )
-      .bind(eventId, `${eventId}-subject`, payload, now, shareableId),
-    db
+      .bind(shareableId)
+      .first<{ count: number }>(),
+    database
       .prepare(
-        `INSERT INTO audit_events (
-          id, workspace_id, actor_user_id, action, subject_type, subject_id,
-          detail, created_at
-        )
-        SELECT ?, workspace_id, NULL, 'shareable.link.suspend', 'shareable',
-          shareable_id, json_remove(payload, '$.recipients'), created_at
-        FROM events WHERE id = ?`,
+        "SELECT COUNT(*) AS count FROM audit_events WHERE subject_id = ? AND action IN ('shareable.link.suspend', 'shareable.link.resume')",
       )
-      .bind(`${eventId}-audit`, eventId),
-    db
-      .prepare(
-        `UPDATE shareables
-         SET link_suspended_at = ?, link_suspended_reason = 'review'
-         WHERE id = ?
-           AND id IN (SELECT shareable_id FROM events WHERE id = ?)`,
-      )
-      .bind(now, shareableId, eventId),
+      .bind(shareableId)
+      .first<{ count: number }>(),
+    database
+      .prepare('SELECT link_suspended_at FROM shareables WHERE id = ?')
+      .bind(shareableId)
+      .first<{ link_suspended_at: string | null }>(),
   ])
+  return {
+    events: Number(event?.count),
+    audits: Number(audit?.count),
+    suspendedAt: shareable?.link_suspended_at ?? null,
+  }
+}
+
+function failStatement(source: D1Database, pattern: RegExp): D1Database {
+  return new Proxy(source, {
+    get(target, property) {
+      if (property === 'prepare') {
+        return (query: string) =>
+          pattern.test(query)
+            ? target.prepare('INSERT INTO table_that_does_not_exist VALUES (1)')
+            : target.prepare(query)
+      }
+      const value = Reflect.get(target, property)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
 }
 
 describe.sequential('link suspension D1 atomicity', () => {
-  it('commits exactly one event, audit, and flag update under concurrent transitions', async () => {
+  it('commits exactly one event, audit, and flag update under concurrent production transitions', async () => {
     const shareableId = 'atomic001a'
     await seedShareable(shareableId)
-
-    await Promise.all([
-      transitionBatch(shareableId, 'credential-atomic-1'),
-      transitionBatch(shareableId, 'credential-atomic-2'),
-    ])
-
-    const eventCount = await db
-      .prepare(
-        "SELECT COUNT(*) AS count FROM events WHERE shareable_id = ? AND type = 'link_suspended'",
-      )
-      .bind(shareableId)
-      .first<{ count: number }>()
-    const auditCount = await db
-      .prepare(
-        "SELECT COUNT(*) AS count FROM audit_events WHERE subject_id = ? AND action = 'shareable.link.suspend'",
-      )
-      .bind(shareableId)
-      .first<{ count: number }>()
-    const shareable = await db
-      .prepare('SELECT link_suspended_at FROM shareables WHERE id = ?')
-      .bind(shareableId)
-      .first<{ link_suspended_at: string | null }>()
-
-    expect(Number(eventCount?.count)).toBe(1)
-    expect(Number(auditCount?.count)).toBe(1)
-    expect(shareable?.link_suspended_at).toBe('2026-09-08T01:00:00.000Z')
-  })
-
-  it('classifies concurrent appeals from the same transactional batch', async () => {
-    const shareableId = 'atomic002a'
-    await seedShareable(shareableId)
-    await db
-      .prepare(
-        "UPDATE shareables SET link_suspended_at = '2026-09-08T01:00:00.000Z' WHERE id = ?",
-      )
-      .bind(shareableId)
-      .run()
-    const now = '2026-09-08T02:00:00.000Z'
-    const since = '2026-09-08T01:00:00.000Z'
-
-    const appeal = (eventId: string) =>
-      db.batch([
-        db
-          .prepare(
-            `INSERT INTO events (
-              id, workspace_id, type, shareable_id, actor_user_id, subject_id,
-              payload, created_at
-            )
-            SELECT ?, workspace_id, 'link_appealed', id, 'atomic-owner', ?, '{}', ?
-            FROM shareables
-            WHERE id = ? AND owner_user_id = 'atomic-owner'
-              AND link_suspended_at IS NOT NULL
-              AND NOT EXISTS (
-                SELECT 1 FROM events recent
-                WHERE recent.shareable_id = shareables.id
-                  AND recent.type = 'link_appealed'
-                  AND recent.created_at >= ?
-              )`,
-          )
-          .bind(eventId, `${eventId}-subject`, now, shareableId, since),
-        db
-          .prepare(
-            `SELECT
-              EXISTS(SELECT 1 FROM events WHERE id = ?) AS inserted,
-              EXISTS(SELECT 1 FROM shareables WHERE id = ?) AS found,
-              EXISTS(SELECT 1 FROM shareables WHERE id = ? AND owner_user_id = 'atomic-owner') AS owned,
-              EXISTS(SELECT 1 FROM shareables WHERE id = ? AND link_suspended_at IS NOT NULL) AS suspended`,
-          )
-          .bind(eventId, shareableId, shareableId, shareableId),
-      ])
+    const db = createDb(database)
 
     const results = await Promise.all([
-      appeal('appeal-atomic-1'),
-      appeal('appeal-atomic-2'),
+      suspendLink(db, { ...ops, shareableId, reason: 'review' }),
+      suspendLink(db, { ...ops, shareableId, reason: 'review' }),
     ])
-    const inserted = results.map((result) =>
-      Number((result[1].results[0] as { inserted: number }).inserted),
-    )
-    const count = await db
+
+    expect(results.map((result) => result.kind).sort()).toEqual([
+      'already',
+      'suspended',
+    ])
+    expect(await transitionCounts(shareableId)).toEqual({
+      events: 1,
+      audits: 1,
+      suspendedAt: expect.any(String),
+    })
+  })
+
+  it.each([
+    ['audit insert', /insert into "audit_events"/u],
+    ['shareable update', /update "shareables"/u],
+  ])(
+    'rolls back every production transition statement when the %s fails',
+    async (_, pattern) => {
+      const shareableId = pattern.source.includes('audit')
+        ? 'atomic003a'
+        : 'atomic004a'
+      await seedShareable(shareableId)
+      const db = createDb(failStatement(database, pattern))
+
+      await expect(
+        suspendLink(db, { ...ops, shareableId, reason: 'review' }),
+      ).rejects.toThrow()
+
+      expect(await transitionCounts(shareableId)).toEqual({
+        events: 0,
+        audits: 0,
+        suspendedAt: null,
+      })
+    },
+  )
+
+  it('serializes an appeal racing a resume through the production batches', async () => {
+    const shareableId = 'atomic005a'
+    await seedShareable(shareableId, true)
+    const db = createDb(database)
+
+    const [appeal, resumed] = await Promise.all([
+      appealLinkSuspension(
+        db,
+        { id: 'atomic-owner' },
+        {
+          shareableId,
+          message: 'Please review',
+          now: '2026-09-08T02:00:00.000Z',
+        },
+      ),
+      resumeLink(db, { ...ops, shareableId }),
+    ])
+    const appealCount = await database
       .prepare(
         "SELECT COUNT(*) AS count FROM events WHERE shareable_id = ? AND type = 'link_appealed'",
       )
       .bind(shareableId)
       .first<{ count: number }>()
 
-    expect(inserted.sort()).toEqual([0, 1])
+    expect(resumed.kind).toBe('resumed')
+    expect(['appealed', 'not-suspended']).toContain(appeal.kind)
+    expect(Number(appealCount?.count)).toBe(appeal.kind === 'appealed' ? 1 : 0)
+    expect((await transitionCounts(shareableId)).suspendedAt).toBeNull()
+  })
+
+  it('classifies concurrent appeals from the production transactional batch', async () => {
+    const shareableId = 'atomic002a'
+    await seedShareable(shareableId, true)
+    const db = createDb(database)
+    const appeal = () =>
+      appealLinkSuspension(
+        db,
+        { id: 'atomic-owner' },
+        {
+          shareableId,
+          message: 'Please review',
+          now: '2026-09-08T02:00:00.000Z',
+        },
+      )
+
+    const results = await Promise.all([appeal(), appeal()])
+    const count = await database
+      .prepare(
+        "SELECT COUNT(*) AS count FROM events WHERE shareable_id = ? AND type = 'link_appealed'",
+      )
+      .bind(shareableId)
+      .first<{ count: number }>()
+
+    expect(results.map((result) => result.kind).sort()).toEqual([
+      'appealed',
+      'cooldown',
+    ])
     expect(Number(count?.count)).toBe(1)
   })
 })

--- a/apps/web/app/d1-tests/link-suspension-atomicity.test.ts
+++ b/apps/web/app/d1-tests/link-suspension-atomicity.test.ts
@@ -1,0 +1,200 @@
+import { fileURLToPath } from 'node:url'
+import { createTestHarness } from 'wrangler'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const server = createTestHarness({
+  root: fileURLToPath(new URL('../..', import.meta.url)),
+  workers: [{ configPath: './wrangler.sandbox.jsonc' }],
+})
+const worker = server.getWorker<{ DB: D1Database }>()
+let db: D1Database
+
+beforeAll(async () => {
+  await server.listen()
+  await worker.applyD1Migrations('DB')
+  db = (await worker.getEnv()).DB
+  await db.batch([
+    db
+      .prepare('INSERT INTO workspaces (id, name, created_at) VALUES (?, ?, ?)')
+      .bind('atomic-ws', 'Atomic', '2026-09-08T00:00:00.000Z'),
+    db
+      .prepare(
+        `INSERT INTO users (
+          id, email, email_verified, name, created_at, updated_at, workspace_id,
+          google_sub, kind
+        ) VALUES (?, ?, 1, ?, ?, ?, ?, ?, 'human')`,
+      )
+      .bind(
+        'atomic-owner',
+        'atomic@example.com',
+        'Owner',
+        '2026-09-08T00:00:00.000Z',
+        '2026-09-08T00:00:00.000Z',
+        'atomic-ws',
+        'atomic-owner-sub',
+      ),
+    db
+      .prepare(
+        `INSERT INTO artifact_containers (
+          id, workspace_id, kind, owner_user_id, created_by_id, name,
+          created_at, updated_at
+        ) VALUES ('atomic-inbox', 'atomic-ws', 'inbox', 'atomic-owner',
+          'atomic-owner', 'Inbox', ?, ?)`,
+      )
+      .bind('2026-09-08T00:00:00.000Z', '2026-09-08T00:00:00.000Z'),
+  ])
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+async function seedShareable(id: string) {
+  await db
+    .prepare(
+      `INSERT INTO shareables (
+        id, workspace_id, owner_user_id, name, artifact_kind, visibility,
+        created_at, updated_at, container_id
+      ) VALUES (?, 'atomic-ws', 'atomic-owner', ?, 'html_page', 'link', ?, ?,
+        'atomic-inbox')`,
+    )
+    .bind(id, id, '2026-09-08T00:00:00.000Z', '2026-09-08T00:00:00.000Z')
+    .run()
+}
+
+function transitionBatch(shareableId: string, eventId: string) {
+  const now = '2026-09-08T01:00:00.000Z'
+  const payload = JSON.stringify({
+    actor: { kind: 'operator_credential', credentialId: eventId },
+    source: { kind: 'judgment', id: 'judgment-1' },
+    reason: 'review',
+    notify: true,
+    recipients: [],
+  })
+  return db.batch([
+    db
+      .prepare(
+        `INSERT INTO events (
+          id, workspace_id, type, shareable_id, actor_user_id, subject_id,
+          payload, created_at
+        )
+        SELECT ?, workspace_id, 'link_suspended', id, NULL, ?, ?, ?
+        FROM shareables
+        WHERE id = ? AND visibility = 'link' AND link_suspended_at IS NULL`,
+      )
+      .bind(eventId, `${eventId}-subject`, payload, now, shareableId),
+    db
+      .prepare(
+        `INSERT INTO audit_events (
+          id, workspace_id, actor_user_id, action, subject_type, subject_id,
+          detail, created_at
+        )
+        SELECT ?, workspace_id, NULL, 'shareable.link.suspend', 'shareable',
+          shareable_id, json_remove(payload, '$.recipients'), created_at
+        FROM events WHERE id = ?`,
+      )
+      .bind(`${eventId}-audit`, eventId),
+    db
+      .prepare(
+        `UPDATE shareables
+         SET link_suspended_at = ?, link_suspended_reason = 'review'
+         WHERE id = ?
+           AND id IN (SELECT shareable_id FROM events WHERE id = ?)`,
+      )
+      .bind(now, shareableId, eventId),
+  ])
+}
+
+describe.sequential('link suspension D1 atomicity', () => {
+  it('commits exactly one event, audit, and flag update under concurrent transitions', async () => {
+    const shareableId = 'atomic001a'
+    await seedShareable(shareableId)
+
+    await Promise.all([
+      transitionBatch(shareableId, 'credential-atomic-1'),
+      transitionBatch(shareableId, 'credential-atomic-2'),
+    ])
+
+    const eventCount = await db
+      .prepare(
+        "SELECT COUNT(*) AS count FROM events WHERE shareable_id = ? AND type = 'link_suspended'",
+      )
+      .bind(shareableId)
+      .first<{ count: number }>()
+    const auditCount = await db
+      .prepare(
+        "SELECT COUNT(*) AS count FROM audit_events WHERE subject_id = ? AND action = 'shareable.link.suspend'",
+      )
+      .bind(shareableId)
+      .first<{ count: number }>()
+    const shareable = await db
+      .prepare('SELECT link_suspended_at FROM shareables WHERE id = ?')
+      .bind(shareableId)
+      .first<{ link_suspended_at: string | null }>()
+
+    expect(Number(eventCount?.count)).toBe(1)
+    expect(Number(auditCount?.count)).toBe(1)
+    expect(shareable?.link_suspended_at).toBe('2026-09-08T01:00:00.000Z')
+  })
+
+  it('classifies concurrent appeals from the same transactional batch', async () => {
+    const shareableId = 'atomic002a'
+    await seedShareable(shareableId)
+    await db
+      .prepare(
+        "UPDATE shareables SET link_suspended_at = '2026-09-08T01:00:00.000Z' WHERE id = ?",
+      )
+      .bind(shareableId)
+      .run()
+    const now = '2026-09-08T02:00:00.000Z'
+    const since = '2026-09-08T01:00:00.000Z'
+
+    const appeal = (eventId: string) =>
+      db.batch([
+        db
+          .prepare(
+            `INSERT INTO events (
+              id, workspace_id, type, shareable_id, actor_user_id, subject_id,
+              payload, created_at
+            )
+            SELECT ?, workspace_id, 'link_appealed', id, 'atomic-owner', ?, '{}', ?
+            FROM shareables
+            WHERE id = ? AND owner_user_id = 'atomic-owner'
+              AND link_suspended_at IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM events recent
+                WHERE recent.shareable_id = shareables.id
+                  AND recent.type = 'link_appealed'
+                  AND recent.created_at >= ?
+              )`,
+          )
+          .bind(eventId, `${eventId}-subject`, now, shareableId, since),
+        db
+          .prepare(
+            `SELECT
+              EXISTS(SELECT 1 FROM events WHERE id = ?) AS inserted,
+              EXISTS(SELECT 1 FROM shareables WHERE id = ?) AS found,
+              EXISTS(SELECT 1 FROM shareables WHERE id = ? AND owner_user_id = 'atomic-owner') AS owned,
+              EXISTS(SELECT 1 FROM shareables WHERE id = ? AND link_suspended_at IS NOT NULL) AS suspended`,
+          )
+          .bind(eventId, shareableId, shareableId, shareableId),
+      ])
+
+    const results = await Promise.all([
+      appeal('appeal-atomic-1'),
+      appeal('appeal-atomic-2'),
+    ])
+    const inserted = results.map((result) =>
+      Number((result[1].results[0] as { inserted: number }).inserted),
+    )
+    const count = await db
+      .prepare(
+        "SELECT COUNT(*) AS count FROM events WHERE shareable_id = ? AND type = 'link_appealed'",
+      )
+      .bind(shareableId)
+      .first<{ count: number }>()
+
+    expect(inserted.sort()).toEqual([0, 1])
+    expect(Number(count?.count)).toBe(1)
+  })
+})

--- a/apps/web/app/lib/link-ops-token.test.ts
+++ b/apps/web/app/lib/link-ops-token.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'vitest'
+import { encodeBase64Url } from './base64url'
+import { hmacSha256Base64Url } from './hmac'
 import {
   LINK_OPS_TOKEN_TTL_SECONDS,
   linkOpsUrl,
@@ -10,15 +12,19 @@ describe('link ops token', () => {
   const secret = 'ops-secret'
   const now = Date.parse('2026-09-07T00:00:00.000Z')
 
-  test('round-trips the shareable and judgment within its lifetime', async () => {
+  const credentialId = 'credential-1234567890'
+  const source = { kind: 'judgment' as const, id: 'judg-1' }
+
+  test('round-trips the credential and source within its lifetime', async () => {
     const token = await signLinkOpsToken(
-      { shareableId: 'abc123def4', judgmentId: 'judg-1', now },
+      { shareableId: 'abc123def4', credentialId, source, now },
       secret,
     )
     expect(await verifyLinkOpsToken(token, secret, now + 1000)).toEqual({
       purpose: 'link-ops',
       shareableId: 'abc123def4',
-      judgmentId: 'judg-1',
+      credentialId,
+      source,
       exp: Math.floor(now / 1000) + LINK_OPS_TOKEN_TTL_SECONDS,
     })
     expect(linkOpsUrl('https://artifactshare.com', 'abc123def4', token)).toBe(
@@ -28,7 +34,7 @@ describe('link ops token', () => {
 
   test('rejects a wrong secret, a tampered body, and an expired token', async () => {
     const token = await signLinkOpsToken(
-      { shareableId: 'abc123def4', now },
+      { shareableId: 'abc123def4', credentialId, source, now },
       secret,
     )
     expect(await verifyLinkOpsToken(token, 'other', now)).toBeNull()
@@ -44,5 +50,23 @@ describe('link ops token', () => {
       ),
     ).toBeNull()
     expect(await verifyLinkOpsToken('garbage', secret, now)).toBeNull()
+  })
+
+  test('rejects the previous judgment-only payload format', async () => {
+    const body = encodeBase64Url(
+      new TextEncoder().encode(
+        JSON.stringify({
+          purpose: 'link-ops',
+          shareableId: 'abc123def4',
+          judgmentId: 'judg-1',
+          exp: Math.floor(now / 1000) + LINK_OPS_TOKEN_TTL_SECONDS,
+        }),
+      ),
+    )
+    const signature = await hmacSha256Base64Url(secret, body)
+
+    expect(
+      await verifyLinkOpsToken(`${body}.${signature}`, secret, now),
+    ).toBeNull()
   })
 })

--- a/apps/web/app/lib/link-ops-token.test.ts
+++ b/apps/web/app/lib/link-ops-token.test.ts
@@ -69,4 +69,26 @@ describe('link ops token', () => {
       await verifyLinkOpsToken(`${body}.${signature}`, secret, now),
     ).toBeNull()
   })
+
+  test('strips unrecognized source properties from a valid token', async () => {
+    const body = encodeBase64Url(
+      new TextEncoder().encode(
+        JSON.stringify({
+          purpose: 'link-ops',
+          shareableId: 'abc123def4',
+          credentialId,
+          source: { ...source, extra: 'discarded' },
+          exp: Math.floor(now / 1000) + LINK_OPS_TOKEN_TTL_SECONDS,
+        }),
+      ),
+    )
+    const signature = await hmacSha256Base64Url(secret, body)
+
+    expect(
+      await verifyLinkOpsToken(`${body}.${signature}`, secret, now),
+    ).toEqual(expect.objectContaining({ source }))
+    expect(
+      (await verifyLinkOpsToken(`${body}.${signature}`, secret, now))?.source,
+    ).toEqual(source)
+  })
 })

--- a/apps/web/app/lib/link-ops-token.ts
+++ b/apps/web/app/lib/link-ops-token.ts
@@ -77,7 +77,7 @@ export async function verifyLinkOpsToken(
     purpose: 'link-ops',
     shareableId: payload.shareableId,
     credentialId: payload.credentialId,
-    source: payload.source,
+    source: { kind: payload.source.kind, id: payload.source.id },
     exp: payload.exp,
   }
 }

--- a/apps/web/app/lib/link-ops-token.ts
+++ b/apps/web/app/lib/link-ops-token.ts
@@ -12,7 +12,8 @@ export const LINK_OPS_TOKEN_TTL_SECONDS = 2 * 24 * 60 * 60
 export type LinkOpsTokenPayload = {
   purpose: 'link-ops'
   shareableId: string
-  judgmentId: string | null
+  credentialId: string
+  source: { kind: 'judgment' | 'appeal'; id: string }
   exp: number
 }
 
@@ -20,13 +21,19 @@ const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 
 export async function signLinkOpsToken(
-  input: { shareableId: string; judgmentId?: string | null; now?: number },
+  input: {
+    shareableId: string
+    credentialId: string
+    source: LinkOpsTokenPayload['source']
+    now?: number
+  },
   secret: string,
 ): Promise<string> {
   const payload: LinkOpsTokenPayload = {
     purpose: 'link-ops',
     shareableId: input.shareableId,
-    judgmentId: input.judgmentId ?? null,
+    credentialId: input.credentialId,
+    source: input.source,
     exp:
       Math.floor((input.now ?? Date.now()) / 1000) + LINK_OPS_TOKEN_TTL_SECONDS,
   }
@@ -53,15 +60,24 @@ export async function verifyLinkOpsToken(
   if (
     payload.purpose !== 'link-ops' ||
     typeof payload.shareableId !== 'string' ||
+    typeof payload.credentialId !== 'string' ||
+    payload.credentialId.length < 16 ||
+    payload.credentialId.length > 128 ||
+    !payload.source ||
+    (payload.source.kind !== 'judgment' && payload.source.kind !== 'appeal') ||
+    typeof payload.source.id !== 'string' ||
+    payload.source.id.length < 1 ||
+    payload.source.id.length > 128 ||
     typeof payload.exp !== 'number' ||
-    (payload.judgmentId !== null && typeof payload.judgmentId !== 'string')
+    !Number.isSafeInteger(payload.exp)
   )
     return null
   if (payload.exp <= Math.floor(now / 1000)) return null
   return {
     purpose: 'link-ops',
     shareableId: payload.shareableId,
-    judgmentId: payload.judgmentId ?? null,
+    credentialId: payload.credentialId,
+    source: payload.source,
     exp: payload.exp,
   }
 }

--- a/apps/web/app/routes/a.$id/index.test.tsx
+++ b/apps/web/app/routes/a.$id/index.test.tsx
@@ -221,6 +221,66 @@ describe('/a/:id loader', () => {
     expect(response.headers.get('cache-control')).toBe('private, no-store')
   })
 
+  test('returns only the generic suspended reason to an anonymous viewer', async () => {
+    dbMock.selectFrom.mockReturnValue(
+      shareableQuery({
+        id: 'html123abc',
+        workspace_id: 'ws1',
+        owner_user_id: 'u1',
+        visibility: 'link',
+        current_version_id: 'v1',
+        r2_key: 'artifacts/html123abc/v1/index.html',
+      }),
+    )
+    viewerDisplayCheckMock.mockResolvedValue({ kind: 'link-suspended' })
+    const context = new Map()
+    context.set(userContext, null)
+
+    const result = await loader({
+      params: { id: 'html123abc' },
+      request: new Request('https://artifactshare.com/a/html123abc'),
+      context,
+    } as never)
+
+    expect(result).toEqual({
+      kind: 'unavailable',
+      user: null,
+      appOrigin: 'https://artifactshare.com',
+      reason: 'link-suspended',
+    })
+    expect(JSON.stringify(result)).not.toContain('private operator reason')
+  })
+
+  test('serializes the saved suspension reason and appeal flag for the owner', async () => {
+    const { context } = setupHtmlShareable({
+      shareable: {
+        visibility: 'link',
+        link_suspended_at: '2026-09-08T00:00:00.000Z',
+        link_suspended_reason: 'private operator reason',
+        link_expires_at: null,
+        link_sharing_enabled: 1,
+        external_posting_enabled: 1,
+        link_expiry_default_days: 30,
+        link_expiry_max_days: null,
+        plan: 'plus',
+      },
+    })
+
+    const result = await loader({
+      params: { id: 'html123abc' },
+      request: new Request('https://artifactshare.com/a/html123abc'),
+      context,
+    } as never)
+
+    expect(result.kind).toBe('ok')
+    if (result.kind !== 'ok') return
+    expect(result.artifact).toMatchObject({
+      linkSuspended: true,
+      linkSuspendedReason: 'private operator reason',
+      canAppealLinkSuspension: true,
+    })
+  })
+
   test('renders a published historical version without recording a view', async () => {
     const shareable = {
       id: 'html123abc',

--- a/apps/web/app/routes/a.$id/index.test.tsx
+++ b/apps/web/app/routes/a.$id/index.test.tsx
@@ -228,6 +228,8 @@ describe('/a/:id loader', () => {
         workspace_id: 'ws1',
         owner_user_id: 'u1',
         visibility: 'link',
+        link_suspended_at: '2026-09-08T00:00:00.000Z',
+        link_suspended_reason: 'private operator reason',
         current_version_id: 'v1',
         r2_key: 'artifacts/html123abc/v1/index.html',
       }),

--- a/apps/web/app/routes/ops.link.$id.test.tsx
+++ b/apps/web/app/routes/ops.link.$id.test.tsx
@@ -38,7 +38,14 @@ const params = { id: 'abc123def4' }
 const base = 'https://artifactshare.com/ops/link/abc123def4'
 
 async function token(shareableId = 'abc123def4') {
-  return signLinkOpsToken({ shareableId, judgmentId: 'judg-1' }, 'ops-secret')
+  return signLinkOpsToken(
+    {
+      shareableId,
+      credentialId: 'credential-1234567890',
+      source: { kind: 'judgment', id: 'judg-1' },
+    },
+    'ops-secret',
+  )
 }
 
 function post(
@@ -105,7 +112,8 @@ describe('link ops route', () => {
     expect(suspendLink).toHaveBeenCalledWith(expect.anything(), {
       shareableId: 'abc123def4',
       reason: 'Phishing',
-      judgmentId: 'judg-1',
+      credentialId: 'credential-1234567890',
+      source: { kind: 'judgment', id: 'judg-1' },
     })
 
     const resumed = await action({

--- a/apps/web/app/routes/ops.link.$id.tsx
+++ b/apps/web/app/routes/ops.link.$id.tsx
@@ -35,7 +35,11 @@ async function authorize(
   if (!token) return null
   const payload = await verifyLinkOpsToken(token, secret)
   if (!payload || payload.shareableId !== shareableId) return null
-  return { token, judgmentId: payload.judgmentId }
+  return {
+    token,
+    credentialId: payload.credentialId,
+    source: payload.source,
+  }
 }
 
 function notFound() {
@@ -77,12 +81,14 @@ export async function action({ request, params }: Route.ActionArgs) {
       ? await suspendLink(db, {
           shareableId: params.id,
           reason: String(form.get('reason') ?? ''),
-          judgmentId: auth.judgmentId,
+          credentialId: auth.credentialId,
+          source: auth.source,
         })
       : move === 'resume'
         ? await resumeLink(db, {
             shareableId: params.id,
-            judgmentId: auth.judgmentId,
+            credentialId: auth.credentialId,
+            source: auth.source,
           })
         : { kind: 'none' as const }
   const done =

--- a/apps/web/app/services/access.server.test.ts
+++ b/apps/web/app/services/access.server.test.ts
@@ -5,9 +5,46 @@ import type { DB } from '~/types/db'
 import {
   isTeamWorkspaceAdmin,
   isWorkspaceAdmin,
+  viewerAccessAllowed,
   viewerDisplayCheck,
   type ArtifactSnapshot,
 } from './access.server'
+
+describe('viewerAccessAllowed', () => {
+  const base = {
+    visibility: 'link' as const,
+    viewerUserId: 'viewer-1',
+    ownerUserId: 'owner-1',
+    viewerWorkspaceId: 'viewer-workspace',
+    artifactWorkspaceId: 'artifact-workspace',
+    viewerEmailVerified: true,
+    anonymousLinkAllowed: false,
+    isTeamAdmin: false,
+    hasShareableGrant: false,
+    containerKind: null,
+    containerBaseVisibility: null,
+    isProjectCreator: false,
+    isProjectAdmin: false,
+    hasProjectGrant: false,
+  }
+
+  test('preserves authenticated rights while a link is suspended', () => {
+    expect(viewerAccessAllowed({ ...base, viewerUserId: 'owner-1' })).toBe(true)
+    expect(viewerAccessAllowed({ ...base, hasShareableGrant: true })).toBe(true)
+    expect(viewerAccessAllowed({ ...base, isTeamAdmin: true })).toBe(true)
+    expect(viewerAccessAllowed(base)).toBe(false)
+  })
+
+  test('does not extend Team administration to non-link artifacts', () => {
+    expect(
+      viewerAccessAllowed({
+        ...base,
+        visibility: 'private',
+        isTeamAdmin: true,
+      }),
+    ).toBe(false)
+  })
+})
 
 const META: ArtifactSnapshot = {
   id: 'share1',

--- a/apps/web/app/services/access.server.test.ts
+++ b/apps/web/app/services/access.server.test.ts
@@ -568,6 +568,21 @@ describe('viewerDisplayCheck', () => {
     expect(result).toEqual({ kind: 'access-granted', meta: META })
   })
 
+  test('project creator access does not require an email identity', async () => {
+    await seedProjectAudience('someone-else@example.com', 'private')
+
+    const result = await viewerDisplayCheck(db, 'project', 'owner-1', META, {
+      ...projectContext,
+      ownerUserId: 'external-1',
+      containerBaseVisibility: 'private',
+      viewerWorkspaceId: 'ws-a',
+      viewerEmail: null,
+      viewerEmailVerified: false,
+    })
+
+    expect(result).toEqual({ kind: 'access-granted', meta: META })
+  })
+
   test('project base=private grants a team workspace admin even when not in the audience', async () => {
     await seedProjectAudience('someone-else@example.com', 'private')
     await db

--- a/apps/web/app/services/access.server.ts
+++ b/apps/web/app/services/access.server.ts
@@ -238,14 +238,7 @@ export async function viewerDisplayCheck(
       context.shareableId,
       context.now,
     )
-    if (
-      linkAccess.kind === 'allowed' &&
-      viewerAccessAllowed(
-        basicViewerAccessFacts(visibility, viewerUserId, context, {
-          anonymousLinkAllowed: true,
-        }),
-      )
-    ) {
+    if (linkAccess.kind === 'allowed') {
       if (!publicMeta) return { kind: 'meta-unavailable' }
       return { kind: 'access-granted', meta: publicMeta }
     }
@@ -260,11 +253,7 @@ export async function viewerDisplayCheck(
 
   if (!viewerUserId) return { kind: 'access-denied' }
 
-  if (
-    viewerAccessAllowed(
-      basicViewerAccessFacts(visibility, viewerUserId, context),
-    )
-  ) {
+  if (viewerUserId === context.ownerUserId) {
     if (!publicMeta) return { kind: 'meta-unavailable' }
     return { kind: 'access-granted', meta: publicMeta }
   }
@@ -325,31 +314,6 @@ export async function viewerDisplayCheck(
   if (!grant) return { kind: 'access-denied' }
   if (!publicMeta) return { kind: 'meta-unavailable' }
   return { kind: 'access-granted', meta: publicMeta }
-}
-
-function basicViewerAccessFacts(
-  visibility: Visibility,
-  viewerUserId: string | null,
-  context: ViewerDisplayContext,
-  override: Partial<ViewerAccessFacts> = {},
-): ViewerAccessFacts {
-  return {
-    visibility,
-    viewerUserId,
-    ownerUserId: context.ownerUserId,
-    viewerWorkspaceId: context.viewerWorkspaceId,
-    artifactWorkspaceId: context.artifactWorkspaceId,
-    viewerEmailVerified: context.viewerEmailVerified,
-    anonymousLinkAllowed: false,
-    isTeamAdmin: false,
-    hasShareableGrant: false,
-    containerKind: context.containerKind,
-    containerBaseVisibility: context.containerBaseVisibility,
-    isProjectCreator: false,
-    isProjectAdmin: false,
-    hasProjectGrant: false,
-    ...override,
-  }
 }
 
 export type ViewerAccessFacts = {

--- a/apps/web/app/services/access.server.ts
+++ b/apps/web/app/services/access.server.ts
@@ -238,7 +238,14 @@ export async function viewerDisplayCheck(
       context.shareableId,
       context.now,
     )
-    if (linkAccess.kind === 'allowed') {
+    if (
+      linkAccess.kind === 'allowed' &&
+      viewerAccessAllowed(
+        basicViewerAccessFacts(visibility, viewerUserId, context, {
+          anonymousLinkAllowed: true,
+        }),
+      )
+    ) {
       if (!publicMeta) return { kind: 'meta-unavailable' }
       return { kind: 'access-granted', meta: publicMeta }
     }
@@ -253,7 +260,11 @@ export async function viewerDisplayCheck(
 
   if (!viewerUserId) return { kind: 'access-denied' }
 
-  if (viewerUserId === context.ownerUserId) {
+  if (
+    viewerAccessAllowed(
+      basicViewerAccessFacts(visibility, viewerUserId, context),
+    )
+  ) {
     if (!publicMeta) return { kind: 'meta-unavailable' }
     return { kind: 'access-granted', meta: publicMeta }
   }
@@ -314,4 +325,69 @@ export async function viewerDisplayCheck(
   if (!grant) return { kind: 'access-denied' }
   if (!publicMeta) return { kind: 'meta-unavailable' }
   return { kind: 'access-granted', meta: publicMeta }
+}
+
+function basicViewerAccessFacts(
+  visibility: Visibility,
+  viewerUserId: string | null,
+  context: ViewerDisplayContext,
+  override: Partial<ViewerAccessFacts> = {},
+): ViewerAccessFacts {
+  return {
+    visibility,
+    viewerUserId,
+    ownerUserId: context.ownerUserId,
+    viewerWorkspaceId: context.viewerWorkspaceId,
+    artifactWorkspaceId: context.artifactWorkspaceId,
+    viewerEmailVerified: context.viewerEmailVerified,
+    anonymousLinkAllowed: false,
+    isTeamAdmin: false,
+    hasShareableGrant: false,
+    containerKind: context.containerKind,
+    containerBaseVisibility: context.containerBaseVisibility,
+    isProjectCreator: false,
+    isProjectAdmin: false,
+    hasProjectGrant: false,
+    ...override,
+  }
+}
+
+export type ViewerAccessFacts = {
+  visibility: Visibility
+  viewerUserId: string | null
+  ownerUserId: string
+  viewerWorkspaceId: string | null
+  artifactWorkspaceId: string
+  viewerEmailVerified: boolean
+  anonymousLinkAllowed: boolean
+  isTeamAdmin: boolean
+  hasShareableGrant: boolean
+  containerKind: 'project' | 'inbox' | null
+  containerBaseVisibility: 'workspace' | 'private' | null
+  isProjectCreator: boolean
+  isProjectAdmin: boolean
+  hasProjectGrant: boolean
+}
+
+/** Pure authorization decision shared by apex tests and sandbox delivery. */
+export function viewerAccessAllowed(facts: ViewerAccessFacts): boolean {
+  if (facts.visibility === 'link' && facts.anonymousLinkAllowed) return true
+  if (!facts.viewerUserId) return false
+  if (facts.viewerUserId === facts.ownerUserId) return true
+  if (facts.visibility === 'link' && facts.isTeamAdmin) return true
+  if (
+    facts.visibility === 'workspace' &&
+    facts.viewerWorkspaceId === facts.artifactWorkspaceId
+  )
+    return true
+  if (facts.visibility === 'project' && facts.containerKind === 'project') {
+    if (
+      facts.containerBaseVisibility === 'workspace' &&
+      facts.viewerWorkspaceId === facts.artifactWorkspaceId
+    )
+      return true
+    if (facts.isProjectCreator || facts.isProjectAdmin) return true
+    if (facts.viewerEmailVerified && facts.hasProjectGrant) return true
+  }
+  return facts.viewerEmailVerified && facts.hasShareableGrant
 }

--- a/apps/web/app/services/access.server.ts
+++ b/apps/web/app/services/access.server.ts
@@ -181,7 +181,7 @@ async function canViewerAccessProjectVisibility(
   db: Kysely<DB>,
   context: ViewerDisplayContext,
   viewerUserId: string,
-  viewerEmail: string,
+  viewerEmail: string | null,
 ): Promise<boolean> {
   if (!context.containerId || context.containerKind !== 'project') return false
 
@@ -215,7 +215,7 @@ async function canViewerAccessProjectVisibility(
 
   // Audience membership is email-grant access → only for a verified email.
   // (Creator / workspace-admin access above is not email-based and still works.)
-  if (!context.viewerEmailVerified) return false
+  if (!viewerEmail || !context.viewerEmailVerified) return false
   const audienceMember = await db
     .selectFrom('project_share_defaults')
     .select('email')
@@ -280,7 +280,6 @@ export async function viewerDisplayCheck(
   }
 
   const viewerEmail = context.viewerEmail?.toLowerCase() ?? null
-  if (!viewerEmail) return { kind: 'access-denied' }
 
   if (visibility === 'project') {
     if (
@@ -295,6 +294,8 @@ export async function viewerDisplayCheck(
       return { kind: 'access-granted', meta: publicMeta }
     }
   }
+
+  if (!viewerEmail) return { kind: 'access-denied' }
 
   // Per-artifact grant is email-grant access → only for a verified email.
   const grant = await db

--- a/apps/web/app/services/link-suspension.server.test.ts
+++ b/apps/web/app/services/link-suspension.server.test.ts
@@ -14,6 +14,7 @@ vi.mock('cloudflare:workers', () => ({
   env: {
     DB: createD1BatchDbMock({ sqlite: sqliteRef }),
     EMAIL: { send: mailSend },
+    BETTER_AUTH_SECRET: 'test-secret-with-enough-entropy-for-hmac',
   },
 }))
 
@@ -310,6 +311,16 @@ describe('link suspension', () => {
       ],
     })
     expect(events[0]!.payload).not.toContain('owner@example.com')
+    const recipient = JSON.parse(events[0]!.payload!).recipients[0]
+    const unkeyed = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode('owner\0owner@example.com'),
+    )
+    expect(recipient.emailHash).not.toBe(
+      Array.from(new Uint8Array(unkeyed), (byte) =>
+        byte.toString(16).padStart(2, '0'),
+      ).join(''),
+    )
     expect(events.slice(1, 2)).toEqual([
       {
         type: 'link_appealed',
@@ -382,6 +393,73 @@ describe('link suspension', () => {
 
     expect(result).toEqual({ kind: 'suspended', ownerNotice: 'skipped' })
     expect(notify).not.toHaveBeenCalled()
+  })
+
+  test('skips delivery when artifact ownership changes after the snapshot', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const notify = vi.fn(async () => 'sent' as const)
+    sqliteRef.beforeNextBatch = () => {
+      sqliteRef
+        .current!.prepare(
+          "UPDATE shareables SET owner_user_id = 'other' WHERE id = 'linked0001'",
+        )
+        .run()
+    }
+
+    const result = await suspendLink(db, {
+      ...ops,
+      shareableId: 'linked0001',
+      reason: 'review',
+      notify,
+    })
+
+    expect(result).toEqual({ kind: 'suspended', ownerNotice: 'skipped' })
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  test('skips bot delivery when the workspace owner is removed after the snapshot', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const notify = vi.fn(async () => 'sent' as const)
+    sqliteRef.beforeNextBatch = () => {
+      sqliteRef
+        .current!.prepare(
+          "UPDATE workspace_members SET status = 'removed' WHERE workspace_id = 'ws-free' AND user_id = 'owner'",
+        )
+        .run()
+    }
+
+    const result = await suspendLink(db, {
+      ...ops,
+      shareableId: 'botlink001',
+      reason: 'review',
+      notify,
+    })
+
+    expect(result).toEqual({ kind: 'suspended', ownerNotice: 'skipped' })
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  test('contains a thrown post-commit notification failure and omits credentials from the marker', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const result = await suspendLink(db, {
+      ...ops,
+      shareableId: 'linked0001',
+      reason: 'review',
+      notify: async () => {
+        throw new Error('mail transport unavailable')
+      },
+    })
+
+    expect(result).toEqual({ kind: 'suspended', ownerNotice: 'failed' })
+    const marker = warn.mock.calls.find(
+      ([name]) => name === 'artifactshare_link_suspension',
+    )
+    expect(marker?.[1]).toMatchObject({
+      notifications: { sent: 0, failed: 1, skipped: 0 },
+      source: ops.source,
+    })
+    expect(JSON.stringify(marker?.[1])).not.toContain(ops.credentialId)
   })
 
   test('keeps bot notification mail free of the reason and appeal instructions', async () => {

--- a/apps/web/app/services/link-suspension.server.test.ts
+++ b/apps/web/app/services/link-suspension.server.test.ts
@@ -6,11 +6,15 @@ import type { DB } from '~/types/db'
 
 const sqliteRef = vi.hoisted(() => ({
   current: null as DatabaseSync | null,
-  beforeNextBatch: null,
+  beforeNextBatch: null as (() => void | Promise<void>) | null,
 }))
+const mailSend = vi.hoisted(() => vi.fn())
 
 vi.mock('cloudflare:workers', () => ({
-  env: { DB: createD1BatchDbMock({ sqlite: sqliteRef }) },
+  env: {
+    DB: createD1BatchDbMock({ sqlite: sqliteRef }),
+    EMAIL: { send: mailSend },
+  },
 }))
 
 import { checkAnonymousLinkAccess } from './link-sharing.server'
@@ -18,6 +22,7 @@ import {
   appealLinkSuspension,
   linkSuspensionState,
   resumeLink,
+  sendOwnerNotice,
   suspendLink,
   type OwnerNotice,
 } from './link-suspension.server'
@@ -25,8 +30,13 @@ import {
 describe('link suspension', () => {
   let db: Kysely<DB>
   const at = '2026-09-07T00:00:00.000Z'
+  const ops = {
+    credentialId: 'credential-1234567890',
+    source: { kind: 'judgment' as const, id: 'judg-1' },
+  }
 
   beforeEach(async () => {
+    mailSend.mockReset().mockResolvedValue(undefined)
     const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
@@ -57,6 +67,7 @@ describe('link suspension', () => {
           updated_at: at,
           workspace_id: 'ws-free',
           locale: null,
+          kind: 'human',
         },
         {
           id: 'other',
@@ -68,8 +79,32 @@ describe('link suspension', () => {
           updated_at: at,
           workspace_id: 'ws-free',
           locale: null,
+          kind: 'human',
+        },
+        {
+          id: 'bot-owner',
+          email: 'bot@bots.artifactshare.invalid',
+          email_verified: 0,
+          name: 'Bot',
+          image: null,
+          created_at: at,
+          updated_at: at,
+          workspace_id: 'ws-free',
+          locale: null,
+          kind: 'bot',
         },
       ])
+      .execute()
+    await db
+      .insertInto('workspace_members')
+      .values({
+        workspace_id: 'ws-free',
+        user_id: 'owner',
+        role: 'owner',
+        status: 'active',
+        created_at: at,
+        updated_at: at,
+      })
       .execute()
     await db
       .insertInto('artifact_containers')
@@ -113,6 +148,18 @@ describe('link suspension', () => {
           updated_at: at,
           link_expires_at: null,
         },
+        {
+          id: 'botlink001',
+          workspace_id: 'ws-free',
+          owner_user_id: 'bot-owner',
+          name: 'bot-report.html',
+          artifact_kind: 'html_page',
+          visibility: 'link',
+          container_id: 'inbox-free',
+          created_at: at,
+          updated_at: at,
+          link_expires_at: null,
+        },
       ])
       .execute()
   })
@@ -133,20 +180,26 @@ describe('link suspension', () => {
 
     expect(
       await suspendLink(db, {
+        ...ops,
         shareableId: 'private001',
         reason: 'x',
         notify,
       }),
     ).toEqual({ kind: 'not-link' })
     expect(
-      await suspendLink(db, { shareableId: 'missing000', reason: 'x', notify }),
+      await suspendLink(db, {
+        ...ops,
+        shareableId: 'missing000',
+        reason: 'x',
+        notify,
+      }),
     ).toEqual({ kind: 'not-found' })
 
     expect(
       await suspendLink(db, {
+        ...ops,
         shareableId: 'linked0001',
         reason: '  Phishing form  ',
-        judgmentId: 'judg-1',
         now: '2026-09-07T01:00:00.000Z',
         notify,
       }),
@@ -162,6 +215,7 @@ describe('link suspension', () => {
     })
     expect(
       await suspendLink(db, {
+        ...ops,
         shareableId: 'linked0001',
         reason: 'again',
         notify,
@@ -174,6 +228,8 @@ describe('link suspension', () => {
         title: 'report.html',
         ownerEmail: 'owner@example.com',
         reason: 'Phishing form',
+        includeReasonAndAppeal: true,
+        includeManageUrl: true,
       },
     ])
 
@@ -210,8 +266,8 @@ describe('link suspension', () => {
 
     expect(
       await resumeLink(db, {
+        ...ops,
         shareableId: 'linked0001',
-        judgmentId: 'judg-1',
         now: '2026-09-07T03:00:00.000Z',
         notify,
       }),
@@ -219,9 +275,9 @@ describe('link suspension', () => {
     expect((await checkAnonymousLinkAccess(db, 'linked0001')).kind).toBe(
       'allowed',
     )
-    expect(await resumeLink(db, { shareableId: 'linked0001', notify })).toEqual(
-      { kind: 'already' },
-    )
+    expect(
+      await resumeLink(db, { ...ops, shareableId: 'linked0001', notify }),
+    ).toEqual({ kind: 'already' })
     expect(
       await appealLinkSuspension(
         db,
@@ -237,25 +293,113 @@ describe('link suspension', () => {
       .where('shareable_id', '=', 'linked0001')
       .orderBy('created_at', 'asc')
       .execute()
-    expect(events).toEqual([
-      {
-        type: 'link_suspended',
-        actor_user_id: null,
-        payload: JSON.stringify({
-          reason: 'Phishing form',
-          judgmentId: 'judg-1',
+    expect(events[0]).toMatchObject({
+      type: 'link_suspended',
+      actor_user_id: null,
+    })
+    expect(JSON.parse(events[0]!.payload!)).toMatchObject({
+      actor: { kind: 'operator_credential', credentialId: ops.credentialId },
+      source: ops.source,
+      reason: 'Phishing form',
+      notify: true,
+      recipients: [
+        expect.objectContaining({
+          userId: 'owner',
+          requiresVerified: false,
         }),
-      },
+      ],
+    })
+    expect(events[0]!.payload).not.toContain('owner@example.com')
+    expect(events.slice(1, 2)).toEqual([
       {
         type: 'link_appealed',
         actor_user_id: 'owner',
         payload: JSON.stringify({ message: 'This is our internal report.' }),
       },
-      {
-        type: 'link_resumed',
-        actor_user_id: null,
-        payload: JSON.stringify({ judgmentId: 'judg-1' }),
-      },
     ])
+    expect(JSON.parse(events[2]!.payload!)).toMatchObject({
+      actor: { kind: 'operator_credential', credentialId: ops.credentialId },
+      source: ops.source,
+      reason: null,
+      notify: true,
+    })
+  })
+
+  test('notifies the verified human workspace owner for a bot artifact without leaking reason or a Free-workspace URL', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const notices: OwnerNotice[] = []
+
+    const result = await suspendLink(db, {
+      ...ops,
+      shareableId: 'botlink001',
+      reason: 'Sensitive reason',
+      notify: async (notice) => {
+        notices.push(notice)
+        return 'sent'
+      },
+    })
+
+    expect(result).toEqual({ kind: 'suspended', ownerNotice: 'sent' })
+    expect(notices).toEqual([
+      expect.objectContaining({
+        ownerEmail: 'owner@example.com',
+        reason: 'Sensitive reason',
+        includeReasonAndAppeal: false,
+        includeManageUrl: false,
+      }),
+    ])
+    const event = await db
+      .selectFrom('events')
+      .select('payload')
+      .where('shareable_id', '=', 'botlink001')
+      .executeTakeFirstOrThrow()
+    expect(event.payload).not.toContain('owner@example.com')
+    const audit = await db
+      .selectFrom('audit_events')
+      .select('detail')
+      .where('subject_id', '=', 'botlink001')
+      .executeTakeFirstOrThrow()
+    expect(audit.detail).not.toContain('recipients')
+  })
+
+  test('skips delivery when the snapshotted email changes before commit', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const notify = vi.fn(async () => 'sent' as const)
+    sqliteRef.beforeNextBatch = () => {
+      sqliteRef
+        .current!.prepare(
+          "UPDATE users SET email = 'changed@example.com' WHERE id = 'owner'",
+        )
+        .run()
+    }
+
+    const result = await suspendLink(db, {
+      ...ops,
+      shareableId: 'linked0001',
+      reason: 'review',
+      notify,
+    })
+
+    expect(result).toEqual({ kind: 'suspended', ownerNotice: 'skipped' })
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  test('keeps bot notification mail free of the reason and appeal instructions', async () => {
+    await sendOwnerNotice({
+      kind: 'suspended',
+      shareableId: 'botlink001',
+      title: 'Bot\r\nreport',
+      ownerEmail: 'owner@example.com',
+      reason: 'Sensitive\r\nreason',
+      includeReasonAndAppeal: false,
+      includeManageUrl: false,
+    })
+
+    expect(mailSend).toHaveBeenCalledOnce()
+    const message = mailSend.mock.calls[0]![0]
+    expect(message.subject).toContain('Bot report')
+    expect(message.text).not.toContain('Sensitive')
+    expect(message.text).not.toContain('appeal')
+    expect(message.text).not.toContain('/a/botlink001')
   })
 })

--- a/apps/web/app/services/link-suspension.server.test.ts
+++ b/apps/web/app/services/link-suspension.server.test.ts
@@ -308,7 +308,7 @@ describe('link suspension', () => {
       recipients: [
         expect.objectContaining({
           userId: 'owner',
-          requiresVerified: false,
+          requiresVerified: true,
         }),
       ],
     })
@@ -518,6 +518,44 @@ describe('link suspension', () => {
       source: ops.source,
     })
     expect(JSON.stringify(marker?.[1])).not.toContain(ops.credentialId)
+  })
+
+  test('does not notify an unverified human artifact owner', async () => {
+    await db
+      .updateTable('users')
+      .set({ email_verified: 0 })
+      .where('id', '=', 'owner')
+      .execute()
+    const notify = vi.fn().mockResolvedValue('sent' as const)
+
+    const result = await suspendLink(db, {
+      ...ops,
+      shareableId: 'linked0001',
+      reason: 'private reason',
+      notify,
+    })
+
+    expect(result).toEqual({ kind: 'suspended', ownerNotice: 'skipped' })
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  test('does not log provider error text from a failed owner notice', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mailSend.mockRejectedValueOnce(new Error('invalid owner@example.com'))
+
+    await expect(
+      sendOwnerNotice({
+        kind: 'suspended',
+        shareableId: 'linked0001',
+        title: 'Title',
+        ownerEmail: 'owner@example.com',
+        reason: 'reason',
+        includeReasonAndAppeal: true,
+        includeManageUrl: true,
+      }),
+    ).resolves.toBe('failed')
+
+    expect(JSON.stringify(error.mock.calls)).not.toContain('owner@example.com')
   })
 
   test('keeps bot notification mail free of the reason and appeal instructions', async () => {

--- a/apps/web/app/services/link-suspension.server.test.ts
+++ b/apps/web/app/services/link-suspension.server.test.ts
@@ -356,7 +356,7 @@ describe('link suspension', () => {
     expect(notices).toEqual([
       expect.objectContaining({
         ownerEmail: 'owner@example.com',
-        reason: 'Sensitive reason',
+        reason: null,
         includeReasonAndAppeal: false,
         includeManageUrl: false,
       }),
@@ -439,6 +439,62 @@ describe('link suspension', () => {
 
     expect(result).toEqual({ kind: 'suspended', ownerNotice: 'skipped' })
     expect(notify).not.toHaveBeenCalled()
+  })
+
+  test('skips a resume notice when visibility changes after the snapshot', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const notify = vi.fn(async () => 'sent' as const)
+    await suspendLink(db, {
+      ...ops,
+      shareableId: 'linked0001',
+      reason: 'review',
+      notify: async () => 'skipped',
+    })
+    sqliteRef.beforeNextBatch = () => {
+      sqliteRef
+        .current!.prepare(
+          "UPDATE shareables SET visibility = 'private' WHERE id = 'linked0001'",
+        )
+        .run()
+    }
+
+    const result = await resumeLink(db, {
+      ...ops,
+      shareableId: 'linked0001',
+      notify,
+    })
+
+    expect(result).toEqual({ kind: 'resumed', ownerNotice: 'skipped' })
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  test('rechecks the Team plan before adding a bot manage URL', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    await db
+      .updateTable('workspaces')
+      .set({ plan: 'team' })
+      .where('id', '=', 'ws-free')
+      .execute()
+    const notify = vi.fn(async () => 'sent' as const)
+    sqliteRef.beforeNextBatch = () => {
+      sqliteRef
+        .current!.prepare(
+          "UPDATE workspaces SET plan = 'plus' WHERE id = 'ws-free'",
+        )
+        .run()
+    }
+
+    const result = await suspendLink(db, {
+      ...ops,
+      shareableId: 'botlink001',
+      reason: 'review',
+      notify,
+    })
+
+    expect(result).toEqual({ kind: 'suspended', ownerNotice: 'sent' })
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ includeManageUrl: false, reason: null }),
+    )
   })
 
   test('contains a thrown post-commit notification failure and omits credentials from the marker', async () => {

--- a/apps/web/app/services/link-suspension.server.test.ts
+++ b/apps/web/app/services/link-suspension.server.test.ts
@@ -38,6 +38,7 @@ describe('link suspension', () => {
 
   beforeEach(async () => {
     mailSend.mockReset().mockResolvedValue(undefined)
+    sqliteRef.beforeNextBatch = null
     const fixture = createD1BatchFixture({ sqlite: sqliteRef })
     db = fixture.db
     sqliteRef.current = fixture.sqlite
@@ -166,6 +167,7 @@ describe('link suspension', () => {
   })
 
   afterEach(() => {
+    sqliteRef.beforeNextBatch = null
     sqliteRef.current?.close()
     sqliteRef.current = null
     vi.restoreAllMocks()

--- a/apps/web/app/services/link-suspension.server.ts
+++ b/apps/web/app/services/link-suspension.server.ts
@@ -90,8 +90,6 @@ function ownerOf(db: Kysely<DB>, shareableId: string) {
       'users.email as owner_email',
       'users.kind as owner_kind',
       'users.id as owner_id',
-      'users.email_verified as owner_email_verified',
-      'users.updated_at as owner_updated_at',
     ])
     .innerJoin('workspaces', 'workspaces.id', 'shareables.workspace_id')
     .select('workspaces.plan as workspace_plan')
@@ -109,6 +107,7 @@ type OwnerRow = NonNullable<Awaited<ReturnType<typeof ownerOf>>>
 type RecipientSnapshot = {
   userId: string
   emailHash: string
+  relationship: 'artifact_owner' | 'workspace_owner'
   requiresVerified: boolean
   includeReasonAndAppeal: boolean
   includeManageUrl: boolean
@@ -123,8 +122,18 @@ type TransitionPayload = {
 }
 
 async function emailHash(userId: string, email: string): Promise<string> {
-  const bytes = new TextEncoder().encode(`${userId}\0${email}`)
-  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(env.BETTER_AUTH_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const digest = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(`link-notice\0${userId}\0${email}`),
+  )
   return Array.from(new Uint8Array(digest), (byte) =>
     byte.toString(16).padStart(2, '0'),
   ).join('')
@@ -139,6 +148,7 @@ async function notificationRecipients(
       {
         userId: row.owner_id,
         emailHash: await emailHash(row.owner_id, row.owner_email),
+        relationship: 'artifact_owner',
         requiresVerified: false,
         includeReasonAndAppeal: true,
         includeManageUrl: true,
@@ -159,6 +169,7 @@ async function notificationRecipients(
     {
       userId: owner.id,
       emailHash: await emailHash(owner.id, owner.email),
+      relationship: 'workspace_owner',
       requiresVerified: true,
       includeReasonAndAppeal: false,
       includeManageUrl: row.workspace_plan === 'team',
@@ -298,28 +309,66 @@ async function transitionLink(
   const outcomes: OwnerNoticeOutcome[] = committed.notify
     ? await Promise.all(
         committed.recipients.map(async (recipient) => {
-          const current = await db
-            .selectFrom('users')
-            .select(['id', 'email', 'email_verified'])
-            .where('id', '=', recipient.userId)
-            .executeTakeFirst()
-          if (
-            !current ||
-            (recipient.requiresVerified && current.email_verified !== 1) ||
-            (await emailHash(recipient.userId, current.email)) !==
-              recipient.emailHash
-          ) {
-            return 'skipped'
+          try {
+            const current = await db
+              .selectFrom('users')
+              .select(['id', 'email', 'email_verified'])
+              .where('id', '=', recipient.userId)
+              .where((eb) =>
+                recipient.relationship === 'artifact_owner'
+                  ? eb.exists(
+                      eb
+                        .selectFrom('shareables')
+                        .select('id')
+                        .where('id', '=', row.id)
+                        .where('owner_user_id', '=', recipient.userId),
+                    )
+                  : eb.exists(
+                      eb
+                        .selectFrom('workspace_members')
+                        .innerJoin(
+                          'shareables',
+                          'shareables.workspace_id',
+                          'workspace_members.workspace_id',
+                        )
+                        .innerJoin(
+                          'users as artifact_owner',
+                          'artifact_owner.id',
+                          'shareables.owner_user_id',
+                        )
+                        .select('workspace_members.user_id')
+                        .where('shareables.id', '=', row.id)
+                        .where(
+                          'workspace_members.user_id',
+                          '=',
+                          recipient.userId,
+                        )
+                        .where('workspace_members.role', '=', 'owner')
+                        .where('workspace_members.status', '=', 'active')
+                        .where('artifact_owner.kind', '=', 'bot'),
+                    ),
+              )
+              .executeTakeFirst()
+            if (
+              !current ||
+              (recipient.requiresVerified && current.email_verified !== 1) ||
+              (await emailHash(recipient.userId, current.email)) !==
+                recipient.emailHash
+            ) {
+              return 'skipped'
+            }
+            return await args.notify({
+              kind: suspending ? 'suspended' : 'resumed',
+              shareableId: row.id,
+              title: row.title_override ?? row.derived_title ?? row.name,
+              ownerEmail: current.email,
+              reason: committed.reason,
+              includeReasonAndAppeal: recipient.includeReasonAndAppeal,
+              includeManageUrl: recipient.includeManageUrl,
+            })
+          } catch {
+            return 'failed'
           }
-          return args.notify({
-            kind: suspending ? 'suspended' : 'resumed',
-            shareableId: row.id,
-            title: row.title_override ?? row.derived_title ?? row.name,
-            ownerEmail: current.email,
-            reason: committed.reason,
-            includeReasonAndAppeal: recipient.includeReasonAndAppeal,
-            includeManageUrl: recipient.includeManageUrl,
-          })
         }),
       )
     : []
@@ -338,7 +387,6 @@ async function transitionLink(
     action: move,
     shareableId: row.id,
     workspaceId: row.workspace_id,
-    actor: committed.actor,
     source: committed.source,
     notifications: counts,
   })
@@ -459,8 +507,10 @@ export async function appealLinkSuspension(
   ])
   const results = await runD1BatchWithResults(db, insert, classification)
   const classified = appealClassificationRow(results[1])
-  if (!classified?.inserted) {
-    if (!classified?.found) return { kind: 'not-found' }
+  if (!classified)
+    throw new Error('Unexpected D1 appeal classification result shape')
+  if (!classified.inserted) {
+    if (!classified.found) return { kind: 'not-found' }
     if (!classified.owned) return { kind: 'forbidden' }
     if (!classified.suspended) return { kind: 'not-suspended' }
     return { kind: 'cooldown' }
@@ -486,7 +536,7 @@ type AppealClassificationRow = {
   workspace_id: string | null
 }
 
-export function appealClassificationRow(
+function appealClassificationRow(
   result: unknown,
 ): AppealClassificationRow | null {
   const rows = Array.isArray(result)

--- a/apps/web/app/services/link-suspension.server.ts
+++ b/apps/web/app/services/link-suspension.server.ts
@@ -139,7 +139,7 @@ async function notificationRecipients(
         userId: row.owner_id,
         emailHash: await emailHash(row.owner_id, row.owner_email),
         relationship: 'artifact_owner',
-        requiresVerified: false,
+        requiresVerified: true,
         includeReasonAndAppeal: true,
         includeManageUrl: true,
       },
@@ -645,13 +645,13 @@ export async function sendOwnerNotice(
       text: text.filter((line) => line !== null).join('\n'),
     })
     return 'sent'
-  } catch (error) {
+  } catch {
     console.error(
       JSON.stringify({
         event: 'link_suspension_email_failed',
         shareableId: notice.shareableId,
         kind: notice.kind,
-        message: error instanceof Error ? error.message : String(error),
+        outcome: 'failed',
       }),
     )
     return 'failed'

--- a/apps/web/app/services/link-suspension.server.ts
+++ b/apps/web/app/services/link-suspension.server.ts
@@ -4,7 +4,7 @@ import { nanoid } from 'nanoid'
 import { runD1Batch, runD1BatchWithResults } from '~/lib/d1-batch.server'
 import { nowIso } from '~/lib/datetime'
 import { APEX_HOST } from '~/lib/hosts'
-import { constantTimeEqual, hmacSha256 } from '~/lib/hmac'
+import { constantTimeEqual, hmacSha256Base64Url } from '~/lib/hmac'
 import type { LinkOpsTokenPayload } from '~/lib/link-ops-token'
 import type { DB } from '~/types/db'
 
@@ -122,14 +122,11 @@ type TransitionPayload = {
   recipients: RecipientSnapshot[]
 }
 
-async function emailHash(userId: string, email: string): Promise<string> {
-  const digest = await hmacSha256(
+function emailHash(userId: string, email: string): Promise<string> {
+  return hmacSha256Base64Url(
     env.BETTER_AUTH_SECRET,
     `link-notice\0${userId}\0${email}`,
   )
-  return Array.from(new Uint8Array(digest), (byte) =>
-    byte.toString(16).padStart(2, '0'),
-  ).join('')
 }
 
 async function notificationRecipients(
@@ -298,14 +295,27 @@ async function transitionLink(
     .where('id', '=', eventId)
     .executeTakeFirst()
   if (!recorded) return { kind: 'already' }
-  const committed = payload
-  const outcomes: OwnerNoticeOutcome[] = committed.notify
+  const outcomes: OwnerNoticeOutcome[] = payload.notify
     ? await Promise.all(
-        committed.recipients.map(async (recipient) => {
+        payload.recipients.map(async (recipient) => {
           try {
             const current = await db
               .selectFrom('users')
-              .select(['id', 'email', 'email_verified'])
+              .select([
+                'id',
+                'email',
+                'email_verified',
+                sql<
+                  string | null
+                >`(SELECT visibility FROM shareables WHERE id = ${row.id})`.as(
+                  'current_visibility',
+                ),
+                sql<
+                  string | null
+                >`(SELECT workspaces.plan FROM shareables JOIN workspaces ON workspaces.id = shareables.workspace_id WHERE shareables.id = ${row.id})`.as(
+                  'current_workspace_plan',
+                ),
+              ])
               .where('id', '=', recipient.userId)
               .where((eb) =>
                 recipient.relationship === 'artifact_owner'
@@ -344,6 +354,7 @@ async function transitionLink(
               .executeTakeFirst()
             if (
               !current ||
+              (!suspending && current.current_visibility !== 'link') ||
               (recipient.requiresVerified && current.email_verified !== 1) ||
               !constantTimeEqual(
                 await emailHash(recipient.userId, current.email),
@@ -357,9 +368,13 @@ async function transitionLink(
               shareableId: row.id,
               title: row.title_override ?? row.derived_title ?? row.name,
               ownerEmail: current.email,
-              reason: committed.reason,
+              reason: recipient.includeReasonAndAppeal
+                ? payload.reason
+                : null,
               includeReasonAndAppeal: recipient.includeReasonAndAppeal,
-              includeManageUrl: recipient.includeManageUrl,
+              includeManageUrl:
+                recipient.relationship === 'artifact_owner' ||
+                current.current_workspace_plan === 'team',
             })
           } catch {
             return 'failed'
@@ -440,6 +455,14 @@ export async function appealLinkSuspension(
   user: { id: string },
   args: { shareableId: string; message: string; now?: string },
 ): Promise<LinkAppealResult> {
+  const preflight = await db
+    .selectFrom('shareables')
+    .select(['owner_user_id', 'link_suspended_at'])
+    .where('id', '=', args.shareableId)
+    .executeTakeFirst()
+  if (!preflight) return { kind: 'not-found' }
+  if (preflight.owner_user_id !== user.id) return { kind: 'forbidden' }
+  if (!preflight.link_suspended_at) return { kind: 'not-suspended' }
   const now = args.now ?? nowIso()
   const since = new Date(Date.parse(now) - APPEAL_COOLDOWN_MS).toISOString()
   const message = clipCodePoints(args.message, LINK_APPEAL_MESSAGE_MAX)
@@ -503,20 +526,30 @@ export async function appealLinkSuspension(
   const results = await runD1BatchWithResults(db, insert, classification)
   let classified = appealClassificationRow(results[1])
   if (!classified) {
-    const recorded = await db
-      .selectFrom('events')
-      .select('workspace_id')
-      .where('id', '=', eventId)
+    const recovered = await db
+      .selectNoFrom([
+        sql<number>`EXISTS(SELECT 1 FROM events WHERE id = ${eventId})`.as(
+          'inserted',
+        ),
+        sql<number>`EXISTS(SELECT 1 FROM shareables WHERE id = ${args.shareableId})`.as(
+          'found',
+        ),
+        sql<number>`EXISTS(SELECT 1 FROM shareables WHERE id = ${args.shareableId} AND owner_user_id = ${user.id})`.as(
+          'owned',
+        ),
+        sql<number>`EXISTS(SELECT 1 FROM shareables WHERE id = ${args.shareableId} AND link_suspended_at IS NOT NULL)`.as(
+          'suspended',
+        ),
+        sql<
+          string | null
+        >`(SELECT workspace_id FROM shareables WHERE id = ${args.shareableId})`.as(
+          'workspace_id',
+        ),
+      ])
       .executeTakeFirst()
-    if (!recorded)
-      throw new Error('Unexpected D1 appeal classification result shape')
-    classified = {
-      inserted: 1,
-      found: 1,
-      owned: 1,
-      suspended: 1,
-      workspace_id: recorded.workspace_id,
-    }
+    if (!recovered)
+      throw new Error('Unable to recover D1 appeal classification')
+    classified = recovered
   }
   if (!classified.inserted) {
     if (!classified.found) return { kind: 'not-found' }

--- a/apps/web/app/services/link-suspension.server.ts
+++ b/apps/web/app/services/link-suspension.server.ts
@@ -4,6 +4,7 @@ import { nanoid } from 'nanoid'
 import { runD1Batch, runD1BatchWithResults } from '~/lib/d1-batch.server'
 import { nowIso } from '~/lib/datetime'
 import { APEX_HOST } from '~/lib/hosts'
+import { constantTimeEqual, hmacSha256 } from '~/lib/hmac'
 import type { LinkOpsTokenPayload } from '~/lib/link-ops-token'
 import type { DB } from '~/types/db'
 
@@ -122,17 +123,9 @@ type TransitionPayload = {
 }
 
 async function emailHash(userId: string, email: string): Promise<string> {
-  const key = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(env.BETTER_AUTH_SECRET),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign'],
-  )
-  const digest = await crypto.subtle.sign(
-    'HMAC',
-    key,
-    new TextEncoder().encode(`link-notice\0${userId}\0${email}`),
+  const digest = await hmacSha256(
+    env.BETTER_AUTH_SECRET,
+    `link-notice\0${userId}\0${email}`,
   )
   return Array.from(new Uint8Array(digest), (byte) =>
     byte.toString(16).padStart(2, '0'),
@@ -301,11 +294,11 @@ async function transitionLink(
   )
   const recorded = await db
     .selectFrom('events')
-    .select('payload')
+    .select('id')
     .where('id', '=', eventId)
     .executeTakeFirst()
   if (!recorded) return { kind: 'already' }
-  const committed = JSON.parse(recorded.payload ?? '{}') as TransitionPayload
+  const committed = payload
   const outcomes: OwnerNoticeOutcome[] = committed.notify
     ? await Promise.all(
         committed.recipients.map(async (recipient) => {
@@ -352,8 +345,10 @@ async function transitionLink(
             if (
               !current ||
               (recipient.requiresVerified && current.email_verified !== 1) ||
-              (await emailHash(recipient.userId, current.email)) !==
-                recipient.emailHash
+              !constantTimeEqual(
+                await emailHash(recipient.userId, current.email),
+                recipient.emailHash,
+              )
             ) {
               return 'skipped'
             }
@@ -506,9 +501,23 @@ export async function appealLinkSuspension(
     ),
   ])
   const results = await runD1BatchWithResults(db, insert, classification)
-  const classified = appealClassificationRow(results[1])
-  if (!classified)
-    throw new Error('Unexpected D1 appeal classification result shape')
+  let classified = appealClassificationRow(results[1])
+  if (!classified) {
+    const recorded = await db
+      .selectFrom('events')
+      .select('workspace_id')
+      .where('id', '=', eventId)
+      .executeTakeFirst()
+    if (!recorded)
+      throw new Error('Unexpected D1 appeal classification result shape')
+    classified = {
+      inserted: 1,
+      found: 1,
+      owned: 1,
+      suspended: 1,
+      workspace_id: recorded.workspace_id,
+    }
+  }
   if (!classified.inserted) {
     if (!classified.found) return { kind: 'not-found' }
     if (!classified.owned) return { kind: 'forbidden' }

--- a/apps/web/app/services/link-suspension.server.ts
+++ b/apps/web/app/services/link-suspension.server.ts
@@ -1,10 +1,10 @@
 import { env } from 'cloudflare:workers'
 import { sql, type Kysely } from 'kysely'
 import { nanoid } from 'nanoid'
-import { runD1Batch } from '~/lib/d1-batch.server'
+import { runD1Batch, runD1BatchWithResults } from '~/lib/d1-batch.server'
 import { nowIso } from '~/lib/datetime'
 import { APEX_HOST } from '~/lib/hosts'
-import { linkOpsUrl, signLinkOpsToken } from '~/lib/link-ops-token'
+import type { LinkOpsTokenPayload } from '~/lib/link-ops-token'
 import type { DB } from '~/types/db'
 
 // An operator pauses a link share while reviewing it (from the Slack judgment
@@ -32,6 +32,8 @@ export type OwnerNotice = {
   title: string
   ownerEmail: string
   reason: string | null
+  includeReasonAndAppeal: boolean
+  includeManageUrl: boolean
 }
 
 export type OwnerNoticeOutcome = 'sent' | 'skipped' | 'failed'
@@ -87,7 +89,12 @@ function ownerOf(db: Kysely<DB>, shareableId: string) {
       'shareables.title_override',
       'users.email as owner_email',
       'users.kind as owner_kind',
+      'users.id as owner_id',
+      'users.email_verified as owner_email_verified',
+      'users.updated_at as owner_updated_at',
     ])
+    .innerJoin('workspaces', 'workspaces.id', 'shareables.workspace_id')
+    .select('workspaces.plan as workspace_plan')
     .where('shareables.id', '=', shareableId)
     .executeTakeFirst()
 }
@@ -98,6 +105,66 @@ function clipCodePoints(value: string, max: number): string {
 }
 
 type OwnerRow = NonNullable<Awaited<ReturnType<typeof ownerOf>>>
+
+type RecipientSnapshot = {
+  userId: string
+  emailHash: string
+  requiresVerified: boolean
+  includeReasonAndAppeal: boolean
+  includeManageUrl: boolean
+}
+
+type TransitionPayload = {
+  actor: { kind: 'operator_credential'; credentialId: string }
+  source: LinkOpsTokenPayload['source']
+  reason: string | null
+  notify: boolean
+  recipients: RecipientSnapshot[]
+}
+
+async function emailHash(userId: string, email: string): Promise<string> {
+  const bytes = new TextEncoder().encode(`${userId}\0${email}`)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('')
+}
+
+async function notificationRecipients(
+  db: Kysely<DB>,
+  row: OwnerRow,
+): Promise<RecipientSnapshot[]> {
+  if (row.owner_kind === 'human')
+    return [
+      {
+        userId: row.owner_id,
+        emailHash: await emailHash(row.owner_id, row.owner_email),
+        requiresVerified: false,
+        includeReasonAndAppeal: true,
+        includeManageUrl: true,
+      },
+    ]
+  const owner = await db
+    .selectFrom('workspace_members')
+    .innerJoin('users', 'users.id', 'workspace_members.user_id')
+    .select(['users.id', 'users.email'])
+    .where('workspace_members.workspace_id', '=', row.workspace_id)
+    .where('workspace_members.role', '=', 'owner')
+    .where('workspace_members.status', '=', 'active')
+    .where('users.kind', '=', 'human')
+    .where('users.email_verified', '=', 1)
+    .executeTakeFirst()
+  if (!owner) return []
+  return [
+    {
+      userId: owner.id,
+      emailHash: await emailHash(owner.id, owner.email),
+      requiresVerified: true,
+      includeReasonAndAppeal: false,
+      includeManageUrl: row.workspace_plan === 'team',
+    },
+  ]
+}
 
 /**
  * Pause or resume in one D1 batch: the event is inserted only while the
@@ -113,18 +180,24 @@ async function transitionLink(
   move: 'suspend' | 'resume',
   args: {
     reason: string | null
-    judgmentId: string | null
+    credentialId: string
+    source: LinkOpsTokenPayload['source']
     now: string
     notify: (notice: OwnerNotice) => Promise<OwnerNoticeOutcome>
   },
 ): Promise<LinkSuspensionResult> {
   const suspending = move === 'suspend'
   const eventId = nanoid()
-  const payload = JSON.stringify(
-    suspending
-      ? { reason: args.reason, judgmentId: args.judgmentId }
-      : { judgmentId: args.judgmentId },
-  )
+  const recipients = await notificationRecipients(db, row)
+  const shouldNotify = suspending || row.visibility === 'link'
+  const payload: TransitionPayload = {
+    actor: { kind: 'operator_credential', credentialId: args.credentialId },
+    source: args.source,
+    reason: suspending ? args.reason : null,
+    notify: shouldNotify,
+    recipients,
+  }
+  const serializedPayload = JSON.stringify(payload)
   await runD1Batch(
     db,
     db
@@ -149,7 +222,7 @@ async function transitionLink(
             eb.val(row.id).as('shareable_id'),
             eb.val(null).as('actor_user_id'),
             eb.val(nanoid()).as('subject_id'),
-            eb.val(payload).as('payload'),
+            eb.val(serializedPayload).as('payload'),
             eb.val(args.now).as('created_at'),
           ])
           .where('id', '=', row.id)
@@ -162,22 +235,9 @@ async function transitionLink(
             q.where('link_suspended_at', 'is not', null),
           ),
       ),
-    db
-      .updateTable('shareables')
-      .set(
-        suspending
-          ? { link_suspended_at: args.now, link_suspended_reason: args.reason }
-          : { link_suspended_at: null, link_suspended_reason: null },
-      )
-      .where('id', '=', row.id)
-      .$if(suspending, (q) =>
-        q
-          .where('visibility', '=', 'link')
-          .where('link_suspended_at', 'is', null),
-      )
-      .$if(!suspending, (q) => q.where('link_suspended_at', 'is not', null)),
-    // Same guard as the event: a transition that loses the race leaves no
-    // audit row either.
+    // Read the event written by the preceding statement. D1 executes batch
+    // statements sequentially in one transaction, so a losing transition
+    // has no event and therefore no audit row.
     db
       .insertInto('audit_events')
       .columns([
@@ -192,10 +252,10 @@ async function transitionLink(
       ])
       .expression((eb) =>
         eb
-          .selectFrom('shareables')
+          .selectFrom('events')
           .select([
             eb.val(nanoid(16)).as('id'),
-            eb.val(row.workspace_id).as('workspace_id'),
+            'events.workspace_id',
             eb.val(null).as('actor_user_id'),
             eb
               .val(
@@ -203,44 +263,84 @@ async function transitionLink(
               )
               .as('action'),
             eb.val('shareable').as('subject_type'),
-            eb.val(row.id).as('subject_id'),
-            eb.val(payload).as('detail'),
-            eb.val(args.now).as('created_at'),
+            'events.shareable_id as subject_id',
+            sql<string>`json_remove(events.payload, '$.recipients')`.as(
+              'detail',
+            ),
+            'events.created_at',
           ])
-          .where('id', '=', row.id)
-          .$if(suspending, (q) =>
-            q
-              .where('visibility', '=', 'link')
-              .where('link_suspended_at', 'is', null),
-          )
-          .$if(!suspending, (q) =>
-            q.where('link_suspended_at', 'is not', null),
-          ),
+          .where('events.id', '=', eventId),
+      ),
+    db
+      .updateTable('shareables')
+      .set(
+        suspending
+          ? { link_suspended_at: args.now, link_suspended_reason: args.reason }
+          : { link_suspended_at: null, link_suspended_reason: null },
+      )
+      .where('id', '=', row.id)
+      .where(
+        'id',
+        'in',
+        db
+          .selectFrom('events')
+          .select('shareable_id')
+          .where('id', '=', eventId),
       ),
   )
   const recorded = await db
     .selectFrom('events')
-    .select('id')
+    .select('payload')
     .where('id', '=', eventId)
     .executeTakeFirst()
   if (!recorded) return { kind: 'already' }
-  // A bot-owned share has no human inbox; a share that is no longer a link
-  // gets its flag cleared without a "resumed" email that would be untrue.
-  const ownerNotice =
-    row.owner_kind === 'bot' || (!suspending && row.visibility !== 'link')
-      ? 'skipped'
-      : await args.notify({
-          kind: suspending ? 'suspended' : 'resumed',
-          shareableId: row.id,
-          title: row.title_override ?? row.derived_title ?? row.name,
-          ownerEmail: row.owner_email,
-          reason: suspending ? args.reason : null,
-        })
+  const committed = JSON.parse(recorded.payload ?? '{}') as TransitionPayload
+  const outcomes: OwnerNoticeOutcome[] = committed.notify
+    ? await Promise.all(
+        committed.recipients.map(async (recipient) => {
+          const current = await db
+            .selectFrom('users')
+            .select(['id', 'email', 'email_verified'])
+            .where('id', '=', recipient.userId)
+            .executeTakeFirst()
+          if (
+            !current ||
+            (recipient.requiresVerified && current.email_verified !== 1) ||
+            (await emailHash(recipient.userId, current.email)) !==
+              recipient.emailHash
+          ) {
+            return 'skipped'
+          }
+          return args.notify({
+            kind: suspending ? 'suspended' : 'resumed',
+            shareableId: row.id,
+            title: row.title_override ?? row.derived_title ?? row.name,
+            ownerEmail: current.email,
+            reason: committed.reason,
+            includeReasonAndAppeal: recipient.includeReasonAndAppeal,
+            includeManageUrl: recipient.includeManageUrl,
+          })
+        }),
+      )
+    : []
+  if (outcomes.length === 0) outcomes.push('skipped')
+  const counts = {
+    sent: outcomes.filter((value) => value === 'sent').length,
+    failed: outcomes.filter((value) => value === 'failed').length,
+    skipped: outcomes.filter((value) => value === 'skipped').length,
+  }
+  const ownerNotice: OwnerNoticeOutcome = counts.failed
+    ? 'failed'
+    : counts.sent
+      ? 'sent'
+      : 'skipped'
   console.warn('artifactshare_link_suspension', {
     action: move,
     shareableId: row.id,
     workspaceId: row.workspace_id,
-    ownerNotice,
+    actor: committed.actor,
+    source: committed.source,
+    notifications: counts,
   })
   return { kind: suspending ? 'suspended' : 'resumed', ownerNotice }
 }
@@ -250,7 +350,8 @@ export async function suspendLink(
   args: {
     shareableId: string
     reason: string
-    judgmentId?: string | null
+    credentialId: string
+    source: LinkOpsTokenPayload['source']
     now?: string
     notify?: (notice: OwnerNotice) => Promise<OwnerNoticeOutcome>
   },
@@ -262,7 +363,8 @@ export async function suspendLink(
   const reason = clipCodePoints(args.reason, LINK_SUSPENSION_REASON_MAX)
   return transitionLink(db, row, 'suspend', {
     reason: reason || null,
-    judgmentId: args.judgmentId ?? null,
+    credentialId: args.credentialId,
+    source: args.source,
     now: args.now ?? nowIso(),
     notify: args.notify ?? sendOwnerNotice,
   })
@@ -272,7 +374,8 @@ export async function resumeLink(
   db: Kysely<DB>,
   args: {
     shareableId: string
-    judgmentId?: string | null
+    credentialId: string
+    source: LinkOpsTokenPayload['source']
     now?: string
     notify?: (notice: OwnerNotice) => Promise<OwnerNoticeOutcome>
   },
@@ -282,7 +385,8 @@ export async function resumeLink(
   if (!row.link_suspended_at) return { kind: 'already' }
   return transitionLink(db, row, 'resume', {
     reason: null,
-    judgmentId: args.judgmentId ?? null,
+    credentialId: args.credentialId,
+    source: args.source,
     now: args.now ?? nowIso(),
     notify: args.notify ?? sendOwnerNotice,
   })
@@ -293,21 +397,11 @@ export async function appealLinkSuspension(
   user: { id: string },
   args: { shareableId: string; message: string; now?: string },
 ): Promise<LinkAppealResult> {
-  const row = await db
-    .selectFrom('shareables')
-    .select(['id', 'workspace_id', 'owner_user_id', 'link_suspended_at'])
-    .where('id', '=', args.shareableId)
-    .executeTakeFirst()
-  if (!row) return { kind: 'not-found' }
-  if (row.owner_user_id !== user.id) return { kind: 'forbidden' }
-  if (!row.link_suspended_at) return { kind: 'not-suspended' }
   const now = args.now ?? nowIso()
   const since = new Date(Date.parse(now) - APPEAL_COOLDOWN_MS).toISOString()
   const message = clipCodePoints(args.message, LINK_APPEAL_MESSAGE_MAX)
   const eventId = nanoid()
-  // The insert carries the preconditions (still paused, no appeal in the
-  // last hour), so two simultaneous appeals cannot both pass the cooldown.
-  await db
+  const insert = db
     .insertInto('events')
     .columns([
       'id',
@@ -324,15 +418,16 @@ export async function appealLinkSuspension(
         .selectFrom('shareables')
         .select([
           eb.val(eventId).as('id'),
-          eb.val(row.workspace_id).as('workspace_id'),
+          'shareables.workspace_id',
           eb.val('link_appealed').as('type'),
-          eb.val(row.id).as('shareable_id'),
+          'shareables.id as shareable_id',
           eb.val(user.id).as('actor_user_id'),
           eb.val(nanoid()).as('subject_id'),
           eb.val(JSON.stringify({ message })).as('payload'),
           eb.val(now).as('created_at'),
         ])
-        .where('id', '=', row.id)
+        .where('id', '=', args.shareableId)
+        .where('owner_user_id', '=', user.id)
         .where('link_suspended_at', 'is not', null)
         .where(
           sql<boolean>`NOT EXISTS (
@@ -343,29 +438,73 @@ export async function appealLinkSuspension(
           )`,
         ),
     )
-    .execute()
-  const recorded = await db
-    .selectFrom('events')
-    .select('id')
-    .where('id', '=', eventId)
-    .executeTakeFirst()
-  if (!recorded) return { kind: 'cooldown' }
-  // Operators get the text and a signed link to resume from the alert.
-  const secret = env.LINK_OPS_ACTION_SECRET
+  const classification = db.selectNoFrom([
+    sql<number>`EXISTS(SELECT 1 FROM events WHERE id = ${eventId})`.as(
+      'inserted',
+    ),
+    sql<number>`EXISTS(SELECT 1 FROM shareables WHERE id = ${args.shareableId})`.as(
+      'found',
+    ),
+    sql<number>`EXISTS(SELECT 1 FROM shareables WHERE id = ${args.shareableId} AND owner_user_id = ${user.id})`.as(
+      'owned',
+    ),
+    sql<number>`EXISTS(SELECT 1 FROM shareables WHERE id = ${args.shareableId} AND link_suspended_at IS NOT NULL)`.as(
+      'suspended',
+    ),
+    sql<
+      string | null
+    >`(SELECT workspace_id FROM shareables WHERE id = ${args.shareableId})`.as(
+      'workspace_id',
+    ),
+  ])
+  const results = await runD1BatchWithResults(db, insert, classification)
+  const classified = appealClassificationRow(results[1])
+  if (!classified?.inserted) {
+    if (!classified?.found) return { kind: 'not-found' }
+    if (!classified.owned) return { kind: 'forbidden' }
+    if (!classified.suspended) return { kind: 'not-suspended' }
+    return { kind: 'cooldown' }
+  }
+  // The alerts worker creates the signed operator credential. Keeping the
+  // token out of this marker prevents the app invocation log from recording
+  // the query string before redaction can be applied downstream.
   console.warn('artifactshare_link_appeal', {
-    shareableId: row.id,
-    workspaceId: row.workspace_id,
-    manageUrl: `https://${APEX_HOST}/a/${row.id}`,
+    shareableId: args.shareableId,
+    workspaceId: classified.workspace_id,
+    manageUrl: `https://${APEX_HOST}/a/${args.shareableId}`,
     message: clipCodePoints(message, 300),
-    actionUrl: secret
-      ? linkOpsUrl(
-          `https://${APEX_HOST}`,
-          row.id,
-          await signLinkOpsToken({ shareableId: row.id }, secret),
-        )
-      : null,
+    source: { kind: 'appeal', id: eventId },
   })
   return { kind: 'appealed' }
+}
+
+type AppealClassificationRow = {
+  inserted: number
+  found: number
+  owned: number
+  suspended: number
+  workspace_id: string | null
+}
+
+export function appealClassificationRow(
+  result: unknown,
+): AppealClassificationRow | null {
+  const rows = Array.isArray(result)
+    ? result
+    : result && typeof result === 'object' && 'results' in result
+      ? (result as { results?: unknown }).results
+      : null
+  if (!Array.isArray(rows) || !rows[0] || typeof rows[0] !== 'object')
+    return null
+  const row = rows[0] as Record<string, unknown>
+  return {
+    inserted: Number(row.inserted) || 0,
+    found: Number(row.found) || 0,
+    owned: Number(row.owned) || 0,
+    suspended: Number(row.suspended) || 0,
+    workspace_id:
+      typeof row.workspace_id === 'string' ? row.workspace_id : null,
+  }
 }
 
 /** Email the owner; a delivery failure is logged and never fails the action. */
@@ -375,8 +514,8 @@ export async function sendOwnerNotice(
   const email: SendEmail | undefined = env.EMAIL
   if (!email) return 'skipped'
   const manageUrl = `https://${APEX_HOST}/a/${notice.shareableId}`
-  // The title is user content: keep it out of header injection.
   const title = notice.title.replace(/[\r\n]+/g, ' ')
+  const reason = notice.reason?.replace(/[\r\n]+/g, ' ') ?? null
   const subject =
     notice.kind === 'suspended'
       ? `リンク共有を一時停止しました / Link sharing paused: ${title}`
@@ -384,20 +523,29 @@ export async function sendOwnerNotice(
   const text =
     notice.kind === 'suspended'
       ? [
-          `「${notice.title}」のリンク共有を、運営が確認のため一時停止しました。`,
-          `Link sharing for “${notice.title}” was paused by the operators while they review it.`,
+          `「${title}」のリンク共有を、運営が確認のため一時停止しました。`,
+          `Link sharing for “${title}” was paused by the operators while they review it.`,
           '',
-          notice.reason ? `理由 / Reason: ${notice.reason}` : null,
-          notice.reason ? '' : null,
-          `停止中もあなたと個別共有の相手は開けます。異議はファイルのページから送れます: ${manageUrl}`,
-          `You and the people you shared it with can still open it. You can appeal from the file's page: ${manageUrl}`,
+          notice.includeReasonAndAppeal && reason
+            ? `理由 / Reason: ${reason}`
+            : null,
+          notice.includeReasonAndAppeal && reason ? '' : null,
+          notice.includeReasonAndAppeal && notice.includeManageUrl
+            ? `停止中もあなたと個別共有の相手は開けます。異議はファイルのページから送れます: ${manageUrl}`
+            : null,
+          notice.includeReasonAndAppeal && notice.includeManageUrl
+            ? `You and the people you shared it with can still open it. You can appeal from the file's page: ${manageUrl}`
+            : null,
+          !notice.includeReasonAndAppeal && notice.includeManageUrl
+            ? `管理 / Manage: ${manageUrl}`
+            : null,
         ]
       : [
-          `「${notice.title}」のリンク共有を再開しました。`,
-          `Link sharing for “${notice.title}” has been resumed.`,
+          `「${title}」のリンク共有を再開しました。`,
+          `Link sharing for “${title}” has been resumed.`,
           '',
-          `ファイル: ${manageUrl}`,
-          `File: ${manageUrl}`,
+          notice.includeManageUrl ? `ファイル: ${manageUrl}` : null,
+          notice.includeManageUrl ? `File: ${manageUrl}` : null,
         ]
   try {
     await email.send({

--- a/apps/web/app/services/link-suspension.server.ts
+++ b/apps/web/app/services/link-suspension.server.ts
@@ -368,9 +368,7 @@ async function transitionLink(
               shareableId: row.id,
               title: row.title_override ?? row.derived_title ?? row.name,
               ownerEmail: current.email,
-              reason: recipient.includeReasonAndAppeal
-                ? payload.reason
-                : null,
+              reason: recipient.includeReasonAndAppeal ? payload.reason : null,
               includeReasonAndAppeal: recipient.includeReasonAndAppeal,
               includeManageUrl:
                 recipient.relationship === 'artifact_owner' ||
@@ -397,7 +395,7 @@ async function transitionLink(
     action: move,
     shareableId: row.id,
     workspaceId: row.workspace_id,
-    source: committed.source,
+    source: payload.source,
     notifications: counts,
   })
   return { kind: suspending ? 'suspended' : 'resumed', ownerNotice }

--- a/apps/web/app/test/vitest.d1.config.ts
+++ b/apps/web/app/test/vitest.d1.config.ts
@@ -1,6 +1,10 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    alias: { '~': fileURLToPath(new URL('..', import.meta.url)) },
+  },
   test: {
     include: ['app/d1-tests/**/*.test.ts'],
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -99,6 +99,6 @@
     "vite": "8.2.2",
     "vite-plus": "0.2.9",
     "vitest": "4.1.10",
-    "wrangler": "4.127.0"
+    "wrangler": "4.129.1"
   }
 }

--- a/apps/web/workers/alerts.test.ts
+++ b/apps/web/workers/alerts.test.ts
@@ -613,10 +613,6 @@ describe('link suspension alerts', () => {
           action: 'suspend',
           shareableId: 'abc123def4',
           workspaceId,
-          actor: {
-            kind: 'operator_credential',
-            credentialId: 'credential-1234567890',
-          },
           source: { kind: 'judgment', id: 'judgment-1' },
           notifications: { sent: 1, failed: 0, skipped: 0 },
         }),

--- a/apps/web/workers/alerts.test.ts
+++ b/apps/web/workers/alerts.test.ts
@@ -25,6 +25,7 @@ function testEnv(): TestEnv {
     ALERT_STATE: new MemoryKv() as unknown as KVNamespace,
     APP_ENV: 'test',
     SLACK_ALERT_WEBHOOK_URL: 'https://hooks.slack.com/services/T/B/C',
+    LINK_OPS_ACTION_SECRET: 'ops-secret',
   }
 }
 
@@ -612,7 +613,12 @@ describe('link suspension alerts', () => {
           action: 'suspend',
           shareableId: 'abc123def4',
           workspaceId,
-          ownerNotice: 'sent',
+          actor: {
+            kind: 'operator_credential',
+            credentialId: 'credential-1234567890',
+          },
+          source: { kind: 'judgment', id: 'judgment-1' },
+          notifications: { sent: 1, failed: 0, skipped: 0 },
         }),
       ],
       testEnv(),
@@ -640,8 +646,7 @@ describe('link suspension alerts', () => {
           workspaceId,
           manageUrl: 'https://artifactshare.com/a/abc123def4',
           message: 'This is our internal report.',
-          actionUrl:
-            'https://artifactshare.com/ops/link/abc123def4?token=abc.def',
+          source: { kind: 'appeal', id: 'appeal-1' },
         },
       ],
       level: 'warn',
@@ -653,7 +658,7 @@ describe('link suspension alerts', () => {
       .mocked(fetch)
       .mock.calls.map(([, init]) => String(init?.body))
     expect(bodies[0]).toContain('link paused')
-    expect(bodies[0]).toContain('owner email: sent')
+    expect(bodies[0]).toContain('owner email: sent 1, failed 0, skipped 0')
     expect(bodies[1]).toContain('link resumed')
     expect(bodies[1]).toContain('owner email: failed')
     expect(bodies[2]).toContain('link appeal')
@@ -693,8 +698,6 @@ describe('link suspension alerts', () => {
   })
 
   test('shows the signed operator link on a judgment when present', async () => {
-    const actionUrl =
-      'https://artifactshare.com/ops/link/abc123def4?token=abc.def'
     await alerts.tail?.(
       [
         linkAbuseJudgmentTrace({
@@ -706,7 +709,7 @@ describe('link suspension alerts', () => {
           impersonatedBrand: null,
           externalTargets: [],
           manageUrl: 'https://artifactshare.com/a/abc123def4',
-          actionUrl,
+          source: { kind: 'judgment', id: 'judgment-1' },
         }),
       ],
       testEnv(),

--- a/apps/web/workers/alerts.test.ts
+++ b/apps/web/workers/alerts.test.ts
@@ -23,7 +23,7 @@ type TestEnv = Parameters<NonNullable<typeof alerts.tail>>[1]
 function testEnv(): TestEnv {
   return {
     ALERT_STATE: new MemoryKv() as unknown as KVNamespace,
-    APP_ENV: 'test',
+    APP_ENV: 'production',
     SLACK_ALERT_WEBHOOK_URL: 'https://hooks.slack.com/services/T/B/C',
     LINK_OPS_ACTION_SECRET: 'ops-secret',
   }
@@ -713,6 +713,31 @@ describe('link suspension alerts', () => {
     expect(fetch).toHaveBeenCalledTimes(1)
     expect(String(vi.mocked(fetch).mock.calls[0][1]?.body)).toContain(
       'pause or resume link sharing',
+    )
+  })
+
+  test('omits production operator links from public-preview alerts', async () => {
+    const env = testEnv()
+    env.APP_ENV = 'development'
+    await alerts.tail?.(
+      [
+        linkAbuseJudgmentTrace({
+          shareableId: 'abc123def4',
+          workspaceId: 'ws-1',
+          trigger: 'manual',
+          risk: 'medium',
+          reason: 'suspicious_form',
+          impersonatedBrand: null,
+          externalTargets: [],
+          manageUrl: 'https://artifactshare.com/a/abc123def4',
+          source: { kind: 'judgment', id: 'judgment-1' },
+        }),
+      ],
+      env,
+    )
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(String(vi.mocked(fetch).mock.calls[0][1]?.body)).toContain(
+      'operate: no signed link in this notification',
     )
   })
 })

--- a/apps/web/workers/alerts.ts
+++ b/apps/web/workers/alerts.ts
@@ -2,6 +2,7 @@ type AlertEnv = {
   ALERT_STATE: KVNamespace
   APP_ENV: string
   SLACK_ALERT_WEBHOOK_URL?: string
+  LINK_OPS_ACTION_SECRET?: string
 }
 
 type SlackBlock = {
@@ -25,6 +26,8 @@ import {
   isUtcIsoMilliseconds,
 } from '../app/lib/sandbox-block-report'
 import { isLinkReportReason } from '../app/lib/link-report'
+import { linkOpsUrl, signLinkOpsToken } from '../app/lib/link-ops-token'
+import { nanoid } from 'nanoid'
 
 const alertPrefix = 'ops-alerts'
 const authHangLogMarker = 'artifactshare_auth_hang'
@@ -173,7 +176,8 @@ async function alertFromTrace(
       cooldownSeconds: immediateCooldownSeconds,
     }
   const linkAppeal = linkAppealFromLogs(item)
-  if (linkAppeal)
+  if (linkAppeal) {
+    const actionUrl = await linkOpsActionUrl(linkAppeal, env)
     return {
       key: `link-appeal:${linkAppeal.shareableId}`,
       title: 'Artifact Share link appeal',
@@ -183,15 +187,17 @@ async function alertFromTrace(
         `workspace: ${escapeSlackText(linkAppeal.workspaceId)}`,
         `appeal: ${escapeSlackText(linkAppeal.message)}`,
         `manage: <${linkAppeal.manageUrl}|file page>`,
-        linkAppeal.actionUrl
-          ? `operate: <${linkAppeal.actionUrl}|resume link sharing>`
+        actionUrl
+          ? `operate: <${actionUrl}|resume link sharing>`
           : 'operate: no signed link in this notification',
       ],
       cooldownSeconds: immediateCooldownSeconds,
     }
+  }
   const linkAbuseJudgment = linkAbuseJudgmentFromLogs(item)
   if (linkAbuseJudgment) {
     const artifactUrl = `https://${linkAbuseJudgment.shareableId}.artifactshare.link/`
+    const actionUrl = await linkOpsActionUrl(linkAbuseJudgment, env)
     const listedTargets = linkAbuseJudgment.externalTargets.slice(0, 10)
     const remainingTargets = linkAbuseJudgment.externalTargets.length - 10
     return {
@@ -207,8 +213,8 @@ async function alertFromTrace(
         `reason: ${escapeSlackText(truncateCodePoints(linkAbuseJudgment.reason, 300))}`,
         `artifact: <${artifactUrl}|anonymous link>`,
         `manage: <${linkAbuseJudgment.manageUrl}|visibility controls>`,
-        linkAbuseJudgment.actionUrl
-          ? `operate: <${linkAbuseJudgment.actionUrl}|pause or resume link sharing>`
+        actionUrl
+          ? `operate: <${actionUrl}|pause or resume link sharing>`
           : 'operate: no signed link in this notification',
         `impersonated brand: ${escapeSlackText(linkAbuseJudgment.impersonatedBrand ?? 'none')}`,
         `external targets: ${listedTargets.length > 0 ? `${escapeSlackText(truncateCodePoints(listedTargets.join(', '), 500))}${remainingTargets > 0 ? `, +${remainingTargets} more` : ''}` : 'none'}`,
@@ -522,7 +528,7 @@ function linkSuspensionFromLogs(item: TraceItem): {
   action: 'suspend' | 'resume'
   shareableId: string
   workspaceId: string
-  ownerNotice: 'sent' | 'skipped' | 'failed'
+  ownerNotice: string
 } | null {
   for (const log of item.logs) {
     const [marker, detail] = log.message ?? []
@@ -533,18 +539,28 @@ function linkSuspensionFromLogs(item: TraceItem): {
     )
       continue
     const raw = detail as Record<string, unknown>
-    if (
-      Object.keys(raw).sort().join(',') !==
-      'action,ownerNotice,shareableId,workspaceId'
-    )
-      continue
+    const keys = Object.keys(raw).sort().join(',')
+    const legacy = keys === 'action,ownerNotice,shareableId,workspaceId'
+    const current =
+      keys === 'action,actor,notifications,shareableId,source,workspaceId'
+    if (!legacy && !current) continue
     if (raw.action !== 'suspend' && raw.action !== 'resume') continue
-    if (
-      raw.ownerNotice !== 'sent' &&
-      raw.ownerNotice !== 'skipped' &&
-      raw.ownerNotice !== 'failed'
-    )
-      continue
+    let ownerNotice: string
+    if (legacy) {
+      if (
+        raw.ownerNotice !== 'sent' &&
+        raw.ownerNotice !== 'skipped' &&
+        raw.ownerNotice !== 'failed'
+      )
+        continue
+      ownerNotice = raw.ownerNotice
+    } else {
+      if (!isOperatorCredentialActor(raw.actor)) continue
+      if (!parseLinkOpsSource(raw.source)) continue
+      const counts = notificationCounts(raw.notifications)
+      if (!counts) continue
+      ownerNotice = `sent ${counts.sent}, failed ${counts.failed}, skipped ${counts.skipped}`
+    }
     if (!isSandboxArtifactId(raw.shareableId)) continue
     if (
       typeof raw.workspaceId !== 'string' ||
@@ -555,7 +571,7 @@ function linkSuspensionFromLogs(item: TraceItem): {
       action: raw.action,
       shareableId: raw.shareableId,
       workspaceId: raw.workspaceId,
-      ownerNotice: raw.ownerNotice,
+      ownerNotice,
     }
   }
   return null
@@ -566,18 +582,18 @@ function linkAppealFromLogs(item: TraceItem): {
   workspaceId: string
   manageUrl: string
   message: string
-  actionUrl: string | null
+  source: LinkOpsSource | null
 } | null {
   for (const log of item.logs) {
     const [marker, detail] = log.message ?? []
     if (marker !== linkAppealMarker || !detail || typeof detail !== 'object')
       continue
     const raw = detail as Record<string, unknown>
-    if (
-      Object.keys(raw).sort().join(',') !==
-      'actionUrl,manageUrl,message,shareableId,workspaceId'
-    )
-      continue
+    const keys = Object.keys(raw).sort().join(',')
+    const legacy =
+      keys === 'actionUrl,manageUrl,message,shareableId,workspaceId'
+    const current = keys === 'manageUrl,message,shareableId,source,workspaceId'
+    if (!legacy && !current) continue
     if (!isSandboxArtifactId(raw.shareableId)) continue
     if (
       typeof raw.workspaceId !== 'string' ||
@@ -588,13 +604,15 @@ function linkAppealFromLogs(item: TraceItem): {
       continue
     if (typeof raw.message !== 'string' || Array.from(raw.message).length > 300)
       continue
-    if (!isLinkOpsActionUrl(raw.actionUrl, raw.shareableId)) continue
+    if (legacy && !isLinkOpsActionUrl(raw.actionUrl, raw.shareableId)) continue
+    const source = current ? parseLinkOpsSource(raw.source, 'appeal') : null
+    if (current && !source) continue
     return {
       shareableId: raw.shareableId,
       workspaceId: raw.workspaceId,
       manageUrl: raw.manageUrl,
       message: raw.message,
-      actionUrl: raw.actionUrl as string | null,
+      source,
     }
   }
   return null
@@ -608,7 +626,7 @@ function linkAbuseJudgmentFromLogs(item: TraceItem): {
   impersonatedBrand: string | null
   externalTargets: string[]
   manageUrl: string
-  actionUrl: string | null
+  source: LinkOpsSource | null
 } | null {
   for (const log of item.logs) {
     const [marker, detail] = log.message ?? []
@@ -619,16 +637,14 @@ function linkAbuseJudgmentFromLogs(item: TraceItem): {
     )
       continue
     const raw = detail as Record<string, unknown>
-    // The alerts worker deploys before the app; a judgment logged by the
-    // previous producer has no actionUrl yet and is still delivered.
     const keys = Object.keys(raw).sort().join(',')
-    if (
-      keys !==
-        'actionUrl,externalTargets,impersonatedBrand,manageUrl,reason,risk,shareableId,trigger,workspaceId' &&
-      keys !==
-        'externalTargets,impersonatedBrand,manageUrl,reason,risk,shareableId,trigger,workspaceId'
-    )
-      continue
+    const legacy =
+      keys ===
+      'actionUrl,externalTargets,impersonatedBrand,manageUrl,reason,risk,shareableId,trigger,workspaceId'
+    const current =
+      keys ===
+      'externalTargets,impersonatedBrand,manageUrl,reason,risk,shareableId,source,trigger,workspaceId'
+    if (!legacy && !current) continue
     if (!isSandboxArtifactId(raw.shareableId)) continue
     if (
       !['view_spike', 'ad_click', 'publish_burst', 'manual'].includes(
@@ -657,7 +673,9 @@ function linkAbuseJudgmentFromLogs(item: TraceItem): {
       continue
     const expectedManageUrl = `https://artifactshare.com/a/${raw.shareableId}`
     if (raw.manageUrl !== expectedManageUrl) continue
-    if (!isLinkOpsActionUrl(raw.actionUrl ?? null, raw.shareableId)) continue
+    if (legacy && !isLinkOpsActionUrl(raw.actionUrl, raw.shareableId)) continue
+    const source = current ? parseLinkOpsSource(raw.source, 'judgment') : null
+    if (current && !source) continue
     if (typeof raw.workspaceId !== 'string' || raw.workspaceId.length === 0)
       continue
     return {
@@ -672,10 +690,79 @@ function linkAbuseJudgmentFromLogs(item: TraceItem): {
       impersonatedBrand: raw.impersonatedBrand as string | null,
       externalTargets: raw.externalTargets,
       manageUrl: raw.manageUrl,
-      actionUrl: (raw.actionUrl ?? null) as string | null,
+      source,
     }
   }
   return null
+}
+
+type LinkOpsSource = { kind: 'judgment' | 'appeal'; id: string }
+
+function parseLinkOpsSource(
+  value: unknown,
+  expectedKind?: LinkOpsSource['kind'],
+): LinkOpsSource | null {
+  if (!value || typeof value !== 'object') return null
+  const raw = value as Record<string, unknown>
+  if (Object.keys(raw).sort().join(',') !== 'id,kind') return null
+  if (
+    (raw.kind !== 'judgment' && raw.kind !== 'appeal') ||
+    (expectedKind && raw.kind !== expectedKind)
+  )
+    return null
+  if (typeof raw.id !== 'string' || raw.id.length < 1 || raw.id.length > 128)
+    return null
+  return { kind: raw.kind, id: raw.id }
+}
+
+function isOperatorCredentialActor(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false
+  const raw = value as Record<string, unknown>
+  return (
+    Object.keys(raw).sort().join(',') === 'credentialId,kind' &&
+    raw.kind === 'operator_credential' &&
+    typeof raw.credentialId === 'string' &&
+    raw.credentialId.length >= 16 &&
+    raw.credentialId.length <= 128
+  )
+}
+
+function notificationCounts(
+  value: unknown,
+): { sent: number; failed: number; skipped: number } | null {
+  if (!value || typeof value !== 'object') return null
+  const raw = value as Record<string, unknown>
+  if (Object.keys(raw).sort().join(',') !== 'failed,sent,skipped') return null
+  if (
+    !['sent', 'failed', 'skipped'].every(
+      (key) => Number.isSafeInteger(raw[key]) && Number(raw[key]) >= 0,
+    )
+  )
+    return null
+  return {
+    sent: Number(raw.sent),
+    failed: Number(raw.failed),
+    skipped: Number(raw.skipped),
+  }
+}
+
+async function linkOpsActionUrl(
+  input: { shareableId: string; source: LinkOpsSource | null },
+  env: AlertEnv,
+): Promise<string | null> {
+  if (!env.LINK_OPS_ACTION_SECRET || !input.source) return null
+  return linkOpsUrl(
+    'https://artifactshare.com',
+    input.shareableId,
+    await signLinkOpsToken(
+      {
+        shareableId: input.shareableId,
+        credentialId: nanoid(24),
+        source: input.source,
+      },
+      env.LINK_OPS_ACTION_SECRET,
+    ),
+  )
 }
 
 function isSafeHostname(value: unknown): value is string {

--- a/apps/web/workers/alerts.ts
+++ b/apps/web/workers/alerts.ts
@@ -542,7 +542,7 @@ function linkSuspensionFromLogs(item: TraceItem): {
     const keys = Object.keys(raw).sort().join(',')
     const legacy = keys === 'action,ownerNotice,shareableId,workspaceId'
     const current =
-      keys === 'action,actor,notifications,shareableId,source,workspaceId'
+      keys === 'action,notifications,shareableId,source,workspaceId'
     if (!legacy && !current) continue
     if (raw.action !== 'suspend' && raw.action !== 'resume') continue
     let ownerNotice: string
@@ -555,7 +555,6 @@ function linkSuspensionFromLogs(item: TraceItem): {
         continue
       ownerNotice = raw.ownerNotice
     } else {
-      if (!isOperatorCredentialActor(raw.actor)) continue
       if (!parseLinkOpsSource(raw.source)) continue
       const counts = notificationCounts(raw.notifications)
       if (!counts) continue
@@ -713,18 +712,6 @@ function parseLinkOpsSource(
   if (typeof raw.id !== 'string' || raw.id.length < 1 || raw.id.length > 128)
     return null
   return { kind: raw.kind, id: raw.id }
-}
-
-function isOperatorCredentialActor(value: unknown): boolean {
-  if (!value || typeof value !== 'object') return false
-  const raw = value as Record<string, unknown>
-  return (
-    Object.keys(raw).sort().join(',') === 'credentialId,kind' &&
-    raw.kind === 'operator_credential' &&
-    typeof raw.credentialId === 'string' &&
-    raw.credentialId.length >= 16 &&
-    raw.credentialId.length <= 128
-  )
 }
 
 function notificationCounts(

--- a/apps/web/workers/alerts.ts
+++ b/apps/web/workers/alerts.ts
@@ -737,7 +737,12 @@ async function linkOpsActionUrl(
   input: { shareableId: string; source: LinkOpsSource | null },
   env: AlertEnv,
 ): Promise<string | null> {
-  if (!env.LINK_OPS_ACTION_SECRET || !input.source) return null
+  if (
+    env.APP_ENV !== 'production' ||
+    !env.LINK_OPS_ACTION_SECRET ||
+    !input.source
+  )
+    return null
   return linkOpsUrl(
     'https://artifactshare.com',
     input.shareableId,

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -509,17 +509,30 @@ async function seedStaticSite(db: Kysely<DB>) {
     .execute()
   await db
     .insertInto('users')
-    .values({
-      id: 'owner-1',
-      email: 'owner@example.com',
-      email_verified: 1,
-      name: 'Owner',
-      image: null,
-      created_at: '2026-05-22T00:00:00.000Z',
-      updated_at: '2026-05-22T00:00:00.000Z',
-      workspace_id: 'ws-a',
-      locale: null,
-    })
+    .values([
+      {
+        id: 'owner-1',
+        email: 'owner@example.com',
+        email_verified: 1,
+        name: 'Owner',
+        image: null,
+        created_at: '2026-05-22T00:00:00.000Z',
+        updated_at: '2026-05-22T00:00:00.000Z',
+        workspace_id: 'ws-a',
+        locale: null,
+      },
+      {
+        id: 'viewer-1',
+        email: 'viewer@example.com',
+        email_verified: 1,
+        name: 'Viewer',
+        image: null,
+        created_at: '2026-05-22T00:00:00.000Z',
+        updated_at: '2026-05-22T00:00:00.000Z',
+        workspace_id: 'ws-a',
+        locale: null,
+      },
+    ])
     .execute()
   await seedOwnerInbox(db)
   await db
@@ -540,6 +553,15 @@ async function seedStaticSite(db: Kysely<DB>) {
       created_at: '2026-05-22T00:00:00.000Z',
       updated_at: '2026-05-22T00:00:00.000Z',
       last_accessed_at: null,
+    })
+    .execute()
+  await db
+    .insertInto('shareable_grants')
+    .values({
+      shareable_id: 'abc123def4',
+      granted_email: 'viewer@example.com',
+      granted_at: '2026-05-22T00:00:00.000Z',
+      granted_by: 'owner-1',
     })
     .execute()
   await db
@@ -787,7 +809,7 @@ function mockFixtureArtifacts(
 async function entrypointToken() {
   return await signSandboxToken(
     {
-      uid: 'viewer-1',
+      uid: 'owner-1',
       wid: 'ws-a',
       aid: 'abc123def4',
       vid: 'v-bundle',
@@ -823,7 +845,7 @@ async function staticSiteToken(args: {
 }) {
   return await signSandboxToken(
     {
-      uid: 'viewer-1',
+      uid: 'owner-1',
       wid: 'ws-a',
       aid: 'abc123def4',
       vid: args.versionId,
@@ -844,7 +866,7 @@ async function singleFileToken(args: {
 }) {
   return await signSandboxToken(
     {
-      uid: 'viewer-1',
+      uid: 'owner-1',
       wid: 'ws-a',
       aid: args.id,
       vid: args.versionId,
@@ -916,6 +938,27 @@ describe('handleArtifactSandboxRequest', () => {
 
     expect(tokenResponse.status).toBe(401)
     expect(assetResponse.status).toBe(401)
+    expect(storageMock.getArtifact).not.toHaveBeenCalled()
+  })
+
+  test('refuses an existing anonymous token immediately after link suspension', async () => {
+    await dbRef
+      .current!.updateTable('shareables')
+      .set({
+        visibility: 'link',
+        link_suspended_at: '2026-09-08T00:00:00.000Z',
+        link_suspended_reason: 'review',
+      })
+      .where('id', '=', 'abc123def4')
+      .execute()
+    const token = await anonymousEntrypointToken()
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
+    )
+
+    expect(response.status).toBe(401)
+    await expect(response.text()).resolves.toBe('Invalid token')
     expect(storageMock.getArtifact).not.toHaveBeenCalled()
   })
 
@@ -1022,6 +1065,47 @@ describe('handleArtifactSandboxRequest', () => {
       {},
       'ws-a/abc123def4/v-bundle/index.html',
     )
+  })
+
+  test('revokes an authenticated bundle cookie after its grant is removed', async () => {
+    storageMock.getArtifact
+      .mockResolvedValueOnce(
+        storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
+      )
+      .mockResolvedValueOnce(
+        storedArtifact('body{}', 'text/css; charset=utf-8'),
+      )
+    const token = await signSandboxToken(
+      {
+        uid: 'viewer-1',
+        wid: 'ws-a',
+        aid: 'abc123def4',
+        vid: 'v-bundle',
+        fid: 'ws-a/abc123def4/v-bundle/index.html',
+        mt: null,
+        t: 'static_site',
+        jti: 'viewer-grant',
+      },
+      'test-secret',
+    )
+    const entrypoint = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
+    )
+    const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+    expect(entrypoint.status).toBe(200)
+    await dbRef
+      .current!.deleteFrom('shareable_grants')
+      .where('shareable_id', '=', 'abc123def4')
+      .execute()
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/style.css`, {
+        headers: { Cookie: cookie ?? '' },
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    expect(storageMock.getArtifact).toHaveBeenCalledTimes(1)
   })
 
   test('serves byte ranges for static-site video assets', async () => {
@@ -1526,7 +1610,7 @@ describe('handleArtifactSandboxRequest', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const token = await signSandboxToken(
       {
-        uid: 'viewer-1',
+        uid: 'owner-1',
         wid: 'ws-a',
         aid: 'abc123def4',
         vid: 'v-bundle',
@@ -1903,7 +1987,7 @@ describe('handleArtifactSandboxRequest', () => {
     )
     const token = await signSandboxToken(
       {
-        uid: 'viewer-1',
+        uid: 'owner-1',
         wid: 'ws-a',
         aid: 'embed12345',
         vid: 'v-embed',

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -2580,6 +2580,24 @@ describe('handleArtifactSandboxRequest', () => {
     },
   )
 
+  test('does not let a future expiry bypass anonymous asset identity guards', async () => {
+    await dbRef
+      .current!.updateTable('shareables')
+      .set({
+        visibility: 'private',
+        link_expires_at: '2099-01-01T00:00:00.000Z',
+      })
+      .where('id', '=', 'abc123def4')
+      .execute()
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/style.css`),
+    )
+
+    expect(response.status).toBe(401)
+    expect(storageMock.getArtifact).not.toHaveBeenCalled()
+  })
+
   test('rejects anonymous link static-site assets that are not in the current version', async () => {
     await dbRef
       .current!.updateTable('shareables')

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -800,6 +800,7 @@ function mockFixtureArtifacts(
       { body: file.body, mimeType: file.mimeType },
     ]),
   )
+
   storageMock.getArtifact.mockImplementation(async (_bucket, key: string) => {
     const file = byKey.get(key)
     return file ? storedBinaryArtifact(file.body, file.mimeType) : null
@@ -1271,6 +1272,93 @@ describe('handleArtifactSandboxRequest', () => {
 
       expect(response.status).toBe(401)
       expect(storageMock.getArtifact).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  test.each(['workspace', 'creator', 'admin', 'grant'] as const)(
+    'authorizes project-visible static sites through the %s rule',
+    async (rule) => {
+      await dbRef
+        .current!.deleteFrom('shareable_grants')
+        .where('shareable_id', '=', 'abc123def4')
+        .execute()
+      await dbRef
+        .current!.insertInto('artifact_containers')
+        .values({
+          id: 'project-a',
+          workspace_id: 'ws-a',
+          kind: 'project',
+          owner_user_id: null,
+          created_by_id: rule === 'creator' ? 'viewer-1' : 'owner-1',
+          name: 'Project A',
+          description: null,
+          base_visibility: rule === 'workspace' ? 'workspace' : 'private',
+          archived_at: null,
+          created_at: '2026-05-22T00:00:00.000Z',
+          updated_at: '2026-05-22T00:00:00.000Z',
+        })
+        .execute()
+      await dbRef
+        .current!.updateTable('shareables')
+        .set({ visibility: 'project', container_id: 'project-a' })
+        .where('id', '=', 'abc123def4')
+        .execute()
+      if (rule === 'admin') {
+        await dbRef
+          .current!.updateTable('workspaces')
+          .set({ plan: 'team' })
+          .where('id', '=', 'ws-a')
+          .execute()
+        await dbRef
+          .current!.insertInto('workspace_members')
+          .values({
+            workspace_id: 'ws-a',
+            user_id: 'viewer-1',
+            role: 'admin',
+            status: 'active',
+            created_at: '2026-05-22T00:00:00.000Z',
+            updated_at: '2026-05-22T00:00:00.000Z',
+          })
+          .execute()
+      }
+      if (rule === 'grant') {
+        await dbRef
+          .current!.insertInto('project_share_defaults')
+          .values({
+            id: 'project-grant',
+            project_container_id: 'project-a',
+            email: 'VIEWER@example.com',
+            role: 'viewer',
+            display_name: null,
+            created_by_id: 'owner-1',
+            created_at: '2026-05-22T00:00:00.000Z',
+            updated_at: '2026-05-22T00:00:00.000Z',
+          })
+          .execute()
+      }
+      storageMock.getArtifact.mockResolvedValue(
+        storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
+      )
+      const token = await signSandboxToken(
+        {
+          uid: 'viewer-1',
+          wid: 'ws-a',
+          aid: 'abc123def4',
+          vid: 'v-bundle',
+          fid: 'ws-a/abc123def4/v-bundle/index.html',
+          mt: null,
+          t: 'static_site',
+          jti: `viewer-project-${rule}`,
+        },
+        'test-secret',
+      )
+
+      const response = await handleArtifactSandboxRequest(
+        new Request(`${sandboxOrigin()}/index.html?t=${token}`),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Set-Cookie')).toContain('as_bnd=')
     },
   )
 

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -1108,6 +1108,62 @@ describe('handleArtifactSandboxRequest', () => {
     expect(storageMock.getArtifact).toHaveBeenCalledTimes(1)
   })
 
+  test.each([
+    ['expired', { expiresAt: '2020-01-01T00:00:00.000Z', enabled: 1 }],
+    ['disabled', { expiresAt: null, enabled: 0 }],
+  ])(
+    'does not use an %s link as fallback after a cookie grant is revoked',
+    async (_, condition) => {
+      storageMock.getArtifact.mockResolvedValue(
+        storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
+      )
+      const token = await signSandboxToken(
+        {
+          uid: 'viewer-1',
+          wid: 'ws-a',
+          aid: 'abc123def4',
+          vid: 'v-bundle',
+          fid: 'ws-a/abc123def4/v-bundle/index.html',
+          mt: null,
+          t: 'static_site',
+          jti: `viewer-${condition.enabled}-${condition.expiresAt ?? 'none'}`,
+        },
+        'test-secret',
+      )
+      const entrypoint = await handleArtifactSandboxRequest(
+        new Request(`${sandboxOrigin()}/index.html?t=${token}`),
+      )
+      const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+      expect(entrypoint.status).toBe(200)
+      await dbRef
+        .current!.deleteFrom('shareable_grants')
+        .where('shareable_id', '=', 'abc123def4')
+        .execute()
+      await dbRef
+        .current!.updateTable('shareables')
+        .set({
+          visibility: 'link',
+          link_expires_at: condition.expiresAt,
+        })
+        .where('id', '=', 'abc123def4')
+        .execute()
+      await dbRef
+        .current!.updateTable('workspaces')
+        .set({ link_sharing_enabled: condition.enabled })
+        .where('id', '=', 'ws-a')
+        .execute()
+
+      const response = await handleArtifactSandboxRequest(
+        new Request(`${sandboxOrigin()}/style.css`, {
+          headers: { Cookie: cookie ?? '' },
+        }),
+      )
+
+      expect(response.status).toBe(401)
+      expect(storageMock.getArtifact).toHaveBeenCalledTimes(1)
+    },
+  )
+
   test('serves byte ranges for static-site video assets', async () => {
     storageMock.getArtifact
       .mockResolvedValueOnce(

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -1108,6 +1108,116 @@ describe('handleArtifactSandboxRequest', () => {
     expect(storageMock.getArtifact).toHaveBeenCalledTimes(1)
   })
 
+  test('does not accept a different viewer cookie for a consumed token', async () => {
+    storageMock.getArtifact.mockResolvedValue(
+      storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
+    )
+    const viewerToken = await signSandboxToken(
+      {
+        uid: 'viewer-1',
+        wid: 'ws-a',
+        aid: 'abc123def4',
+        vid: 'v-bundle',
+        fid: 'ws-a/abc123def4/v-bundle/index.html',
+        mt: null,
+        t: 'static_site',
+        jti: 'viewer-cookie',
+      },
+      'test-secret',
+    )
+    const first = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/index.html?t=${viewerToken}`),
+    )
+    const viewerCookie = first.headers.get('Set-Cookie')?.split(';')[0]
+    consumeJtiMock.mockResolvedValueOnce(false)
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(
+        `${sandboxOrigin()}/index.html?t=${await entrypointToken()}`,
+        {
+          headers: { Cookie: viewerCookie ?? '' },
+        },
+      ),
+    )
+
+    expect(response.status).toBe(401)
+  })
+
+  test('revokes stale Team admin authority after the viewer changes workspace', async () => {
+    storageMock.getArtifact.mockResolvedValue(
+      storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
+    )
+    const token = await signSandboxToken(
+      {
+        uid: 'viewer-1',
+        wid: 'ws-a',
+        aid: 'abc123def4',
+        vid: 'v-bundle',
+        fid: 'ws-a/abc123def4/v-bundle/index.html',
+        mt: null,
+        t: 'static_site',
+        jti: 'viewer-stale-admin',
+      },
+      'test-secret',
+    )
+    const entrypoint = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
+    )
+    const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+    await dbRef
+      .current!.insertInto('workspaces')
+      .values({
+        id: 'ws-b',
+        name: 'Other workspace',
+        created_at: '2026-05-22T00:00:00.000Z',
+        plan: 'plus',
+        link_sharing_enabled: 1,
+        external_posting_enabled: 1,
+      })
+      .execute()
+    await dbRef
+      .current!.updateTable('workspaces')
+      .set({ plan: 'team' })
+      .where('id', '=', 'ws-a')
+      .execute()
+    await dbRef
+      .current!.insertInto('workspace_members')
+      .values({
+        workspace_id: 'ws-a',
+        user_id: 'viewer-1',
+        role: 'admin',
+        status: 'active',
+        created_at: '2026-05-22T00:00:00.000Z',
+        updated_at: '2026-05-22T00:00:00.000Z',
+      })
+      .execute()
+    await dbRef
+      .current!.updateTable('users')
+      .set({ workspace_id: 'ws-b' })
+      .where('id', '=', 'viewer-1')
+      .execute()
+    await dbRef
+      .current!.deleteFrom('shareable_grants')
+      .where('shareable_id', '=', 'abc123def4')
+      .execute()
+    await dbRef
+      .current!.updateTable('shareables')
+      .set({
+        visibility: 'link',
+        link_suspended_at: '2026-09-08T00:00:00.000Z',
+      })
+      .where('id', '=', 'abc123def4')
+      .execute()
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/style.css`, {
+        headers: { Cookie: cookie ?? '' },
+      }),
+    )
+
+    expect(response.status).toBe(401)
+  })
+
   test.each([
     ['expired', { expiresAt: '2020-01-01T00:00:00.000Z', enabled: 1 }],
     ['disabled', { expiresAt: null, enabled: 0 }],

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -1109,6 +1109,43 @@ describe('handleArtifactSandboxRequest', () => {
     expect(storageMock.getArtifact).toHaveBeenCalledTimes(1)
   })
 
+  test('does not reveal missing bundle paths after access is revoked', async () => {
+    storageMock.getArtifact.mockResolvedValueOnce(
+      storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
+    )
+    const token = await signSandboxToken(
+      {
+        uid: 'viewer-1',
+        wid: 'ws-a',
+        aid: 'abc123def4',
+        vid: 'v-bundle',
+        fid: 'ws-a/abc123def4/v-bundle/index.html',
+        mt: null,
+        t: 'static_site',
+        jti: 'viewer-missing-path',
+      },
+      'test-secret',
+    )
+    const entrypoint = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/index.html?t=${token}`),
+    )
+    const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+    expect(entrypoint.status).toBe(200)
+    await dbRef
+      .current!.deleteFrom('shareable_grants')
+      .where('shareable_id', '=', 'abc123def4')
+      .execute()
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/missing.js`, {
+        headers: { Cookie: cookie ?? '' },
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    expect(storageMock.getArtifact).toHaveBeenCalledTimes(1)
+  })
+
   test('does not accept a different viewer cookie for a consumed token', async () => {
     storageMock.getArtifact.mockResolvedValue(
       storedArtifact('<!doctype html><body>Hello</body>', 'text/html'),
@@ -1221,6 +1258,7 @@ describe('handleArtifactSandboxRequest', () => {
 
   test.each([
     ['expired', { expiresAt: '2020-01-01T00:00:00.000Z', enabled: 1 }],
+    ['malformed', { expiresAt: 'not-a-date', enabled: 1 }],
     ['disabled', { expiresAt: null, enabled: 0 }],
   ])(
     'does not use an %s link as fallback after a cookie grant is revoked',

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -2598,6 +2598,24 @@ describe('handleArtifactSandboxRequest', () => {
     expect(storageMock.getArtifact).not.toHaveBeenCalled()
   })
 
+  test('rejects anonymous link assets with a calendar-invalid hour 24 expiry', async () => {
+    await dbRef
+      .current!.updateTable('shareables')
+      .set({
+        visibility: 'link',
+        link_expires_at: '2099-01-01T24:00:00.000Z',
+      })
+      .where('id', '=', 'abc123def4')
+      .execute()
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/style.css`),
+    )
+
+    expect(response.status).toBe(401)
+    expect(storageMock.getArtifact).not.toHaveBeenCalled()
+  })
+
   test('rejects anonymous link static-site assets that are not in the current version', async () => {
     await dbRef
       .current!.updateTable('shareables')

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -1259,6 +1259,8 @@ describe('handleArtifactSandboxRequest', () => {
   test.each([
     ['expired', { expiresAt: '2020-01-01T00:00:00.000Z', enabled: 1 }],
     ['malformed', { expiresAt: 'not-a-date', enabled: 1 }],
+    ['noncanonical', { expiresAt: '2099-01-01 00:00:00', enabled: 1 }],
+    ['offset', { expiresAt: '2099-01-01T09:00:00+09:00', enabled: 1 }],
     ['disabled', { expiresAt: null, enabled: 0 }],
   ])(
     'does not use an %s link as fallback after a cookie grant is revoked',

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -20,6 +20,7 @@ import {
 import { type ArtifactKind } from '../app/lib/shareable-types'
 import { renderMarkdownDocument } from '../app/lib/markdown-render'
 import { createDb } from '../app/services/db.server'
+import { checkAnonymousLinkAccess } from '../app/services/link-sharing.server'
 import { consumeJti } from '../app/services/sandbox-jti.server'
 import { getArtifact } from '../app/services/storage.server'
 import {
@@ -231,17 +232,13 @@ async function handleEntrypointRequest(
   if (payload.uid === null) {
     const responseDomain = anonymousResponseDomain(identity)
     const db = createDb()
-    const vis = await db
-      .selectFrom('shareables')
-      .select(['visibility', 'link_suspended_at'])
-      .where('id', '=', payload.aid)
-      .executeTakeFirst()
-    if (vis?.visibility !== 'link' || vis.link_suspended_at !== null) {
+    const linkAccess = await checkAnonymousLinkAccess(db, payload.aid)
+    if (linkAccess.kind !== 'allowed') {
       return deniedResponse(
         'anon_not_link',
         'Invalid token',
         401,
-        { aid: payload.aid, visibility: vis?.visibility ?? null, path },
+        { aid: payload.aid, path },
         responseDomain,
       )
     }
@@ -483,87 +480,57 @@ async function serveBundleAsset(
 ): Promise<Response> {
   const db = createDb()
   const candidatePaths = hasFileExtension(path) ? [path] : [path, '/index.html']
+  const viewerId = bundle.uid ?? ''
+  const now = new Date().toISOString()
   const files = await db
     .selectFrom('versions')
     .innerJoin('shareables', 'shareables.id', 'versions.shareable_id')
     .innerJoin('version_files', 'version_files.version_id', 'versions.id')
-    .leftJoin('users as sandbox_viewer', (join) =>
-      join.on('sandbox_viewer.id', '=', bundle.uid ?? ''),
-    )
     .select([
       'versions.fallback_to_index',
       'version_files.path',
       'version_files.r2_key',
       'version_files.mime_type',
       'version_files.size_bytes',
-      'shareables.visibility',
-      'shareables.owner_user_id',
-      'shareables.workspace_id as artifact_workspace_id',
-      'shareables.container_id',
-      sql<
-        string | null
-      >`(SELECT kind FROM artifact_containers WHERE id = shareables.container_id)`.as(
-        'container_kind',
-      ),
-      sql<
-        string | null
-      >`(SELECT base_visibility FROM artifact_containers WHERE id = shareables.container_id)`.as(
-        'container_base_visibility',
-      ),
-      sql<number>`CASE WHEN shareables.visibility = 'link'
-        AND shareables.link_suspended_at IS NULL THEN 1 ELSE 0 END`.as(
-        'anonymous_link_allowed',
-      ),
-      sql<string | null>`sandbox_viewer.workspace_id`.as('viewer_workspace_id'),
-      sql<number>`sandbox_viewer.email_verified`.as('viewer_email_verified'),
-      sql<number>`EXISTS(
-        SELECT 1 FROM workspace_members wm
-        JOIN workspaces w ON w.id = wm.workspace_id
-        WHERE wm.workspace_id = shareables.workspace_id
-          AND wm.user_id = sandbox_viewer.id
-          AND wm.status = 'active'
-          AND wm.role IN ('owner', 'admin')
-          AND w.plan = 'team'
-      )`.as('is_team_admin'),
-      sql<number>`EXISTS(
-        SELECT 1 FROM shareable_grants sg
-        WHERE sg.shareable_id = shareables.id
-          AND lower(sg.granted_email) = lower(sandbox_viewer.email)
-      )`.as('has_shareable_grant'),
-      sql<number>`EXISTS(
-        SELECT 1 FROM artifact_containers ac
-        WHERE ac.id = shareables.container_id
-          AND ac.kind = 'project'
-          AND ac.created_by_id = sandbox_viewer.id
-      )`.as('is_project_creator'),
-      sql<number>`EXISTS(
-        SELECT 1 FROM artifact_containers ac
-        JOIN workspace_members wm ON wm.workspace_id = ac.workspace_id
-        JOIN workspaces w ON w.id = ac.workspace_id
-        WHERE ac.id = shareables.container_id
-          AND ac.kind = 'project'
-          AND wm.user_id = sandbox_viewer.id
-          AND wm.status = 'active'
-          AND wm.role IN ('owner', 'admin')
-          AND w.plan = 'team'
-      )`.as('is_project_admin'),
-      sql<number>`EXISTS(
-        SELECT 1 FROM project_share_defaults psd
-        WHERE psd.project_container_id = shareables.container_id
-          AND lower(psd.email) = lower(sandbox_viewer.email)
-      )`.as('has_project_grant'),
     ])
+    .$if(Boolean(bundle.uid), (query) =>
+      query
+        .innerJoin('users as sandbox_viewer', (join) =>
+          join.on('sandbox_viewer.id', '=', viewerId),
+        )
+        .select(sandboxViewerFactSelections(now)),
+    )
     .where('shareables.id', '=', bundle.aid)
     .where('shareables.workspace_id', '=', bundle.wid)
     .where('versions.id', '=', bundle.vid)
     .where('versions.status', '=', 'published')
     .where('versions.artifact_kind', '=', 'static_site')
     .where('version_files.path', 'in', candidatePaths)
+    .$if(!bundle.uid, (query) =>
+      query
+        .where('shareables.visibility', '=', 'link')
+        .where('shareables.link_suspended_at', 'is', null)
+        .where((eb) =>
+          eb.or([
+            eb('shareables.link_expires_at', 'is', null),
+            eb('shareables.link_expires_at', '>', now),
+          ]),
+        )
+        .where((eb) =>
+          eb.exists(
+            eb
+              .selectFrom('workspaces')
+              .select('workspaces.id')
+              .whereRef('workspaces.id', '=', 'shareables.workspace_id')
+              .where('workspaces.link_sharing_enabled', '=', 1),
+          ),
+        ),
+    )
     .execute()
   if (
     bundle.uid &&
     files[0] &&
-    !sandboxAccessRowAllowed(files[0], bundle.uid)
+    !sandboxAccessRowAllowed(files[0] as SandboxAccessRow, bundle.uid)
   ) {
     return deniedResponse('viewer_access_revoked', 'Invalid token', 401, {
       aid: bundle.aid,
@@ -601,64 +568,74 @@ async function authenticatedSandboxAccess(
     .innerJoin('users as sandbox_viewer', (join) =>
       join.on('sandbox_viewer.id', '=', payload.uid!),
     )
-    .select([
-      'shareables.visibility',
-      'shareables.owner_user_id',
-      'shareables.workspace_id as artifact_workspace_id',
-      sql<
-        string | null
-      >`(SELECT kind FROM artifact_containers WHERE id = shareables.container_id)`.as(
-        'container_kind',
-      ),
-      sql<
-        string | null
-      >`(SELECT base_visibility FROM artifact_containers WHERE id = shareables.container_id)`.as(
-        'container_base_visibility',
-      ),
-      sql<number>`CASE WHEN shareables.visibility = 'link'
-        AND shareables.link_suspended_at IS NULL THEN 1 ELSE 0 END`.as(
-        'anonymous_link_allowed',
-      ),
-      'sandbox_viewer.workspace_id as viewer_workspace_id',
-      'sandbox_viewer.email_verified as viewer_email_verified',
-      sql<number>`EXISTS(SELECT 1 FROM workspace_members wm JOIN workspaces w ON w.id = wm.workspace_id WHERE wm.workspace_id = shareables.workspace_id AND wm.user_id = sandbox_viewer.id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
-        'is_team_admin',
-      ),
-      sql<number>`EXISTS(SELECT 1 FROM shareable_grants sg WHERE sg.shareable_id = shareables.id AND lower(sg.granted_email) = lower(sandbox_viewer.email))`.as(
-        'has_shareable_grant',
-      ),
-      sql<number>`EXISTS(SELECT 1 FROM artifact_containers ac WHERE ac.id = shareables.container_id AND ac.kind = 'project' AND ac.created_by_id = sandbox_viewer.id)`.as(
-        'is_project_creator',
-      ),
-      sql<number>`EXISTS(SELECT 1 FROM artifact_containers ac JOIN workspace_members wm ON wm.workspace_id = ac.workspace_id JOIN workspaces w ON w.id = ac.workspace_id WHERE ac.id = shareables.container_id AND ac.kind = 'project' AND wm.user_id = sandbox_viewer.id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
-        'is_project_admin',
-      ),
-      sql<number>`EXISTS(SELECT 1 FROM project_share_defaults psd WHERE psd.project_container_id = shareables.container_id AND lower(psd.email) = lower(sandbox_viewer.email))`.as(
-        'has_project_grant',
-      ),
-    ])
+    .select(sandboxViewerFactSelections(new Date().toISOString()))
     .where('shareables.id', '=', payload.aid)
     .where('shareables.workspace_id', '=', payload.wid)
     .executeTakeFirst()
   return Boolean(row && sandboxAccessRowAllowed(row, payload.uid))
 }
 
+type SandboxAccessRow = {
+  visibility: string
+  owner_user_id: string
+  artifact_workspace_id: string
+  container_kind: string | null
+  container_base_visibility: string | null
+  anonymous_link_allowed: number
+  viewer_workspace_id: string | null
+  viewer_email_verified: number
+  is_team_admin: number
+  has_shareable_grant: number
+  is_project_creator: number
+  is_project_admin: number
+  has_project_grant: number
+}
+
+function sandboxViewerFactSelections(now: string) {
+  return [
+    sql<string>`shareables.visibility`.as('visibility'),
+    sql<string>`shareables.owner_user_id`.as('owner_user_id'),
+    sql<string>`shareables.workspace_id`.as('artifact_workspace_id'),
+    sql<
+      string | null
+    >`(SELECT kind FROM artifact_containers WHERE id = shareables.container_id)`.as(
+      'container_kind',
+    ),
+    sql<
+      string | null
+    >`(SELECT base_visibility FROM artifact_containers WHERE id = shareables.container_id)`.as(
+      'container_base_visibility',
+    ),
+    sql<number>`CASE WHEN shareables.visibility = 'link'
+      AND shareables.link_suspended_at IS NULL
+      AND (shareables.link_expires_at IS NULL OR shareables.link_expires_at > ${now})
+      AND EXISTS(
+        SELECT 1 FROM workspaces link_workspace
+        WHERE link_workspace.id = shareables.workspace_id
+          AND link_workspace.link_sharing_enabled = 1
+      ) THEN 1 ELSE 0 END`.as('anonymous_link_allowed'),
+    sql<string | null>`sandbox_viewer.workspace_id`.as('viewer_workspace_id'),
+    sql<number>`sandbox_viewer.email_verified`.as('viewer_email_verified'),
+    sql<number>`EXISTS(SELECT 1 FROM workspace_members wm JOIN workspaces w ON w.id = wm.workspace_id WHERE wm.workspace_id = shareables.workspace_id AND wm.user_id = sandbox_viewer.id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
+      'is_team_admin',
+    ),
+    sql<number>`EXISTS(SELECT 1 FROM shareable_grants sg WHERE sg.shareable_id = shareables.id AND lower(sg.granted_email) = lower(sandbox_viewer.email))`.as(
+      'has_shareable_grant',
+    ),
+    sql<number>`EXISTS(SELECT 1 FROM artifact_containers ac WHERE ac.id = shareables.container_id AND ac.kind = 'project' AND ac.created_by_id = sandbox_viewer.id)`.as(
+      'is_project_creator',
+    ),
+    sql<number>`EXISTS(SELECT 1 FROM artifact_containers ac JOIN workspace_members wm ON wm.workspace_id = ac.workspace_id JOIN workspaces w ON w.id = ac.workspace_id WHERE ac.id = shareables.container_id AND ac.kind = 'project' AND wm.user_id = sandbox_viewer.id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
+      'is_project_admin',
+    ),
+    sql<number>`EXISTS(SELECT 1 FROM project_share_defaults psd WHERE psd.project_container_id = shareables.container_id AND lower(psd.email) = lower(sandbox_viewer.email))`.as(
+      'has_project_grant',
+    ),
+  ] as const
+}
+
 function sandboxAccessRowAllowed(
-  row: {
-    visibility: string
-    owner_user_id: string
-    artifact_workspace_id: string
-    container_kind: string | null
-    container_base_visibility: string | null
-    anonymous_link_allowed: number
-    viewer_workspace_id: string | null
-    viewer_email_verified: number
-    is_team_admin: number
-    has_shareable_grant: number
-    is_project_creator: number
-    is_project_admin: number
-    has_project_grant: number
-  },
+  row: SandboxAccessRow,
   viewerUserId: string,
 ): boolean {
   return viewerAccessAllowed({

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -487,7 +487,11 @@ async function serveBundleAsset(
   const files = await db
     .selectFrom('versions')
     .innerJoin('shareables', 'shareables.id', 'versions.shareable_id')
-    .innerJoin('version_files', 'version_files.version_id', 'versions.id')
+    .leftJoin('version_files', (join) =>
+      join
+        .onRef('version_files.version_id', '=', 'versions.id')
+        .on('version_files.path', 'in', candidatePaths),
+    )
     .select([
       'versions.fallback_to_index',
       'version_files.path',
@@ -497,7 +501,7 @@ async function serveBundleAsset(
     ])
     .$if(Boolean(bundle.uid), (query) =>
       query
-        .innerJoin('users as sandbox_viewer', (join) =>
+        .leftJoin('users as sandbox_viewer', (join) =>
           join.on('sandbox_viewer.id', '=', viewerId),
         )
         .select(sandboxViewerFactSelections(now)),
@@ -507,7 +511,6 @@ async function serveBundleAsset(
     .where('versions.id', '=', bundle.vid)
     .where('versions.status', '=', 'published')
     .where('versions.artifact_kind', '=', 'static_site')
-    .where('version_files.path', 'in', candidatePaths)
     .$if(!bundle.uid, (query) =>
       query
         .where('shareables.visibility', '=', 'link')
@@ -515,7 +518,7 @@ async function serveBundleAsset(
         .where((eb) =>
           eb.or([
             eb('shareables.link_expires_at', 'is', null),
-            eb('shareables.link_expires_at', '>', now),
+            sql<boolean>`datetime(shareables.link_expires_at) > datetime(${now})`,
           ]),
         )
         .where((eb) =>
@@ -540,13 +543,19 @@ async function serveBundleAsset(
       path,
     })
   }
-  const requested = files.find((file) => file.path === path)
+  const requested = files.find(
+    (file): file is typeof file & { r2_key: string; size_bytes: number } =>
+      file.path === path && file.r2_key !== null && file.size_bytes !== null,
+  )
   if (requested)
     return await serveBundleFile(requested, request, responseDomain)
 
   const fallback = files.find(
-    (file) =>
-      file.path === '/index.html' && Number(file.fallback_to_index) === 1,
+    (file): file is typeof file & { r2_key: string; size_bytes: number } =>
+      file.path === '/index.html' &&
+      file.r2_key !== null &&
+      file.size_bytes !== null &&
+      Number(file.fallback_to_index) === 1,
   )
   if (!fallback) {
     return deniedResponse(
@@ -610,7 +619,7 @@ function sandboxViewerFactSelections(now: string) {
     ),
     sql<number>`CASE WHEN shareables.visibility = 'link'
       AND shareables.link_suspended_at IS NULL
-      AND (shareables.link_expires_at IS NULL OR shareables.link_expires_at > ${now})
+      AND (shareables.link_expires_at IS NULL OR datetime(shareables.link_expires_at) > datetime(${now}))
       AND EXISTS(
         SELECT 1 FROM workspaces link_workspace
         WHERE link_workspace.id = shareables.workspace_id

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -565,7 +565,7 @@ async function serveBundleAsset(
 }
 
 function activeLinkExpiry(now: string) {
-  return sql<boolean>`shareables.link_expires_at IS NULL OR (
+  return sql<boolean>`(shareables.link_expires_at IS NULL OR (
     strftime('%Y-%m-%dT%H:%M:%S', shareables.link_expires_at) = substr(shareables.link_expires_at, 1, 19)
     AND substr(shareables.link_expires_at, -1) = 'Z'
     AND (
@@ -577,7 +577,7 @@ function activeLinkExpiry(now: string) {
       )
     )
     AND julianday(shareables.link_expires_at) > julianday(${now})
-  )`
+  ))`
 }
 
 async function authenticatedSandboxAccess(

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -515,12 +515,7 @@ async function serveBundleAsset(
       query
         .where('shareables.visibility', '=', 'link')
         .where('shareables.link_suspended_at', 'is', null)
-        .where((eb) =>
-          eb.or([
-            eb('shareables.link_expires_at', 'is', null),
-            sql<boolean>`datetime(shareables.link_expires_at) > datetime(${now})`,
-          ]),
-        )
+        .where(activeLinkExpiry(now))
         .where((eb) =>
           eb.exists(
             eb
@@ -569,6 +564,22 @@ async function serveBundleAsset(
   return await serveBundleFile(fallback, request, responseDomain)
 }
 
+function activeLinkExpiry(now: string) {
+  return sql<boolean>`shareables.link_expires_at IS NULL OR (
+    strftime('%Y-%m-%dT%H:%M:%S', shareables.link_expires_at) = substr(shareables.link_expires_at, 1, 19)
+    AND substr(shareables.link_expires_at, -1) = 'Z'
+    AND (
+      length(shareables.link_expires_at) = 20
+      OR (
+        length(shareables.link_expires_at) > 21
+        AND substr(shareables.link_expires_at, 20, 1) = '.'
+        AND substr(shareables.link_expires_at, 21, length(shareables.link_expires_at) - 21) NOT GLOB '*[^0-9]*'
+      )
+    )
+    AND julianday(shareables.link_expires_at) > julianday(${now})
+  )`
+}
+
 async function authenticatedSandboxAccess(
   db: Kysely<DB>,
   payload: SandboxPayload,
@@ -593,6 +604,7 @@ type SandboxAccessRow = {
   container_kind: string | null
   container_base_visibility: string | null
   anonymous_link_allowed: number
+  viewer_exists: number
   viewer_workspace_id: string | null
   viewer_email_verified: number
   is_team_admin: number
@@ -619,12 +631,15 @@ function sandboxViewerFactSelections(now: string) {
     ),
     sql<number>`CASE WHEN shareables.visibility = 'link'
       AND shareables.link_suspended_at IS NULL
-      AND (shareables.link_expires_at IS NULL OR datetime(shareables.link_expires_at) > datetime(${now}))
+      AND (${activeLinkExpiry(now)})
       AND EXISTS(
         SELECT 1 FROM workspaces link_workspace
         WHERE link_workspace.id = shareables.workspace_id
           AND link_workspace.link_sharing_enabled = 1
-      ) THEN 1 ELSE 0 END`.as('anonymous_link_allowed'),
+    ) THEN 1 ELSE 0 END`.as('anonymous_link_allowed'),
+    sql<number>`CASE WHEN sandbox_viewer.id IS NULL THEN 0 ELSE 1 END`.as(
+      'viewer_exists',
+    ),
     sql<string | null>`sandbox_viewer.workspace_id`.as('viewer_workspace_id'),
     sql<number>`sandbox_viewer.email_verified`.as('viewer_email_verified'),
     sql<number>`EXISTS(SELECT 1 FROM workspace_members wm JOIN workspaces w ON w.id = wm.workspace_id WHERE wm.workspace_id = shareables.workspace_id AND wm.user_id = sandbox_viewer.id AND sandbox_viewer.workspace_id = shareables.workspace_id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
@@ -649,6 +664,7 @@ function sandboxAccessRowAllowed(
   row: SandboxAccessRow,
   viewerUserId: string,
 ): boolean {
+  if (row.viewer_exists !== 1) return false
   return viewerAccessAllowed({
     visibility: row.visibility as ViewerAccessFacts['visibility'],
     viewerUserId,

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -1144,6 +1144,7 @@ async function verifyBundleCookie(
   }
   if (
     typeof payload.uid !== 'string' ||
+    payload.uid.length === 0 ||
     typeof payload.wid !== 'string' ||
     typeof payload.aid !== 'string' ||
     typeof payload.vid !== 'string' ||

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -1,5 +1,5 @@
 import { env } from 'cloudflare:workers'
-import type { Kysely } from 'kysely'
+import { sql, type Kysely } from 'kysely'
 import type { ArtifactType } from '../app/lib/artifact-type'
 import { decodeBase64Url, encodeBase64Url } from '../app/lib/base64url'
 import {
@@ -22,7 +22,11 @@ import { renderMarkdownDocument } from '../app/lib/markdown-render'
 import { createDb } from '../app/services/db.server'
 import { consumeJti } from '../app/services/sandbox-jti.server'
 import { getArtifact } from '../app/services/storage.server'
-import { viewerDisplayCheck } from '../app/services/access.server'
+import {
+  viewerAccessAllowed,
+  viewerDisplayCheck,
+  type ViewerAccessFacts,
+} from '../app/services/access.server'
 import type { ArtifactSnapshot } from '../app/services/access.server'
 import type { DB } from '../app/types/db'
 import {
@@ -66,6 +70,7 @@ const ENCODER = new TextEncoder()
 const DECODER = new TextDecoder()
 
 interface BundleCookiePayload {
+  uid: string
   wid: string
   aid: string
   vid: string
@@ -110,16 +115,14 @@ export async function handleArtifactSandboxRequest(
     return await serveAnonymousLinkBundleAsset(identity, path, request)
   }
 
-  const cookie = await verifyBundleCookie(
+  const cookieResult = await verifyBundleCookie(
     cookieValue(request.headers.get('Cookie'), COOKIE_NAME),
     env.BETTER_AUTH_SECRET,
   )
-  if (!cookie) {
-    if (identity !== null) {
-      return await serveAnonymousLinkBundleAsset(identity, path, request)
-    }
-    return deniedResponse('no_bundle_cookie', 'Invalid token', 401, { path })
+  if (cookieResult.kind !== 'valid') {
+    return await serveAnonymousLinkBundleAsset(identity, path, request)
   }
+  const cookie = cookieResult.payload
   if (
     identity !== null &&
     (cookie.aid !== identity.shareableId || cookie.vid !== identity.versionId)
@@ -230,10 +233,10 @@ async function handleEntrypointRequest(
     const db = createDb()
     const vis = await db
       .selectFrom('shareables')
-      .select('visibility')
+      .select(['visibility', 'link_suspended_at'])
       .where('id', '=', payload.aid)
       .executeTakeFirst()
-    if (vis?.visibility !== 'link') {
+    if (vis?.visibility !== 'link' || vis.link_suspended_at !== null) {
       return deniedResponse(
         'anon_not_link',
         'Invalid token',
@@ -270,12 +273,18 @@ async function handleEntrypointRequest(
       payload.jti,
       new Date(payload.exp * 1000).toISOString(),
     )
-    if (!consumed && !sameBundle(existingCookie, payload)) {
+    if (
+      !consumed &&
+      !sameBundle(
+        existingCookie.kind === 'valid' ? existingCookie.payload : null,
+        payload,
+      )
+    ) {
       return deniedResponse('jti_replayed', 'Invalid token', 401, {
         aid: payload.aid,
         vid: payload.vid,
         path,
-        hasBundleCookie: existingCookie !== null,
+        hasBundleCookie: existingCookie.kind === 'valid',
         secondsUntilExp: payload.exp - Math.floor(Date.now() / 1000),
       })
     }
@@ -297,12 +306,21 @@ async function handleEntrypointRequest(
     })
   }
 
+  if (!(await authenticatedSandboxAccess(db, payload))) {
+    return deniedResponse('viewer_access_revoked', 'Invalid token', 401, {
+      aid: payload.aid,
+      vid: payload.vid,
+      path,
+    })
+  }
+
   if (entrypoint.renderType !== 'static_site') {
     return await serveEntrypoint(entrypoint, payload.emb === true)
   }
 
   const cookie = `${COOKIE_NAME}=${await signBundleCookie(
     {
+      uid: payload.uid,
       wid: payload.wid,
       aid: payload.aid,
       vid: payload.vid,
@@ -458,7 +476,7 @@ async function serveEntrypoint(
 }
 
 async function serveBundleAsset(
-  bundle: { wid: string; aid: string; vid: string },
+  bundle: { uid?: string; wid: string; aid: string; vid: string },
   path: string,
   request: Request,
   responseDomain?: SandboxResponseDomain,
@@ -469,12 +487,71 @@ async function serveBundleAsset(
     .selectFrom('versions')
     .innerJoin('shareables', 'shareables.id', 'versions.shareable_id')
     .innerJoin('version_files', 'version_files.version_id', 'versions.id')
+    .leftJoin('users as sandbox_viewer', (join) =>
+      join.on('sandbox_viewer.id', '=', bundle.uid ?? ''),
+    )
     .select([
       'versions.fallback_to_index',
       'version_files.path',
       'version_files.r2_key',
       'version_files.mime_type',
       'version_files.size_bytes',
+      'shareables.visibility',
+      'shareables.owner_user_id',
+      'shareables.workspace_id as artifact_workspace_id',
+      'shareables.container_id',
+      sql<
+        string | null
+      >`(SELECT kind FROM artifact_containers WHERE id = shareables.container_id)`.as(
+        'container_kind',
+      ),
+      sql<
+        string | null
+      >`(SELECT base_visibility FROM artifact_containers WHERE id = shareables.container_id)`.as(
+        'container_base_visibility',
+      ),
+      sql<number>`CASE WHEN shareables.visibility = 'link'
+        AND shareables.link_suspended_at IS NULL THEN 1 ELSE 0 END`.as(
+        'anonymous_link_allowed',
+      ),
+      sql<string | null>`sandbox_viewer.workspace_id`.as('viewer_workspace_id'),
+      sql<number>`sandbox_viewer.email_verified`.as('viewer_email_verified'),
+      sql<number>`EXISTS(
+        SELECT 1 FROM workspace_members wm
+        JOIN workspaces w ON w.id = wm.workspace_id
+        WHERE wm.workspace_id = shareables.workspace_id
+          AND wm.user_id = sandbox_viewer.id
+          AND wm.status = 'active'
+          AND wm.role IN ('owner', 'admin')
+          AND w.plan = 'team'
+      )`.as('is_team_admin'),
+      sql<number>`EXISTS(
+        SELECT 1 FROM shareable_grants sg
+        WHERE sg.shareable_id = shareables.id
+          AND lower(sg.granted_email) = lower(sandbox_viewer.email)
+      )`.as('has_shareable_grant'),
+      sql<number>`EXISTS(
+        SELECT 1 FROM artifact_containers ac
+        WHERE ac.id = shareables.container_id
+          AND ac.kind = 'project'
+          AND ac.created_by_id = sandbox_viewer.id
+      )`.as('is_project_creator'),
+      sql<number>`EXISTS(
+        SELECT 1 FROM artifact_containers ac
+        JOIN workspace_members wm ON wm.workspace_id = ac.workspace_id
+        JOIN workspaces w ON w.id = ac.workspace_id
+        WHERE ac.id = shareables.container_id
+          AND ac.kind = 'project'
+          AND wm.user_id = sandbox_viewer.id
+          AND wm.status = 'active'
+          AND wm.role IN ('owner', 'admin')
+          AND w.plan = 'team'
+      )`.as('is_project_admin'),
+      sql<number>`EXISTS(
+        SELECT 1 FROM project_share_defaults psd
+        WHERE psd.project_container_id = shareables.container_id
+          AND lower(psd.email) = lower(sandbox_viewer.email)
+      )`.as('has_project_grant'),
     ])
     .where('shareables.id', '=', bundle.aid)
     .where('shareables.workspace_id', '=', bundle.wid)
@@ -483,6 +560,17 @@ async function serveBundleAsset(
     .where('versions.artifact_kind', '=', 'static_site')
     .where('version_files.path', 'in', candidatePaths)
     .execute()
+  if (
+    bundle.uid &&
+    files[0] &&
+    !sandboxAccessRowAllowed(files[0], bundle.uid)
+  ) {
+    return deniedResponse('viewer_access_revoked', 'Invalid token', 401, {
+      aid: bundle.aid,
+      vid: bundle.vid,
+      path,
+    })
+  }
   const requested = files.find((file) => file.path === path)
   if (requested)
     return await serveBundleFile(requested, request, responseDomain)
@@ -501,6 +589,95 @@ async function serveBundleAsset(
     )
   }
   return await serveBundleFile(fallback, request, responseDomain)
+}
+
+async function authenticatedSandboxAccess(
+  db: Kysely<DB>,
+  payload: SandboxPayload,
+): Promise<boolean> {
+  if (!payload.uid) return false
+  const row = await db
+    .selectFrom('shareables')
+    .innerJoin('users as sandbox_viewer', (join) =>
+      join.on('sandbox_viewer.id', '=', payload.uid!),
+    )
+    .select([
+      'shareables.visibility',
+      'shareables.owner_user_id',
+      'shareables.workspace_id as artifact_workspace_id',
+      sql<
+        string | null
+      >`(SELECT kind FROM artifact_containers WHERE id = shareables.container_id)`.as(
+        'container_kind',
+      ),
+      sql<
+        string | null
+      >`(SELECT base_visibility FROM artifact_containers WHERE id = shareables.container_id)`.as(
+        'container_base_visibility',
+      ),
+      sql<number>`CASE WHEN shareables.visibility = 'link'
+        AND shareables.link_suspended_at IS NULL THEN 1 ELSE 0 END`.as(
+        'anonymous_link_allowed',
+      ),
+      'sandbox_viewer.workspace_id as viewer_workspace_id',
+      'sandbox_viewer.email_verified as viewer_email_verified',
+      sql<number>`EXISTS(SELECT 1 FROM workspace_members wm JOIN workspaces w ON w.id = wm.workspace_id WHERE wm.workspace_id = shareables.workspace_id AND wm.user_id = sandbox_viewer.id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
+        'is_team_admin',
+      ),
+      sql<number>`EXISTS(SELECT 1 FROM shareable_grants sg WHERE sg.shareable_id = shareables.id AND lower(sg.granted_email) = lower(sandbox_viewer.email))`.as(
+        'has_shareable_grant',
+      ),
+      sql<number>`EXISTS(SELECT 1 FROM artifact_containers ac WHERE ac.id = shareables.container_id AND ac.kind = 'project' AND ac.created_by_id = sandbox_viewer.id)`.as(
+        'is_project_creator',
+      ),
+      sql<number>`EXISTS(SELECT 1 FROM artifact_containers ac JOIN workspace_members wm ON wm.workspace_id = ac.workspace_id JOIN workspaces w ON w.id = ac.workspace_id WHERE ac.id = shareables.container_id AND ac.kind = 'project' AND wm.user_id = sandbox_viewer.id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
+        'is_project_admin',
+      ),
+      sql<number>`EXISTS(SELECT 1 FROM project_share_defaults psd WHERE psd.project_container_id = shareables.container_id AND lower(psd.email) = lower(sandbox_viewer.email))`.as(
+        'has_project_grant',
+      ),
+    ])
+    .where('shareables.id', '=', payload.aid)
+    .where('shareables.workspace_id', '=', payload.wid)
+    .executeTakeFirst()
+  return Boolean(row && sandboxAccessRowAllowed(row, payload.uid))
+}
+
+function sandboxAccessRowAllowed(
+  row: {
+    visibility: string
+    owner_user_id: string
+    artifact_workspace_id: string
+    container_kind: string | null
+    container_base_visibility: string | null
+    anonymous_link_allowed: number
+    viewer_workspace_id: string | null
+    viewer_email_verified: number
+    is_team_admin: number
+    has_shareable_grant: number
+    is_project_creator: number
+    is_project_admin: number
+    has_project_grant: number
+  },
+  viewerUserId: string,
+): boolean {
+  return viewerAccessAllowed({
+    visibility: row.visibility as ViewerAccessFacts['visibility'],
+    viewerUserId,
+    ownerUserId: row.owner_user_id,
+    viewerWorkspaceId: row.viewer_workspace_id,
+    artifactWorkspaceId: row.artifact_workspace_id,
+    viewerEmailVerified: row.viewer_email_verified === 1,
+    anonymousLinkAllowed: row.anonymous_link_allowed === 1,
+    isTeamAdmin: row.is_team_admin === 1,
+    hasShareableGrant: row.has_shareable_grant === 1,
+    containerKind: row.container_kind as ViewerAccessFacts['containerKind'],
+    containerBaseVisibility:
+      row.container_base_visibility as ViewerAccessFacts['containerBaseVisibility'],
+    isProjectCreator: row.is_project_creator === 1,
+    isProjectAdmin: row.is_project_admin === 1,
+    hasProjectGrant: row.has_project_grant === 1,
+  })
 }
 
 async function serveAnonymousLinkBundleAsset(
@@ -968,31 +1145,35 @@ async function signBundleCookie(
 async function verifyBundleCookie(
   value: string | null,
   secret: string,
-): Promise<BundleCookiePayload | null> {
-  if (!value) return null
+): Promise<
+  | { kind: 'valid'; payload: BundleCookiePayload }
+  | { kind: 'absent-or-invalid' }
+> {
+  if (!value) return { kind: 'absent-or-invalid' }
   const dot = value.indexOf('.')
-  if (dot < 0) return null
+  if (dot < 0) return { kind: 'absent-or-invalid' }
   const body = value.slice(0, dot)
   const sig = value.slice(dot + 1)
   const expected = encodeBase64Url(await hmac(secret, body))
-  if (!constantTimeEqual(sig, expected)) return null
+  if (!constantTimeEqual(sig, expected)) return { kind: 'absent-or-invalid' }
 
   let payload: BundleCookiePayload
   try {
     payload = JSON.parse(DECODER.decode(decodeBase64Url(body)))
   } catch {
-    return null
+    return { kind: 'absent-or-invalid' }
   }
   if (
+    typeof payload.uid !== 'string' ||
     typeof payload.wid !== 'string' ||
     typeof payload.aid !== 'string' ||
     typeof payload.vid !== 'string' ||
     typeof payload.exp !== 'number' ||
     payload.exp < Math.floor(Date.now() / 1000)
   ) {
-    return null
+    return { kind: 'absent-or-invalid' }
   }
-  return payload
+  return { kind: 'valid', payload }
 }
 
 const keyCache = new Map<string, Promise<CryptoKey>>()

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -568,6 +568,7 @@ function activeLinkExpiry(now: string) {
   return sql<boolean>`(shareables.link_expires_at IS NULL OR (
     strftime('%Y-%m-%dT%H:%M:%S', shareables.link_expires_at) = substr(shareables.link_expires_at, 1, 19)
     AND substr(shareables.link_expires_at, -1) = 'Z'
+    AND substr(shareables.link_expires_at, 12, 2) BETWEEN '00' AND '23'
     AND (
       length(shareables.link_expires_at) = 20
       OR (

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -2,6 +2,7 @@ import { env } from 'cloudflare:workers'
 import { sql, type Kysely } from 'kysely'
 import type { ArtifactType } from '../app/lib/artifact-type'
 import { decodeBase64Url, encodeBase64Url } from '../app/lib/base64url'
+import { lowerEmail } from '../app/lib/grant-emails.server'
 import {
   APEX_HOST,
   APP_DEV_PORT,
@@ -238,7 +239,7 @@ async function handleEntrypointRequest(
         'anon_not_link',
         'Invalid token',
         401,
-        { aid: payload.aid, path },
+        { aid: payload.aid, linkAccess: linkAccess.kind, path },
         responseDomain,
       )
     }
@@ -429,6 +430,7 @@ function sameBundle(
 ): boolean {
   return (
     cookie !== null &&
+    cookie.uid === payload.uid &&
     cookie.wid === payload.wid &&
     cookie.aid === payload.aid &&
     cookie.vid === payload.vid
@@ -616,19 +618,19 @@ function sandboxViewerFactSelections(now: string) {
       ) THEN 1 ELSE 0 END`.as('anonymous_link_allowed'),
     sql<string | null>`sandbox_viewer.workspace_id`.as('viewer_workspace_id'),
     sql<number>`sandbox_viewer.email_verified`.as('viewer_email_verified'),
-    sql<number>`EXISTS(SELECT 1 FROM workspace_members wm JOIN workspaces w ON w.id = wm.workspace_id WHERE wm.workspace_id = shareables.workspace_id AND wm.user_id = sandbox_viewer.id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
+    sql<number>`EXISTS(SELECT 1 FROM workspace_members wm JOIN workspaces w ON w.id = wm.workspace_id WHERE wm.workspace_id = shareables.workspace_id AND wm.user_id = sandbox_viewer.id AND sandbox_viewer.workspace_id = shareables.workspace_id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
       'is_team_admin',
     ),
-    sql<number>`EXISTS(SELECT 1 FROM shareable_grants sg WHERE sg.shareable_id = shareables.id AND lower(sg.granted_email) = lower(sandbox_viewer.email))`.as(
+    sql<number>`EXISTS(SELECT 1 FROM shareable_grants sg WHERE sg.shareable_id = shareables.id AND ${lowerEmail('sg.granted_email')} = ${lowerEmail('sandbox_viewer.email')})`.as(
       'has_shareable_grant',
     ),
     sql<number>`EXISTS(SELECT 1 FROM artifact_containers ac WHERE ac.id = shareables.container_id AND ac.kind = 'project' AND ac.created_by_id = sandbox_viewer.id)`.as(
       'is_project_creator',
     ),
-    sql<number>`EXISTS(SELECT 1 FROM artifact_containers ac JOIN workspace_members wm ON wm.workspace_id = ac.workspace_id JOIN workspaces w ON w.id = ac.workspace_id WHERE ac.id = shareables.container_id AND ac.kind = 'project' AND wm.user_id = sandbox_viewer.id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
+    sql<number>`EXISTS(SELECT 1 FROM artifact_containers ac JOIN workspace_members wm ON wm.workspace_id = ac.workspace_id JOIN workspaces w ON w.id = ac.workspace_id WHERE ac.id = shareables.container_id AND ac.kind = 'project' AND wm.user_id = sandbox_viewer.id AND sandbox_viewer.workspace_id = ac.workspace_id AND wm.status = 'active' AND wm.role IN ('owner', 'admin') AND w.plan = 'team')`.as(
       'is_project_admin',
     ),
-    sql<number>`EXISTS(SELECT 1 FROM project_share_defaults psd WHERE psd.project_container_id = shareables.container_id AND lower(psd.email) = lower(sandbox_viewer.email))`.as(
+    sql<number>`EXISTS(SELECT 1 FROM project_share_defaults psd WHERE psd.project_container_id = shareables.container_id AND ${lowerEmail('psd.email')} = ${lowerEmail('sandbox_viewer.email')})`.as(
       'has_project_grant',
     ),
   ] as const

--- a/apps/web/workers/link-abuse-judgment-workflow.test.ts
+++ b/apps/web/workers/link-abuse-judgment-workflow.test.ts
@@ -127,7 +127,7 @@ describe('LinkAbuseJudgmentWorkflow', () => {
       impersonatedBrand: 'ChatGPT',
       externalTargets: ['download.example.test'],
       manageUrl: 'https://artifactshare.com/a/abc123def4',
-      actionUrl: null,
+      source: { kind: 'judgment', id: 'workflow-1' },
     })
     // Announce only: the judgment never writes to shareables.
     expect(

--- a/apps/web/workers/link-abuse-judgment-workflow.ts
+++ b/apps/web/workers/link-abuse-judgment-workflow.ts
@@ -5,7 +5,6 @@ import {
 } from 'cloudflare:workers'
 import { extractLinkAbuseContentFromHtml } from '../app/services/link-abuse-judgment/extract-rewriter'
 import { linkAbuseJudgmentProvider } from '../app/services/link-abuse-judgment/providers'
-import { linkOpsUrl, signLinkOpsToken } from '../app/lib/link-ops-token'
 
 type ShareableContext = {
   shareableId: string
@@ -151,20 +150,6 @@ export class LinkAbuseJudgmentWorkflow extends WorkflowEntrypoint<
         )
         .run()
 
-      // The operator page link is signed so a person can pause or resume
-      // from Slack; the judgment itself never changes the link.
-      const opsSecret = this.env.LINK_OPS_ACTION_SECRET
-      const actionUrl = opsSecret
-        ? // The alerts worker accepts only the production origin.
-          linkOpsUrl(
-            'https://artifactshare.com',
-            context.shareableId,
-            await signLinkOpsToken(
-              { shareableId: context.shareableId, judgmentId },
-              opsSecret,
-            ),
-          )
-        : null
       console.warn('artifactshare_link_abuse_judgment', {
         shareableId: context.shareableId,
         workspaceId: context.workspaceId,
@@ -174,7 +159,7 @@ export class LinkAbuseJudgmentWorkflow extends WorkflowEntrypoint<
         impersonatedBrand: judgment.impersonatedBrand,
         externalTargets: judgment.externalTargets,
         manageUrl: `https://artifactshare.com/a/${context.shareableId}`,
-        actionUrl,
+        source: { kind: 'judgment', id: judgmentId },
       })
       return { kind: 'judged' as const, judgmentId, risk: judgment.risk }
     })

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -6,7 +6,7 @@
   "main": "./workers/app.ts",
   "workers_dev": false,
   "preview_urls": false,
-  "observability": { "enabled": true },
+  "observability": { "enabled": true, "redact_query_string": true },
   "tail_consumers": [{ "service": "artifactshare-alerts-public-preview" }],
   "workflows": [
     {

--- a/apps/web/wrangler.production.jsonc
+++ b/apps/web/wrangler.production.jsonc
@@ -16,6 +16,7 @@
   ],
   "observability": {
     "enabled": true,
+    "redact_query_string": true,
     "logs": { "enabled": true, "head_sampling_rate": 1 },
     "traces": { "enabled": true, "head_sampling_rate": 1 },
   },

--- a/apps/web/wrangler.sandbox.jsonc
+++ b/apps/web/wrangler.sandbox.jsonc
@@ -6,6 +6,7 @@
   "main": "./workers/sandbox.ts",
   "workers_dev": false,
   "preview_urls": false,
+  "observability": { "enabled": true, "redact_query_string": true },
   "d1_databases": [
     {
       "binding": "DB",
@@ -25,6 +26,7 @@
   "env": {
     "production": {
       "name": "artifactshare-sandbox",
+      "observability": { "enabled": true, "redact_query_string": true },
       "routes": [
         { "pattern": "sandbox.artifactshare.com", "custom_domain": true },
         {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "oxc-parser": "0.143.0",
     "react-doctor": "0.9.12",
     "vite-plus": "0.2.9",
-    "wrangler": "4.127.0",
+    "wrangler": "4.129.1",
     "yaml": "2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,13 +122,13 @@ importers:
         version: 0.143.0
       react-doctor:
         specifier: 0.9.12
-        version: 0.9.12(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@7.0.2001)(supports-color@10.2.2)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
+        version: 0.9.12(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@7.0.2001)(supports-color@10.2.2)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
       vite-plus:
         specifier: 0.2.9
-        version: 0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
       wrangler:
-        specifier: 4.127.0
-        version: 4.127.0(@cloudflare/workers-types@5.20260827.1)
+        specifier: 4.129.1
+        version: 4.129.1(@cloudflare/workers-types@5.20260827.1)
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -249,13 +249,13 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.54.1
-        version: 1.54.1(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.127.0(@cloudflare/workers-types@5.20260827.1))
+        version: 1.54.1(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.129.1(@cloudflare/workers-types@5.20260827.1))
       '@cloudflare/workers-types':
         specifier: 5.20260827.1
         version: 5.20260827.1
       '@react-router/dev':
         specifier: 8.3.0
-        version: 8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.127.0(@cloudflare/workers-types@5.20260827.1))
+        version: 8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.129.1)
       '@tailwindcss/vite':
         specifier: 4.3.3
         version: 4.3.3(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -308,8 +308,8 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.6)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       wrangler:
-        specifier: 4.127.0
-        version: 4.127.0(@cloudflare/workers-types@5.20260827.1)
+        specifier: 4.129.1
+        version: 4.129.1(@cloudflare/workers-types@5.20260827.1)
 
   packages/cli:
     dependencies:
@@ -371,7 +371,7 @@ importers:
     dependencies:
       '@react-router/dev':
         specifier: 8.3.0
-        version: 8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.127.0(@cloudflare/workers-types@5.20260827.1))
+        version: 8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.129.1)
       '@tailwindcss/vite':
         specifier: 4.3.3
         version: 4.3.3(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -679,8 +679,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20260907.1':
+    resolution: {integrity: sha512-Xaum46kviN8xixl0axXm7mfLTf2GAG+baotnEIv8M5EbvyHxHagvS5Z8bU5B/WJlTWwwvGzItFfKZvga78o3ew==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20260826.1':
     resolution: {integrity: sha512-0bLqVQYsQ3v3FdYGmzh23vi9fJeYTBx19o4LUySIsRcgBggGSlR39ml162vTXvZzUISOjVW2qfL7Y+SMrrfXmQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260907.1':
+    resolution: {integrity: sha512-P2o7xpZbxvoES9xY5uHqJPXvsWBWi0w1STCGoYLqxI1rh1gSUdlr4HruMiWq/TA94PPoQCg0eUfoshyQxMdGpA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -691,14 +703,32 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20260907.1':
+    resolution: {integrity: sha512-4aXjFMtD76FgVmDm7vUtl96LWNmFScfrYZ9lA6JpP5+svRfUQOYaJKcYK4g9IVmAxemItJizTTIA8jhEZaw0vg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20260826.1':
     resolution: {integrity: sha512-PFerWi+DP2Ckc6eATAS4dhotBt8IeXJjTzIgy18H+uqsswlXc7A8HsnAunHL9v/7/BjCgq46iMo2g4iUAsEpDw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260907.1':
+    resolution: {integrity: sha512-nex+emDfyOYnQlhfPoCfLYQN6L+Ng0fVg5f3+8Ot4XRZaKJUzpiBFiRkgpoUuEN47U8Pm8BwhhOK2dQwtKwivQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260826.1':
     resolution: {integrity: sha512-X26hulrG2MSSfpRmjZbCq98LNaZnrRqbmGcgo7g1U/U0nJ5npYruPm3fAyZ2y6VDr5CmQo9BLCahxP8VB/QR6A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260907.1':
+    resolution: {integrity: sha512-/ZHtEmpdSUKZyQCBUSqmGp+I7GwWVR2eUaGE5NzFJIu31HBsoQEakXaDpTrbwXydpBzpI9N0DC83W7qekkGPMQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -5493,6 +5523,10 @@ packages:
     resolution: {integrity: sha512-ZXR3Bieg+B5MK0T/zYIWaZiCGCb9Z3en4+/TleYKhIGPLx/e0cRcG/ZvvTviUapVBBK2zODB+aiypdIojU3x6Q==}
     engines: {node: '>=22.0.0'}
 
+  miniflare@5.20260907.0-alpha:
+    resolution: {integrity: sha512-56F13BeJQuDbTxcoGGN4MGxN8oNNIH3pK48VyJ1JGmjbzE9MMu6S2kxoON3nOBHlLdNjXyzg1Rz3jdHx+JpuZA==}
+    engines: {node: '>=22.0.0'}
+
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
@@ -6653,12 +6687,17 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.127.0:
-    resolution: {integrity: sha512-4dPqcBEMJfGeZeNnjHT7ThNJs+EiNYxUTg4ywqIdQubcXHBhFeVMQyHV4A9AOhZRFr83cckqdds034KGcr/dtw==}
+  workerd@1.20260907.1:
+    resolution: {integrity: sha512-MN/jgZkg2y9ZOOXdN9ecYynRFaqTCRkmpt3jS6LQNPoSx8HxTgcG947SduxJEB38YisB7RJ3Gu/y7fpd7fZ5bA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.129.1:
+    resolution: {integrity: sha512-u1Q8dMAczlmj41K0xk5LkfcHHmbwq5xZRctlyrErVqpcoGsSIW07i74phv3B9xt6mTEO1dX3U5d9WVxR3GFRfA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^5.20260826.1
+      '@cloudflare/workers-types': ^5.20260907.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -7072,14 +7111,20 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260826.1
 
-  '@cloudflare/vite-plugin@1.54.1(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.127.0(@cloudflare/workers-types@5.20260827.1))':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260907.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260907.1
+
+  '@cloudflare/vite-plugin@1.54.1(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.129.1(@cloudflare/workers-types@5.20260827.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260826.1)
       miniflare: 5.20260826.0-alpha
       unenv: 2.0.0-rc.24
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       workerd: 1.20260826.1
-      wrangler: 4.127.0(@cloudflare/workers-types@5.20260827.1)
+      wrangler: 4.129.1(@cloudflare/workers-types@5.20260827.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -7088,16 +7133,31 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260826.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20260907.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20260826.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260907.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260826.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20260907.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20260826.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260907.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260826.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260907.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260702.1': {}
@@ -8793,7 +8853,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.3': {}
 
-  '@react-router/dev@8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.127.0(@cloudflare/workers-types@5.20260827.1))':
+  '@react-router/dev@8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.129.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.8
@@ -8825,7 +8885,7 @@ snapshots:
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
       typescript: 7.0.2
-      wrangler: 4.127.0(@cloudflare/workers-types@5.20260827.1)
+      wrangler: 4.129.1(@cloudflare/workers-types@5.20260827.1)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9381,7 +9441,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       playwright: 1.62.1
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(happy-dom@20.11.6)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.6)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -9406,7 +9466,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.5(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(happy-dom@20.11.6)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.6)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -9440,7 +9500,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(happy-dom@20.11.6)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.6)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -11267,6 +11327,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@5.20260907.0-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260907.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.9
@@ -11495,31 +11567,6 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
-  oxfmt@0.62.0(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
-    dependencies:
-      tinypool: 2.1.0
-    optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.62.0
-      '@oxfmt/binding-android-arm64': 0.62.0
-      '@oxfmt/binding-darwin-arm64': 0.62.0
-      '@oxfmt/binding-darwin-x64': 0.62.0
-      '@oxfmt/binding-freebsd-x64': 0.62.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.62.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.62.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.62.0
-      '@oxfmt/binding-linux-arm64-musl': 0.62.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.62.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.62.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.62.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.62.0
-      '@oxfmt/binding-linux-x64-gnu': 0.62.0
-      '@oxfmt/binding-linux-x64-musl': 0.62.0
-      '@oxfmt/binding-openharmony-arm64': 0.62.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.62.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.62.0
-      '@oxfmt/binding-win32-x64-msvc': 0.62.0
-      vite-plus: 0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
-
   oxfmt@0.62.0(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
@@ -11562,30 +11609,6 @@ snapshots:
       '@oxlint-tsgolint/linux-x64': 7.0.2001
       '@oxlint-tsgolint/win32-arm64': 7.0.2001
       '@oxlint-tsgolint/win32-x64': 7.0.2001
-
-  oxlint@1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
-    optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.77.0
-      '@oxlint/binding-android-arm64': 1.77.0
-      '@oxlint/binding-darwin-arm64': 1.77.0
-      '@oxlint/binding-darwin-x64': 1.77.0
-      '@oxlint/binding-freebsd-x64': 1.77.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.77.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.77.0
-      '@oxlint/binding-linux-arm64-gnu': 1.77.0
-      '@oxlint/binding-linux-arm64-musl': 1.77.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.77.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.77.0
-      '@oxlint/binding-linux-riscv64-musl': 1.77.0
-      '@oxlint/binding-linux-s390x-gnu': 1.77.0
-      '@oxlint/binding-linux-x64-gnu': 1.77.0
-      '@oxlint/binding-linux-x64-musl': 1.77.0
-      '@oxlint/binding-openharmony-arm64': 1.77.0
-      '@oxlint/binding-win32-arm64-msvc': 1.77.0
-      '@oxlint/binding-win32-ia32-msvc': 1.77.0
-      '@oxlint/binding-win32-x64-msvc': 1.77.0
-      oxlint-tsgolint: 7.0.2001
-      vite-plus: 0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
   oxlint@1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
@@ -11823,7 +11846,7 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
-  react-doctor@0.9.12(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@7.0.2001)(supports-color@10.2.2)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
+  react-doctor@0.9.12(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@7.0.2001)(supports-color@10.2.2)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@sentry/node': 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(supports-color@10.2.2)
@@ -11835,7 +11858,7 @@ snapshots:
       jiti: 2.7.0
       magicast: 0.5.4
       oxc-resolver: 11.24.2
-      oxlint: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-plugin-react-doctor: 0.9.12
       prompts: 2.4.2
       typescript: 5.9.3
@@ -12502,65 +12525,6 @@ snapshots:
 
   verkit@0.3.2: {}
 
-  vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0):
-    dependencies:
-      '@oxc-project/types': 0.143.0
-      '@oxlint/plugins': 1.73.0
-      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/browser-preview': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      '@voidzero-dev/vite-plus-core': 0.2.9(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
-      oxfmt: 0.62.0(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(happy-dom@20.11.6)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
-    optionalDependencies:
-      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
-      '@voidzero-dev/vite-plus-darwin-arm64': 0.2.9
-      '@voidzero-dev/vite-plus-darwin-x64': 0.2.9
-      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.2.9
-      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.2.9
-      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.2.9
-      '@voidzero-dev/vite-plus-linux-x64-musl': 0.2.9
-      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.2.9
-      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.2.9
-    transitivePeerDependencies:
-      - '@arethetypeswrong/core'
-      - '@edge-runtime/vm'
-      - '@opentelemetry/api'
-      - '@types/node'
-      - '@vitejs/devtools'
-      - '@vitest/coverage-istanbul'
-      - '@vitest/coverage-v8'
-      - '@vitest/ui'
-      - bufferutil
-      - esbuild
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - msw
-      - publint
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - svelte
-      - terser
-      - tsx
-      - typescript
-      - unplugin-unused
-      - unrun
-      - utf-8-validate
-      - vite
-      - yaml
-
   vite-plus@0.2.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.143.0
@@ -12679,37 +12643,6 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(happy-dom@20.11.6)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.2
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.13.3
-      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/browser-preview': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
-      happy-dom: 20.11.6
-    transitivePeerDependencies:
-      - msw
-
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.6)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -12792,16 +12725,24 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260826.1
       '@cloudflare/workerd-windows-64': 1.20260826.1
 
-  wrangler@4.127.0(@cloudflare/workers-types@5.20260827.1):
+  workerd@1.20260907.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260907.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260907.1
+      '@cloudflare/workerd-linux-64': 1.20260907.1
+      '@cloudflare/workerd-linux-arm64': 1.20260907.1
+      '@cloudflare/workerd-windows-64': 1.20260907.1
+
+  wrangler@4.129.1(@cloudflare/workers-types@5.20260827.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260826.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260907.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 5.20260826.0-alpha
+      miniflare: 5.20260907.0-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260826.1
+      workerd: 1.20260907.1
     optionalDependencies:
       '@cloudflare/workers-types': 5.20260827.1
       fsevents: 2.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,13 +31,13 @@ minimumReleaseAgeExclude:
   - '@better-fetch/fetch@1.2.2'
   - better-auth@1.6.16
   - better-call@1.3.6
-  - '@cloudflare/workerd-darwin-64@1.20260826.1'
-  - '@cloudflare/workerd-darwin-arm64@1.20260826.1'
-  - '@cloudflare/workerd-linux-64@1.20260826.1'
-  - '@cloudflare/workerd-linux-arm64@1.20260826.1'
-  - '@cloudflare/workerd-windows-64@1.20260826.1'
+  - '@cloudflare/workerd-darwin-64@1.20260826.1 || 1.20260907.1'
+  - '@cloudflare/workerd-darwin-arm64@1.20260826.1 || 1.20260907.1'
+  - '@cloudflare/workerd-linux-64@1.20260826.1 || 1.20260907.1'
+  - '@cloudflare/workerd-linux-arm64@1.20260826.1 || 1.20260907.1'
+  - '@cloudflare/workerd-windows-64@1.20260826.1 || 1.20260907.1'
   - miniflare@5.20260826.0-alpha || 5.20260907.0-alpha
-  - workerd@1.20260826.1
+  - workerd@1.20260826.1 || 1.20260907.1
   - wrangler@4.129.1
   - '@cloudflare/workers-types@5.20260827.1'
   - '@cloudflare/vite-plugin@1.54.1'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,8 +36,8 @@ minimumReleaseAgeExclude:
   - '@cloudflare/workerd-linux-64@1.20260826.1'
   - '@cloudflare/workerd-linux-arm64@1.20260826.1'
   - '@cloudflare/workerd-windows-64@1.20260826.1'
-  - miniflare@5.20260826.0-alpha
+  - miniflare@5.20260826.0-alpha || 5.20260907.0-alpha
   - workerd@1.20260826.1
-  - wrangler@4.127.0
+  - wrangler@4.129.1
   - '@cloudflare/workers-types@5.20260827.1'
   - '@cloudflare/vite-plugin@1.54.1'

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -15,6 +15,8 @@ const app = config('wrangler.production.jsonc')
 const alerts = config('wrangler.alerts.jsonc', 'production')
 const ogImage = config('wrangler.og-image.jsonc', 'production')
 const sandbox = config('wrangler.sandbox.jsonc', 'production')
+const previewApp = config('wrangler.jsonc')
+const previewSandbox = config('wrangler.sandbox.jsonc')
 const webPackage = JSON.parse(fs.readFileSync('apps/web/package.json', 'utf8'))
 const workflowSource = fs.readFileSync(
   '.github/workflows/deploy-production.yml',
@@ -44,6 +46,12 @@ test('production app and sandbox share D1 and artifact storage', () => {
   assert.equal(app.r2_buckets[0].bucket_name, sandbox.r2_buckets[0].bucket_name)
   assert.equal(app.services[0].service, ogImage.name)
   assert.equal(app.tail_consumers[0].service, alerts.name)
+})
+
+test('app and sandbox logs redact credential query strings in every environment', () => {
+  for (const worker of [app, sandbox, previewApp, previewSandbox]) {
+    assert.equal(worker.observability.redact_query_string, true)
+  }
 })
 
 test('production deployment keeps migration and Workers in one order', () => {


### PR DESCRIPTION
Operator link suspension and resumption now record the signed operator credential and source atomically with each state change, while keeping action credentials and recipient addresses out of logs and audit detail. Owner notifications cover human-owned and bot-owned artifacts with post-commit identity rechecks, and sandbox entrypoints and static assets revalidate current link, user, workspace, project, and grant access so suspended or revoked access stops immediately.

The change also adds real-D1 race and rollback coverage, aligns apex and sandbox authorization decisions, rejects malformed link expiries consistently, and configures preview and production Worker observability to redact query strings.

Validation:

- `pnpm validate:static`
- `pnpm validate:build`
- focused link-suspension, access, alerts, and sandbox tests (61 passed)
- independent Codex and Claude implementation review on `883eb3b`

Operational follow-up: provision the same link-operations action secret for the app and alerts Workers through the protected production rollout.
