### PR TITLE
fix: admit generated root viewer revalidation requests

### DIFF
--- a/apps/web/app/routes/a.$id/link-root.behavior.browser.test.tsx
+++ b/apps/web/app/routes/a.$id/link-root.behavior.browser.test.tsx
@@ -2,6 +2,11 @@ import { hydrateRoot, type Root } from 'react-dom/client'
 import { renderToString } from 'react-dom/server'
 import {
   createBrowserRouter,
+  createRequestHandler,
+  UNSAFE_createClientRoutes,
+  UNSAFE_getTurboStreamSingleFetchDataStrategy,
+  type UNSAFE_AssetsManifest,
+  type ServerBuild,
   createStaticHandler,
   createStaticRouter,
   Outlet,
@@ -10,6 +15,7 @@ import {
   useLoaderData,
 } from 'react-router'
 import { afterEach, expect, test, vi } from 'vitest'
+import { ViewerTimezone } from '~/components/app/viewer-timezone'
 import Viewer from './+viewer'
 
 // Import the real shared viewer without mocking any server modules. A runtime
@@ -24,12 +30,21 @@ function ViewerPage() {
   return <Viewer loaderData={useLoaderData<typeof viewerData>()} />
 }
 
+function RootLayout() {
+  return (
+    <>
+      <ViewerTimezone />
+      <Outlet />
+    </>
+  )
+}
+
 const routes = [
   {
     id: 'root',
     path: '/',
     loader: () => ({ locale: 'en', user: null }),
-    Component: Outlet,
+    Component: RootLayout,
     children: [
       {
         id: 'home',
@@ -47,6 +62,66 @@ const routes = [
   },
 ]
 
+// Use the installed framework's client routes, single-fetch URL generation and
+// server encoder. The browser harness cannot import the application's Worker;
+// app.test.ts separately checks this exact request path at that boundary.
+const routeEntries = [routes[0], ...routes[0].children]
+const manifest: UNSAFE_AssetsManifest = {
+  entry: { module: '/entry.js', imports: [] },
+  url: '/manifest.js',
+  version: 'synthetic',
+  routes: Object.fromEntries(
+    routeEntries.map((route) => [
+      route.id,
+      {
+        id: route.id,
+        parentId: route.id === 'root' ? undefined : 'root',
+        path: 'path' in route ? route.path : undefined,
+        index: 'index' in route ? route.index : undefined,
+        module: `/routes/${route.id}.js`,
+        hasLoader: true,
+        hasAction: false,
+        hasClientLoader: false,
+        hasClientAction: false,
+        hasClientMiddleware: false,
+        hasErrorBoundary: false,
+        clientActionModule: undefined,
+        clientLoaderModule: undefined,
+        clientMiddlewareModule: undefined,
+        hydrateFallbackModule: undefined,
+      },
+    ]),
+  ),
+}
+const routeModules = Object.fromEntries(
+  routeEntries.map((route) => [
+    route.id,
+    {
+      default: route.Component,
+    },
+  ]),
+)
+const serverBuild: ServerBuild = {
+  entry: { module: { default: () => new Response('unused document entry') } },
+  routes: Object.fromEntries(
+    routeEntries.map((route) => [
+      route.id,
+      {
+        ...manifest.routes[route.id]!,
+        module: { default: route.Component, loader: route.loader },
+      },
+    ]),
+  ),
+  assets: manifest,
+  publicPath: '/',
+  assetsBuildDirectory: 'assets',
+  future: {},
+  ssr: true,
+  isSpaMode: false,
+  prerender: [],
+  routeDiscovery: { mode: 'initial', manifestPath: '/__manifest' },
+}
+
 let root: Root | undefined
 let router: ReturnType<typeof createBrowserRouter> | undefined
 let container: HTMLDivElement | undefined
@@ -57,6 +132,7 @@ afterEach(() => {
   root?.unmount()
   router?.dispose()
   container?.remove()
+  document.cookie = '__as_tz=; Path=/; Max-Age=0'
   vi.restoreAllMocks()
   window.history.replaceState(initialState, '', initialUrl)
 })
@@ -64,6 +140,19 @@ afterEach(() => {
 test.each(['/', '/a/abc123def4'])(
   'hydrates the shared viewer at %s without an intermediate URL or lost state',
   async (pathname) => {
+    document.cookie = '__as_tz=; Path=/; Max-Age=0'
+    const resolved = Intl.DateTimeFormat().resolvedOptions()
+    vi.spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions').mockReturnValue({
+      ...resolved,
+      timeZone: 'Asia/Tokyo',
+    })
+    const dataHandler = createRequestHandler(serverBuild, 'test')
+    const fetchData = vi
+      .spyOn(window, 'fetch')
+      .mockImplementation(async (input, init) => {
+        expect(document.cookie).toContain('__as_tz=Asia%2FTokyo')
+        return dataHandler(new Request(input, init))
+      })
     const url = `${pathname}?panel=comments&tag=one&tag=two&version=old#section`
     window.history.replaceState({ usr: { returnTo: '/files' } }, '', url)
     const historyLength = window.history.length
@@ -93,7 +182,22 @@ test.each(['/', '/a/abc123def4'])(
       window.location.pathname + window.location.search + window.location.hash,
     ).toBe(url)
 
-    router = createBrowserRouter(routes, { hydrationData: context })
+    const clientRoutes = UNSAFE_createClientRoutes(
+      manifest.routes,
+      routeModules,
+      context,
+      true,
+      false,
+    )
+    router = createBrowserRouter(clientRoutes, {
+      hydrationData: context,
+      dataStrategy: UNSAFE_getTurboStreamSingleFetchDataStrategy(
+        () => router!,
+        manifest,
+        routeModules,
+        true,
+      ),
+    })
     const onRecoverableError = vi.fn()
     root = hydrateRoot(container, <RouterProvider router={router} />, {
       onRecoverableError,
@@ -103,6 +207,17 @@ test.each(['/', '/a/abc123def4'])(
       requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
     )
 
+    await vi.waitFor(() => {
+      expect(fetchData).toHaveBeenCalledTimes(1)
+      expect(router?.state.revalidation).toBe('idle')
+    })
+    const dataUrl = new URL(String(fetchData.mock.calls[0]![0]))
+    expect(dataUrl.pathname).toBe(
+      pathname === '/' ? '/_.data' : `${pathname}.data`,
+    )
+    expect(dataUrl.search).toBe(new URL(url, window.location.origin).search)
+    expect(dataUrl.hash).toBe('')
+    expect(router.state.errors).toBeNull()
     expect(container.querySelector('main')).toBe(serverMain)
     expect(onRecoverableError).not.toHaveBeenCalled()
     expect(router.state.matches.at(-1)?.route.id).toBe(
@@ -116,5 +231,35 @@ test.each(['/', '/a/abc123def4'])(
     expect(push).not.toHaveBeenCalled()
     // Router initialization may add its history index, but must not rewrite URL.
     expect(replace.mock.calls.every((call) => call[2] === undefined)).toBe(true)
+
+    // A document reload keeps the cookie, so mounting again must not fetch.
+    root.unmount()
+    router.dispose()
+    container.innerHTML = renderToString(
+      <StaticRouterProvider
+        router={serverRouter}
+        context={context}
+        hydrate={false}
+      />,
+    )
+    router = createBrowserRouter(clientRoutes, {
+      hydrationData: context,
+      dataStrategy: UNSAFE_getTurboStreamSingleFetchDataStrategy(
+        () => router!,
+        manifest,
+        routeModules,
+        true,
+      ),
+    })
+    root = hydrateRoot(container, <RouterProvider router={router} />)
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    )
+    expect(fetchData).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('main')).not.toBeNull()
+    expect(router.state.errors).toBeNull()
+    expect(
+      window.location.pathname + window.location.search + window.location.hash,
+    ).toBe(url)
   },
 )

--- a/apps/web/app/routes/a.$id/link-root.behavior.browser.test.tsx
+++ b/apps/web/app/routes/a.$id/link-root.behavior.browser.test.tsx
@@ -2,11 +2,6 @@ import { hydrateRoot, type Root } from 'react-dom/client'
 import { renderToString } from 'react-dom/server'
 import {
   createBrowserRouter,
-  createRequestHandler,
-  UNSAFE_createClientRoutes,
-  UNSAFE_getTurboStreamSingleFetchDataStrategy,
-  type UNSAFE_AssetsManifest,
-  type ServerBuild,
   createStaticHandler,
   createStaticRouter,
   Outlet,
@@ -15,7 +10,6 @@ import {
   useLoaderData,
 } from 'react-router'
 import { afterEach, expect, test, vi } from 'vitest'
-import { ViewerTimezone } from '~/components/app/viewer-timezone'
 import Viewer from './+viewer'
 
 // Import the real shared viewer without mocking any server modules. A runtime
@@ -30,21 +24,12 @@ function ViewerPage() {
   return <Viewer loaderData={useLoaderData<typeof viewerData>()} />
 }
 
-function RootLayout() {
-  return (
-    <>
-      <ViewerTimezone />
-      <Outlet />
-    </>
-  )
-}
-
 const routes = [
   {
     id: 'root',
     path: '/',
     loader: () => ({ locale: 'en', user: null }),
-    Component: RootLayout,
+    Component: Outlet,
     children: [
       {
         id: 'home',
@@ -62,66 +47,6 @@ const routes = [
   },
 ]
 
-// Use the installed framework's client routes, single-fetch URL generation and
-// server encoder. The browser harness cannot import the application's Worker;
-// app.test.ts separately checks this exact request path at that boundary.
-const routeEntries = [routes[0], ...routes[0].children]
-const manifest: UNSAFE_AssetsManifest = {
-  entry: { module: '/entry.js', imports: [] },
-  url: '/manifest.js',
-  version: 'synthetic',
-  routes: Object.fromEntries(
-    routeEntries.map((route) => [
-      route.id,
-      {
-        id: route.id,
-        parentId: route.id === 'root' ? undefined : 'root',
-        path: 'path' in route ? route.path : undefined,
-        index: 'index' in route ? route.index : undefined,
-        module: `/routes/${route.id}.js`,
-        hasLoader: true,
-        hasAction: false,
-        hasClientLoader: false,
-        hasClientAction: false,
-        hasClientMiddleware: false,
-        hasErrorBoundary: false,
-        clientActionModule: undefined,
-        clientLoaderModule: undefined,
-        clientMiddlewareModule: undefined,
-        hydrateFallbackModule: undefined,
-      },
-    ]),
-  ),
-}
-const routeModules = Object.fromEntries(
-  routeEntries.map((route) => [
-    route.id,
-    {
-      default: route.Component,
-    },
-  ]),
-)
-const serverBuild: ServerBuild = {
-  entry: { module: { default: () => new Response('unused document entry') } },
-  routes: Object.fromEntries(
-    routeEntries.map((route) => [
-      route.id,
-      {
-        ...manifest.routes[route.id]!,
-        module: { default: route.Component, loader: route.loader },
-      },
-    ]),
-  ),
-  assets: manifest,
-  publicPath: '/',
-  assetsBuildDirectory: 'assets',
-  future: {},
-  ssr: true,
-  isSpaMode: false,
-  prerender: [],
-  routeDiscovery: { mode: 'initial', manifestPath: '/__manifest' },
-}
-
 let root: Root | undefined
 let router: ReturnType<typeof createBrowserRouter> | undefined
 let container: HTMLDivElement | undefined
@@ -132,7 +57,6 @@ afterEach(() => {
   root?.unmount()
   router?.dispose()
   container?.remove()
-  document.cookie = '__as_tz=; Path=/; Max-Age=0'
   vi.restoreAllMocks()
   window.history.replaceState(initialState, '', initialUrl)
 })
@@ -140,19 +64,6 @@ afterEach(() => {
 test.each(['/', '/a/abc123def4'])(
   'hydrates the shared viewer at %s without an intermediate URL or lost state',
   async (pathname) => {
-    document.cookie = '__as_tz=; Path=/; Max-Age=0'
-    const resolved = Intl.DateTimeFormat().resolvedOptions()
-    vi.spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions').mockReturnValue({
-      ...resolved,
-      timeZone: 'Asia/Tokyo',
-    })
-    const dataHandler = createRequestHandler(serverBuild, 'test')
-    const fetchData = vi
-      .spyOn(window, 'fetch')
-      .mockImplementation(async (input, init) => {
-        expect(document.cookie).toContain('__as_tz=Asia%2FTokyo')
-        return dataHandler(new Request(input, init))
-      })
     const url = `${pathname}?panel=comments&tag=one&tag=two&version=old#section`
     window.history.replaceState({ usr: { returnTo: '/files' } }, '', url)
     const historyLength = window.history.length
@@ -182,22 +93,7 @@ test.each(['/', '/a/abc123def4'])(
       window.location.pathname + window.location.search + window.location.hash,
     ).toBe(url)
 
-    const clientRoutes = UNSAFE_createClientRoutes(
-      manifest.routes,
-      routeModules,
-      context,
-      true,
-      false,
-    )
-    router = createBrowserRouter(clientRoutes, {
-      hydrationData: context,
-      dataStrategy: UNSAFE_getTurboStreamSingleFetchDataStrategy(
-        () => router!,
-        manifest,
-        routeModules,
-        true,
-      ),
-    })
+    router = createBrowserRouter(routes, { hydrationData: context })
     const onRecoverableError = vi.fn()
     root = hydrateRoot(container, <RouterProvider router={router} />, {
       onRecoverableError,
@@ -207,17 +103,6 @@ test.each(['/', '/a/abc123def4'])(
       requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
     )
 
-    await vi.waitFor(() => {
-      expect(fetchData).toHaveBeenCalledTimes(1)
-      expect(router?.state.revalidation).toBe('idle')
-    })
-    const dataUrl = new URL(String(fetchData.mock.calls[0]![0]))
-    expect(dataUrl.pathname).toBe(
-      pathname === '/' ? '/_.data' : `${pathname}.data`,
-    )
-    expect(dataUrl.search).toBe(new URL(url, window.location.origin).search)
-    expect(dataUrl.hash).toBe('')
-    expect(router.state.errors).toBeNull()
     expect(container.querySelector('main')).toBe(serverMain)
     expect(onRecoverableError).not.toHaveBeenCalled()
     expect(router.state.matches.at(-1)?.route.id).toBe(
@@ -231,35 +116,5 @@ test.each(['/', '/a/abc123def4'])(
     expect(push).not.toHaveBeenCalled()
     // Router initialization may add its history index, but must not rewrite URL.
     expect(replace.mock.calls.every((call) => call[2] === undefined)).toBe(true)
-
-    // A document reload keeps the cookie, so mounting again must not fetch.
-    root.unmount()
-    router.dispose()
-    container.innerHTML = renderToString(
-      <StaticRouterProvider
-        router={serverRouter}
-        context={context}
-        hydrate={false}
-      />,
-    )
-    router = createBrowserRouter(clientRoutes, {
-      hydrationData: context,
-      dataStrategy: UNSAFE_getTurboStreamSingleFetchDataStrategy(
-        () => router!,
-        manifest,
-        routeModules,
-        true,
-      ),
-    })
-    root = hydrateRoot(container, <RouterProvider router={router} />)
-    await new Promise<void>((resolve) =>
-      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-    )
-    expect(fetchData).toHaveBeenCalledTimes(1)
-    expect(container.querySelector('main')).not.toBeNull()
-    expect(router.state.errors).toBeNull()
-    expect(
-      window.location.pathname + window.location.search + window.location.hash,
-    ).toBe(url)
   },
 )

--- a/apps/web/workers/app.test.ts
+++ b/apps/web/workers/app.test.ts
@@ -148,12 +148,12 @@ describe('app worker link-domain routing', () => {
     expect(requestHandlerMock).not.toHaveBeenCalled()
   })
 
-  test.each(['/', '/_root.data'])(
+  test.each(['/', '/_.data'])(
     'preserves viewer path %s and strips credentials and version',
     async (pathname) => {
       const response = await app.fetch(
         workerRequest(
-          `https://abc123def4.artifactshare.link${pathname}?version=old&theme=dark`,
+          `https://abc123def4.artifactshare.link${pathname}?version=old&theme=dark&tag=one&tag=two&version=older`,
           {
             headers: {
               authorization: 'Bearer secret',
@@ -169,7 +169,7 @@ describe('app worker link-domain routing', () => {
       expect(response.status).toBe(200)
       const forwarded = requestHandlerMock.mock.calls.at(-1)?.[0]
       expect(new URL(forwarded!.url).pathname).toBe(pathname)
-      expect(new URL(forwarded!.url).search).toBe('?theme=dark')
+      expect(new URL(forwarded!.url).search).toBe('?theme=dark&tag=one&tag=two')
       expect(forwarded?.headers.get('cookie')).toBe(
         '__as_viewer=anonymous; __as_analytics_consent=granted; __as_tz=Asia%2FTokyo',
       )
@@ -182,7 +182,7 @@ describe('app worker link-domain routing', () => {
 
   test('forwards the viewer-only data paths the anonymous page needs', async () => {
     for (const path of [
-      '/api/shareables/abc123def4/versions',
+      '/api/shareables/abc123def4/versions?version=1',
       '/a/abc123def4.data',
       '/__manifest?paths=%2Fa%2Fabc123def4&version=1',
     ]) {
@@ -195,7 +195,7 @@ describe('app worker link-domain routing', () => {
       expect(response.status).toBe(200)
       const forwarded = requestHandlerMock.mock.calls.at(-1)?.[0]
       expect(new URL(forwarded!.url).pathname).toBe(path.split('?')[0])
-      if (path.startsWith('/__manifest')) {
+      if (path.includes('version=1')) {
         expect(new URL(forwarded!.url).searchParams.get('version')).toBe('1')
       }
     }
@@ -292,17 +292,26 @@ describe('app worker link-domain routing', () => {
     expect(requestHandlerMock).not.toHaveBeenCalled()
   })
 
-  test('returns a private no-store 404 for a disallowed viewer path', async () => {
-    const response = await app.fetch(
-      workerRequest('https://abc123def4.artifactshare.link/settings'),
-      productionEnv({ maintenance: false }),
-      executionContext(),
-    )
+  test.each([
+    '/settings',
+    '/settings.data',
+    '/_root.data',
+    '/other/_.data',
+    '/a/other12345.data',
+  ])(
+    'returns a private no-store 404 for disallowed viewer path %s',
+    async (path) => {
+      const response = await app.fetch(
+        workerRequest(`https://abc123def4.artifactshare.link${path}`),
+        productionEnv({ maintenance: false }),
+        executionContext(),
+      )
 
-    expect(response.status).toBe(404)
-    expect(response.headers.get('cache-control')).toBe('private, no-store')
-    expect(requestHandlerMock).not.toHaveBeenCalled()
-  })
+      expect(response.status).toBe(404)
+      expect(response.headers.get('cache-control')).toBe('private, no-store')
+      expect(requestHandlerMock).not.toHaveBeenCalled()
+    },
+  )
 
   test('rejects allowed route shapes when the path ID differs', async () => {
     const response = await app.fetch(
@@ -674,23 +683,26 @@ describe('app worker viewer rate limit', () => {
     },
   )
 
-  test('rate limits the per-ID viewer root', async () => {
-    const limit = vi.fn().mockResolvedValue({ success: false })
-    const response = await app.fetch(
-      workerRequest('https://abc123def4.artifactshare.link/', {
-        headers: { 'cf-connecting-ip': '203.0.113.11' },
-      }),
-      {
-        ...productionEnv({ maintenance: false }),
-        VIEWER_RATELIMIT: { limit },
-      } as unknown as Cloudflare.Env,
-      executionContext(),
-    )
+  test.each(['/', '/_.data'])(
+    'rate limits the per-ID viewer path %s',
+    async (path) => {
+      const limit = vi.fn().mockResolvedValue({ success: false })
+      const response = await app.fetch(
+        workerRequest(`https://abc123def4.artifactshare.link${path}`, {
+          headers: { 'cf-connecting-ip': '203.0.113.11' },
+        }),
+        {
+          ...productionEnv({ maintenance: false }),
+          VIEWER_RATELIMIT: { limit },
+        } as unknown as Cloudflare.Env,
+        executionContext(),
+      )
 
-    expect(response.status).toBe(429)
-    expect(requestHandlerMock).not.toHaveBeenCalled()
-    expect(limit).toHaveBeenCalledWith({ key: '203.0.113.11' })
-  })
+      expect(response.status).toBe(429)
+      expect(requestHandlerMock).not.toHaveBeenCalled()
+      expect(limit).toHaveBeenCalledWith({ key: '203.0.113.11' })
+    },
+  )
 
   test('rate limits link-domain report actions before the application handler', async () => {
     const limit = vi.fn().mockResolvedValue({ success: false })
@@ -990,7 +1002,7 @@ describe('app worker maintenance mode', () => {
     }
   })
 
-  test.each(['/', '/_root.data'] as const)(
+  test.each(['/', '/_.data'] as const)(
     'blocks link-host viewer path %s during maintenance',
     async (path) => {
       const response = await app.fetch(
@@ -1024,7 +1036,7 @@ describe('app worker maintenance mode', () => {
   })
 
   test('passes public React Router data requests through without auth cookies', async () => {
-    for (const path of ['/_root.data', '/connect.data'] as const) {
+    for (const path of ['/_.data', '/connect.data'] as const) {
       const response = await app.fetch(
         workerRequest(`https://artifactshare.com${path}`, {
           headers: {

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -187,7 +187,7 @@ export default {
       isViewerRateLimitedPath(routedRequest) ||
       (linkShareableId &&
         (routedRequest.method === 'GET' || routedRequest.method === 'HEAD') &&
-        ['/', '/_root.data'].includes(new URL(routedRequest.url).pathname))
+        ['/', '/_.data'].includes(new URL(routedRequest.url).pathname))
     ) {
       const limited = await checkViewerRateLimit(
         routedRequest,
@@ -207,8 +207,7 @@ export default {
     let handlerRequest: Request = sanitizedRequest
     if (await isMaintenanceEnabled(env, url, hostname)) {
       const isLinkViewerDocument =
-        linkShareableId &&
-        (url.pathname === '/' || url.pathname === '/_root.data')
+        linkShareableId && (url.pathname === '/' || url.pathname === '/_.data')
       if (isLinkViewerDocument || !isMaintenanceExempt(url))
         return maintenanceResponse(url)
       handlerRequest = maintenanceExemptRequest(sanitizedRequest)
@@ -367,16 +366,17 @@ function linkDomainRequest(
   }
 
   const encodedId = encodeURIComponent(shareableId)
+  // React Router single fetch appends _.data to a trailing slash, including /.
   const viewerDocumentPath =
     url.pathname === '/' ||
-    url.pathname === '/_root.data' ||
+    url.pathname === '/_.data' ||
     url.pathname === `/a/${encodedId}` ||
     url.pathname === `/a/${encodedId}.data`
   const allowedManifest = isLinkDomainManifestRequest(url, encodedId)
   const reportPath = `/api/shareables/${encodedId}/report`
   const allowed =
     url.pathname === '/' ||
-    url.pathname === '/_root.data' ||
+    url.pathname === '/_.data' ||
     url.pathname === `/a/${encodedId}` ||
     url.pathname === `/a/${encodedId}.data` ||
     url.pathname === `/a/${encodedId}/og-image` ||
@@ -592,7 +592,7 @@ function isMaintenancePublicPagePath(pathname: string): boolean {
 function isMaintenancePublicDataRequest(pathname: string): boolean {
   if (!pathname.endsWith('.data')) return false
   const routePathname =
-    pathname === '/_root.data' ? '/' : pathname.slice(0, -'.data'.length)
+    pathname === '/_.data' ? '/' : pathname.slice(0, -'.data'.length)
   return isMaintenancePublicPagePath(routePathname)
 }
 


### PR DESCRIPTION
## Summary

- Fix the deployed link-host first-visit regression that replaced a rendered root viewer with a full-page 404 after timezone-cookie initialization.
- Admit React Router 8.3.0's generated root single-fetch request at `/_.data` through the same link-host filtering, rate-limit, and maintenance rules as the root document.
- Preserve the existing Worker boundary coverage and the existing hydration browser test; remove the synthetic UNSAFE browser revalidation harness from the correction commit.

## Reproduction and cause

In a clean browser context with no timezone cookie, the link-host root document and viewer content initially returned 200. `ViewerTimezone` then wrote the browser timezone cookie and called `revalidate()`. React Router generated `GET /_.data` for the root data revalidation, while the Worker only admitted `/_root.data`; the request therefore returned the link-host 404 response and React Router replaced the document with 404. Reloading worked because the timezone cookie was already present and no revalidation request was made.

React Router 8.3.0's trailing-slash-aware single-fetch implementation appends `_.data` to a root pathname ending in `/`, producing `/_.data`. The repair admits exactly `/_.data` at the link-host document boundary and keeps the obsolete `/_root.data` path rejected. The forwarded request still removes `version` and authentication credentials while preserving the other query parameters.

## Validation

The final correction commit is `6f80a14a68e9eb89c88574a46253faa1bd8e6186`, and its diff from `origin/main` contains only `apps/web/workers/app.ts` and `apps/web/workers/app.test.ts`; `apps/web/app/routes/a.$id/link-root.behavior.browser.test.tsx` is identical to the base version after the synthetic harness was removed.

- `pnpm --filter @artifactshare/web test:behavior-browser 'app/routes/a.$id/link-root.behavior.browser.test.tsx'` — 2 passed on the correction commit
- `pnpm --filter @artifactshare/web test:unit workers/app.test.ts` — 65 passed on the correction commit
- `pnpm --filter @artifactshare/web test:unit workers/app.test.ts app/lib/viewer-timezone.client.test.ts app/lib/viewer-timezone.server.test.ts app/routes/_home/index.test.tsx` — 87 passed during initial implementation validation
- `pnpm validate:static` — typechecks, D1 26 tests, scripts 574 tests, web 3,708 passed and 1 skipped, qm-bridge 81 tests, React Doctor 100, public scan 0
- `pnpm validate:build` — web build, dry-run alert/OG/sandbox builds, integration 31/31, and runtime smoke 200/scheduled 200/dev sign-in 404
- Trusted-main public-development boundary guard passed from a clean `origin/main` checkout; `git diff --check` passed; the remote branch head matches the local head and the worktree is clean
- A negative control restoring the old root-path allow-list produced the expected five Worker test failures

The accepted existing local built-app browser proof used the e879b4e build, a seeded local D1/R2 fixture, and a fresh Playwright Chromium context at `https://abcde12345.localhost:8787/?panel=comments&tag=one&tag=two&version=old#section`. The document returned 200, the expected title/heading rendered, `/_.data?panel=comments&tag=one&tag=two&version=old` returned 200, the exact query and hash remained after first visit, the timezone cookie was written, and reload preserved the URL and heading without another `.data` request. This proof is limited to the built-app first-visit/reload URL and rendering path: the sandbox iframe was not started and the anonymous versions endpoint returned 401, so it does not establish all viewer features or anonymous-version behavior. No new built-app proof or browser harness was added for the correction because it only removes the synthetic test harness.

## Review status

The final controlled implementation pair reviewed exactly `origin/main` → `6f80a14a68e9eb89c88574a46253faa1bd8e6186` with Codex `gpt-5.6-sol/medium` and Claude `claude-opus-5/high`. Both returned GO with no unresolved blocker. The prior F1 duplicate `/_.data` literal observation remains non-actionable because the duplication predates this change and all sites were updated consistently. The prior F2 weak two-rAF reload assertion is fixed by removing the synthetic UNSAFE harness. Claude's new C1 is a base-identical apex-host trailing-slash public-page maintenance gap outside I1–I3; it is deferred as a follow-up and is not part of this repair.

## Deferred follow-up

- Claude C1: under apex-host maintenance, a public page URL with a trailing slash (for example `/connect/`) can render its document while its generated `/connect/_.data` request is not normalized by the existing exact-root maintenance exception. This behavior is identical on `origin/main`, is outside the link-host root objective, and remains unmodified here.

## Workflow usage

The empty Codex/Astra rows were backfilled after merge using ccusage 20.0.20 and native session records. Attribution was checked against each fresh session's task prompt or fixed review target, model, worktree, and single completed task. These are recovered session totals, not reconstructed start/end snapshots; the task registry was not retroactively sealed. Native session identifiers and local paths are omitted from this public summary.

Each provider row describes one invocation (a Claude review row includes its finder and verifier). Input is normalized consistently across providers; cache read/write are subsets of input, and reasoning is included in output. The interrupted dispatch's recorded values are retained as partial evidence. Missing stage boundaries are explained rather than converted to zero.

| Execution | Requested model / effort | Reported model | Start → end (UTC) | Elapsed / basis | Normalized input | Cache read | Cache write | Output | Recorded total tokens | Result / coverage |
|---|---|---|---|---:|---:|---:|---:|---:|---:|---|
| Aborted implementation dispatch | gpt-6-astra / medium | gpt-6-astra | Sep 11 02:04:38.386 → unknown | unknown | 24,545 | 0 | 0 | 153 | 24,698 | Stopped before editing because the working directory was wrong; recorded usage only, interrupted-run coverage is partial |
| Post-deployment implementation repair (e879b4e) | gpt-6-astra / medium | gpt-6-astra | Sep 11 02:05:15.961 → 02:09:41.705 | 265.744s (native session span) | 1,394,551 | 1,298,432 | 0 | 6,257 | 1,400,808 | Completed; fresh one-task session, reconstructed from native task attribution and ccusage |
| Initial implementation review — Claude (e879b4e) | Claude Opus / high | claude-opus-5 (+ haiku adapter) | Sep 11 02:14:16.431 → 02:20:17.741 | 6m 1.232s | 743,827 | 626,376 | 107,983 | 27,127 | 770,954 | GO; F1 non-actionable, F2 follow-up |
| Initial implementation review — Codex (e879b4e) | gpt-5.6-sol / medium | gpt-5.6-sol | Sep 11 02:14:16.517 → 02:17:56.119 | 219.602s (native session span) | 1,047,641 | 952,704 | 0 | 7,568 | 1,055,209 | GO; fresh finder session; no verifier was launched |
| Assumption challenge (Fable) | claude-fable-5-1 / low | claude-fable-5-1 | Sep 11 02:24:04 → 02:25:02 | 56.080s API (58s wall span) | 42,360 | 11,263 | 31,014 | 3,689 | 46,049 | Completed; premise challenge recorded for coordinator review |
| Correction implementation repair (6f80a14) | gpt-6-astra / medium | gpt-6-astra | Sep 11 02:33:19.384 → 02:36:06.232 | 166.848s (native session span) | 1,023,147 | 937,856 | 0 | 2,763 | 1,025,910 | Completed; removed the synthetic UNSAFE test harness; fresh one-task session |
| First correction review pair — Claude (incomplete pair) | Claude Opus / high | claude-opus-5 (+ haiku adapter) | Sep 11 02:38:51.226 → 02:43:29.597 | 4m 38.312s | 378,360 | 294,653 | 74,325 | 21,902 | 400,262 | Finder complete; verifier incomplete due missing fixed `react-router@8.3.0` source input |
| First correction review — Codex (incomplete pair) | gpt-5.6-sol / medium | gpt-5.6-sol | Sep 11 02:38:51.296 → 02:41:32.436 | 161.140s (native session span) | 1,086,944 | 966,656 | 0 | 6,297 | 1,093,241 | Codex completed; pair remained incomplete because Claude verifier lacked dependency evidence |
| Final correction review pair — Claude | Claude Opus / high | claude-opus-5 (+ haiku adapter) | Sep 11 02:45:08.974 → 02:49:38.019 | 4m 28.977s | 531,001 | 430,376 | 90,420 | 20,962 | 551,963 | GO; C1 follow-up, no blocker |
| Final correction review — Codex | gpt-5.6-sol / medium | gpt-5.6-sol | Sep 11 02:45:09.031 → 02:46:58.640 | 109.609s (native session span) | 408,495 | 340,352 | 0 | 5,072 | 413,567 | GO; fresh finder session; prior F1/F2 dispositions retained |
| Coordination, validation, and publication | gpt-5.6-luna / xhigh | not established per stage | unknown | unknown | unknown | unknown | unknown | unknown | unknown | Invocation/stage boundaries were not registered; the shared session also contains preceding work, so no stage allocation is inferred |
| Correction review input validation (no provider launch) | not launched | n/a | unknown | 0.628s observed | n/a | n/a | n/a | n/a | n/a | Failed before review launch; disposition heading format corrected |

**Known subtotal (partial):** normalized input 6,680,871, cache read 5,858,668, cache write 303,742, output 101,790, and recorded total 6,782,661 tokens. Six recovered Codex/Astra sessions contribute 5,013,433 tokens to this subtotal. The earlier Claude/Fable subtotal of 1,769,228 is retained within it. This is not a complete task total: coordination boundaries and usage outside the listed invocations remain unmeasured.

**Timing basis:** Codex/Astra start/end cells come from native session creation and the task-complete event; they describe the recorded session span, not process launch/exit. Claude rows retain caller invocation bounds and reported durations; Fable retains its recorded API duration. The known model execution spans/durations sum to 1887.544s; the aborted dispatch and coordination duration are unknown. The non-provider input-validation failure took a separately observed 0.628s. The known wall span is 2699.633s from Sep 11 02:04:38.386 to 02:49:38.019, including gaps; it excludes the unbounded coordination tail.

The first correction pair was incomplete because its Claude verifier could not read the dependency implementation from its fixed snapshot. The final pair received a read-only public-source evidence file and completed. Failed attempts remain in the table; no review was rerun to obtain usage.

## Scope

This is a post-deployment regression repair continuing the link-host URL stability trial. It does not merge, queue, or deploy production changes.

