### PR TITLE
fix: limit timezone synchronization to project routes

### DIFF
--- a/apps/web/app/root.test.tsx
+++ b/apps/web/app/root.test.tsx
@@ -10,7 +10,7 @@ vi.mock('cloudflare:workers', () => ({
   },
 }))
 
-import { links, loader, shouldRevalidate } from './root'
+import { isProjectTimezonePath, links, loader, shouldRevalidate } from './root'
 import { linkDomainContext, userContext } from '~/middleware/context'
 import { linkViewerHistoryUrl } from '~/lib/link-viewer-history'
 
@@ -38,6 +38,23 @@ describe('root links', () => {
         },
       ]),
     )
+  })
+})
+
+describe('project timezone routes', () => {
+  test.each([
+    ['/projects/project-1', true],
+    ['/projects/project-1/', true],
+    ['/projects/project-1/activity', true],
+    ['/projects/project-1/activity/', true],
+    ['/', false],
+    ['/about', false],
+    ['/a/shareable-1', false],
+    ['/projects', false],
+    ['/projects/project-1/files', false],
+    ['/projects/project-1/slack', false],
+  ] as const)('%s', (pathname, expected) => {
+    expect(isProjectTimezonePath(pathname)).toBe(expected)
   })
 })
 

--- a/apps/web/app/root.test.tsx
+++ b/apps/web/app/root.test.tsx
@@ -10,7 +10,7 @@ vi.mock('cloudflare:workers', () => ({
   },
 }))
 
-import { isProjectTimezonePath, links, loader, shouldRevalidate } from './root'
+import { isProjectTimezoneRoute, links, loader, shouldRevalidate } from './root'
 import { linkDomainContext, userContext } from '~/middleware/context'
 import { linkViewerHistoryUrl } from '~/lib/link-viewer-history'
 
@@ -43,18 +43,23 @@ describe('root links', () => {
 
 describe('project timezone routes', () => {
   test.each([
-    ['/projects/project-1', true],
-    ['/projects/project-1/', true],
-    ['/projects/project-1/activity', true],
-    ['/projects/project-1/activity/', true],
-    ['/', false],
-    ['/about', false],
-    ['/a/shareable-1', false],
-    ['/projects', false],
-    ['/projects/project-1/files', false],
-    ['/projects/project-1/slack', false],
-  ] as const)('%s', (pathname, expected) => {
-    expect(isProjectTimezonePath(pathname)).toBe(expected)
+    [['routes/_protected/projects.$id'], true],
+    [['routes/_protected/projects.$id.activity'], true],
+    [
+      [
+        'routes/_protected/projects.$id',
+        'routes/_protected/projects.$id.activity',
+      ],
+      true,
+    ],
+    [['routes/_protected/projects.archived'], false],
+    [['routes/_protected/projects.$id.files'], false],
+    [['routes/_protected/settings/activity'], false],
+    [[], false],
+  ] as const)('%s', (routeIds, expected) => {
+    expect(isProjectTimezoneRoute(routeIds.map((id) => ({ id })))).toBe(
+      expected,
+    )
   })
 })
 

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -5,7 +5,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-  useLocation,
+  useMatches,
   useRouteLoaderData,
 } from 'react-router'
 import { env } from 'cloudflare:workers'
@@ -49,10 +49,15 @@ import { countReceivedAccessRequests } from '~/services/access-requests.server'
 import { linkViewerHistoryUrl } from '~/lib/link-viewer-history'
 export { shouldRevalidate } from '~/lib/root-locale'
 
-const PROJECT_TIMEZONE_PATH = /^\/projects\/[^/]+(?:\/activity)?\/?$/
+const PROJECT_TIMEZONE_ROUTE_IDS = new Set([
+  'routes/_protected/projects.$id',
+  'routes/_protected/projects.$id.activity',
+])
 
-export function isProjectTimezonePath(pathname: string): boolean {
-  return PROJECT_TIMEZONE_PATH.test(pathname)
+export function isProjectTimezoneRoute(
+  matches: ReadonlyArray<{ id: string }>,
+): boolean {
+  return matches.some((match) => PROJECT_TIMEZONE_ROUTE_IDS.has(match.id))
 }
 
 export const links: Route.LinksFunction = () => [
@@ -213,11 +218,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  const { pathname } = useLocation()
+  const matches = useMatches()
   return (
     <>
       <Outlet />
-      {isProjectTimezonePath(pathname) ? <ViewerTimezone /> : null}
+      {isProjectTimezoneRoute(matches) ? <ViewerTimezone /> : null}
     </>
   )
 }

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -5,6 +5,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useLocation,
   useRouteLoaderData,
 } from 'react-router'
 import { env } from 'cloudflare:workers'
@@ -47,6 +48,12 @@ import { isDevScreenStateRequest } from '~/services/dev-screen-state.server'
 import { countReceivedAccessRequests } from '~/services/access-requests.server'
 import { linkViewerHistoryUrl } from '~/lib/link-viewer-history'
 export { shouldRevalidate } from '~/lib/root-locale'
+
+const PROJECT_TIMEZONE_PATH = /^\/projects\/[^/]+(?:\/activity)?\/?$/
+
+export function isProjectTimezonePath(pathname: string): boolean {
+  return PROJECT_TIMEZONE_PATH.test(pathname)
+}
 
 export const links: Route.LinksFunction = () => [
   { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
@@ -198,7 +205,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
             data?.analyticsConsent?.shouldLoadAnalytics ?? false
           }
         />
-        <ViewerTimezone />
         <ScrollRestoration />
         <Scripts />
       </body>
@@ -207,7 +213,13 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  return <Outlet />
+  const { pathname } = useLocation()
+  return (
+    <>
+      <Outlet />
+      {isProjectTimezonePath(pathname) ? <ViewerTimezone /> : null}
+    </>
+  )
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {

--- a/apps/web/workers/app.test.ts
+++ b/apps/web/workers/app.test.ts
@@ -149,7 +149,7 @@ describe('app worker link-domain routing', () => {
   })
 
   test.each(['/', '/_.data'])(
-    'preserves viewer path %s and strips credentials and version',
+    'preserves viewer path %s and strips credentials, version, and timezone',
     async (pathname) => {
       const response = await app.fetch(
         workerRequest(
@@ -171,7 +171,7 @@ describe('app worker link-domain routing', () => {
       expect(new URL(forwarded!.url).pathname).toBe(pathname)
       expect(new URL(forwarded!.url).search).toBe('?theme=dark&tag=one&tag=two')
       expect(forwarded?.headers.get('cookie')).toBe(
-        '__as_viewer=anonymous; __as_analytics_consent=granted; __as_tz=Asia%2FTokyo',
+        '__as_viewer=anonymous; __as_analytics_consent=granted',
       )
       expect(forwarded?.headers.has('authorization')).toBe(false)
       expect(routerContextSetMock).toHaveBeenCalledWith(expect.anything(), {
@@ -179,6 +179,20 @@ describe('app worker link-domain routing', () => {
       })
     },
   )
+
+  test('does not forward a timezone-only cookie to the application', async () => {
+    const response = await app.fetch(
+      workerRequest('https://abc123def4.artifactshare.link/', {
+        headers: { cookie: '__as_tz=Asia%2FTokyo' },
+      }),
+      productionEnv({ maintenance: false }),
+      executionContext(),
+    )
+
+    expect(response.status).toBe(200)
+    const forwarded = requestHandlerMock.mock.calls.at(-1)?.[0]
+    expect(forwarded?.headers.has('cookie')).toBe(false)
+  })
 
   test('forwards the viewer-only data paths the anonymous page needs', async () => {
     for (const path of [

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -46,7 +46,6 @@ import {
 import { handleArtifactSandboxRequest } from './bundle-sandbox'
 import { ANON_VIEWER_COOKIE } from '../app/services/views.server'
 import { ANALYTICS_CONSENT_COOKIE } from '../app/lib/analytics-consent.server'
-import { VIEWER_TIMEZONE_COOKIE } from '../app/lib/viewer-timezone.server'
 
 export { ArtifactLiveRoom } from './artifact-live-room'
 export { D1BackupWorkflow } from './d1-backup-workflow'
@@ -403,11 +402,7 @@ function linkDomainRequest(
       .map((part) => part.trim())
       .filter((part) => {
         const name = part.split('=', 1)[0]?.trim() ?? ''
-        return (
-          name === ANON_VIEWER_COOKIE ||
-          name === ANALYTICS_CONSENT_COOKIE ||
-          name === VIEWER_TIMEZONE_COOKIE
-        )
+        return name === ANON_VIEWER_COOKIE || name === ANALYTICS_CONSENT_COOKIE
       })
     if (kept.length > 0) headers.set('cookie', kept.join('; '))
     else headers.delete('cookie')


### PR DESCRIPTION
## What changed

Timezone synchronization now runs only when React Router has matched the project detail or project activity route. Public pages and artifact viewers no longer write `__as_tz` or trigger timezone-driven loader revalidation, including when a viewer is signed in.

Link-domain requests no longer forward `__as_tz` to the application handler. The existing anonymous-viewer and analytics-consent cookies remain forwarded.

The route gate and link-domain sanitizer have focused positive and negative tests, including the archived-project list and timezone-only cookie requests.

## Validation

- `pnpm --filter @artifactshare/web test:unit` — 337 files, 3,716 passed, 1 skipped
- `pnpm --filter @artifactshare/web test:behavior-browser` — 16 files, 80 passed
- `pnpm --filter @artifactshare/web typecheck` — passed
- `pnpm --filter @artifactshare/web lint` — passed
- `pnpm --filter @artifactshare/web format` — passed
- `pnpm --filter @artifactshare/web build` — passed
- `pnpm check:doctor` — score 100
- `pnpm public:scan .` — 0 findings

## UI review

The affected project-detail and project-activity states were captured at desktop and mobile on this commit, including light/dark states. Supplemental browser evidence used `Pacific/Kiritimati` around a local midnight boundary: cookie-less SSR showed no day headings, then the project routes wrote `__as_tz`, received HTTP 200 `.data` revalidation, and regrouped into local `Today`/`Yesterday` headings. A fresh `/` control session kept `__as_tz` absent.

Claude Opus/high and Codex Astra/medium independently reviewed the same fixed project-route evidence and source. Both found no blocker in this change's timezone scope. The republish walkthrough was supplementary context only; its duplicate-post/version-menu evidence gaps are outside this change and do not alter the timezone decision.

Two follow-ups are recorded for landing: first-visit project list regrouping/layout transition is measure-first because it is existing hydration behavior and has no observed task failure; route-ID literal drift against generated routes is a non-blocking maintenance follow-up.

## Review

The implementation was reviewed independently by Codex and Claude on the initial candidate and on the correction candidate. The first pair's route matching and scope findings were fixed together; the correction pair returned GO. A non-blocking observation about guarding route-ID literals against future route-generator drift was checked against the current generated route manifest and classified as a follow-up outside this change's acceptance criteria.

## Workflow usage

| execution | requested model / effort | observed model / effort | elapsed | normalized input | cache read | cache write | output | total | result |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| implementation | coordinator / manual | n/a | n/a | n/a | n/a | n/a | n/a | n/a | committed initial candidate |
| Codex review (initial) | gpt-5.6-sol / medium | gpt-5.6-sol / medium (usage not reported) | 424s | unknown | unknown | unknown | unknown | unknown | completed; findings fixed |
| Claude review (initial) | claude-opus-5 / high | claude-opus-5 + claude-haiku-4-5-20251001 / high | 390s | 987,556 | 863,676 | 113,447 | 30,567 | 1,018,123 | completed; findings fixed |
| correction | coordinator / manual | n/a | n/a | n/a | n/a | n/a | n/a | n/a | committed correction candidate |
| Codex review (correction) | gpt-5.6-sol / medium | gpt-5.6-sol / medium (usage not reported) | 189s | unknown | unknown | unknown | unknown | unknown | GO |
| Claude review (correction) | claude-opus-5 / high | claude-opus-5 + claude-haiku-4-5-20251001 / high | 312s | 532,327 | 448,136 | 74,341 | 24,065 | 556,392 | GO |
| standalone + walkthrough capture | coordinator / manual | n/a | unknown | n/a | n/a | n/a | n/a | n/a | 168 standalone screens and 5 tasks, all successful |
| supplemental timezone capture | coordinator / manual | Chromium / Pacific/Kiritimati | unknown | n/a | n/a | n/a | n/a | n/a | project detail/activity desktop+mobile and out-of-scope home control |
| UI critique (Claude) | claude-opus-5 / high | claude-opus-5 / high | unknown | unknown | unknown | unknown | unknown | unknown | completed; timezone scope verified, no blocker in scope |
| UI critique (Codex) | gpt-6-astra / medium | gpt-6-astra / medium | unknown | unknown | unknown | unknown | unknown | unknown | completed; timezone scope verified, no blocker in scope |
