### PR TITLE
perf: avoid D1 reads for anonymous bundle assets

### DIFF
--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -39,6 +39,8 @@ vi.mock('../app/services/sandbox-jti.server', () => ({
 
 import { signSandboxToken } from '../app/lib/sandbox-token'
 import { sandboxVersionLabel } from '../app/lib/hosts'
+import { encodeBase64Url } from '../app/lib/base64url'
+import { hmacSha256 } from '../app/lib/hmac'
 import {
   VIOLATION_REPORTER_SHA256,
   VIOLATION_REPORTER_TAG,
@@ -893,6 +895,22 @@ async function singleFileToken(args: {
   )
 }
 
+async function legacyAuthenticatedBundleCookie() {
+  const body = encodeBase64Url(
+    new TextEncoder().encode(
+      JSON.stringify({
+        uid: 'owner-1',
+        wid: 'ws-a',
+        aid: 'abc123def4',
+        vid: 'v-bundle',
+        exp: Math.floor(Date.now() / 1000) + 600,
+      }),
+    ),
+  )
+  const signature = encodeBase64Url(await hmacSha256('test-secret', body))
+  return `as_bnd=${body}.${signature}`
+}
+
 describe('handleArtifactSandboxRequest', () => {
   beforeEach(async () => {
     envMock.APP_ENV = 'development'
@@ -1080,6 +1098,21 @@ describe('handleArtifactSandboxRequest', () => {
       {},
       'ws-a/abc123def4/v-bundle/index.html',
     )
+  })
+
+  test('keeps accepting authenticated bundle cookies issued before the schema change', async () => {
+    storageMock.getArtifact.mockResolvedValue(
+      storedArtifact('body{}', 'text/css; charset=utf-8'),
+    )
+
+    const response = await handleArtifactSandboxRequest(
+      new Request(`${sandboxOrigin()}/style.css`, {
+        headers: { Cookie: await legacyAuthenticatedBundleCookie() },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toBe('body{}')
   })
 
   test('revokes an authenticated bundle cookie after its grant is removed', async () => {
@@ -2544,6 +2577,68 @@ describe('handleArtifactSandboxRequest', () => {
     )
   })
 
+  test('uses the upload-time R2 prefix after a workspace migration', async () => {
+    envMock.APP_ENV = 'production'
+    await dbRef
+      .current!.insertInto('workspaces')
+      .values({
+        id: 'ws-migrated',
+        hd: 'migrated.example.com',
+        name: 'Migrated workspace',
+        created_at: '2026-05-22T00:00:00.000Z',
+        plan: 'plus',
+        link_sharing_enabled: 1,
+        external_posting_enabled: 1,
+      })
+      .execute()
+    await dbRef
+      .current!.updateTable('shareables')
+      .set({ visibility: 'link', workspace_id: 'ws-migrated' })
+      .where('id', '=', 'abc123def4')
+      .execute()
+    storageMock.getArtifact
+      .mockResolvedValueOnce(
+        storedArtifact('<!doctype html><body>Link</body>', 'text/html'),
+      )
+      .mockResolvedValueOnce(storedArtifact('body{}', 'text/css'))
+    storageMock.headArtifact.mockResolvedValue(
+      storedHeadArtifact('body{}', 'text/css'),
+    )
+    const token = await signSandboxToken(
+      {
+        uid: null,
+        wid: 'ws-migrated',
+        aid: 'abc123def4',
+        vid: 'v-bundle',
+        fid: 'ws-a/abc123def4/v-bundle/index.html',
+        mt: null,
+        t: 'static_site',
+        jti: 'j-migrated-anonymous',
+      },
+      'test-secret',
+    )
+    const host = `${sandboxVersionLabel('abc123def4', 'v-bundle')}.artifactshare.link`
+
+    const entrypoint = await handleArtifactSandboxRequest(
+      new Request(`https://${host}/?t=${token}`),
+    )
+    const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+    expect(entrypoint.status).toBe(200)
+
+    dbRef.current = null
+    const asset = await handleArtifactSandboxRequest(
+      new Request(`https://${host}/style.css`, {
+        headers: { Cookie: cookie ?? '' },
+      }),
+    )
+
+    expect(asset.status).toBe(200)
+    expect(storageMock.headArtifact).toHaveBeenCalledWith(
+      {},
+      'ws-a/abc123def4/v-bundle/style.css',
+    )
+  })
+
   test('keeps index fallback for anonymous bundle cookies without touching D1', async () => {
     envMock.APP_ENV = 'production'
     await dbRef
@@ -2611,11 +2706,12 @@ describe('handleArtifactSandboxRequest', () => {
     storageMock.getArtifact.mockResolvedValue(
       storedArtifact('<!doctype html><body>Link</body>', 'text/html'),
     )
-    const token = await anonymousEntrypointToken()
     const host = `${sandboxVersionLabel('abc123def4', 'v-bundle')}.artifactshare.link`
 
     vi.useFakeTimers()
     try {
+      const token = await anonymousEntrypointToken()
+      const issuedAt = Math.floor(Date.now() / 1000)
       const entrypoint = await handleArtifactSandboxRequest(
         new Request(`https://${host}/?t=${token}`),
       )
@@ -2627,7 +2723,7 @@ describe('handleArtifactSandboxRequest', () => {
         .set({ visibility: 'private' })
         .where('id', '=', 'abc123def4')
         .execute()
-      vi.advanceTimersByTime(10 * 60 * 1000 + 1000)
+      vi.setSystemTime(new Date((issuedAt + 10 * 60) * 1000))
 
       const asset = await handleArtifactSandboxRequest(
         new Request(`https://${host}/style.css`, {

--- a/apps/web/workers/bundle-sandbox.test.ts
+++ b/apps/web/workers/bundle-sandbox.test.ts
@@ -10,6 +10,7 @@ const dbRef = vi.hoisted(() => ({
 
 const storageMock = vi.hoisted(() => ({
   getArtifact: vi.fn(),
+  headArtifact: vi.fn(),
 }))
 
 const consumeJtiMock = vi.hoisted(() => vi.fn())
@@ -264,6 +265,7 @@ describe('violation reporter injection handler', () => {
     await seedStaticSite(fixture.db)
     consumeJtiMock.mockReset().mockResolvedValue(true)
     storageMock.getArtifact.mockReset()
+    storageMock.headArtifact.mockReset()
   })
 
   test('injects before the first element only', () => {
@@ -783,6 +785,17 @@ function storedBinaryArtifact(body: Uint8Array, contentType: string) {
   }
 }
 
+function storedHeadArtifact(body: string | Uint8Array, contentType: string) {
+  const size =
+    typeof body === 'string'
+      ? new TextEncoder().encode(body).byteLength
+      : body.byteLength
+  return {
+    httpMetadata: { contentType },
+    size,
+  } as unknown as R2Object
+}
+
 function arrayBufferFromBytes(bytes: Uint8Array): ArrayBuffer {
   return bytes.buffer.slice(
     bytes.byteOffset,
@@ -888,6 +901,7 @@ describe('handleArtifactSandboxRequest', () => {
     await seedStaticSite(fixture.db)
     consumeJtiMock.mockReset().mockResolvedValue(true)
     storageMock.getArtifact.mockReset()
+    storageMock.headArtifact.mockReset()
   })
 
   test('serves an anonymous link-domain entrypoint with isolated headers', async () => {
@@ -908,7 +922,7 @@ describe('handleArtifactSandboxRequest', () => {
     )
 
     expect(response.status).toBe(200)
-    expect(response.headers.get('Set-Cookie')).toBeNull()
+    expect(response.headers.get('Set-Cookie')).toContain('as_bnd=')
     expect(response.headers.get('Cross-Origin-Resource-Policy')).toBe(
       'cross-origin',
     )
@@ -2482,6 +2496,150 @@ describe('handleArtifactSandboxRequest', () => {
       'ws-a/abc123def4/v-bundle/style.css',
     )
     expect(consumeJtiMock).not.toHaveBeenCalled()
+  })
+
+  test('serves anonymous link assets from the bundle cookie without touching D1', async () => {
+    envMock.APP_ENV = 'production'
+    await dbRef
+      .current!.updateTable('shareables')
+      .set({ visibility: 'link' })
+      .where('id', '=', 'abc123def4')
+      .execute()
+    storageMock.getArtifact
+      .mockResolvedValueOnce(
+        storedArtifact('<!doctype html><body>Link</body>', 'text/html'),
+      )
+      .mockResolvedValueOnce(storedArtifact('body{}', 'text/css'))
+    storageMock.headArtifact.mockResolvedValue(
+      storedHeadArtifact('body{}', 'text/css'),
+    )
+    const token = await anonymousEntrypointToken()
+    const host = `${sandboxVersionLabel('abc123def4', 'v-bundle')}.artifactshare.link`
+
+    const entrypoint = await handleArtifactSandboxRequest(
+      new Request(`https://${host}/?t=${token}`),
+    )
+    const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+    expect(entrypoint.status).toBe(200)
+    expect(cookie).toContain('as_bnd=')
+
+    // A cookie-authorized asset only needs the signed bundle identity and R2;
+    // making the DB unavailable proves the hot path does not regress to D1.
+    dbRef.current = null
+    const asset = await handleArtifactSandboxRequest(
+      new Request(`https://${host}/style.css`, {
+        headers: { Cookie: cookie ?? '' },
+      }),
+    )
+
+    expect(asset.status).toBe(200)
+    await expect(asset.text()).resolves.toBe('body{}')
+    expect(storageMock.headArtifact).toHaveBeenCalledWith(
+      {},
+      'ws-a/abc123def4/v-bundle/style.css',
+    )
+    expect(storageMock.getArtifact).toHaveBeenLastCalledWith(
+      {},
+      'ws-a/abc123def4/v-bundle/style.css',
+    )
+  })
+
+  test('keeps index fallback for anonymous bundle cookies without touching D1', async () => {
+    envMock.APP_ENV = 'production'
+    await dbRef
+      .current!.updateTable('shareables')
+      .set({ visibility: 'link' })
+      .where('id', '=', 'abc123def4')
+      .execute()
+    await dbRef
+      .current!.updateTable('versions')
+      .set({ fallback_to_index: 1 })
+      .where('id', '=', 'v-bundle')
+      .execute()
+    storageMock.getArtifact
+      .mockResolvedValueOnce(
+        storedArtifact('<!doctype html><body>Link</body>', 'text/html'),
+      )
+      .mockResolvedValueOnce(
+        storedArtifact('<!doctype html><body>Fallback</body>', 'text/html'),
+      )
+    storageMock.headArtifact.mockImplementation(async (_bucket, key: string) =>
+      key.endsWith('/index.html')
+        ? storedHeadArtifact(
+            '<!doctype html><body>Fallback</body>',
+            'text/html',
+          )
+        : null,
+    )
+    const token = await anonymousEntrypointToken()
+    const host = `${sandboxVersionLabel('abc123def4', 'v-bundle')}.artifactshare.link`
+
+    const entrypoint = await handleArtifactSandboxRequest(
+      new Request(`https://${host}/?t=${token}`),
+    )
+    const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+    expect(entrypoint.status).toBe(200)
+
+    dbRef.current = null
+    const asset = await handleArtifactSandboxRequest(
+      new Request(`https://${host}/projects/alpha`, {
+        headers: { Cookie: cookie ?? '' },
+      }),
+    )
+
+    expect(asset.status).toBe(200)
+    await expect(asset.text()).resolves.toContain('Fallback')
+    expect(storageMock.headArtifact).toHaveBeenNthCalledWith(
+      1,
+      {},
+      'ws-a/abc123def4/v-bundle/projects/alpha',
+    )
+    expect(storageMock.headArtifact).toHaveBeenNthCalledWith(
+      2,
+      {},
+      'ws-a/abc123def4/v-bundle/index.html',
+    )
+  })
+
+  test('stops serving an anonymous bundle cookie after its ten-minute TTL', async () => {
+    envMock.APP_ENV = 'production'
+    await dbRef
+      .current!.updateTable('shareables')
+      .set({ visibility: 'link' })
+      .where('id', '=', 'abc123def4')
+      .execute()
+    storageMock.getArtifact.mockResolvedValue(
+      storedArtifact('<!doctype html><body>Link</body>', 'text/html'),
+    )
+    const token = await anonymousEntrypointToken()
+    const host = `${sandboxVersionLabel('abc123def4', 'v-bundle')}.artifactshare.link`
+
+    vi.useFakeTimers()
+    try {
+      const entrypoint = await handleArtifactSandboxRequest(
+        new Request(`https://${host}/?t=${token}`),
+      )
+      const cookie = entrypoint.headers.get('Set-Cookie')?.split(';')[0]
+      expect(entrypoint.status).toBe(200)
+
+      await dbRef
+        .current!.updateTable('shareables')
+        .set({ visibility: 'private' })
+        .where('id', '=', 'abc123def4')
+        .execute()
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1000)
+
+      const asset = await handleArtifactSandboxRequest(
+        new Request(`https://${host}/style.css`, {
+          headers: { Cookie: cookie ?? '' },
+        }),
+      )
+
+      expect(asset.status).toBe(401)
+      expect(storageMock.getArtifact).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('serves anonymous link static-site assets when the bundle cookie is invalid', async () => {

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -79,7 +79,14 @@ interface BundleCookiePayload {
   aid: string
   vid: string
   exp: number
+  fallbackToIndex?: boolean
+  r2Prefix?: string
+}
+
+type AnonymousBundleCookiePayload = BundleCookiePayload & {
+  uid: null
   fallbackToIndex: boolean
+  r2Prefix: string
 }
 
 type SandboxIdentity = NonNullable<
@@ -140,6 +147,15 @@ export async function handleArtifactSandboxRequest(
       )
     }
     if (cookie.uid === null) {
+      if (!isAnonymousBundleCookie(cookie)) {
+        return deniedResponse(
+          'anonymous_cookie_invalid',
+          'Invalid token',
+          401,
+          { aid: identity.shareableId, vid: identity.versionId, path },
+          identity,
+        )
+      }
       if (identity.domain !== 'link' && isProduction(env)) {
         return deniedResponse(
           'anonymous_cookie_wrong_domain',
@@ -168,9 +184,6 @@ export async function handleArtifactSandboxRequest(
     return await serveBundleAsset(cookie, path, request)
   }
 
-  if (identity.domain === 'link') {
-    return await serveAnonymousLinkBundleAsset(identity, path, request)
-  }
   return await serveAnonymousLinkBundleAsset(identity, path, request)
 }
 
@@ -289,7 +302,12 @@ async function handleEntrypointRequest(
       )
     }
     const response = await serveEntrypoint(entrypoint, false, responseDomain)
-    if (!response.ok || entrypoint.renderType !== 'static_site') return response
+    if (
+      !response.ok ||
+      entrypoint.renderType !== 'static_site' ||
+      !entrypoint.r2Prefix
+    )
+      return response
     response.headers.append(
       'Set-Cookie',
       await bundleCookieFor(payload, entrypoint),
@@ -397,6 +415,7 @@ interface Entrypoint {
   r2Key: string
   contentType: string | null
   fallbackToIndex: boolean
+  r2Prefix: string | null
 }
 
 async function publishedEntrypoint(
@@ -434,6 +453,7 @@ async function publishedEntrypoint(
       r2Key: version.r2_key,
       contentType: 'text/html; charset=utf-8',
       fallbackToIndex: false,
+      r2Prefix: null,
     }
   }
 
@@ -445,29 +465,43 @@ async function publishedEntrypoint(
     .where('r2_key', '=', payload.fid)
     .executeTakeFirst()
   if (!file) return null
+  const r2Prefix = staticSiteR2PrefixFromEntrypoint(file.r2_key, path)
+  if (!r2Prefix) return null
   return {
     renderType: 'static_site',
     r2Key: file.r2_key,
     contentType: file.mime_type,
     fallbackToIndex: Number(version.fallback_to_index) === 1,
+    r2Prefix,
   }
+}
+
+function staticSiteR2PrefixFromEntrypoint(
+  r2Key: string,
+  path: string,
+): string | null {
+  const suffix = path.slice(1)
+  if (!suffix || !r2Key.endsWith(suffix)) return null
+  return r2Key.slice(0, -suffix.length)
 }
 
 async function bundleCookieFor(
   payload: SandboxPayload,
   entrypoint: Entrypoint,
 ): Promise<string> {
-  const value = await signBundleCookie(
-    {
-      uid: payload.uid,
-      wid: payload.wid,
-      aid: payload.aid,
-      vid: payload.vid,
-      exp: Math.floor(Date.now() / 1000) + COOKIE_TTL_SECONDS,
-      fallbackToIndex: entrypoint.fallbackToIndex,
-    },
-    env.BETTER_AUTH_SECRET,
-  )
+  const cookiePayload: BundleCookiePayload = {
+    uid: payload.uid,
+    wid: payload.wid,
+    aid: payload.aid,
+    vid: payload.vid,
+    exp: Math.floor(Date.now() / 1000) + COOKIE_TTL_SECONDS,
+  }
+  if (payload.uid === null) {
+    if (!entrypoint.r2Prefix) throw new Error('Missing static-site R2 prefix')
+    cookiePayload.fallbackToIndex = entrypoint.fallbackToIndex
+    cookiePayload.r2Prefix = entrypoint.r2Prefix
+  }
+  const value = await signBundleCookie(cookiePayload, env.BETTER_AUTH_SECRET)
   return `${COOKIE_NAME}=${value}; Path=/; Max-Age=${COOKIE_TTL_SECONDS}; HttpOnly; Secure; SameSite=None`
 }
 
@@ -619,18 +653,15 @@ async function serveBundleAsset(
 }
 
 async function serveAnonymousCookieBundleAsset(
-  bundle: BundleCookiePayload,
+  bundle: AnonymousBundleCookiePayload,
   path: string,
   request: Request,
   responseDomain: SandboxResponseDomain,
 ): Promise<Response> {
-  // Static-site uploads store every file below this deterministic prefix (the
-  // same layout as staticSiteR2Prefix in the upload service).
-  const prefix = `${bundle.wid}/${bundle.aid}/${bundle.vid}/`
   const candidates = [
-    { path, key: `${prefix}${path.slice(1)}` },
+    { path, key: `${bundle.r2Prefix}${path.slice(1)}` },
     ...(!hasFileExtension(path) && bundle.fallbackToIndex
-      ? [{ path: '/index.html', key: `${prefix}index.html` }]
+      ? [{ path: '/index.html', key: `${bundle.r2Prefix}index.html` }]
       : []),
   ]
 
@@ -654,6 +685,18 @@ async function serveAnonymousCookieBundleAsset(
     404,
     { aid: bundle.aid, vid: bundle.vid, path },
     responseDomain,
+  )
+}
+
+function isAnonymousBundleCookie(
+  payload: BundleCookiePayload,
+): payload is AnonymousBundleCookiePayload {
+  return (
+    payload.uid === null &&
+    typeof payload.fallbackToIndex === 'boolean' &&
+    typeof payload.r2Prefix === 'string' &&
+    payload.r2Prefix.length > 0 &&
+    payload.r2Prefix.endsWith('/')
   )
 }
 
@@ -1268,9 +1311,11 @@ async function verifyBundleCookie(
     typeof payload.aid !== 'string' ||
     typeof payload.vid !== 'string' ||
     typeof payload.exp !== 'number' ||
-    typeof payload.fallbackToIndex !== 'boolean' ||
-    payload.exp < Math.floor(Date.now() / 1000)
+    payload.exp <= Math.floor(Date.now() / 1000)
   ) {
+    return { kind: 'absent-or-invalid' }
+  }
+  if (payload.uid === null && !isAnonymousBundleCookie(payload)) {
     return { kind: 'absent-or-invalid' }
   }
   return { kind: 'valid', payload }

--- a/apps/web/workers/bundle-sandbox.ts
+++ b/apps/web/workers/bundle-sandbox.ts
@@ -23,7 +23,7 @@ import { renderMarkdownDocument } from '../app/lib/markdown-render'
 import { createDb } from '../app/services/db.server'
 import { checkAnonymousLinkAccess } from '../app/services/link-sharing.server'
 import { consumeJti } from '../app/services/sandbox-jti.server'
-import { getArtifact } from '../app/services/storage.server'
+import { getArtifact, headArtifact } from '../app/services/storage.server'
 import {
   viewerAccessAllowed,
   viewerDisplayCheck,
@@ -45,6 +45,8 @@ import {
 } from '../app/lib/sandbox-block-report'
 
 const COOKIE_NAME = 'as_bnd'
+// Anonymous link bundle grants may outlive a visibility change by this bounded
+// interval; the next entrypoint or expired-cookie asset request rechecks D1.
 const COOKIE_TTL_SECONDS = 10 * 60
 const CSP_HEADER = 'Content-Security-Policy'
 const ROBOTS_HEADER = 'X-Robots-Tag'
@@ -72,11 +74,12 @@ const ENCODER = new TextEncoder()
 const DECODER = new TextDecoder()
 
 interface BundleCookiePayload {
-  uid: string
+  uid: string | null
   wid: string
   aid: string
   vid: string
   exp: number
+  fallbackToIndex: boolean
 }
 
 type SandboxIdentity = NonNullable<
@@ -113,30 +116,62 @@ export async function handleArtifactSandboxRequest(
     return await handleEntrypointRequest(request, url, identity, path, token)
   }
 
-  if (identity.domain === 'link') {
-    return await serveAnonymousLinkBundleAsset(identity, path, request)
-  }
-
   const cookieResult = await verifyBundleCookie(
     cookieValue(request.headers.get('Cookie'), COOKIE_NAME),
     env.BETTER_AUTH_SECRET,
   )
-  if (cookieResult.kind !== 'valid') {
+  if (cookieResult.kind === 'valid') {
+    const cookie = cookieResult.payload
+    if (
+      identity !== null &&
+      (cookie.aid !== identity.shareableId || cookie.vid !== identity.versionId)
+    ) {
+      return deniedResponse(
+        'cookie_identity_mismatch',
+        'Invalid token',
+        401,
+        {
+          aid: identity.shareableId,
+          vid: identity.versionId,
+          cookieAid: cookie.aid,
+          path,
+        },
+        identity,
+      )
+    }
+    if (cookie.uid === null) {
+      if (identity.domain !== 'link' && isProduction(env)) {
+        return deniedResponse(
+          'anonymous_cookie_wrong_domain',
+          'Invalid token',
+          401,
+          {
+            aid: identity.shareableId,
+            vid: identity.versionId,
+            path,
+          },
+          anonymousResponseDomain(identity),
+        )
+      }
+      return await serveAnonymousCookieBundleAsset(
+        cookie,
+        path,
+        request,
+        anonymousResponseDomain(identity),
+      )
+    }
+    if (identity.domain === 'link') {
+      // Authenticated cookies are host-scoped in normal browsers, but do not
+      // allow a manually replayed viewer cookie to become a link grant.
+      return await serveAnonymousLinkBundleAsset(identity, path, request)
+    }
+    return await serveBundleAsset(cookie, path, request)
+  }
+
+  if (identity.domain === 'link') {
     return await serveAnonymousLinkBundleAsset(identity, path, request)
   }
-  const cookie = cookieResult.payload
-  if (
-    identity !== null &&
-    (cookie.aid !== identity.shareableId || cookie.vid !== identity.versionId)
-  ) {
-    return deniedResponse('cookie_identity_mismatch', 'Invalid token', 401, {
-      aid: identity.shareableId,
-      vid: identity.versionId,
-      cookieAid: cookie.aid,
-      path,
-    })
-  }
-  return await serveBundleAsset(cookie, path, request)
+  return await serveAnonymousLinkBundleAsset(identity, path, request)
 }
 
 function sandboxProbeResponse(
@@ -253,7 +288,13 @@ async function handleEntrypointRequest(
         responseDomain,
       )
     }
-    return await serveEntrypoint(entrypoint, false, responseDomain)
+    const response = await serveEntrypoint(entrypoint, false, responseDomain)
+    if (!response.ok || entrypoint.renderType !== 'static_site') return response
+    response.headers.append(
+      'Set-Cookie',
+      await bundleCookieFor(payload, entrypoint),
+    )
+    return response
   }
 
   const db = createDb()
@@ -316,16 +357,7 @@ async function handleEntrypointRequest(
     return await serveEntrypoint(entrypoint, payload.emb === true)
   }
 
-  const cookie = `${COOKIE_NAME}=${await signBundleCookie(
-    {
-      uid: payload.uid,
-      wid: payload.wid,
-      aid: payload.aid,
-      vid: payload.vid,
-      exp: Math.floor(Date.now() / 1000) + COOKIE_TTL_SECONDS,
-    },
-    env.BETTER_AUTH_SECRET,
-  )}; Path=/; Max-Age=${COOKIE_TTL_SECONDS}; HttpOnly; Secure; SameSite=None`
+  const cookie = await bundleCookieFor(payload, entrypoint)
   const redirectTarget = sameOriginRedirectTarget(url)
   if (redirectTarget) {
     const redirect = new Response(null, {
@@ -364,6 +396,7 @@ interface Entrypoint {
   renderType: ArtifactType
   r2Key: string
   contentType: string | null
+  fallbackToIndex: boolean
 }
 
 async function publishedEntrypoint(
@@ -383,6 +416,7 @@ async function publishedEntrypoint(
       'versions.entrypoint_path',
       'versions.r2_key',
       'shareables.current_version_id',
+      'versions.fallback_to_index',
     ])
     .where('shareables.id', '=', payload.aid)
     .where('shareables.workspace_id', '=', payload.wid)
@@ -399,6 +433,7 @@ async function publishedEntrypoint(
       renderType: payload.t,
       r2Key: version.r2_key,
       contentType: 'text/html; charset=utf-8',
+      fallbackToIndex: false,
     }
   }
 
@@ -414,7 +449,26 @@ async function publishedEntrypoint(
     renderType: 'static_site',
     r2Key: file.r2_key,
     contentType: file.mime_type,
+    fallbackToIndex: Number(version.fallback_to_index) === 1,
   }
+}
+
+async function bundleCookieFor(
+  payload: SandboxPayload,
+  entrypoint: Entrypoint,
+): Promise<string> {
+  const value = await signBundleCookie(
+    {
+      uid: payload.uid,
+      wid: payload.wid,
+      aid: payload.aid,
+      vid: payload.vid,
+      exp: Math.floor(Date.now() / 1000) + COOKIE_TTL_SECONDS,
+      fallbackToIndex: entrypoint.fallbackToIndex,
+    },
+    env.BETTER_AUTH_SECRET,
+  )
+  return `${COOKIE_NAME}=${value}; Path=/; Max-Age=${COOKIE_TTL_SECONDS}; HttpOnly; Secure; SameSite=None`
 }
 
 function artifactKindForToken(renderType: ArtifactType): ArtifactKind | null {
@@ -475,7 +529,7 @@ async function serveEntrypoint(
 }
 
 async function serveBundleAsset(
-  bundle: { uid?: string; wid: string; aid: string; vid: string },
+  bundle: { uid?: string | null; wid: string; aid: string; vid: string },
   path: string,
   request: Request,
   responseDomain?: SandboxResponseDomain,
@@ -562,6 +616,45 @@ async function serveBundleAsset(
     )
   }
   return await serveBundleFile(fallback, request, responseDomain)
+}
+
+async function serveAnonymousCookieBundleAsset(
+  bundle: BundleCookiePayload,
+  path: string,
+  request: Request,
+  responseDomain: SandboxResponseDomain,
+): Promise<Response> {
+  // Static-site uploads store every file below this deterministic prefix (the
+  // same layout as staticSiteR2Prefix in the upload service).
+  const prefix = `${bundle.wid}/${bundle.aid}/${bundle.vid}/`
+  const candidates = [
+    { path, key: `${prefix}${path.slice(1)}` },
+    ...(!hasFileExtension(path) && bundle.fallbackToIndex
+      ? [{ path: '/index.html', key: `${prefix}index.html` }]
+      : []),
+  ]
+
+  for (const candidate of candidates) {
+    const object = await headArtifact(env.BUCKET, candidate.key)
+    if (!object) continue
+    return await serveBundleFile(
+      {
+        r2_key: candidate.key,
+        mime_type: object.httpMetadata?.contentType ?? null,
+        size_bytes: object.size,
+      },
+      request,
+      responseDomain,
+    )
+  }
+
+  return deniedResponse(
+    'bundle_file_missing',
+    'This artifact is unavailable.',
+    404,
+    { aid: bundle.aid, vid: bundle.vid, path },
+    responseDomain,
+  )
 }
 
 function activeLinkExpiry(now: string) {
@@ -1169,12 +1262,13 @@ async function verifyBundleCookie(
     return { kind: 'absent-or-invalid' }
   }
   if (
-    typeof payload.uid !== 'string' ||
-    payload.uid.length === 0 ||
+    (payload.uid !== null &&
+      (typeof payload.uid !== 'string' || payload.uid.length === 0)) ||
     typeof payload.wid !== 'string' ||
     typeof payload.aid !== 'string' ||
     typeof payload.vid !== 'string' ||
     typeof payload.exp !== 'number' ||
+    typeof payload.fallbackToIndex !== 'boolean' ||
     payload.exp < Math.floor(Date.now() / 1000)
   ) {
     return { kind: 'absent-or-invalid' }


### PR DESCRIPTION
## What changed

Anonymous static-site link entrypoints now issue a signed, ten-minute bundle cookie carrying the verified artifact identity, upload-time R2 prefix, and index-fallback decision. Requests for bundle assets authorized by that cookie go straight to R2 HEAD/GET and avoid a D1 lookup for each asset.

The existing visibility boundary is preserved by the bounded cookie TTL: a new entrypoint or an expired grant rechecks authorization in D1. The asset path keeps serving the stored upload-time prefix after workspace migration, and index fallback remains available without per-asset D1 reads.

Authenticated bundle cookies issued before the schema extension remain valid. The exact expiration boundary and anonymous, migrated-prefix, fallback, and no-D1 paths have regression coverage.

## Validation

- `pnpm validate:static` — passed (format, lint, guards, D1 checks, script checks, typechecks, unit tests, React Doctor score 100, public scan 0)
- `pnpm --filter @artifactshare/web build:sandbox` — passed
- `pnpm public:scan .` — 0 findings
- `git diff --check` — passed
- Trusted `origin/main` boundary guard — passed

## Review

Codex and Claude independently reviewed both committed candidates. The initial pair's blockers were fixed in the correction commit: legacy authenticated-cookie compatibility, the exact TTL boundary, and the upload-time R2 prefix after workspace migration. A duplicate branch and the HEAD/GET round-trip tradeoff were classified non-actionable. The correction pair returned GO with no unresolved blockers; two observations outside the trusted deterministic upload layout remain follow-ups.

## Workflow usage

| execution | requested model / effort | observed model / effort | elapsed | normalized input | cache read | cache write | output | total | result |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| implementation (initial) | coordinator / manual | n/a | unknown | unknown | unknown | unknown | unknown | unknown | committed initial candidate |
| Codex review (initial) | gpt-5.6-sol / medium | gpt-5.6-sol / medium (usage not reported) | 337s | unknown | unknown | unknown | unknown | unknown | completed; blockers fixed |
| Claude review (initial) | claude-opus-5 / high | claude-opus-5 + claude-haiku-4-5-20251001 / high | 503s | 1,727,420 | 1,549,334 | 167,173 | 38,509 | 1,765,929 | completed; findings fixed |
| implementation (correction) | coordinator / manual | n/a | unknown | unknown | unknown | unknown | unknown | unknown | committed correction candidate |
| Codex review (correction) | gpt-5.6-sol / medium | gpt-5.6-sol / medium (usage not reported) | 164s | unknown | unknown | unknown | unknown | unknown | GO |
| Claude review (correction) | claude-opus-5 / high | claude-opus-5 + adapter model (partial usage) / high | 323s | unknown | unknown | unknown | unknown | unknown | GO |
