### PR TITLE
fix: remove implementation review candidate cap

### DIFF
--- a/scripts/implementation-review-gate.test.mjs
+++ b/scripts/implementation-review-gate.test.mjs
@@ -29,7 +29,12 @@ import {
 import { finalReviews } from './agent-role-settings.mjs'
 import { reviewReminder } from './codex-review.mjs'
 import { readRounds, roundsPath } from './review-rounds.mjs'
-import { taskScopeContext } from './task-scope.mjs'
+import {
+  initializeTaskScope,
+  readTaskScopeState,
+  taskScopeContext,
+  taskScopeStatus,
+} from './task-scope.mjs'
 
 const head = 'a'.repeat(40)
 const base = 'b'.repeat(40)
@@ -42,7 +47,6 @@ const scope = {
   ],
   trusted_inputs: ['A clean attached task branch'],
   manual_recovery: 'Start a fresh branch and scope.',
-  max_corrections: 1,
 }
 
 function scopeHarness(overrides = {}) {
@@ -351,6 +355,105 @@ test('hands second-candidate dispositions to both reviewers from one stable snap
     assert.doesNotMatch(snapshots[0], /None yet/u)
   } finally {
     rmSync(fixture.directory, { recursive: true, force: true })
+  }
+})
+
+test('reviews third and later committed candidates through the real scope admission path', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'implementation-multi-candidate-'))
+  const repo = join(root, 'repo')
+  const template = join(root, 'git-template')
+  const globalConfig = join(root, 'global.gitconfig')
+  const dispositionsPath = join(root, 'dispositions.md')
+  mkdirSync(repo)
+  mkdirSync(template)
+  writeFileSync(globalConfig, '')
+  writeFileSync(dispositionsPath, 'None yet\n')
+  const gitEnvironment = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: globalConfig,
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_TEMPLATE_DIR: template,
+  }
+  const git = (args) =>
+    execFileSync('git', ['-C', repo, ...args], {
+      encoding: 'utf8',
+      env: gitEnvironment,
+    }).trim()
+  const commit = (content, message) => {
+    writeFileSync(join(repo, 'file.txt'), `${content}\n`)
+    git(['add', 'file.txt'])
+    git([
+      '-c',
+      'user.name=Test',
+      '-c',
+      'user.email=test@example.test',
+      'commit',
+      '-m',
+      message,
+    ])
+    return git(['rev-parse', 'HEAD'])
+  }
+  try {
+    git(['init', '-b', 'main'])
+    const baseHead = commit('base', 'base')
+    git(['switch', '-c', 'feature'])
+    const run = (file, args) => {
+      const output = execFileSync(file, args, {
+        cwd: repo,
+        encoding: 'utf8',
+        env: gitEnvironment,
+      }).trim()
+      return file === 'git' && args.join(' ') === 'rev-parse --git-common-dir'
+        ? resolvePath(repo, output)
+        : output
+    }
+    initializeTaskScope('feature', scope, run)
+    const candidates = []
+    let launches = 0
+    const reviewCandidate = (corrected) =>
+      main({
+        argv: [
+          '--base',
+          baseHead,
+          ...(corrected ? ['--dispositions-file', dispositionsPath] : []),
+        ],
+        run,
+        acquireLock: () => Promise.resolve(() => Promise.resolve()),
+        acquireScopeLock: () => Promise.resolve(() => Promise.resolve()),
+        review: (name) => {
+          launches += 1
+          return Promise.resolve({ name, stdout: `${name} result`, stderr: '' })
+        },
+        log: () => {},
+        timingLog: () => {},
+        recordRounds: () => {},
+      })
+
+    for (const [index, label] of [
+      'first',
+      'second',
+      'third',
+      'fourth',
+    ].entries()) {
+      candidates.push(commit(label, `${label} candidate`))
+      assert.equal(await reviewCandidate(index > 0), 0)
+    }
+    assert.equal(await reviewCandidate(true), 0)
+    assert.equal(launches, 10)
+    assert.deepEqual(
+      readTaskScopeState('feature', run).admitted_heads,
+      candidates,
+    )
+    assert.deepEqual(taskScopeStatus(readTaskScopeState('feature', run)), {
+      status: 'ACTIVE',
+      objective: scope.objective,
+      failures: scope.failures,
+      trusted_inputs: scope.trusted_inputs,
+      manual_recovery: scope.manual_recovery,
+      admitted_candidates: 4,
+    })
+  } finally {
+    rmSync(root, { recursive: true, force: true })
   }
 })
 

--- a/scripts/task-scope.mjs
+++ b/scripts/task-scope.mjs
@@ -18,11 +18,11 @@ const MAX_SCOPE_BYTES = 4 * 1024
 const SCOPE_KEYS = [
   'failures',
   'manual_recovery',
-  'max_corrections',
   'objective',
   'schema_version',
   'trusted_inputs',
 ]
+const LEGACY_SCOPE_KEYS = [...SCOPE_KEYS, 'max_corrections'].sort()
 
 function commandOutput(file, args) {
   return execFileSync(file, args, { encoding: 'utf8' }).trim()
@@ -58,16 +58,20 @@ function nonempty(value, label) {
   return value.trim()
 }
 
-export function validateTaskScope(value) {
+function validateTaskScopeShape(value, { allowLegacyLimit = false } = {}) {
   if (!value || typeof value !== 'object' || Array.isArray(value))
     throw new Error('Task scope must be a JSON object.')
-  if (Object.keys(value).sort().join(',') !== SCOPE_KEYS.join(','))
+  const keys = Object.keys(value).sort()
+  const expectedKeys = [...SCOPE_KEYS].sort()
+  const legacy =
+    allowLegacyLimit && keys.join(',') === LEGACY_SCOPE_KEYS.join(',')
+  if (!legacy && keys.join(',') !== expectedKeys.join(','))
     throw new Error(
-      `Task scope fields must be exactly: ${SCOPE_KEYS.join(', ')}.`,
+      `Task scope fields must be exactly: ${expectedKeys.join(', ')}.`,
     )
   if (value.schema_version !== 1)
     throw new Error('Task scope schema_version must be 1.')
-  if (value.max_corrections !== 1)
+  if (legacy && value.max_corrections !== 1)
     throw new Error('Task scope max_corrections must be 1.')
   if (
     !Array.isArray(value.failures) ||
@@ -107,8 +111,11 @@ export function validateTaskScope(value) {
       nonempty(item, `trusted_inputs item ${index + 1}`),
     ),
     manual_recovery: nonempty(value.manual_recovery, 'manual_recovery'),
-    max_corrections: 1,
   }
+}
+
+export function validateTaskScope(value) {
+  return validateTaskScopeShape(value)
 }
 
 export function readScopeFile(path) {
@@ -153,7 +160,9 @@ export function readTaskScopeState(branch, run = commandOutput) {
     state.admitted_heads.some((head) => !/^[0-9a-f]{40}$/u.test(head))
   )
     throw new Error(`Task scope state for branch ${branch} is invalid.`)
-  const scope = validateTaskScope(state.scope)
+  // Scopes persisted before correction limits were removed remain usable. The
+  // obsolete limit is normalized away and is not written on the next update.
+  const scope = validateTaskScopeShape(state.scope, { allowLegacyLimit: true })
   return {
     schema_version: 1,
     branch,
@@ -193,29 +202,19 @@ export function admitTaskCandidate(branch, head, run = commandOutput) {
     throw new Error('Task candidate HEAD is invalid.')
   const state = readTaskScopeState(branch, run)
   if (state.admitted_heads.includes(head)) return state
-  const limit = 1 + state.scope.max_corrections
-  if (state.admitted_heads.length >= limit)
-    throw new Error(
-      `OBJECTIVE_REBASE_REQUIRED: ${state.scope.objective} (${state.scope.failures.length} named failures; ${limit} candidates already admitted). Start a fresh branch and scope from the objective.`,
-    )
   state.admitted_heads.push(head)
   writeState(taskScopePaths(branch, run).state, state)
   return state
 }
 
 export function taskScopeStatus(state) {
-  const limit = 1 + state.scope.max_corrections
   return {
-    status:
-      state.admitted_heads.length >= limit
-        ? 'OBJECTIVE_REBASE_REQUIRED'
-        : 'ACTIVE',
+    status: 'ACTIVE',
     objective: state.scope.objective,
     failures: state.scope.failures,
     trusted_inputs: state.scope.trusted_inputs,
     manual_recovery: state.scope.manual_recovery,
     admitted_candidates: state.admitted_heads.length,
-    candidate_limit: limit,
   }
 }
 

--- a/scripts/task-scope.test.mjs
+++ b/scripts/task-scope.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -19,14 +19,13 @@ import {
 
 const scope = {
   schema_version: 1,
-  objective: 'Stop implementation review after one correction.',
+  objective: 'Review every correction against one immutable scope.',
   failures: [
     { id: 'I1', scenario: 'A third distinct candidate is submitted.' },
     { id: 'I2', scenario: 'A session resumes on the same task branch.' },
   ],
   trusted_inputs: ['An attached Git branch', 'A clean committed HEAD'],
   manual_recovery: 'Start a fresh branch and initialize a fresh scope.',
-  max_corrections: 1,
 }
 
 function fixture() {
@@ -38,10 +37,14 @@ function fixture() {
   return { directory, run }
 }
 
-test('accepts only the bounded strict scope schema', () => {
+test('accepts only the strict scope schema without a correction limit', () => {
   assert.deepEqual(validateTaskScope(scope), scope)
   assert.throws(
     () => validateTaskScope({ ...scope, extra: true }),
+    /fields must be exactly/u,
+  )
+  assert.throws(
+    () => validateTaskScope({ ...scope, max_corrections: 1 }),
     /fields must be exactly/u,
   )
   assert.throws(
@@ -104,7 +107,6 @@ test('initialization is immutable and status survives a later read', () => {
       trusted_inputs: scope.trusted_inputs,
       manual_recovery: scope.manual_recovery,
       admitted_candidates: 0,
-      candidate_limit: 2,
     })
     assert.throws(() => readTaskScopeState('missing', run), /NO_ACTIVE_SCOPE/u)
   } finally {
@@ -112,28 +114,53 @@ test('initialization is immutable and status survives a later read', () => {
   }
 })
 
-test('admits the initial HEAD and one correction and rejects a third HEAD', () => {
+test('admits third and later distinct HEADs and allows same-HEAD reruns', () => {
   const { directory, run } = fixture()
   const first = 'a'.repeat(40)
-  const correction = 'b'.repeat(40)
+  const corrections = ['b', 'c', 'd'].map((value) => value.repeat(40))
   try {
     initializeTaskScope('feature', scope, run)
     admitTaskCandidate('feature', first, run)
     assert.deepEqual(admitTaskCandidate('feature', first, run).admitted_heads, [
       first,
     ])
+    for (const correction of corrections)
+      admitTaskCandidate('feature', correction, run)
+    const admitted = [first, ...corrections]
     assert.deepEqual(
-      admitTaskCandidate('feature', correction, run).admitted_heads,
-      [first, correction],
+      readTaskScopeState('feature', run).admitted_heads,
+      admitted,
     )
-    assert.throws(
-      () => admitTaskCandidate('feature', 'c'.repeat(40), run),
-      /OBJECTIVE_REBASE_REQUIRED/u,
+    assert.deepEqual(
+      admitTaskCandidate('feature', corrections[1], run).admitted_heads,
+      admitted,
     )
-    assert.deepEqual(readTaskScopeState('feature', run).admitted_heads, [
-      first,
-      correction,
-    ])
+    assert.deepEqual(taskScopeStatus(readTaskScopeState('feature', run)), {
+      status: 'ACTIVE',
+      objective: scope.objective,
+      failures: scope.failures,
+      trusted_inputs: scope.trusted_inputs,
+      manual_recovery: scope.manual_recovery,
+      admitted_candidates: 4,
+    })
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('normalizes the obsolete persisted correction limit without changing scope', () => {
+  const { directory, run } = fixture()
+  try {
+    initializeTaskScope('feature', scope, run)
+    const path = taskScopePaths('feature', run).state
+    const legacy = JSON.parse(readFileSync(path, 'utf8'))
+    legacy.scope.max_corrections = 1
+    writeFileSync(path, `${JSON.stringify(legacy)}\n`)
+
+    assert.deepEqual(readTaskScopeState('feature', run).scope, scope)
+    admitTaskCandidate('feature', 'a'.repeat(40), run)
+    const persisted = JSON.parse(readFileSync(path, 'utf8'))
+    assert.deepEqual(persisted.scope, scope)
   } finally {
     rmSync(directory, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- Remove the fixed correction-commit limit from implementation-review task scopes.
- Admit and review every distinct committed HEAD on the same immutable branch scope while allowing same-HEAD reruns.
- Preserve strict new-scope validation, legacy persisted-scope normalization, correction dispositions, clean-target checks, locks, and review history.
- Add focused coverage for four committed candidates and a same-HEAD rerun through the real gate admission path.

## Validation

- `node --test scripts/task-scope.test.mjs scripts/implementation-review-gate.test.mjs`
- `pnpm verify`
- `git diff --check`

All checks passed: 605 script tests, formatting, lint, public scan, hook/guard checks, and test audit.

## Review

An independent fixed-snapshot Codex/Claude review found no blockers. Two small P3 refactoring suggestions were assessed as non-actionable because they do not affect the requested behavior.

## Workflow usage

<!-- artifactshare:workflow-usage:start -->
**Target commit:** `20d717bf87a13a430dfbfb8079f24432946dc212`
**Workflow usage coverage:** partial
**Measured total:** 3809912 in / 17167 out / 3827079 total (cache read 3660416, cache write 0)
**Complete total:** unknown
**Wall elapsed:** 635480 ms
**Sum of invocation durations:** 635480 ms

| Stage | Attempt | Provider | Requested model | Requested effort | Reported effort | Reported models | Outcome | Duration | Usage source | Tokens | Reason |
| --- | ---: | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- |
| implementation | 1 | codex | gpt-5.6-sol | medium | unknown | gpt-5.6-sol | succeeded | 635480 ms | ccusage_interval | 3809912 in / 17167 out / 3827079 total (cache read 3660416, cache write 0) | reported_effort_unavailable |

**Coverage reasons:**
- reported_effort_unavailable
<!-- artifactshare:workflow-usage:end -->
