### PR TITLE
fix: make workflow usage and landing records optional

### DIFF
--- a/scripts/pr-landed.mjs
+++ b/scripts/pr-landed.mjs
@@ -10,23 +10,16 @@ import {
   writeLedgerAtomic,
 } from './landing-ledger.mjs'
 
-/** Run after a PR lands. It finishes the local lifecycle and forces every
- * finding the change deferred to reach a disposition, which is the step no
- * feature task ever reaches on its own: mid-change the right call is to keep
- * the scope, and by the time it lands nobody is looking. */
+/** Run after a PR lands. It finishes the local lifecycle, releases the landing
+ * ledger entry, fast-forwards main, and removes the merged branch when safe. */
 
 function output(exec, file, args) {
   return exec(file, args, { encoding: 'utf8' }).trim()
 }
 
-/** `fixed` closes a deferral the change ended up addressing after all: reruns
- * of `pr:ready` merge rather than replace, so an item recorded once stays until
- * it is dispositioned here. */
-const DISPOSITIONS = new Set(['issue', 'promoted', 'dropped', 'fixed'])
-
 export function parseLandedArgs(args) {
   const normalized = args[0] === '--' ? args.slice(1) : args
-  const values = { pr: undefined, dispositions: [], dryRun: false }
+  const values = { pr: undefined, dryRun: false }
   for (let index = 0; index < normalized.length; index += 1) {
     const name = normalized[index]
     if (name === '--dry-run') {
@@ -36,7 +29,6 @@ export function parseLandedArgs(args) {
     const value = normalized[++index]
     if (!value || value.startsWith('--')) throw new Error(usage())
     if (name === '--pr') values.pr = Number.parseInt(value, 10)
-    else if (name === '--disposition') values.dispositions.push(value)
     else throw new Error(usage())
   }
   if (!Number.isInteger(values.pr) || values.pr <= 0) throw new Error(usage())
@@ -44,23 +36,7 @@ export function parseLandedArgs(args) {
 }
 
 function usage() {
-  return 'Usage: pnpm pr:landed -- --pr <number> [--disposition issue|promoted|dropped|fixed:<note> ...] [--dry-run]'
-}
-
-/** A disposition is `kind:note`. `dropped` states why the item is not worth
- * doing; `issue` and `promoted` name where it went. A bare kind is refused so
- * that "handled" always carries evidence. */
-export function parseDisposition(raw) {
-  const separator = raw.indexOf(':')
-  if (separator <= 0) throw new Error(`disposition needs kind:note — ${raw}`)
-  const kind = raw.slice(0, separator).trim()
-  const note = raw.slice(separator + 1).trim()
-  if (!DISPOSITIONS.has(kind))
-    throw new Error(
-      `disposition kind must be issue, promoted, dropped, or fixed — ${raw}`,
-    )
-  if (note === '') throw new Error(`disposition needs a note — ${raw}`)
-  return { kind, note }
+  return 'Usage: pnpm pr:landed -- --pr <number> [--dry-run]'
 }
 
 /** Registered worktrees with the branch each has checked out (`null` when
@@ -133,9 +109,9 @@ export function landed({
       `The landing ledger at ${path} could not be read. Repair or remove it, then retry.`,
     )
   // A change that deferred nothing still finishes its lifecycle here, so a
-  // missing entry means "nothing to discharge" rather than an error.
+  // missing entry means "nothing to release" rather than an error.
   const entry = outstandingEntries(state).find((row) => row.pr === parsed.pr)
-  const deferred = entry?.deferred ?? []
+  const releasedDeferred = entry?.deferred.length ?? 0
 
   const view = JSON.parse(
     output(exec, 'gh', [
@@ -146,40 +122,18 @@ export function landed({
       'state,headRefName',
     ]),
   )
-  // A PR closed without merging still has to release its deferrals, or every
+  // A PR closed without merging still has to release its ledger entry, or every
   // later publish is refused with no way out but editing the ledger by hand.
   if (view.state !== 'MERGED' && view.state !== 'CLOSED')
     throw new Error(
-      `PR #${parsed.pr} is ${view.state}; discharge it once it has landed or been closed.`,
+      `PR #${parsed.pr} is ${view.state}; finish it once it has landed or been closed.`,
     )
-
-  const dispositions = parsed.dispositions.map(parseDisposition)
-  if (dispositions.length !== deferred.length)
-    throw new Error(
-      [
-        `PR #${parsed.pr} deferred ${deferred.length} finding(s); ${dispositions.length} disposition(s) given.`,
-        ...(deferred.length === 0
-          ? [
-              'This ledger holds no entry for that PR. It may already be discharged, the number may be wrong, or the record may belong to another checkout.',
-              'If it was discharged, rerun without --disposition to finish the local cleanup.',
-            ]
-          : []),
-        ...deferred.map((item, index) => `  ${index + 1}. ${item}`),
-        'Give one --disposition issue|promoted|dropped|fixed:<note> per item, in the same order.',
-      ].join('\n'),
-    )
-  // Pair each note with the finding it answers. A count alone lets a note be
-  // recorded against the wrong item, and this pairing is the record the
-  // workflow promises.
-  const discharged = deferred.map((finding, index) => ({
-    finding,
-    ...dispositions[index],
-  }))
 
   const problems = []
   const notes = []
   if (!parsed.dryRun) {
-    // Discharge first. The sync and branch cleanup below are conveniences that
+    // Release the ledger entry first. The sync and branch cleanup below are
+    // conveniences that
     // fail for ordinary local reasons — a linked worktree already on main, a
     // dirty tree, a non-fast-forward pull — and leaving the entry behind then
     // blocks every later publish with no way out but editing the file by hand.
@@ -236,7 +190,7 @@ export function landed({
   return {
     pr: parsed.pr,
     state: view.state,
-    discharged,
+    releasedDeferred,
     notes,
     problems,
     // The lifecycle is only finished when the cleanup finished too, and the
@@ -255,18 +209,13 @@ if (
     process.exitCode = result.exitCode
     process.stdout.write(
       [
-        `${result.dryRun ? 'Would discharge' : 'Discharged'} ${result.discharged.length} deferred finding(s) for PR #${result.pr} (${result.state}).`,
-        ...result.discharged.map(
-          (item) => `  ${item.kind}: ${item.finding} — ${item.note}`,
-        ),
+        `${result.dryRun ? 'Would finish' : 'Finished'} landing cleanup for PR #${result.pr} (${result.state}); ${result.releasedDeferred} deferred finding(s) released.`,
         ...result.notes.map((note) => `  ${note}`),
         ...result.problems.map(
           (problem) => `  local cleanup did not finish: ${problem}`,
         ),
         ...(result.problems.length > 0
-          ? [
-              '  The ledger is settled; rerun without --disposition once the checkout is clean.',
-            ]
+          ? ['  The ledger is settled; rerun once the checkout is clean.']
           : []),
         '',
       ].join('\n'),

--- a/scripts/pr-landed.test.mjs
+++ b/scripts/pr-landed.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { landed, parseDisposition, parseLandedArgs } from './pr-landed.mjs'
+import { landed, parseLandedArgs } from './pr-landed.mjs'
 import {
   readLedger,
   recordDeferred,
@@ -93,43 +93,40 @@ function harness({
   return { calls, exec }
 }
 
-test('a disposition must name a kind and a note', () => {
-  assert.deepEqual(parseDisposition('issue:filed as #1666'), {
-    kind: 'issue',
-    note: 'filed as #1666',
-  })
-  assert.throws(() => parseDisposition('issue'), /kind:note/u)
-  assert.throws(() => parseDisposition('issue:'), /needs a note/u)
-  assert.throws(() => parseDisposition('later:next time'), /must be issue/u)
-})
-
 test('a PR number is required', () => {
   assert.throws(() => parseLandedArgs([]), /Usage/u)
-  assert.deepEqual(parseLandedArgs(['--pr', '7']).pr, 7)
-})
-
-test('every deferred finding needs its own disposition', () => {
-  const h = harness()
+  assert.deepEqual(parseLandedArgs(['--pr', '7']), { pr: 7, dryRun: false })
+  assert.deepEqual(parseLandedArgs(['--', '--pr', '7', '--dry-run']), {
+    pr: 7,
+    dryRun: true,
+  })
   assert.throws(
-    () =>
-      landed({
-        exec: h.exec,
-        parsed: { pr: 7, dispositions: ['issue:filed'], dryRun: false },
-        ledger: ledgerWith(['name the select', 'evict snapshots']),
-      }),
-    /deferred 2 finding\(s\); 1 disposition\(s\) given/u,
+    () => parseLandedArgs(['--pr', '7', '--disposition', 'issue:filed']),
+    /Usage/u,
   )
 })
 
-test('discharging clears the entry and finishes the local lifecycle', () => {
+test('deferred findings are released without landing dispositions', () => {
+  const h = harness()
+  const path = ledgerWith(['name the select', 'evict snapshots'])
+  const result = landed({
+    exec: h.exec,
+    parsed: { pr: 7, dryRun: false },
+    ledger: path,
+  })
+  assert.equal(result.releasedDeferred, 2)
+  assert.deepEqual(readLedger(path).entries, [])
+})
+
+test('landing clears the entry and finishes the local lifecycle', () => {
   const h = harness()
   const path = ledgerWith(['name the select'])
   const result = landed({
     exec: h.exec,
-    parsed: { pr: 7, dispositions: ['issue:filed as #1666'], dryRun: false },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
-  assert.equal(result.discharged.length, 1)
+  assert.equal(result.releasedDeferred, 1)
   assert.deepEqual(readLedger(path).entries, [])
   const commands = h.calls.map(([file, args]) => `${file} ${args.join(' ')}`)
   assert.ok(!commands.includes('git checkout main'))
@@ -143,7 +140,7 @@ test('from a feature worktree it syncs main where it is checked out and parks th
   const h = harness({ here: '/repo/feature', mainWorktree: '/repo/main' })
   const result = landed({
     exec: h.exec,
-    parsed: { pr: 7, dispositions: ['issue:filed as #1666'], dryRun: false },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
   assert.equal(result.exitCode, 0)
@@ -164,7 +161,7 @@ test('a feature worktree on another branch is left alone while the merged branch
   })
   const result = landed({
     exec: h.exec,
-    parsed: { pr: 7, dispositions: ['issue:filed as #1666'], dryRun: false },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
   assert.equal(result.exitCode, 0)
@@ -187,7 +184,7 @@ test('a closed but unmerged PR does not move the worktree', () => {
       : h.exec(file, args)
   landed({
     exec,
-    parsed: { pr: 7, dispositions: ['issue:filed as #1666'], dryRun: false },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
   const commands = h.calls.map(([file, args]) => `${file} ${args.join(' ')}`)
@@ -205,7 +202,7 @@ test('a merged branch is recognised only by its full ref', () => {
       : h.exec(file, args)
   const result = landed({
     exec,
-    parsed: { pr: 7, dispositions: ['issue:filed as #1666'], dryRun: false },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
   const commands = h.calls.map(([file, args]) => `${file} ${args.join(' ')}`)
@@ -223,7 +220,7 @@ test('without a worktree on main it refuses to hijack main into a feature worktr
   })
   const result = landed({
     exec: h.exec,
-    parsed: { pr: 7, dispositions: ['issue:filed as #1666'], dryRun: false },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
   assert.equal(result.exitCode, 1)
@@ -242,7 +239,7 @@ test('in the main checkout with main not checked out it checks main out here', (
   })
   landed({
     exec: h.exec,
-    parsed: { pr: 7, dispositions: ['issue:filed as #1666'], dryRun: false },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
   const commands = h.calls.map(([file, args]) => `${file} ${args.join(' ')}`)
@@ -250,24 +247,24 @@ test('in the main checkout with main not checked out it checks main out here', (
   assert.ok(commands.includes('git pull --ff-only'))
 })
 
-test('a PR with no record discharges nothing and still succeeds', () => {
+test('a PR with no record releases nothing and still succeeds', () => {
   const h = harness()
   const result = landed({
     exec: h.exec,
-    parsed: { pr: 99, dispositions: [], dryRun: false },
+    parsed: { pr: 99, dryRun: false },
     ledger: ledgerWith(['name the select']),
   })
-  assert.deepEqual(result.discharged, [])
+  assert.equal(result.releasedDeferred, 0)
 })
 
 test('a change that deferred nothing still finishes its lifecycle', () => {
   const h = harness()
   const result = landed({
     exec: h.exec,
-    parsed: { pr: 7, dispositions: [], dryRun: false },
+    parsed: { pr: 7, dryRun: false },
     ledger: emptyLedger(),
   })
-  assert.deepEqual(result.discharged, [])
+  assert.equal(result.releasedDeferred, 0)
   const commands = h.calls.map(([file, args]) => `${file} ${args.join(' ')}`)
   assert.ok(commands.includes('git pull --ff-only'))
   assert.ok(commands.includes('git branch -D feat/x'))
@@ -278,32 +275,28 @@ test('a PR closed without merging can still release its deferrals', () => {
   const path = ledgerWith(['name the select'])
   const result = landed({
     exec: h.exec,
-    parsed: {
-      pr: 7,
-      dispositions: ['dropped:the screen was removed'],
-      dryRun: false,
-    },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
   assert.equal(result.state, 'CLOSED')
   assert.deepEqual(readLedger(path).entries, [])
 })
 
-test('each disposition is recorded against the finding it answers', () => {
+test('dry run verifies the PR state without releasing or cleaning up', () => {
   const h = harness()
+  const path = ledgerWith(['name the select'])
   const result = landed({
     exec: h.exec,
-    parsed: {
-      pr: 7,
-      dispositions: ['issue:filed as #1666', 'dropped:single occurrence'],
-      dryRun: false,
-    },
-    ledger: ledgerWith(['name the select', 'evict snapshots']),
+    parsed: { pr: 7, dryRun: true },
+    ledger: path,
   })
-  assert.deepEqual(result.discharged, [
-    { finding: 'name the select', kind: 'issue', note: 'filed as #1666' },
-    { finding: 'evict snapshots', kind: 'dropped', note: 'single occurrence' },
-  ])
+  assert.equal(result.releasedDeferred, 1)
+  assert.equal(result.dryRun, true)
+  assert.equal(
+    h.calls.some(([file]) => file === 'git'),
+    false,
+  )
+  assert.equal(readLedger(path).entries.length, 1)
 })
 
 test('an unlanded PR is refused', () => {
@@ -312,16 +305,16 @@ test('an unlanded PR is refused', () => {
     () =>
       landed({
         exec: h.exec,
-        parsed: { pr: 7, dispositions: ['dropped:x'], dryRun: false },
+        parsed: { pr: 7, dryRun: false },
         ledger: ledgerWith(['name the select']),
       }),
-    /is OPEN; discharge it once it has landed/u,
+    /is OPEN; finish it once it has landed/u,
   )
 })
 
 test('local cleanup failure does not leave the deferral blocking every publish', () => {
   // A linked worktree already on main, a dirty tree, or a non-ff pull must not
-  // strand the entry: the discharge is the point, the sync is convenience.
+  // strand the entry: releasing it is part of landing; sync is convenience.
   const path = ledgerWith(['name the select'])
   const exec = (file, args) => {
     if (file === 'gh')
@@ -331,11 +324,7 @@ test('local cleanup failure does not leave the deferral blocking every publish',
   }
   const result = landed({
     exec,
-    parsed: {
-      pr: 7,
-      dispositions: ['fixed:addressed in a later commit'],
-      dryRun: false,
-    },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
   assert.deepEqual(readLedger(path).entries, [])
@@ -344,29 +333,14 @@ test('local cleanup failure does not leave the deferral blocking every publish',
   assert.equal(result.exitCode, 1)
 })
 
-test('a rerun after a cleanup failure says what to do instead of a bare count', () => {
-  const h = harness()
-  assert.throws(
-    () =>
-      landed({
-        exec: h.exec,
-        parsed: { pr: 7, dispositions: ['fixed:done'], dryRun: false },
-        ledger: emptyLedger(),
-      }),
-    /holds no entry for that PR/u,
-  )
-})
-
-test('a deferral the change later fixed can be closed as fixed', () => {
+test('a rerun after cleanup succeeds without a ledger entry', () => {
   const h = harness()
   const result = landed({
     exec: h.exec,
-    parsed: { pr: 7, dispositions: ['fixed:done in a5c1e2f'], dryRun: false },
-    ledger: ledgerWith(['name the select']),
+    parsed: { pr: 7, dryRun: false },
+    ledger: emptyLedger(),
   })
-  assert.deepEqual(result.discharged, [
-    { finding: 'name the select', kind: 'fixed', note: 'done in a5c1e2f' },
-  ])
+  assert.equal(result.releasedDeferred, 0)
   assert.equal(result.exitCode, 0)
 })
 
@@ -380,7 +354,7 @@ test('a merged branch checked out in another worktree is left with a note', () =
   })
   const result = landed({
     exec: h.exec,
-    parsed: { pr: 7, dispositions: ['issue:filed as #1666'], dryRun: false },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
   assert.equal(result.exitCode, 0)
@@ -401,7 +375,7 @@ test('a prunable worktree registration holding main is ignored', () => {
   })
   const result = landed({
     exec: h.exec,
-    parsed: { pr: 7, dispositions: ['issue:filed as #1666'], dryRun: false },
+    parsed: { pr: 7, dryRun: false },
     ledger: path,
   })
   assert.equal(result.exitCode, 0)

--- a/scripts/pr-publish.mjs
+++ b/scripts/pr-publish.mjs
@@ -97,8 +97,8 @@ export function assertNoOutstandingLanding(exec, ledger, branch) {
     [
       'A previous change deferred review findings that were never discharged; no write performed.',
       ...lines,
-      'Discharge them with one disposition per item, for example:',
-      "  pnpm pr:landed -- --pr <number> --disposition 'issue:filed as #123'",
+      'Finish the prior landing cleanup:',
+      '  pnpm pr:landed -- --pr <number>',
     ].join('\n'),
   )
 }

--- a/scripts/pr-ready.mjs
+++ b/scripts/pr-ready.mjs
@@ -584,7 +584,7 @@ function parseArgs(args) {
 }
 
 function usage() {
-  return 'Usage: pnpm pr:ready -- --task-usage-report <path> [--dry-run] [--ui-gate-complete] (--no-deferred | --deferred <text> ... | --deferred-file <path>)'
+  return 'Usage: pnpm pr:ready -- [--task-usage-report <path>] [--dry-run] [--ui-gate-complete] (--no-deferred | --deferred <text> ... | --deferred-file <path>)'
 }
 
 /** Every review finding this change chose not to fix has to be named here.
@@ -732,16 +732,14 @@ function ready({
   readFile = readFileSync,
   ledger = undefined,
 } = {}) {
-  if (!parsed.taskUsageReport)
-    throw new Error(
-      'A sanitized task usage report is required. Generate one from the task-usage operation and pass --task-usage-report <path>.',
-    )
-  const taskUsageReport = readTaskUsageReport(parsed.taskUsageReport, readFile)
+  const taskUsageReport = parsed.taskUsageReport
+    ? readTaskUsageReport(parsed.taskUsageReport, readFile)
+    : null
   const branch = output(exec, 'git', ['branch', '--show-current'])
   const head = output(exec, 'git', ['rev-parse', 'HEAD'])
   if (!branch || branch === 'main')
     throw new Error('A topic branch is required.')
-  if (taskUsageReport.target.headSha !== head)
+  if (taskUsageReport && taskUsageReport.target.headSha !== head)
     throw new Error(
       'The sanitized task usage report does not target the current local HEAD.',
     )
@@ -754,43 +752,62 @@ function ready({
     )
   if (
     pr.headRefOid !== head ||
-    taskUsageReport.target.headSha !== pr.headRefOid
+    (taskUsageReport && taskUsageReport.target.headSha !== pr.headRefOid)
   )
     throw new Error('Push the current HEAD before making the PR ready.')
-  let reportBlock
-  let bodyBlock
-  let bodySection
-  try {
-    reportBlock = extractWorkflowUsageBlock(
-      taskUsageReport.markdown,
-      'markdown',
-    )
-    bodyBlock = extractWorkflowUsageBlock(pr.body, 'PR body')
-    bodySection = extractWorkflowUsageSection(pr.body, 'PR body')
-  } catch {
-    throw new Error(
-      'The PR body must contain exactly one workflow usage marker block from the supplied task usage report.',
-    )
-  }
-  if (
-    normalizeWorkflowUsageText(reportBlock) !==
-    normalizeWorkflowUsageText(bodyBlock)
-  )
-    throw new Error(
-      'The PR body must contain exactly the generated workflow usage block from the supplied task usage report.',
-    )
+  const normalizedBody = normalizeWorkflowUsageText(pr.body)
+  const hasWorkflowUsageMarker =
+    markerCount(normalizedBody, workflowUsageStart) > 0 ||
+    markerCount(normalizedBody, workflowUsageEnd) > 0
   if (legacyWorkflowUsageHeader.test(normalizeWorkflowUsageText(pr.body)))
     throw new Error(
       'The PR body must not contain the legacy workflow usage table.',
     )
-  rejectUnmarkedWorkflowUsageTables(pr.body, bodyBlock)
-  if (
-    normalizeWorkflowUsageText(bodySection) !==
-    normalizeWorkflowUsageText(bodyBlock)
-  )
-    throw new Error(
-      'The PR body Workflow usage section must contain only the generated workflow usage block.',
+  if (!hasWorkflowUsageMarker) {
+    if (normalizedBody.search(workflowUsageTableHeader) >= 0)
+      throw new Error(
+        'The PR body must not contain an unmarked workflow usage table.',
+      )
+    if (taskUsageReport)
+      throw new Error(
+        'The PR body must contain exactly one workflow usage marker block from the supplied task usage report.',
+      )
+  } else {
+    if (!taskUsageReport)
+      throw new Error(
+        'A workflow usage marker block requires a sanitized task usage report passed with --task-usage-report <path>.',
+      )
+    let reportBlock
+    let bodyBlock
+    let bodySection
+    try {
+      reportBlock = extractWorkflowUsageBlock(
+        taskUsageReport.markdown,
+        'markdown',
+      )
+      bodyBlock = extractWorkflowUsageBlock(pr.body, 'PR body')
+      bodySection = extractWorkflowUsageSection(pr.body, 'PR body')
+    } catch {
+      throw new Error(
+        'The PR body must contain exactly one workflow usage marker block from the supplied task usage report.',
+      )
+    }
+    if (
+      normalizeWorkflowUsageText(reportBlock) !==
+      normalizeWorkflowUsageText(bodyBlock)
     )
+      throw new Error(
+        'The PR body must contain exactly the generated workflow usage block from the supplied task usage report.',
+      )
+    rejectUnmarkedWorkflowUsageTables(pr.body, bodyBlock)
+    if (
+      normalizeWorkflowUsageText(bodySection) !==
+      normalizeWorkflowUsageText(bodyBlock)
+    )
+      throw new Error(
+        'The PR body Workflow usage section must contain only the generated workflow usage block.',
+      )
+  }
   const changedUiFiles = uiFiles(exec, pr.baseRefName)
   if (changedUiFiles.length > 0 && !parsed.uiGateComplete)
     throw new Error(
@@ -801,7 +818,7 @@ function ready({
         '- Two-layer UI critique using walkthrough evidence, PNGs, task/persona context, and relevant source is complete; captures alone are not sufficient.',
         '- HEAD has no UI changes after that critique. If it does, recapture and repeat the critique.',
         'Then rerun with --ui-gate-complete and the deferral decision, for example:',
-        '  pnpm pr:ready -- --task-usage-report <path> --ui-gate-complete --no-deferred',
+        '  pnpm pr:ready -- --ui-gate-complete --no-deferred',
       ].join('\n'),
     )
   const deferred = deferredItems(parsed, readFile)

--- a/scripts/pr-ready.test.mjs
+++ b/scripts/pr-ready.test.mjs
@@ -132,7 +132,22 @@ test('needs no reviewer SHA arguments', () => {
   assert.throws(() => parseArgs(['--codex-go', head]), /Usage/u)
 })
 
-test('requires a sanitized task usage report before Ready', () => {
+test('allows Ready with no workflow usage block and no report', () => {
+  const h = harness({
+    body: '## Workflow usage\n\nOptional. No workflow usage was included.',
+  })
+  ready({
+    exec: h.exec,
+    parsed: { dryRun: false, deferred: [], noDeferred: true },
+    ledger: tempLedger(),
+  })
+  assert.equal(
+    h.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
+    true,
+  )
+})
+
+test('requires a sanitized report when the PR body has a usage block', () => {
   const h = harness()
   assert.throws(
     () =>
@@ -141,7 +156,7 @@ test('requires a sanitized task usage report before Ready', () => {
         parsed: { dryRun: false, deferred: [], noDeferred: true },
         ledger: tempLedger(),
       }),
-    /sanitized task usage report is required/u,
+    /marker block requires a sanitized task usage report/u,
   )
   assert.equal(
     h.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
@@ -1078,7 +1093,7 @@ test('blocks UI changes until capture and source-based critique are confirmed', 
       assert.match(error.message, /recapture and repeat the critique/u)
       assert.match(
         error.message,
-        /--task-usage-report <path> --ui-gate-complete/u,
+        /pnpm pr:ready -- --ui-gate-complete --no-deferred/u,
       )
       return true
     },


### PR DESCRIPTION
## Summary

- Make the workflow-usage report optional when a PR has no workflow-usage block.
- Keep strict report, marker, arithmetic, coverage, and target validation when a usage block is present.
- Remove landing-time per-finding disposition arguments and release the landing ledger entry automatically.
- Preserve PR-state checks, main fast-forwarding, worktree handling, and merged-branch cleanup.

## Validation

- `node --test scripts/pr-ready.test.mjs scripts/pr-landed.test.mjs scripts/pr-publish.test.mjs scripts/development-workflow-contract.test.mjs`
- `pnpm verify`
- `git diff --check`

All checks passed: 604 script tests, formatting, lint, public scan, hook/guard checks, and test audit.

## Review

The committed target received the independent Codex/Claude implementation review pair. Codex returned GO with no findings; Claude found no blockers. A marker-free current-format table regression test remains a non-blocking coverage follow-up.

## Workflow usage

<!-- artifactshare:workflow-usage:start -->
**Target commit:** `5c33ccbeda853702a2633f3f4cdb3838800952eb`
**Workflow usage coverage:** partial
**Measured total:** 3901792 in / 41262 out / 3943054 total (cache read 3577243, cache write 120591)
**Complete total:** unknown
**Wall elapsed:** 815108 ms
**Sum of invocation durations:** 786107 ms

| Stage | Attempt | Provider | Requested model | Requested effort | Reported effort | Reported models | Outcome | Duration | Usage source | Tokens | Reason |
| --- | ---: | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- |
| implementation | 1 | codex | gpt-5.6-sol | medium | unknown | gpt-5.6-sol | succeeded | 322192 ms | ccusage_interval | 2428920 in / 13118 out / 2442038 total (cache read 2294400, cache write 0) | reported_effort_unavailable |
| public-review:implementation:codex:finder | 1 | codex | gpt-5.6-sol | medium | unknown | gpt-5.6-sol | succeeded | 114905 ms | ccusage_interval | 434971 in / 4131 out / 439102 total (cache read 374912, cache write 0) | reported_effort_unavailable |
| public-review:implementation:claude:finder | 1 | claude | claude-opus-5 | high | unknown | claude-haiku-4-5-20251001, claude-opus-5 | succeeded | 231870 ms | claude_final | 730390 in / 16961 out / 747351 total (cache read 647958, cache write 78281) | reported_effort_unavailable |
| public-review:implementation:claude:verifier | 1 | claude | claude-opus-5 | high | unknown | claude-haiku-4-5-20251001, claude-opus-5 | succeeded | 117140 ms | claude_final | 307511 in / 7052 out / 314563 total (cache read 259973, cache write 42310) | reported_effort_unavailable |

**Coverage reasons:**
- reported_effort_unavailable
<!-- artifactshare:workflow-usage:end -->
