### PR TITLE
fix: allow three concurrent pull requests

### DIFF
--- a/scripts/pr-publish.mjs
+++ b/scripts/pr-publish.mjs
@@ -12,32 +12,70 @@ function output(exec, file, args) {
   return exec(file, args, { encoding: 'utf8' }).trim()
 }
 
+function parsePullRequestRows(value, { includeBase }) {
+  if (!Array.isArray(value))
+    throw new Error(
+      'GitHub PR query returned an unexpected result; no write performed',
+    )
+  const numbers = new Set()
+  const branches = new Set()
+  for (const row of value) {
+    if (
+      !row ||
+      typeof row !== 'object' ||
+      !Number.isInteger(row.number) ||
+      row.number <= 0 ||
+      typeof row.headRefName !== 'string' ||
+      row.headRefName.length === 0 ||
+      (includeBase &&
+        (typeof row.baseRefName !== 'string' ||
+          row.baseRefName.length === 0)) ||
+      numbers.has(row.number) ||
+      branches.has(row.headRefName)
+    )
+      throw new Error(
+        'GitHub PR query returned an unexpected result; no write performed',
+      )
+    numbers.add(row.number)
+    branches.add(row.headRefName)
+  }
+  return value
+}
+
 function branchPullRequest(exec, branch) {
   let rows
   try {
-    rows = JSON.parse(
-      output(exec, 'gh', [
-        'pr',
-        'list',
-        '--state',
-        'open',
-        '--json',
-        'number,baseRefName,headRefName',
-      ]),
+    rows = parsePullRequestRows(
+      JSON.parse(
+        output(exec, 'gh', [
+          'pr',
+          'list',
+          '--state',
+          'open',
+          '--json',
+          'number,baseRefName,headRefName',
+        ]),
+      ),
+      { includeBase: true },
     )
   } catch (error) {
     throw new Error(
       `GitHub PR query failed; no write performed: ${error.message}`,
     )
   }
-  if (!Array.isArray(rows) || rows.length > 1)
+  if (rows.length > 3)
     throw new Error(
-      'GitHub PR query returned an unexpected result; no write performed',
+      'more than three open pull requests exist; no write performed',
     )
-  const pr = rows[0] ?? null
-  if (pr && pr.headRefName !== branch)
+  const wrongBase = rows.find((row) => row.baseRefName !== 'main')
+  if (wrongBase)
     throw new Error(
-      'another branch already has the open PR; no write performed',
+      `pull request #${wrongBase.number} base must be main, found ${wrongBase.baseRefName}; no write performed`,
+    )
+  const pr = rows.find((row) => row.headRefName === branch) ?? null
+  if (!pr && rows.length === 3)
+    throw new Error(
+      'creating this pull request would exceed the three-open-PR limit; no write performed',
     )
   return pr
 }
@@ -49,25 +87,24 @@ function currentPrNumber(exec, branch) {
   if (!branch) return null
   let rows
   try {
-    rows = JSON.parse(
-      output(exec, 'gh', [
-        'pr',
-        'list',
-        '--state',
-        'open',
-        '--json',
-        'number,headRefName',
-      ]),
+    rows = parsePullRequestRows(
+      JSON.parse(
+        output(exec, 'gh', [
+          'pr',
+          'list',
+          '--state',
+          'open',
+          '--json',
+          'number,headRefName',
+        ]),
+      ),
+      { includeBase: false },
     )
   } catch (error) {
     throw new Error(
       `GitHub PR query failed; no write performed: ${error.message}`,
     )
   }
-  if (!Array.isArray(rows))
-    throw new Error(
-      'GitHub PR query returned an unexpected result; no write performed',
-    )
   return rows.find((row) => row.headRefName === branch)?.number ?? null
 }
 

--- a/scripts/pr-publish.mjs
+++ b/scripts/pr-publish.mjs
@@ -1,6 +1,8 @@
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
+import { join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import { acquireFileLock } from './os-file-lock.mjs'
 import { inspectMetadata } from './public-development-guard.mjs'
 import {
   ledgerPath,
@@ -27,17 +29,18 @@ function parsePullRequestRows(value, { includeBase }) {
       row.number <= 0 ||
       typeof row.headRefName !== 'string' ||
       row.headRefName.length === 0 ||
+      typeof row.isCrossRepository !== 'boolean' ||
       (includeBase &&
         (typeof row.baseRefName !== 'string' ||
           row.baseRefName.length === 0)) ||
       numbers.has(row.number) ||
-      branches.has(row.headRefName)
+      (!row.isCrossRepository && branches.has(row.headRefName))
     )
       throw new Error(
         'GitHub PR query returned an unexpected result; no write performed',
       )
     numbers.add(row.number)
-    branches.add(row.headRefName)
+    if (!row.isCrossRepository) branches.add(row.headRefName)
   }
   return value
 }
@@ -53,7 +56,7 @@ function branchPullRequest(exec, branch) {
           '--state',
           'open',
           '--json',
-          'number,baseRefName,headRefName',
+          'number,baseRefName,headRefName,isCrossRepository',
         ]),
       ),
       { includeBase: true },
@@ -72,7 +75,9 @@ function branchPullRequest(exec, branch) {
     throw new Error(
       `pull request #${wrongBase.number} base must be main, found ${wrongBase.baseRefName}; no write performed`,
     )
-  const pr = rows.find((row) => row.headRefName === branch) ?? null
+  const pr =
+    rows.find((row) => !row.isCrossRepository && row.headRefName === branch) ??
+    null
   if (!pr && rows.length === 3)
     throw new Error(
       'creating this pull request would exceed the three-open-PR limit; no write performed',
@@ -95,7 +100,7 @@ function currentPrNumber(exec, branch) {
           '--state',
           'open',
           '--json',
-          'number,headRefName',
+          'number,headRefName,isCrossRepository',
         ]),
       ),
       { includeBase: false },
@@ -105,7 +110,18 @@ function currentPrNumber(exec, branch) {
       `GitHub PR query failed; no write performed: ${error.message}`,
     )
   }
-  return rows.find((row) => row.headRefName === branch)?.number ?? null
+  return (
+    rows.find((row) => !row.isCrossRepository && row.headRefName === branch)
+      ?.number ?? null
+  )
+}
+
+export function publishLockPath(exec) {
+  return join(
+    resolve(output(exec, 'git', ['rev-parse', '--git-common-dir'])),
+    'artifactshare',
+    'pr-publish.lock',
+  )
 }
 
 /** A previous change deferred review findings and has not discharged them.
@@ -140,13 +156,14 @@ export function assertNoOutstandingLanding(exec, ledger, branch) {
   )
 }
 
-export function publishPullRequest({
+export async function publishPullRequest({
   bodyFile,
   title,
   exec = execFileSync,
   readFile = fs.readFileSync,
   dryRun = false,
   ledger = undefined,
+  acquireLock = acquireFileLock,
 } = {}) {
   if (!bodyFile || !title)
     throw new Error(
@@ -167,39 +184,62 @@ export function publishPullRequest({
   if (!branch || branch === 'main')
     throw new Error('A topic branch is required.')
   assertNoOutstandingLanding(exec, ledger, branch)
-  const pr = branchPullRequest(exec, branch)
-  if (pr && pr.baseRefName !== 'main')
-    throw new Error(
-      `pull request base must be main, found ${pr.baseRefName}; no write performed`,
-    )
-  if (dryRun)
-    return { mode: pr ? 'update' : 'create', number: pr?.number, dryRun: true }
-
-  if (pr) {
-    exec('gh', [
-      'pr',
-      'edit',
-      String(pr.number),
-      '--title',
-      title,
-      '--body-file',
-      bodyFile,
-    ])
-    return { mode: 'update', number: pr.number }
+  const release = await acquireLock(publishLockPath(exec))
+  let operationError
+  let result
+  try {
+    // This is the authoritative slot snapshot. Keep the shared lock until the
+    // corresponding create or edit finishes so concurrent publishers cannot
+    // both consume the same remaining slot.
+    const pr = branchPullRequest(exec, branch)
+    if (dryRun) {
+      result = {
+        mode: pr ? 'update' : 'create',
+        number: pr?.number,
+        dryRun: true,
+      }
+    } else if (pr) {
+      exec('gh', [
+        'pr',
+        'edit',
+        String(pr.number),
+        '--title',
+        title,
+        '--body-file',
+        bodyFile,
+      ])
+      result = { mode: 'update', number: pr.number }
+    } else {
+      exec('git', ['push', '--set-upstream', 'origin', branch])
+      exec('gh', [
+        'pr',
+        'create',
+        '--draft',
+        '--base',
+        'main',
+        '--title',
+        title,
+        '--body-file',
+        bodyFile,
+      ])
+      result = { mode: 'create' }
+    }
+  } catch (error) {
+    operationError = error
   }
-  exec('git', ['push', '--set-upstream', 'origin', branch])
-  exec('gh', [
-    'pr',
-    'create',
-    '--draft',
-    '--base',
-    'main',
-    '--title',
-    title,
-    '--body-file',
-    bodyFile,
-  ])
-  return { mode: 'create' }
+  try {
+    await release()
+  } catch (releaseError) {
+    if (!operationError) throw releaseError
+    const diagnostic =
+      releaseError instanceof Error
+        ? releaseError.message
+        : String(releaseError)
+    if (operationError instanceof Error)
+      operationError.message += `\nAdditionally, publish-lock release failed: ${diagnostic}`
+  }
+  if (operationError) throw operationError
+  return result
 }
 
 export function parsePublishArgs(args) {
@@ -240,5 +280,5 @@ if (
     console.log(
       'Usage: pnpm pr:publish -- --body-file <path> --title <title> [--dry-run]',
     )
-  else console.log(JSON.stringify(publishPullRequest(options)))
+  else console.log(JSON.stringify(await publishPullRequest(options)))
 }

--- a/scripts/pr-publish.test.mjs
+++ b/scripts/pr-publish.test.mjs
@@ -15,7 +15,7 @@ const tempLedger = () =>
   joinPath(osTmpdir(), `pr-publish-ledger-${randomUUID()}.json`)
 
 function harness({
-  pr = null,
+  prs = [],
   title = 'Public title',
   body = 'Public body',
 } = {}) {
@@ -23,8 +23,7 @@ function harness({
   const exec = (file, args) => {
     calls.push([file, args])
     if (file === 'git' && args[0] === 'branch') return 'feature/x\n'
-    if (file === 'gh' && args[1] === 'list')
-      return JSON.stringify(pr ? [{ headRefName: 'feature/x', ...pr }] : [])
+    if (file === 'gh' && args[1] === 'list') return JSON.stringify(prs)
     return ''
   }
   // One ledger per harness; publish never writes it, so no cleanup is needed.
@@ -64,7 +63,9 @@ test('checks public metadata then pushes and creates a Draft', () => {
 })
 
 test('updates an existing branch PR without lifecycle snapshots', () => {
-  const h = harness({ pr: { number: 3, baseRefName: 'main' } })
+  const h = harness({
+    prs: [{ number: 3, baseRefName: 'main', headRefName: 'feature/x' }],
+  })
   assert.deepEqual(h.run(), { mode: 'update', number: 3 })
   assert.equal(
     h.calls.some(([file, args]) => file === 'git' && args[0] === 'fetch'),
@@ -95,7 +96,7 @@ test('rejects private metadata before any command or remote write', () => {
   assert.equal(called, false)
 })
 
-test('requires a topic branch, main base, and no other open PR', () => {
+test('requires a topic branch and main bases for every listed PR', () => {
   assert.throws(
     () =>
       publishPullRequest({
@@ -111,16 +112,116 @@ test('requires a topic branch, main base, and no other open PR', () => {
     /topic branch/u,
   )
   assert.throws(
-    () => harness({ pr: { number: 3, baseRefName: 'release' } }).run(),
+    () =>
+      harness({
+        prs: [{ number: 3, baseRefName: 'release', headRefName: 'feature/x' }],
+      }).run(),
     /base must be main/u,
   )
   assert.throws(
     () =>
       harness({
-        pr: { number: 3, baseRefName: 'main', headRefName: 'other' },
+        prs: [
+          { number: 2, baseRefName: 'release', headRefName: 'other' },
+          { number: 3, baseRefName: 'main', headRefName: 'feature/x' },
+        ],
       }).run(),
-    /another branch/u,
+    /pull request #2 base must be main/u,
   )
+})
+
+test('accepts up to three open PRs when this branch already owns one', () => {
+  for (let count = 1; count <= 3; count += 1) {
+    const prs = [
+      { number: 10, baseRefName: 'main', headRefName: 'feature/x' },
+      { number: 11, baseRefName: 'main', headRefName: 'feature/y' },
+      { number: 12, baseRefName: 'main', headRefName: 'feature/z' },
+    ].slice(0, count)
+    const h = harness({ prs })
+    assert.deepEqual(h.run(), { mode: 'update', number: 10 })
+    assert.deepEqual(h.calls.at(-1)[1].slice(0, 3), ['pr', 'edit', '10'])
+  }
+})
+
+test('does not mistake other branches for this branch and may create through the third PR', () => {
+  const available = [
+    { number: 11, baseRefName: 'main', headRefName: 'feature/y' },
+    { number: 12, baseRefName: 'main', headRefName: 'feature/z' },
+  ]
+  for (let count = 0; count <= 2; count += 1) {
+    const h = harness({ prs: available.slice(0, count) })
+    assert.deepEqual(h.run(), { mode: 'create' })
+    assert.deepEqual(h.calls.at(-2), [
+      'git',
+      ['push', '--set-upstream', 'origin', 'feature/x'],
+    ])
+    assert.deepEqual(h.calls.at(-1)[1].slice(0, 2), ['pr', 'create'])
+  }
+})
+
+test('rejects creating a fourth PR while preserving the other branch identities', () => {
+  const h = harness({
+    prs: [
+      { number: 11, baseRefName: 'main', headRefName: 'feature/y' },
+      { number: 12, baseRefName: 'main', headRefName: 'feature/z' },
+      { number: 13, baseRefName: 'main', headRefName: 'feature/w' },
+    ],
+  })
+  assert.throws(() => h.run(), /three-open-PR limit/u)
+  assert.equal(
+    h.calls.some(
+      ([file, args]) =>
+        (file === 'git' && args[0] === 'push') ||
+        (file === 'gh' && ['create', 'edit'].includes(args[1])),
+    ),
+    false,
+  )
+})
+
+test('rejects an already-invalid fourth open PR before push, create, or edit', () => {
+  const h = harness({
+    prs: [
+      { number: 10, baseRefName: 'main', headRefName: 'feature/x' },
+      { number: 11, baseRefName: 'main', headRefName: 'feature/y' },
+      { number: 12, baseRefName: 'main', headRefName: 'feature/z' },
+      { number: 13, baseRefName: 'main', headRefName: 'feature/w' },
+    ],
+  })
+  assert.throws(() => h.run(), /more than three/u)
+  assert.equal(
+    h.calls.some(
+      ([file, args]) =>
+        (file === 'git' && args[0] === 'push') ||
+        (file === 'gh' && ['create', 'edit'].includes(args[1])),
+    ),
+    false,
+  )
+})
+
+test('malformed GitHub PR list responses fail closed before any write', () => {
+  const malformed = [
+    {},
+    [null],
+    [{ number: 1, baseRefName: 'main' }],
+    [{ number: 1, headRefName: 'feature/x' }],
+    [{ number: '1', baseRefName: 'main', headRefName: 'feature/x' }],
+    [
+      { number: 1, baseRefName: 'main', headRefName: 'feature/x' },
+      { number: 1, baseRefName: 'main', headRefName: 'feature/y' },
+    ],
+  ]
+  for (const response of malformed) {
+    const h = harness({ prs: response })
+    assert.throws(() => h.run(), /GitHub PR query failed/u)
+    assert.equal(
+      h.calls.some(
+        ([file, args]) =>
+          (file === 'git' && args[0] === 'push') ||
+          (file === 'gh' && ['create', 'edit'].includes(args[1])),
+      ),
+      false,
+    )
+  }
 })
 
 test('parses the small publication option set', () => {

--- a/scripts/pr-publish.test.mjs
+++ b/scripts/pr-publish.test.mjs
@@ -20,16 +20,27 @@ function harness({
   body = 'Public body',
 } = {}) {
   const calls = []
+  const normalizedPrs = Array.isArray(prs)
+    ? prs.map((row) =>
+        row && typeof row === 'object' && !Array.isArray(row)
+          ? { isCrossRepository: false, ...row }
+          : row,
+      )
+    : prs
   const exec = (file, args) => {
     calls.push([file, args])
     if (file === 'git' && args[0] === 'branch') return 'feature/x\n'
-    if (file === 'gh' && args[1] === 'list') return JSON.stringify(prs)
+    if (file === 'git' && args.join(' ') === 'rev-parse --git-common-dir')
+      return '/repo/.git\n'
+    if (file === 'gh' && args[1] === 'list')
+      return JSON.stringify(normalizedPrs)
     return ''
   }
   // One ledger per harness; publish never writes it, so no cleanup is needed.
   const ledger = tempLedger()
   return {
     calls,
+    runExec: exec,
     ledger,
     run: (options = {}) =>
       publishPullRequest({
@@ -37,6 +48,7 @@ function harness({
         title,
         readFile: () => body,
         exec,
+        acquireLock: () => Promise.resolve(() => {}),
         ...options,
         // Never the checkout's own ledger: an undischarged deferral from a
         // real PR would fail these tests in every worktree of the checkout.
@@ -45,9 +57,9 @@ function harness({
   }
 }
 
-test('checks public metadata then pushes and creates a Draft', () => {
+test('checks public metadata then pushes and creates a Draft', async () => {
   const h = harness()
-  assert.deepEqual(h.run(), { mode: 'create' })
+  assert.deepEqual(await h.run(), { mode: 'create' })
   assert.deepEqual(h.calls.at(-2), [
     'git',
     ['push', '--set-upstream', 'origin', 'feature/x'],
@@ -62,11 +74,11 @@ test('checks public metadata then pushes and creates a Draft', () => {
   ])
 })
 
-test('updates an existing branch PR without lifecycle snapshots', () => {
+test('updates an existing branch PR without lifecycle snapshots', async () => {
   const h = harness({
     prs: [{ number: 3, baseRefName: 'main', headRefName: 'feature/x' }],
   })
-  assert.deepEqual(h.run(), { mode: 'update', number: 3 })
+  assert.deepEqual(await h.run(), { mode: 'update', number: 3 })
   assert.equal(
     h.calls.some(([file, args]) => file === 'git' && args[0] === 'fetch'),
     false,
@@ -78,59 +90,55 @@ test('updates an existing branch PR without lifecycle snapshots', () => {
   assert.deepEqual(h.calls.at(-1)[1].slice(0, 3), ['pr', 'edit', '3'])
 })
 
-test('rejects private metadata before any command or remote write', () => {
+test('rejects private metadata before any command or remote write', async () => {
   let called = false
-  assert.throws(
-    () =>
-      publishPullRequest({
-        bodyFile: 'body.md',
-        title: 'fix #1552',
-        readFile: () => 'Public body',
-        ledger: tempLedger(),
-        exec: () => {
-          called = true
-        },
-      }),
+  await assert.rejects(
+    publishPullRequest({
+      bodyFile: 'body.md',
+      title: 'fix #1552',
+      readFile: () => 'Public body',
+      ledger: tempLedger(),
+      exec: () => {
+        called = true
+      },
+    }),
     /forbidden metadata/u,
   )
   assert.equal(called, false)
 })
 
-test('requires a topic branch and main bases for every listed PR', () => {
-  assert.throws(
-    () =>
-      publishPullRequest({
-        bodyFile: 'body.md',
-        title: 'Public title',
-        readFile: () => 'Public body',
-        ledger: tempLedger(),
-        exec: (file, args) => {
-          if (file === 'git' && args[0] === 'branch') return 'main\n'
-          return ''
-        },
-      }),
+test('requires a topic branch and main bases for every listed PR', async () => {
+  await assert.rejects(
+    publishPullRequest({
+      bodyFile: 'body.md',
+      title: 'Public title',
+      readFile: () => 'Public body',
+      ledger: tempLedger(),
+      exec: (file, args) => {
+        if (file === 'git' && args[0] === 'branch') return 'main\n'
+        return ''
+      },
+    }),
     /topic branch/u,
   )
-  assert.throws(
-    () =>
-      harness({
-        prs: [{ number: 3, baseRefName: 'release', headRefName: 'feature/x' }],
-      }).run(),
+  await assert.rejects(
+    harness({
+      prs: [{ number: 3, baseRefName: 'release', headRefName: 'feature/x' }],
+    }).run(),
     /base must be main/u,
   )
-  assert.throws(
-    () =>
-      harness({
-        prs: [
-          { number: 2, baseRefName: 'release', headRefName: 'other' },
-          { number: 3, baseRefName: 'main', headRefName: 'feature/x' },
-        ],
-      }).run(),
+  await assert.rejects(
+    harness({
+      prs: [
+        { number: 2, baseRefName: 'release', headRefName: 'other' },
+        { number: 3, baseRefName: 'main', headRefName: 'feature/x' },
+      ],
+    }).run(),
     /pull request #2 base must be main/u,
   )
 })
 
-test('accepts up to three open PRs when this branch already owns one', () => {
+test('accepts up to three open PRs when this branch already owns one', async () => {
   for (let count = 1; count <= 3; count += 1) {
     const prs = [
       { number: 10, baseRefName: 'main', headRefName: 'feature/x' },
@@ -138,19 +146,19 @@ test('accepts up to three open PRs when this branch already owns one', () => {
       { number: 12, baseRefName: 'main', headRefName: 'feature/z' },
     ].slice(0, count)
     const h = harness({ prs })
-    assert.deepEqual(h.run(), { mode: 'update', number: 10 })
+    assert.deepEqual(await h.run(), { mode: 'update', number: 10 })
     assert.deepEqual(h.calls.at(-1)[1].slice(0, 3), ['pr', 'edit', '10'])
   }
 })
 
-test('does not mistake other branches for this branch and may create through the third PR', () => {
+test('does not mistake other branches for this branch and may create through the third PR', async () => {
   const available = [
     { number: 11, baseRefName: 'main', headRefName: 'feature/y' },
     { number: 12, baseRefName: 'main', headRefName: 'feature/z' },
   ]
   for (let count = 0; count <= 2; count += 1) {
     const h = harness({ prs: available.slice(0, count) })
-    assert.deepEqual(h.run(), { mode: 'create' })
+    assert.deepEqual(await h.run(), { mode: 'create' })
     assert.deepEqual(h.calls.at(-2), [
       'git',
       ['push', '--set-upstream', 'origin', 'feature/x'],
@@ -159,7 +167,7 @@ test('does not mistake other branches for this branch and may create through the
   }
 })
 
-test('rejects creating a fourth PR while preserving the other branch identities', () => {
+test('rejects creating a fourth PR while preserving the other branch identities', async () => {
   const h = harness({
     prs: [
       { number: 11, baseRefName: 'main', headRefName: 'feature/y' },
@@ -167,7 +175,7 @@ test('rejects creating a fourth PR while preserving the other branch identities'
       { number: 13, baseRefName: 'main', headRefName: 'feature/w' },
     ],
   })
-  assert.throws(() => h.run(), /three-open-PR limit/u)
+  await assert.rejects(h.run(), /three-open-PR limit/u)
   assert.equal(
     h.calls.some(
       ([file, args]) =>
@@ -178,7 +186,7 @@ test('rejects creating a fourth PR while preserving the other branch identities'
   )
 })
 
-test('rejects an already-invalid fourth open PR before push, create, or edit', () => {
+test('rejects an already-invalid fourth open PR before push, create, or edit', async () => {
   const h = harness({
     prs: [
       { number: 10, baseRefName: 'main', headRefName: 'feature/x' },
@@ -187,7 +195,7 @@ test('rejects an already-invalid fourth open PR before push, create, or edit', (
       { number: 13, baseRefName: 'main', headRefName: 'feature/w' },
     ],
   })
-  assert.throws(() => h.run(), /more than three/u)
+  await assert.rejects(h.run(), /more than three/u)
   assert.equal(
     h.calls.some(
       ([file, args]) =>
@@ -198,7 +206,7 @@ test('rejects an already-invalid fourth open PR before push, create, or edit', (
   )
 })
 
-test('malformed GitHub PR list responses fail closed before any write', () => {
+test('malformed GitHub PR list responses fail closed before any write', async () => {
   const malformed = [
     {},
     [null],
@@ -206,13 +214,21 @@ test('malformed GitHub PR list responses fail closed before any write', () => {
     [{ number: 1, headRefName: 'feature/x' }],
     [{ number: '1', baseRefName: 'main', headRefName: 'feature/x' }],
     [
+      {
+        number: 1,
+        baseRefName: 'main',
+        headRefName: 'feature/x',
+        isCrossRepository: undefined,
+      },
+    ],
+    [
       { number: 1, baseRefName: 'main', headRefName: 'feature/x' },
       { number: 1, baseRefName: 'main', headRefName: 'feature/y' },
     ],
   ]
   for (const response of malformed) {
     const h = harness({ prs: response })
-    assert.throws(() => h.run(), /GitHub PR query failed/u)
+    await assert.rejects(h.run(), /GitHub PR query failed/u)
     assert.equal(
       h.calls.some(
         ([file, args]) =>
@@ -222,6 +238,92 @@ test('malformed GitHub PR list responses fail closed before any write', () => {
       false,
     )
   }
+})
+
+test('ignores a fork PR whose branch name collides with the local branch', async () => {
+  const h = harness({
+    prs: [
+      {
+        number: 20,
+        baseRefName: 'main',
+        headRefName: 'feature/x',
+        isCrossRepository: true,
+      },
+      { number: 21, baseRefName: 'main', headRefName: 'feature/y' },
+    ],
+  })
+  assert.deepEqual(await h.run(), { mode: 'create' })
+  assert.equal(
+    h.calls.some(
+      ([file, args]) => file === 'gh' && args[1] === 'edit' && args[2] === '20',
+    ),
+    false,
+  )
+  assert.equal(
+    h.calls
+      .filter(([file, args]) => file === 'gh' && args[1] === 'list')
+      .every(([, args]) => args.at(-1).includes('isCrossRepository')),
+    true,
+  )
+})
+
+test('releases the publish lock after success and operation failure', async () => {
+  for (const failCreate of [false, true]) {
+    const events = []
+    let listCalls = 0
+    const h = harness()
+    const exec = (file, args, options) => {
+      if (file === 'gh' && args[1] === 'list') {
+        listCalls += 1
+        events.push(listCalls === 1 ? 'ledger-snapshot' : 'slot-snapshot')
+      }
+      if (failCreate && file === 'gh' && args[1] === 'create') {
+        events.push('operation-failed')
+        throw new Error('create failed')
+      }
+      return h.runExec(file, args, options)
+    }
+    const run = h.run({
+      exec,
+      acquireLock: (path) => {
+        assert.equal(path, '/repo/.git/artifactshare/pr-publish.lock')
+        events.push('acquired')
+        return Promise.resolve(() => events.push('released'))
+      },
+    })
+    if (failCreate) await assert.rejects(run, /create failed/u)
+    else assert.deepEqual(await run, { mode: 'create' })
+    assert.deepEqual(
+      events,
+      failCreate
+        ? [
+            'ledger-snapshot',
+            'acquired',
+            'slot-snapshot',
+            'operation-failed',
+            'released',
+          ]
+        : ['ledger-snapshot', 'acquired', 'slot-snapshot', 'released'],
+    )
+  }
+})
+
+test('a publish-lock failure performs no push, create, or edit', async () => {
+  const h = harness()
+  await assert.rejects(
+    h.run({
+      acquireLock: () => Promise.reject(new Error('lock unavailable')),
+    }),
+    /lock unavailable/u,
+  )
+  assert.equal(
+    h.calls.some(
+      ([file, args]) =>
+        (file === 'git' && args[0] === 'push') ||
+        (file === 'gh' && ['create', 'edit'].includes(args[1])),
+    ),
+    false,
+  )
 })
 
 test('parses the small publication option set', () => {
@@ -239,7 +341,7 @@ test('parses the small publication option set', () => {
   assert.throws(() => parsePublishArgs(['--unknown']), /unknown argument/u)
 })
 
-test('publishing refuses while a previous change has undischarged deferrals', (t) => {
+test('publishing refuses while a previous change has undischarged deferrals', async (t) => {
   const path = tempLedger()
   t.after(() => rmSync(path, { force: true }))
   writeLandingLedger(
@@ -250,15 +352,14 @@ test('publishing refuses while a previous change has undischarged deferrals', (t
       deferred: ['name the select for screen readers'],
     }),
   )
-  assert.throws(
-    () =>
-      publishPullRequest({
-        bodyFile: 'body.md',
-        title: 'Next change',
-        exec: (file) => (file === 'git' ? 'feat/next' : '[]'),
-        readFile: () => 'body',
-        ledger: path,
-      }),
+  await assert.rejects(
+    publishPullRequest({
+      bodyFile: 'body.md',
+      title: 'Next change',
+      exec: (file) => (file === 'git' ? 'feat/next' : '[]'),
+      readFile: () => 'body',
+      ledger: path,
+    }),
     (error) => {
       assert.match(error.message, /deferred review findings/u)
       assert.match(error.message, /PR #41/u)
@@ -269,7 +370,7 @@ test('publishing refuses while a previous change has undischarged deferrals', (t
   )
 })
 
-test('a change may update its own body while its deferrals are still pending', (t) => {
+test('a change may update its own body while its deferrals are still pending', async (t) => {
   const path = tempLedger()
   t.after(() => rmSync(path, { force: true }))
   writeLandingLedger(
@@ -280,7 +381,7 @@ test('a change may update its own body while its deferrals are still pending', (
       deferred: ['name the select for screen readers'],
     }),
   )
-  const result = publishPullRequest({
+  const result = await publishPullRequest({
     bodyFile: 'body.md',
     title: 'Same change, better body',
     dryRun: true,
@@ -288,27 +389,38 @@ test('a change may update its own body while its deferrals are still pending', (
     exec: (file, args) => {
       if (file === 'git') return 'feat/current'
       return JSON.stringify([
-        { number: 52, baseRefName: 'main', headRefName: 'feat/current' },
+        {
+          number: 51,
+          baseRefName: 'main',
+          headRefName: 'feat/current',
+          isCrossRepository: true,
+        },
+        {
+          number: 52,
+          baseRefName: 'main',
+          headRefName: 'feat/current',
+          isCrossRepository: false,
+        },
       ])
     },
+    acquireLock: () => Promise.resolve(() => {}),
     ledger: path,
   })
   assert.deepEqual(result, { mode: 'update', number: 52, dryRun: true })
 })
 
-test('a corrupt ledger refuses the publish rather than reading as empty', (t) => {
+test('a corrupt ledger refuses the publish rather than reading as empty', async (t) => {
   const path = tempLedger()
   t.after(() => rmSync(path, { force: true }))
   writeFileSync(path, '{ truncated')
-  assert.throws(
-    () =>
-      publishPullRequest({
-        bodyFile: 'body.md',
-        title: 'Next change',
-        exec: (file) => (file === 'git' ? 'feat/next' : '[]'),
-        readFile: () => 'body',
-        ledger: path,
-      }),
+  await assert.rejects(
+    publishPullRequest({
+      bodyFile: 'body.md',
+      title: 'Next change',
+      exec: (file) => (file === 'git' ? 'feat/next' : '[]'),
+      readFile: () => 'body',
+      ledger: path,
+    }),
     /could not be read/u,
   )
 })

--- a/scripts/pr-queue.test.mjs
+++ b/scripts/pr-queue.test.mjs
@@ -94,7 +94,7 @@ test('parses the PR number and polling options', () => {
   assert.throws(() => parseArgs(['--pr', '3', '--interval', '1']))
 })
 
-test('filters queue runs to this PR, drops known ids, and sorts newest first', () => {
+test('isolates one of three concurrent PRs, drops known ids, and sorts newest first', () => {
   const exec = () =>
     JSON.stringify([
       run(1, 'completed', 'cancelled'),
@@ -102,7 +102,11 @@ test('filters queue runs to this PR, drops known ids, and sorts newest first', (
       run(4, 'in_progress'),
       {
         ...run(3, 'in_progress'),
-        headBranch: 'gh-readonly-queue/main/pr-120-xyz',
+        headBranch: 'gh-readonly-queue/main/pr-11-xyz',
+      },
+      {
+        ...run(5, 'in_progress'),
+        headBranch: 'gh-readonly-queue/main/pr-13-xyz',
       },
     ])
   assert.deepEqual(

--- a/scripts/pr-ready.mjs
+++ b/scripts/pr-ready.mjs
@@ -629,14 +629,14 @@ function uiFiles(exec, base) {
     .filter(isUiFile)
 }
 
-function openPullRequest(exec) {
+function openPullRequest(exec, branch) {
   const raw = output(exec, 'gh', [
     'pr',
     'list',
     '--state',
     'open',
     '--json',
-    'number,isDraft,baseRefName,headRefName,headRefOid,body',
+    'number,isDraft,baseRefName,headRefName,headRefOid,body,isCrossRepository',
   ])
   let rows
   try {
@@ -644,9 +644,38 @@ function openPullRequest(exec) {
   } catch {
     throw new Error('Exactly one open PR for the current branch is required.')
   }
-  if (!Array.isArray(rows) || rows.length !== 1)
+  if (!Array.isArray(rows) || rows.length === 0 || rows.length > 3)
     throw new Error('Exactly one open PR for the current branch is required.')
-  return rows[0]
+  const numbers = new Set()
+  const sameRepositoryHeads = new Set()
+  for (const row of rows) {
+    if (
+      !row ||
+      typeof row !== 'object' ||
+      !Number.isInteger(row.number) ||
+      row.number <= 0 ||
+      typeof row.isDraft !== 'boolean' ||
+      typeof row.baseRefName !== 'string' ||
+      row.baseRefName !== 'main' ||
+      typeof row.headRefName !== 'string' ||
+      row.headRefName.length === 0 ||
+      typeof row.headRefOid !== 'string' ||
+      row.headRefOid.length === 0 ||
+      typeof row.body !== 'string' ||
+      typeof row.isCrossRepository !== 'boolean' ||
+      numbers.has(row.number) ||
+      (!row.isCrossRepository && sameRepositoryHeads.has(row.headRefName))
+    )
+      throw new Error('Exactly one open PR for the current branch is required.')
+    numbers.add(row.number)
+    if (!row.isCrossRepository) sameRepositoryHeads.add(row.headRefName)
+  }
+  const matches = rows.filter(
+    (row) => !row.isCrossRepository && row.headRefName === branch,
+  )
+  if (matches.length !== 1)
+    throw new Error('Exactly one open PR for the current branch is required.')
+  return matches[0]
 }
 
 function samePullRequestBody(left, right) {
@@ -692,7 +721,7 @@ function revertReadyAfterStateChange(exec, pr, error) {
 function assertReadyResult(exec, pr, branch, head) {
   let current
   try {
-    current = openPullRequest(exec)
+    current = openPullRequest(exec, branch)
   } catch (error) {
     return revertReadyAfterStateChange(exec, pr, error)
   }
@@ -745,7 +774,7 @@ function ready({
     )
   if (output(exec, 'git', ['status', '--porcelain']))
     throw new Error('Working tree must be clean.')
-  const pr = openPullRequest(exec)
+  const pr = openPullRequest(exec, branch)
   if (!pr.isDraft || pr.baseRefName !== 'main' || pr.headRefName !== branch)
     throw new Error(
       'PR must be a Draft targeting main from the current branch.',
@@ -834,7 +863,15 @@ function ready({
     throw new Error('--no-deferred cannot be combined with deferred items.')
   exec('gh', ['pr', 'checks', String(pr.number), '--required'])
   if (!parsed.dryRun) {
-    const current = openPullRequest(exec)
+    let current
+    try {
+      current = openPullRequest(exec, branch)
+    } catch (error) {
+      throw new Error(
+        'The PR changed while Ready was being prepared; rerun pr:ready.',
+        { cause: error },
+      )
+    }
     assertReadyPreparationState(pr, current, branch, head)
     const path = ledger ?? ledgerPath()
     const state = readLedger(path)

--- a/scripts/pr-ready.test.mjs
+++ b/scripts/pr-ready.test.mjs
@@ -13,6 +13,19 @@ import {
 
 const head = 'a'.repeat(40)
 
+function otherPr(number, branch, overrides = {}) {
+  return {
+    number,
+    isDraft: true,
+    baseRefName: 'main',
+    headRefName: branch,
+    headRefOid: String(number).padStart(40, '0'),
+    body: 'Other public PR',
+    isCrossRepository: false,
+    ...overrides,
+  }
+}
+
 /** Never the checkout's own ledger: a test that wrote there would discharge a
  * real deferral, which is the loss this record exists to prevent. */
 const tempLedger = () => join(tmpdir(), `pr-ready-ledger-${randomUUID()}.json`)
@@ -65,6 +78,7 @@ function harness({
   dirty = false,
   changedFiles = [],
   body = undefined,
+  otherPrs = [],
 } = {}) {
   const calls = []
   const usageReport = tempUsageReport()
@@ -83,10 +97,12 @@ function harness({
           baseRefName: base,
           headRefName: 'topic',
           headRefOid: remoteHead,
+          isCrossRepository: false,
           body:
             body ??
             `## Workflow usage\n\n${JSON.parse(readFileSync(usageReport, 'utf8')).markdown}`,
         },
+        ...otherPrs,
       ])
     if (file === 'gh' && args[1] === 'ready') {
       currentDraft = args.includes('--undo')
@@ -144,6 +160,99 @@ test('allows Ready with no workflow usage block and no report', () => {
   assert.equal(
     h.calls.some(([file, args]) => file === 'gh' && args[1] === 'ready'),
     true,
+  )
+})
+
+test('selects the current branch with two or three open PRs', () => {
+  for (const otherPrs of [
+    [otherPr(57, 'other/one')],
+    [otherPr(57, 'other/one'), otherPr(58, 'other/two')],
+  ]) {
+    const h = harness({
+      body: '## Workflow usage\n\nOptional. No workflow usage was included.',
+      otherPrs,
+    })
+    assert.deepEqual(
+      ready({
+        exec: h.exec,
+        parsed: { dryRun: false, deferred: [], noDeferred: true },
+        ledger: tempLedger(),
+      }),
+      { number: 56, head, dryRun: false, deferred: 0 },
+    )
+  }
+})
+
+test('does not select a cross-repository branch-name collision', () => {
+  const h = harness({
+    body: '## Workflow usage\n\nOptional. No workflow usage was included.',
+    otherPrs: [
+      otherPr(57, 'topic', { isCrossRepository: true }),
+      otherPr(58, 'other/two'),
+    ],
+  })
+  assert.deepEqual(
+    ready({
+      exec: h.exec,
+      parsed: { dryRun: false, deferred: [], noDeferred: true },
+      ledger: tempLedger(),
+    }),
+    { number: 56, head, dryRun: false, deferred: 0 },
+  )
+  assert.equal(
+    h.calls.some(
+      ([file, args]) =>
+        file === 'gh' && args[1] === 'ready' && args[2] === '57',
+    ),
+    false,
+  )
+})
+
+test('fails closed for malformed, ambiguous, over-limit, and wrong-head rows', () => {
+  const cases = [
+    [otherPr(57, 'other/one', { isCrossRepository: undefined })],
+    [otherPr(57, 'topic')],
+    [
+      otherPr(57, 'other/one'),
+      otherPr(58, 'other/two'),
+      otherPr(59, 'other/three'),
+    ],
+  ]
+  for (const otherPrs of cases) {
+    const h = harness({
+      body: '## Workflow usage\n\nOptional. No workflow usage was included.',
+      otherPrs,
+    })
+    assert.throws(
+      () =>
+        ready({
+          exec: h.exec,
+          parsed: { dryRun: false, deferred: [], noDeferred: true },
+          ledger: tempLedger(),
+        }),
+      /Exactly one open PR for the current branch/u,
+    )
+  }
+
+  const h = harness({
+    body: '## Workflow usage\n\nOptional. No workflow usage was included.',
+  })
+  const original = h.exec
+  h.exec = (file, args, options) => {
+    const result = original(file, args, options)
+    if (file !== 'gh' || args[1] !== 'list') return result
+    const rows = JSON.parse(result)
+    rows[0].headRefName = 'other/head'
+    return JSON.stringify(rows)
+  }
+  assert.throws(
+    () =>
+      ready({
+        exec: h.exec,
+        parsed: { dryRun: false, deferred: [], noDeferred: true },
+        ledger: tempLedger(),
+      }),
+    /Exactly one open PR for the current branch/u,
   )
 })
 
@@ -1151,7 +1260,9 @@ test('checks required status then makes the pushed Draft ready', () => {
 })
 
 test('rechecks the PR body before marking it ready', () => {
-  const h = harness()
+  const h = harness({
+    otherPrs: [otherPr(57, 'other/one'), otherPr(58, 'other/two')],
+  })
   const original = h.exec
   let listCalls = 0
   h.exec = (file, args, options) => {
@@ -1188,7 +1299,9 @@ test('rechecks the PR body before marking it ready', () => {
 })
 
 test('reverts Ready when the PR body changes during the mutation', () => {
-  const h = harness()
+  const h = harness({
+    otherPrs: [otherPr(57, 'other/one'), otherPr(58, 'other/two')],
+  })
   const original = h.exec
   let listCalls = 0
   h.exec = (file, args, options) => {


### PR DESCRIPTION
## Summary

- Allow up to three open pull requests to be published concurrently.
- Select the current branch's pull request from a bounded, validated listing for every Ready check.
- Serialize publication through a shared Git-common-directory lock and reject unsafe ownership or malformed listings.

## Validation

- `node --test scripts/pr-publish.test.mjs scripts/pr-ready.test.mjs scripts/pr-queue.test.mjs`
- `pnpm test:scripts`
- `pnpm verify`
- `pnpm format`
- `pnpm lint`
